### PR TITLE
chore(catalyst): HEADLESS-00 add Reactant playground page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Devpage
+src/pages/_reactant.tsx

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,5 @@
 const isProduction = process.env.NODE_ENV !== 'development';
+const isDevelopment = process.env.NODE_ENV === 'development';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -6,6 +7,16 @@ const nextConfig = {
   images: {
     loaderFile: isProduction ? './src/bigcommerceImageLoader.ts' : undefined,
     domains: ['cdn11.bigcommerce.com'],
+  },
+  exportPathMap: (defaultPathMap) => {
+    if (isDevelopment) {
+      return defaultPathMap;
+    }
+
+    // Ensures the reactant playground page doesn't get built to production
+    const { '/_reactant': reactant, ...rest } = defaultPathMap;
+
+    return rest;
   },
 };
 


### PR DESCRIPTION
## What/why?

Create a local development page for playing with Reactant components.


## How to create it?

Create a local page in `src/pages` called `_reactant.tsx` and use it like any other NextJS page:
```tsx
export default function ReactantPage() {
  return <div>Reactant Page</div>;
}
```

_Make sure you delete that page if you are going to try and build a production build._

## Testing/proof
![Screenshot 2023-03-02 at 09 56 55](https://user-images.githubusercontent.com/10539418/222464776-f16aba9b-7292-423c-a9e8-250dc385f6b9.png)
![Screenshot 2023-03-02 at 09 57 03](https://user-images.githubusercontent.com/10539418/222464797-20b4bda3-b727-46cb-a50a-f43f6865404d.png)
