### PR TITLE
Add some initial session management logic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,7 @@ NEXT_PUBLIC_BIGCOMMERCE_ACCESS_TOKEN=""
 NEXT_PUBLIC_BIGCOMMERCE_CANONICAL_STORE_DOMAIN="mybigcommerce.com"
 NEXT_PUBLIC_BIGCOMMERCE_API_URL="https://api.bigcommerce.com"
 NEXT_PUBLIC_BIGCOMMERCE_CHANNEL_ID=1
+
+SESSION_ID="session-id"
+SESSION_PASSWORD="thisissomekindof32characterlongpassworddontuseinproduction"
+SESSION_TTL=604800 # 7 days

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,3 @@ next-env.d.ts
 
 # Devpage
 src/pages/_reactant.tsx
-
-# intellij
-.idea/

--- a/src/pages/api/create-cart.ts
+++ b/src/pages/api/create-cart.ts
@@ -1,0 +1,18 @@
+import { withIronSessionApiRoute } from 'iron-session/next';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+import { cartCreated, sessionOptions } from '../../session';
+
+export const config = {
+  runtime: 'nodejs',
+};
+
+export default withIronSessionApiRoute(handler, sessionOptions);
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const cartId = 'some-cart-id';
+
+  await cartCreated(req.session, cartId);
+
+  res.status(200).json({ cartId });
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -32,7 +32,6 @@ interface HomePageQuery {
 }
 
 export const getServerSideProps: GetServerSideProps = async () => {
-
   const { data } = await serverClient.query<HomePageQuery>({
     query: gql`
       query HomePageQuery($pageSize: Int = 4) {

--- a/src/pages/product/[pid].tsx
+++ b/src/pages/product/[pid].tsx
@@ -1,11 +1,8 @@
 import { gql } from '@apollo/client';
-import { getIronSession } from 'iron-session/edge';
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
-import { NextResponse } from 'next/server';
 
 import { serverClient } from '../../client/server';
-import { sessionOptions } from '../../session';
 
 interface Product {
   name: string;
@@ -29,11 +26,7 @@ interface ProductPageParams {
 
 export const getServerSideProps: GetServerSideProps<ProductPageProps, ProductPageParams> = async ({
   params,
-  req,
 }) => {
-  const res = NextResponse.next();
-  const session = await getIronSession(req, res, sessionOptions);
-
   if (!params?.pid) {
     return {
       notFound: true,
@@ -41,10 +34,6 @@ export const getServerSideProps: GetServerSideProps<ProductPageProps, ProductPag
   }
 
   const productId = parseInt(params.pid, 10);
-
-  session.recentlyViewedProducts.push(productId);
-
-  await session.save();
 
   const { data } = await serverClient.query<ProductQuery>({
     query: gql`
@@ -59,9 +48,6 @@ export const getServerSideProps: GetServerSideProps<ProductPageProps, ProductPag
     `,
     variables: {
       productId,
-    },
-    context: {
-      // pass in context here
     },
   });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,10 +22,7 @@
       {
         "name": "next"
       }
-    ],
-    "paths": {
-      "crypto": ["node_modules/@peculiar/webcrypto"]
-    }
+    ]
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
# What
This is the first step towards adding a shopper session for catalyst. We should see a cookie `session-id` set in the browser when we load any page. This will have an expiry of 7 days and contain a set of data that initially looks something like this

```
{
  "initTimestamp": 1679585989297,
  "initRequestUrl": "/",
  "recentlyViewedProducts": []
}
```
<img width="1440" alt="Screen Shot 2023-03-23 at 10 40 00 AM" src="https://user-images.githubusercontent.com/1263106/227257154-d4814753-0d39-4143-89d6-e9853a953638.png">

As we navigate through the application we should see the session expiry time extend, as well as a few bits of data added to the session (right now it's just recently viewed products).

I've also added a dummy api route just as an example of the pattern for api requests modifying the session, in this case it just puts in a placeholder value for `cart_id`, since I know that's one we're gonna want eventually.

So after viewing some products and navigating to `/api/create-cart` our session looks like this

```
{
  "initTimestamp": 1679585989383,
  "initRequestUrl": "/",
  "recentlyViewedProducts": [
    97,
    86
  ],
  "cartId": "some-cart-id"
}
```
