### PR TITLE
feat(catalyst): BCTHEME-1452 add pagination for PLP

### DIFF
--- a/reactant/components/Pagination.tsx
+++ b/reactant/components/Pagination.tsx
@@ -1,0 +1,28 @@
+import { PropsWithChildren } from 'react';
+
+interface ClassName {
+  className: string;
+}
+
+type ComponentProps<Props, VariantKey extends string> = React.FC<Props> &
+  Record<VariantKey, ClassName>;
+
+type PaginationProps = React.HTMLAttributes<HTMLDivElement> & PropsWithChildren;
+type Pagination = ComponentProps<PaginationProps, 'default'> & {
+  NextPage?: { className: string };
+  PrevPage?: { className: string };
+};
+
+export const Pagination: Pagination = ({ children, ...props }) => {
+  return <div {...props}>{children}</div>;
+};
+
+Pagination.default = {
+  className: 'flex flex-row justify-center items-center gap-2 mt-11 mb-14',
+};
+Pagination.NextPage = {
+  className: 'fill-none stroke-black hover:stroke-[#053FB0] cursor-pointer m-3',
+};
+Pagination.PrevPage = {
+  className: 'fill-none stroke-black hover:stroke-[#053FB0] cursor-pointer m-3',
+};

--- a/reactant/icons/ChevronLeft.tsx
+++ b/reactant/icons/ChevronLeft.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export const ChevronLeftIcon: React.FC<React.SVGAttributes<HTMLOrSVGElement>> = ({ ...props }) => (
+  <svg height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path
+      clipRule="evenodd"
+      d="M14.7071 5.29289C15.0976 5.68342 15.0976 6.31658 14.7071 6.70711L9.41421 12L14.7071 17.2929C15.0976 17.6834 15.0976 18.3166 14.7071 18.7071C14.3166 19.0976 13.6834 19.0976 13.2929 18.7071L7.29289 12.7071C6.90237 12.3166 6.90237 11.6834 7.29289 11.2929L13.2929 5.29289C13.6834 4.90237 14.3166 4.90237 14.7071 5.29289Z"
+      fill="currentcolor"
+      fillRule="evenodd"
+    />
+  </svg>
+);

--- a/reactant/icons/ChevronRight.tsx
+++ b/reactant/icons/ChevronRight.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export const ChevronRightIcon: React.FC<React.SVGAttributes<HTMLOrSVGElement>> = ({ ...props }) => {
+  return (
+    <svg height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path
+        clipRule="evenodd"
+        d="M9.29289 18.7071C8.90237 18.3166 8.90237 17.6834 9.29289 17.2929L14.5858 12L9.29289 6.70711C8.90237 6.31658 8.90237 5.68342 9.29289 5.29289C9.68342 4.90237 10.3166 4.90237 10.7071 5.29289L16.7071 11.2929C17.0976 11.6834 17.0976 12.3166 16.7071 12.7071L10.7071 18.7071C10.3166 19.0976 9.68342 19.0976 9.29289 18.7071Z"
+        fill="currentcolor"
+        fillRule="evenodd"
+      />
+    </svg>
+  );
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -51,7 +51,10 @@ export async function middleware(request: NextRequest) {
 
     case 'Category':
       return NextResponse.rewrite(
-        new URL(`/category/${data.site.route.node.entityId}`, request.url),
+        new URL(
+          `/category/${data.site.route.node.entityId}/${request.nextUrl.search}`,
+          request.url,
+        ),
       );
   }
 


### PR DESCRIPTION
### What

 This PR adds pagination to the PLP page in Catalyst. 

For now we use next type of URL based on cursor:
- for moving forward - `${category.path}?page=9&after=${category.products.pageInfo.endCursor}`
- for moving back  -`${category.path}?first=9&before=${category.products.pageInfo.startCursor}`

where `page=9` shows quantity of products per page and `after=` || `before=` is for showing trajectory of moving between list of products since we don't have a page as entity.

### Proof

https://user-images.githubusercontent.com/67792608/224106822-111e20d4-5c66-4499-8d4a-db2561307c34.mov

