### PR TITLE
feat(catalyst): MERC-9401 Render pages in homepage menu and widgets in pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ next-env.d.ts
 
 # Devpage
 src/pages/_reactant.tsx
+.idea

--- a/next.config.js
+++ b/next.config.js
@@ -6,7 +6,7 @@ const nextConfig = {
   reactStrictMode: true,
   images: {
     loaderFile: isProduction ? './src/bigcommerceImageLoader.ts' : undefined,
-    domains: ['cdn11.bigcommerce.com'],
+    domains: ['cdn11.bigcommerce.com', 'cdn.store.bcdev'],
   },
   i18n: {
     locales: ['en'],

--- a/src/pages/category/[cid].tsx
+++ b/src/pages/category/[cid].tsx
@@ -5,7 +5,7 @@ import { MergeDeep } from 'type-fest';
 
 import { serverClient } from '../../client/server';
 import { Header, query as HeaderQuery, HeaderSiteQuery } from '../../components/Header';
-import type { StoreLogo } from '../../components/Header';
+import type { Page, StoreLogo } from '../../components/Header';
 import {
   ProductTiles,
   ProductTilesConnection,
@@ -26,7 +26,7 @@ interface Category {
   products: ProductTilesConnection;
 }
 
-interface CategoryTree {
+export interface CategoryTree {
   name: string;
   path: string;
   children?: CategoryTree[];
@@ -51,6 +51,13 @@ interface CategoryQuery {
 interface CategoryPageProps {
   category: Category;
   categories: CategoryTree[];
+  content: {
+    pages: {
+      edges: Array<{
+        node: Page;
+      }>;
+    };
+  };
   storeName: string;
   logo: StoreLogo;
   storefront: {
@@ -122,6 +129,7 @@ export const getServerSideProps: GetServerSideProps<
     props: {
       category: data.site.category,
       categories: data.site.categoryTree,
+      content: data.site.content,
       storeName: data.site.settings.storeName,
       logo: data.site.settings.logoV2,
       storefront: data.site.settings.storefront,
@@ -133,6 +141,7 @@ export const getServerSideProps: GetServerSideProps<
 export default function CategoryPage({
   category,
   categories,
+  content,
   storeName,
   storefront,
   logo,
@@ -142,7 +151,7 @@ export default function CategoryPage({
       <Head>
         <title>{category.name}</title>
       </Head>
-      <Header categoryTree={categories} settings={{ logoV2: logo, storeName }} />
+      <Header categoryTree={categories} content={content} settings={{ logoV2: logo, storeName }} />
       <main>
         <div className="md:container md:mx-auto">
           <h1 className="font-black text-5xl leading-[4rem]">{category.name}</h1>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -75,7 +75,11 @@ export default function HomePage({ data }: { data: HomePageQuery }) {
         <title>BigCommerce Swag Store</title>
         <meta content="BigCommerce Swag Store" name="description" />
       </Head>
-      <Header categoryTree={data.site.categoryTree} settings={data.site.settings} />
+      <Header
+        categoryTree={data.site.categoryTree}
+        content={data.site.content}
+        settings={data.site.settings}
+      />
       <main>
         <div className="md:container md:mx-auto">
           <div className="aspect-[9/16] md:aspect-[2/1] bg-slate-100 relative flex flex-col items-start justify-center p-6 sm:p-16 md:p-24">

--- a/src/pages/page/[pageid].tsx
+++ b/src/pages/page/[pageid].tsx
@@ -1,0 +1,118 @@
+import { gql } from '@apollo/client';
+import { GetServerSideProps } from 'next';
+import Head from 'next/head';
+import { MergeDeep } from 'type-fest';
+
+import { serverClient } from '../../client/server';
+import { Header, query as HeaderQuery, HeaderSiteQuery } from '../../components/Header';
+import type { Page, StoreLogo } from '../../components/Header';
+import { CategoryTree } from '../category/[cid]';
+
+interface Region {
+  name: string;
+  html: string;
+}
+
+interface PageQuery {
+  site: MergeDeep<
+    HeaderSiteQuery,
+    {
+      content: {
+        renderedRegionsByPageTypeAndEntityId: {
+          regions: Region[];
+        };
+      };
+    }
+  >;
+}
+
+interface PageProps {
+  content: {
+    regions: Region[];
+    pages: {
+      edges: Array<{
+        node: Page;
+      }>;
+    };
+  };
+  page: Page;
+  categories: CategoryTree[];
+  storeName: string;
+  logo: StoreLogo;
+}
+
+interface PageParams {
+  [key: string]: string | string[];
+  pageid: string;
+}
+
+export const getServerSideProps: GetServerSideProps<PageProps, PageParams> = async ({ params }) => {
+  if (!params?.pageid) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const pageId = parseInt(params.pageid, 10);
+
+  const { data } = await serverClient.query<PageQuery>({
+    query: gql`
+    query regionsByPage($pageId: Long!) {
+      site {
+        content {
+          renderedRegionsByPageTypeAndEntityId(entityPageType: PAGE, entityId: $pageId) {
+            regions {
+              name
+              html
+            }
+          }
+        }
+        ...${HeaderQuery.fragmentName}
+      }
+    }
+
+    ${HeaderQuery.fragment}
+    `,
+    variables: { pageId },
+  });
+
+  return {
+    props: {
+      content: {
+        regions: data.site.content.renderedRegionsByPageTypeAndEntityId.regions.filter(
+          (region) => region.name === 'page_content',
+        ),
+        pages: data.site.content.pages,
+      },
+      page: data.site.content.pages.edges.filter(({ node }) => node.entityId === pageId)[0].node,
+      categories: data.site.categoryTree,
+      storeName: data.site.settings.storeName,
+      logo: data.site.settings.logoV2,
+    },
+  };
+};
+
+export default function Page({ content, page, categories, logo, storeName }: PageProps) {
+  return (
+    <>
+      <Head>
+        <title>{page.name}</title>
+      </Head>
+      <Header categoryTree={categories} content={content} settings={{ logoV2: logo, storeName }} />
+      <main>
+        <div className="md:container md:mx-auto">
+          <h1 className="font-black text-5xl leading-[4rem]">{page.name}</h1>
+          <div className="my-12 mx-6 sm:mx-10 md:mx-auto">
+            {content.regions.map(({ name, html }) => (
+              <div
+                dangerouslySetInnerHTML={{ __html: html }}
+                data-content-region={name}
+                key={name}
+              />
+            ))}
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION
This PR enables rendering Web Pages in Homepage menu and rendering Widgets on Web Pages.

https://user-images.githubusercontent.com/45639285/226718050-636d0e35-8d9f-4fcf-8cb8-937d05107255.mov

There's caching issue that can be observed in the above video. For example, after adding 1 widget and another later, Catalyst shows only the first widget unless refreshing the page every single time.
```
Cache data may be lost when replacing the content field of a Site object.

To address this problem (which is not a bug in Apollo Client), either ensure all objects of type Content have an ID or a custom merge function, or define a custom merge function for the Site.content field, so InMemoryCache can safely merge these objects: existing, incoming

For more information about these options, please refer to the documentation:

  * Ensuring entity objects have IDs: https://go.apollo.dev/c/generating-unique-identifiers
  * Defining custom merge functions: https://go.apollo.dev/c/merging-non-normalized-objects

Cache data may be lost when replacing the settings field of a Site object.

To address this problem (which is not a bug in Apollo Client), either ensure all objects of type Settings have an ID or a custom merge function, or define a custom merge function for the Site.settings field, so InMemoryCache can safely merge these objects: existing, incoming

For more information about these options, please refer to the documentation:

  * Ensuring entity objects have IDs: https://go.apollo.dev/c/generating-unique-identifiers
  * Defining custom merge functions: https://go.apollo.dev/c/merging-non-normalized-objects
```

