### PR TITLE
feat(client): HEADLESS-231 add client-side gql entrypoint

### DIFF
--- a/src/client/client/index.ts
+++ b/src/client/client/index.ts
@@ -1,0 +1,29 @@
+import { MutationOptions, QueryOptions } from '@apollo/client';
+
+export { gql } from '@apollo/client';
+
+const fetchFn = async (body: QueryOptions | MutationOptions) => {
+  if (typeof window === 'undefined') {
+    throw new Error(
+      'This client is only for use in the browser. Use serverClient for server requests.',
+    );
+  }
+
+  return fetch('/api/graphql', {
+    method: 'POST',
+    headers: {
+      accept: 'application/json',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+};
+
+export const clientClient = {
+  query: async (options: QueryOptions) => {
+    return fetchFn(options);
+  },
+  mutate: async (options: MutationOptions) => {
+    return fetchFn(options);
+  },
+};

--- a/src/pages/api/graphql.ts
+++ b/src/pages/api/graphql.ts
@@ -1,0 +1,38 @@
+import { MutationOptions, QueryOptions } from '@apollo/client';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+import { serverClient } from '../../client/server';
+
+const isQueryRequest = (body: unknown): body is QueryOptions => {
+  return typeof body === 'object' && body !== null && 'query' in body;
+};
+
+const isMutationRequest = (body: unknown): body is MutationOptions => {
+  return typeof body === 'object' && body !== null && 'mutation' in body;
+};
+
+export default async function graphqlHandler(req: NextApiRequest, res: NextApiResponse) {
+  if (typeof req.method !== 'string') {
+    return res.status(405).send(`No request method provided`);
+  }
+
+  if (req.method !== 'POST') {
+    return res.status(405).send(`Method ${req.method} not allowed`);
+  }
+
+  const body: unknown = typeof req.body === 'string' ? JSON.parse(req.body) : req.body;
+
+  if (isQueryRequest(body)) {
+    const response = await serverClient.query(body);
+
+    return res.status(200).send(response);
+  }
+
+  if (isMutationRequest(body)) {
+    const response = await serverClient.mutate(body);
+
+    return res.status(200).send(response);
+  }
+
+  return res.status(400).send(`Request body is invalid ${JSON.stringify(body)}`);
+}


### PR DESCRIPTION
## What/why?

Adds a `/api/graphql` endpoint for client-side usage. Also provides a barebones `clientClient` 😅 

Note: `clientClient` and `serverClient` can probably be refactored later on... ~we may just have a `getClient` factory function that determines which client is provided so the consumer doesn't need to be concerned with which client it receives.~ _Edit: I tinkered with this a bit and because TypeScript is statically typed, returning the correct type is almost impossible without some weird work-a-rounds._

## Testing/proof
_Fetching storeName client-side:_
![Screenshot 2023-03-21 at 15 41 32](https://user-images.githubusercontent.com/10539418/226727242-107d36f6-da0b-4ec7-8275-3638c9eb4263.png)
