### PR TITLE
chore(ci): HEADLESS-00 add typecheck to CI

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -45,3 +45,6 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Typecheck
+        run: tsc --noEmit
+


### PR DESCRIPTION
## What/why?

Adds typechecking as apart of the CI process. This should help us determine if we have any typescript issues going further.

## Testing/proof
(The current CI run) https://github.com/bigcommerce/catalyst/actions/runs/4471261773/jobs/7855908326?pr=33