### PR TITLE
Add some initial session management logic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,7 @@ BIGCOMMERCE_CHANNEL_ID=1
 # Optional
 BIGCOMMERCE_CANONICAL_STORE_DOMAIN="mybigcommerce.com"
 BIGCOMMERCE_API_URL="https://api.bigcommerce.com"
+
+SESSION_ID="session-id"
+SESSION_PASSWORD="thisissomekindof32characterlongpassworddontuseinproduction"
+SESSION_TTL=604800 # 7 days

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,3 @@ next-env.d.ts
 
 # Devpage
 src/pages/_reactant.tsx
-
-# intellij
-.idea/

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -26,10 +26,9 @@ export async function rewriteUrlMiddleware(
   requestResponse: Promise<{ request: NextRequest; response: NextResponse }>,
 ) {
   const client = getServerClient();
-
   const { request, response } = await requestResponse;
 
-  const { data } =  await client.query<RoutesResponse>({
+  const { data } = await client.query<RoutesResponse>({
     query: gql`
       query Routes($path: String!) {
         site {
@@ -57,13 +56,13 @@ export async function rewriteUrlMiddleware(
     case 'Product':
       return NextResponse.rewrite(
         new URL(`/product/${data.site.route.node.entityId}`, request.url),
-        response
+        response,
       );
 
     case 'Category':
       return NextResponse.rewrite(
         new URL(`/category/${data.site.route.node.entityId}`, request.url),
-        response
+        response,
       );
   }
 
@@ -93,5 +92,6 @@ export const config = {
      * - favicon.ico (favicon file)
      */
     '/((?!api|_next/static|_next/image|favicon.ico).*)',
+    '/',
   ],
 };

--- a/src/pages/product/[pid].tsx
+++ b/src/pages/product/[pid].tsx
@@ -25,8 +25,8 @@ interface ProductPageParams {
 }
 
 export const getServerSideProps: GetServerSideProps<ProductPageProps, ProductPageParams> = async ({
-                                                                                                    params,
-                                                                                                  }) => {
+  params,
+}) => {
   if (!params?.pid) {
     return {
       notFound: true,
@@ -38,14 +38,14 @@ export const getServerSideProps: GetServerSideProps<ProductPageProps, ProductPag
 
   const { data } = await client.query<ProductQuery>({
     query: gql`
-        query productById($productId: Int!) {
-            site {
-                product(entityId: $productId) {
-                    name
-                    plainTextDescription
-                }
-            }
+      query productById($productId: Int!) {
+        site {
+          product(entityId: $productId) {
+            name
+            plainTextDescription
+          }
         }
+      }
     `,
     variables: {
       productId,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,10 +22,7 @@
       {
         "name": "next"
       }
-    ],
-    "paths": {
-      "crypto": ["node_modules/@peculiar/webcrypto"]
-    }
+    ]
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
# What
This is the first step towards adding a shopper session for catalyst. We should see a cookie `session-id` set in the browser when we load any page. This will have an expiry of 7 days and contain a set of data that initially looks something like this

```
{
  "initTimestamp": 1679585989297,
  "initRequestUrl": "/",
  "recentlyViewedProducts": []
}
```
<img width="1440" alt="Screen Shot 2023-03-23 at 10 40 00 AM" src="https://user-images.githubusercontent.com/1263106/227257154-d4814753-0d39-4143-89d6-e9853a953638.png">

As we navigate through the application we should see the session expiry time extend, as well as a few bits of data added to the session (right now it's just recently viewed products).

I've also added a dummy api route just as an example of the pattern for api requests modifying the session, in this case it just puts in a placeholder value for `cart_id`, since I know that's one we're gonna want eventually.

So after viewing some products and navigating to `/api/create-cart` our session looks like this

```
{
  "initTimestamp": 1679585989383,
  "initRequestUrl": "/",
  "recentlyViewedProducts": [
    97,
    86
  ],
  "cartId": "some-cart-id"
}
```
