### PR TITLE
fix(client): HEADLESS-00 update graphql proxy to edge runtime

### DIFF
--- a/src/graphql/browser/index.ts
+++ b/src/graphql/browser/index.ts
@@ -1,6 +1,12 @@
 import { MutationOptions, QueryOptions } from '@apollo/client';
 
 const fetchFn = async (body: QueryOptions | MutationOptions) => {
+  if (typeof window === 'undefined') {
+    throw new Error(
+      'getBrowserClient is only for use in the browser. Use getServerClient for server requests.',
+    );
+  }
+
   const response = await fetch('/api/graphql', {
     method: 'POST',
     headers: {
@@ -16,12 +22,6 @@ const fetchFn = async (body: QueryOptions | MutationOptions) => {
 };
 
 export const getBrowserClient = () => {
-  if (typeof window === 'undefined') {
-    throw new Error(
-      'getBrowserClient is only for use in the browser. Use getServerClient for server requests.',
-    );
-  }
-
   return {
     query: async (options: QueryOptions) => {
       return fetchFn(options);


### PR DESCRIPTION
## What/why

Fixes the graphql proxy endpoint due to the switch to edge runtime. With edge runtime, requests/responses are streamed causing us to rewrite how endpoint work with NextJS's edge helper methods.

## Testing

_I used this diff to test it out:_
```diff
diff --git a/src/pages/index.tsx b/src/pages/index.tsx
index a0321d4..88e8b87 100644
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,6 +3,7 @@ import Head from 'next/head';
 import React from 'react';
 import { MergeDeep } from 'type-fest';
 
+import { Button } from '../../reactant/components/Button';
 import { Link } from '../../reactant/components/Link';
 import { Footer, query as FooterQuery, FooterSiteQuery } from '../components/Footer';
 import { Header, query as HeaderQuery, HeaderSiteQuery } from '../components/Header';
@@ -11,6 +12,7 @@ import {
   ProductTilesConnection,
   query as ProductTilesQuery,
 } from '../components/ProductTiles';
+import { getBrowserClient } from '../graphql/browser';
 import { getServerClient } from '../graphql/server';
 import { gql } from '../graphql/utils';
 
@@ -71,6 +73,27 @@ export const getServerSideProps: GetServerSideProps = async () => {
 };
 
 export default function HomePage({ data }: { data: HomePageQuery }) {
+  const client = getBrowserClient();
+  const [storeName, setStoreName] = React.useState('');
+
+  const fetchStoreName = async () => {
+    const response = await client.query({
+      query: gql`
+        query {
+          site {
+            settings {
+              storeName
+            }
+          }
+        }
+      `,
+    });
+
+    // @ts-expect-error testing
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+    setStoreName(response.site.settings.storeName);
+  };
+
   return (
     <>
       <Head>
@@ -80,6 +103,10 @@ export default function HomePage({ data }: { data: HomePageQuery }) {
       <Header categoryTree={data.site.categoryTree} settings={data.site.settings} />
       <main>
         <div className="md:container md:mx-auto">
+          {storeName ? <h1>{storeName}</h1> : null}
+          <Button className={Button.primary.className} onClick={fetchStoreName}>
+            Fetch data
+          </Button>
           <div className="aspect-[9/16] md:aspect-[2/1] bg-slate-100 relative flex flex-col items-start justify-center p-6 sm:p-16 md:p-24">
             <h1 className="text-4xl font-black mb-4">New collection</h1>
             <p className="md:max-w-lg mb-10">

```


https://user-images.githubusercontent.com/10539418/228867077-f1f61d97-3f51-498b-b493-a99d0aaba856.mov

