### PR TITLE
refactor(catalyst): HEADLESS-00 colocate ProductTile query

### DIFF
--- a/src/components/ProductTiles.tsx
+++ b/src/components/ProductTiles.tsx
@@ -7,16 +7,115 @@ import { Link as ReactantLink } from '../../reactant/components/Link';
 import { H3, P, ProductTile } from '../../reactant/components/ProducTile';
 import { Swatch, SwatchGroup } from '../../reactant/components/Swatch';
 import { HeartIcon } from '../../reactant/icons/Heart';
-import { Product } from '../pages';
+
+export interface ProductTilesConnection {
+  edges: Array<{
+    node: {
+      addToCartUrl: string;
+      showCartAction: boolean;
+      entityId: number;
+      name: string;
+      path: string;
+      brand: {
+        name: string;
+      } | null;
+      defaultImage?: {
+        url: string;
+        altText: string;
+      };
+      prices: {
+        price: {
+          formatted: string;
+        } | null;
+      };
+      productOptions: {
+        edges: Array<{
+          node: {
+            entityId: number;
+            displayName: string;
+            isRequired: boolean;
+            __typename: string;
+            displayStyle: string;
+            values: {
+              edges: Array<{
+                node: {
+                  entityId: number;
+                  label: string;
+                  isDefault: boolean;
+                  hexColors: string[];
+                  imageUrl: string | null;
+                  isSelected: boolean;
+                };
+              }>;
+            };
+          };
+        }>;
+      };
+    };
+  }>;
+}
+
+export const query = {
+  fragmentName: 'ProductTilesQuery',
+  fragment: /* GraphQL */ `
+    fragment ProductTilesQuery on ProductConnection {
+      edges {
+        node {
+          addToCartUrl
+          entityId
+          name
+          path
+          showCartAction
+          brand {
+            name
+          }
+          defaultImage {
+            url(width: 300, height: 300)
+            altText
+          }
+          prices(currencyCode: USD) {
+            price {
+              formatted
+            }
+          }
+          productOptions(first: 3) {
+            edges {
+              node {
+                entityId
+                displayName
+                isRequired
+                __typename
+                ... on MultipleChoiceOption {
+                  displayStyle
+                  values(first: 5) {
+                    edges {
+                      node {
+                        entityId
+                        isDefault
+                        ... on SwatchOptionValue {
+                          hexColors
+                          imageUrl(width: 200)
+                          isSelected
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `,
+};
 
 interface ProductTilesProps {
   cols?: keyof typeof COLS;
   title?: string;
   priority?: boolean;
   // TODO: See if we can make this more generic
-  products: {
-    edges: Product[];
-  };
+  products: ProductTilesConnection;
   productComparisonsEnabled: boolean;
 }
 

--- a/src/pages/category/[cid].tsx
+++ b/src/pages/category/[cid].tsx
@@ -3,11 +3,14 @@ import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import { MergeDeep } from 'type-fest';
 
-import { Product } from '..';
 import { serverClient } from '../../client/server';
 import { Header, query as HeaderQuery, HeaderSiteQuery } from '../../components/Header';
 import type { StoreLogo } from '../../components/Header';
-import { ProductTiles } from '../../components/ProductTiles';
+import {
+  ProductTiles,
+  ProductTilesConnection,
+  query as ProductTilesQuery,
+} from '../../components/ProductTiles';
 
 interface Category {
   name: string;
@@ -20,9 +23,7 @@ interface Category {
       };
     }>;
   };
-  products: {
-    edges: Product[];
-  };
+  products: ProductTilesConnection;
 }
 
 interface CategoryTree {
@@ -92,54 +93,7 @@ export const getServerSideProps: GetServerSideProps<
             }
           }
           products(first: $perPage) {
-            edges {
-              node {
-                id
-                addToCartUrl
-                path
-                name
-                defaultImage {
-                  url: url(width: 300)
-                  altText
-                }
-                showCartAction
-                brand {
-                  name
-                }
-                prices {
-                  price {
-                    formatted
-                  }
-                }
-                productOptions(first: 3) {
-                  edges {
-                    node {
-                      entityId
-                      displayName
-                      isRequired
-                      __typename
-                      ... on MultipleChoiceOption {
-                        displayStyle
-                        values(first: 5) {
-                          edges {
-                            node {
-                              entityId
-                                
-                              isDefault
-                              ... on SwatchOptionValue {
-                                hexColors
-                                imageUrl(width: 200)
-                                isSelected
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
+            ...${ProductTilesQuery.fragmentName}
           }
         }
         settings {
@@ -155,6 +109,7 @@ export const getServerSideProps: GetServerSideProps<
     }
 
     ${HeaderQuery.fragment}
+    ${ProductTilesQuery.fragment}
     `,
     variables: { categoryId },
   });

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,63 +8,18 @@ import { Link } from '../../reactant/components/Link';
 import { serverClient } from '../client/server';
 import { Footer, query as FooterQuery, FooterSiteQuery } from '../components/Footer';
 import { Header, query as HeaderQuery, HeaderSiteQuery } from '../components/Header';
-import { ProductTiles } from '../components/ProductTiles';
-
-export interface Product {
-  node: {
-    addToCartUrl: string;
-    showCartAction: boolean;
-    entityId: number;
-    name: string;
-    path: string;
-    brand: {
-      name: string;
-    } | null;
-    defaultImage?: {
-      url: string;
-      altText: string;
-    };
-    prices: {
-      price: {
-        formatted: string;
-      } | null;
-    };
-    productOptions: {
-      edges: Array<{
-        node: {
-          entityId: number;
-          displayName: string;
-          isRequired: boolean;
-          __typename: string;
-          displayStyle: string;
-          values: {
-            edges: Array<{
-              node: {
-                entityId: number;
-                label: string;
-                isDefault: boolean;
-                hexColors: string[];
-                imageUrl: string | null;
-                isSelected: boolean;
-              };
-            }>;
-          };
-        };
-      }>;
-    };
-  };
-}
-
-interface ProductConnection {
-  edges: Product[];
-}
+import {
+  ProductTiles,
+  ProductTilesConnection,
+  query as ProductTilesQuery,
+} from '../components/ProductTiles';
 
 interface HomePageQuery {
   site: MergeDeep<
     MergeDeep<HeaderSiteQuery, FooterSiteQuery>,
     {
-      featuredProducts: ProductConnection;
-      bestSellingProducts: ProductConnection;
+      featuredProducts: ProductTilesConnection;
+      bestSellingProducts: ProductTilesConnection;
       settings: {
         storefront: {
           catalog: {
@@ -82,10 +37,10 @@ export const getServerSideProps: GetServerSideProps = async () => {
       query HomePageQuery($pageSize: Int = 4) {
       site {
         featuredProducts (first: $pageSize) {
-          ...Product
+          ...${ProductTilesQuery.fragmentName}
         }
         bestSellingProducts (first: $pageSize) {
-          ...Product
+          ...${ProductTilesQuery.fragmentName}
         }
         settings {
           storefront {
@@ -100,58 +55,9 @@ export const getServerSideProps: GetServerSideProps = async () => {
       }
     }
 
-    fragment Product on ProductConnection {
-      edges {
-        node {
-          addToCartUrl
-          entityId
-          name
-          path
-          showCartAction
-          brand {
-            name
-          }
-          defaultImage {
-            url(width: 300, height: 300)
-            altText
-          }
-          prices(currencyCode: USD) {
-            price {
-              formatted
-            }
-          }
-          productOptions(first: 3) {
-            edges {
-              node {
-                entityId
-                displayName
-                isRequired
-                __typename
-                ... on MultipleChoiceOption {
-                  displayStyle
-                  values(first: 5) {
-                    edges {
-                      node {
-                        entityId
-                        isDefault
-                        ... on SwatchOptionValue {
-                          hexColors
-                          imageUrl(width: 200)
-                          isSelected
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-
     ${HeaderQuery.fragment}
     ${FooterQuery.fragment}
+    ${ProductTilesQuery.fragment}
     `,
   });
 


### PR DESCRIPTION
## What/why?

This co-locates the `ProductTile` query closer to the component. It ensures that the data-fetching and types are closer to the consumer, making it harder for data/type mismatches to happen. This also cleans up the error as shown on https://github.com/bigcommerce/catalyst/actions/runs/4471261773/jobs/7855908326?pr=33.

## Testing/proof
![screencapture-localhost-3000-2023-03-20-14_09_35](https://user-images.githubusercontent.com/10539418/226429233-525b0045-74b4-4333-b998-032b452a5338.png)
