### PR TITLE
chore(ci): fix validate commit command

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -8,7 +8,8 @@ on:
 
 jobs:
   validate-commits:
-
+    # Skip if not a Pull Request
+    if: github.base_ref
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## What/why?

Copying over the same orb logic we have for commit validation. Normally it shouldn't run on the `main` branch otherwise it'll validate over ALL commits.

**tl'dr** I'm copying the same functionality our circle orbs have https://github.com/bigcommerce/circle-orbs/blob/master/orbs/internal.yml#L306-L331

But in order for this to work appropriately with forks of this repo, I need to get a GitHub Org Admin to enable actions running on forks. It's disabled currently:
![Screenshot 2023-02-08 at 16 04 17](https://user-images.githubusercontent.com/10539418/217650531-712aa93f-1a5c-4abb-868a-0dd69c7059a3.png)
