### PR TITLE
chore(catalyst): HEADLESS-226 add middleware to handle custom urls

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,85 @@
+import { NextResponse, URLPattern } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+import { http } from './client';
+
+interface RoutesResponse {
+  data: {
+    site: {
+      route: {
+        node: {
+          __typename: string;
+          entityId: string;
+        } | null;
+      };
+    };
+  };
+}
+
+// This is a POC middleware intended to redirect all page requests to the right NextJS route.
+// TODO: Internationalization, trailing slash, etc.
+export async function middleware(request: NextRequest) {
+  const { data } = await http.query<RoutesResponse>(
+    `
+    query Routes($path: String!) {
+        site {
+            route(path: $path) {
+                node {
+                    __typename
+                    ... on Product {
+                      entityId
+                    }
+                    ... on Category {
+                      entityId
+                    }
+                    ... on Brand {
+                      entityId
+                    }
+                }
+            }
+        }
+    }
+  `,
+    { path: request.nextUrl.pathname },
+  );
+
+  switch (data.site.route.node?.__typename) {
+    case 'Product':
+      return NextResponse.rewrite(
+        new URL(`/product/${data.site.route.node.entityId}`, request.url),
+      );
+
+    case 'Category':
+      return NextResponse.rewrite(
+        new URL(`/category/${data.site.route.node.entityId}`, request.url),
+      );
+  }
+
+  // These are paths we want to hide from customers as it's internal to our application.
+  // We rewrite to these paths using merchants custom URLs for each entity.
+  const OBFUSCATED_PATTERNS = [
+    new URLPattern('/product/:pid(\\d+)', request.nextUrl.origin),
+    new URLPattern('/category/:cid(\\d+)', request.nextUrl.origin),
+    new URLPattern('/brand/:bid(\\d+)', request.nextUrl.origin),
+  ];
+
+  // Prevent customers from directly navigating to a obfuscated URL.
+  if (OBFUSCATED_PATTERNS.find((pattern) => pattern.exec(request.url))) {
+    return NextResponse.redirect(new URL('/404', request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - api (API routes)
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     */
+    '/((?!api|_next/static|_next/image|favicon.ico).*)',
+  ],
+};

--- a/src/pages/category/[cid].tsx
+++ b/src/pages/category/[cid].tsx
@@ -1,0 +1,213 @@
+import { GetServerSideProps } from 'next';
+import Head from 'next/head';
+import Image from 'next/image';
+
+import { http } from '../../client';
+import { Header } from '../../components/Header';
+import type { StoreLogo } from '../../components/Header';
+
+interface Category {
+  name: string;
+  path: string;
+  breadcrumbs: {
+    edges: Array<{
+      node: {
+        entityId: number;
+        name: string;
+      };
+    }>;
+  };
+  products: {
+    edges: Array<{
+      node: {
+        id: string;
+        name: string;
+        path: string;
+        defaultImage: {
+          url: string;
+          altText: string;
+        } | null;
+        brand: {
+          name: string;
+        } | null;
+        prices: {
+          price: {
+            formatted: string;
+          } | null;
+        };
+      };
+    }>;
+  };
+}
+
+interface CategoryTree {
+  name: string;
+  path: string;
+  children?: CategoryTree[];
+}
+
+interface CategoryPageProps {
+  category: Category;
+  categories: CategoryTree[];
+  storeName: string;
+  logo: StoreLogo;
+}
+
+interface CategoryQuery {
+  data: {
+    site: {
+      category: Category | null;
+      categoryTree: CategoryTree[];
+      settings: {
+        storeName: string;
+        logoV2: StoreLogo;
+      };
+    };
+  };
+}
+
+interface CategoryPageParams {
+  [key: string]: string | string[] | undefined;
+  cid: string;
+}
+
+export const getServerSideProps: GetServerSideProps<
+  CategoryPageProps,
+  CategoryPageParams
+> = async ({ params }) => {
+  if (!params?.cid) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const categoryId = parseInt(params.cid, 10);
+
+  const { data } = await http.query<CategoryQuery>(
+    `
+    query category($categoryId: Int!, $perPage: Int = 9) {
+      site {
+        category(entityId: $categoryId) {
+          name
+          path
+          breadcrumbs(depth: 1) {
+            edges {
+              node {
+                entityId
+                name
+              }
+            }
+          }
+          products(first: $perPage) {
+            edges {
+              node {
+                id
+                path
+                name
+                defaultImage {
+                  url: url(width: 300)
+                  altText
+                }
+                brand {
+                  name
+                }
+                prices {
+                  price {
+                    formatted
+                  }
+                }
+              }
+            }
+          }
+        }
+        categoryTree {
+          ...Category
+          children {
+            ...Category
+            children {
+              ...Category
+            }
+          }
+        }
+        settings {
+          storeName
+          logoV2 {
+            __typename
+            ... on StoreTextLogo{
+              text
+            }
+            ... on StoreImageLogo{
+              image {
+                url(width: 155)
+                altText
+              }
+            }
+          }
+        }
+      }
+    }
+
+    fragment Category on CategoryTreeItem {
+      name
+      path
+    }
+  `,
+    { categoryId },
+  );
+
+  if (data.site.category == null) {
+    return { notFound: true };
+  }
+
+  return {
+    props: {
+      category: data.site.category,
+      categories: data.site.categoryTree,
+      storeName: data.site.settings.storeName,
+      logo: data.site.settings.logoV2,
+    },
+  };
+};
+
+export default function CategoryPage({ category, categories, storeName, logo }: CategoryPageProps) {
+  return (
+    <>
+      <Head>
+        <title>{category.name}</title>
+      </Head>
+      <Header categories={categories} logo={logo} storeName={storeName} />
+      <main>
+        <div className="md:container md:mx-auto">
+          <h1 className="font-black text-5xl leading-[4rem]">{category.name}</h1>
+          <div className="grid grid-cols-4">
+            <div className="col-span-1" />
+            <div className="col-span-3">
+              <ul className="grid grid-cols-2 md:grid-cols-3 grid-flow-cols gap-8">
+                {category.products.edges.map(({ node }) => (
+                  <li className="basis-1/3" key={node.id}>
+                    <a href={node.path}>
+                      {node.defaultImage?.url ? (
+                        <Image
+                          alt={node.defaultImage.altText || node.name}
+                          className="aspect-[7/5] object-cover mb-5"
+                          height={208}
+                          src={node.defaultImage.url}
+                          width={292}
+                        />
+                      ) : null}
+                      {node.brand?.name ? (
+                        <p className="text-[#546E7A] text-base">{node.brand.name}</p>
+                      ) : null}
+                      <h4 className="text-xl font-bold mb-3">{node.name}</h4>
+                      <p className="text-base">{node.prices.price?.formatted}</p>
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/src/pages/product/[pid].tsx
+++ b/src/pages/product/[pid].tsx
@@ -1,0 +1,75 @@
+import { GetServerSideProps } from 'next';
+import Head from 'next/head';
+
+import { http } from '../../client';
+
+interface Product {
+  name: string;
+  plainTextDescription: string;
+}
+
+interface ProductQuery {
+  data: {
+    site: {
+      product: Product | null;
+    };
+  };
+}
+
+interface ProductPageProps {
+  product: Product;
+}
+
+interface ProductPageParams {
+  [key: string]: string | string[];
+  pid: string;
+}
+
+export const getServerSideProps: GetServerSideProps<ProductPageProps, ProductPageParams> = async ({
+  params,
+}) => {
+  if (!params?.pid) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const productId = parseInt(params.pid, 10);
+
+  const { data } = await http.query<ProductQuery>(
+    `
+    query productById($productId: Int!) {
+      site {
+        product(entityId: $productId) {
+          name
+          plainTextDescription
+        }
+      }
+    }
+  `,
+    { productId },
+  );
+
+  if (data.site.product == null) {
+    return { notFound: true };
+  }
+
+  return {
+    props: {
+      product: data.site.product,
+    },
+  };
+};
+
+export default function ProductPage({ product }: ProductPageProps) {
+  return (
+    <>
+      <Head>
+        <title>{product.name}</title>
+      </Head>
+      <pre className="bg-slate-100 m-4 p-4 border-2 rounded">
+        {JSON.stringify(product, undefined, 2)}
+      </pre>
+    </>
+  );
+}


### PR DESCRIPTION
## What/why

Adds a middleware to resolve custom product or category urls (will work for brands too). This helps determine which url resolves to which file-based route in NextJS. We also lock down navigating directly to the file-based routes, as we don't want customers/bots to find those routes.

The file-based routes use SSR to render each page. Previously, I had demo'd off ISR, however after exploring using query params, it was nearly impossible:tm: to do with ISR.

> Why expose the middleware vs. abstracting this functionality on the hosting side?

If merchants decide to detach from Vercel they'll need to duplicate the same logic hosted on their platform. In the end, when built into Cloudflare, this middleware will be generated as a CF Worker. In the end it's the same, however the code lives here.

~### Other notable changes:~
~- Bumps NextJS to the latest canary to fix a layout issue on the default 404 page.~
~- Moved the Header component into its own component so I could test and reuse it within the category pages.~
~- Added variable to be passed into GraphQL queries so we can pass in category or product ids in.~

EDIT: Cherry-picked in #16 

## Testing/proof

### Homepage
![screencapture-localhost-3000-2023-02-20-16_20_44](https://user-images.githubusercontent.com/10539418/220200470-fbe59733-844b-4cba-bdb6-766be37d2ffe.png)

### PLP
![screencapture-localhost-3000-classics-erg-merch-2023-02-20-16_22_35](https://user-images.githubusercontent.com/10539418/220200472-c0c3878c-1c74-454f-865a-36ea6efaeba2.png)

### PDP
![screencapture-localhost-3000-bcincolor-unisex-t-shirt-2023-02-20-16_23_07](https://user-images.githubusercontent.com/10539418/220200471-d011c622-64d2-47e3-b378-4ba2e6af34ba.png)
