### PR TITLE
chore(catalyst): HEADLESS-00 clean up Reactant types

### DIFF
--- a/reactant/components/Accordion.tsx
+++ b/reactant/components/Accordion.tsx
@@ -1,16 +1,14 @@
 import {
+  ComponentPropsWithoutRef,
   createContext,
   Dispatch,
-  PropsWithChildren,
   SetStateAction,
   useContext,
   useId,
   useState,
 } from 'react';
 
-interface ClassName {
-  className: string;
-}
+import { ComponentClasses } from './types';
 
 const AccordionTogglerContext = createContext<{
   accordionId: string | undefined;
@@ -19,25 +17,15 @@ const AccordionTogglerContext = createContext<{
   setToggle: Dispatch<SetStateAction<boolean>> | null;
 }>({ toggle: null, setToggle: null, accordionId: undefined, accordionItemId: undefined });
 
-type ComponentProps<Props, VariantKey extends string> = React.FC<Props> &
-  Record<VariantKey, ClassName>;
+interface AccordionProps extends ComponentPropsWithoutRef<'div'> {
+  isExtended: boolean;
+}
 
-type ContentProps = React.HTMLAttributes<HTMLDivElement> & PropsWithChildren;
-type Content = ComponentProps<ContentProps, 'default'>;
-type ToggleProps = React.HTMLAttributes<HTMLDivElement> &
-  PropsWithChildren & {
-    title: string;
-    icons: React.ReactNode[];
+type Accordion = React.FC<AccordionProps> &
+  ComponentClasses<'default'> & {
+    Toggle: React.FC<ToggleProps> & ComponentClasses<'default'>;
+    Content: React.FC<ContentProps> & ComponentClasses<'default'>;
   };
-type Toggle = ComponentProps<ToggleProps, 'default'>;
-type AccordionProps = React.HTMLAttributes<HTMLDivElement> &
-  PropsWithChildren & {
-    isExtended: boolean;
-  };
-type Accordion = ComponentProps<AccordionProps, 'default'> & {
-  Toggle: Toggle;
-  Content: Content;
-};
 
 export const Accordion: Accordion = ({ children, isExtended, ...props }) => {
   const [toggle, setToggle] = useState(isExtended);
@@ -55,8 +43,13 @@ Accordion.default = {
   className: ' flex flex-col leading-7 gap-y-4',
 };
 
-const Toggle: Toggle = ({ children, icons, title, ...props }) => {
-  const { accordionId, accordionItemId,  toggle, setToggle } = useContext(AccordionTogglerContext);
+interface ToggleProps extends ComponentPropsWithoutRef<'div'> {
+  title: string;
+  icons: React.ReactNode[];
+}
+
+const Toggle: Accordion['Toggle'] = ({ children, icons, title, ...props }) => {
+  const { accordionId, accordionItemId, toggle, setToggle } = useContext(AccordionTogglerContext);
   const [IconA, IconB] = icons;
   const handleToggleAction = () => {
     if (setToggle) {
@@ -85,7 +78,9 @@ Toggle.default = {
   className: 'flex items-center justify-between hover:cursor-pointer',
 };
 
-const Content: Content = ({ children, ...props }) => {
+type ContentProps = ComponentPropsWithoutRef<'div'>;
+
+const Content: Accordion['Content'] = ({ children, ...props }) => {
   const { accordionId, accordionItemId, toggle } = useContext(AccordionTogglerContext);
 
   if (!toggle) {

--- a/reactant/components/Badge.tsx
+++ b/reactant/components/Badge.tsx
@@ -1,16 +1,12 @@
-import { PropsWithChildren } from 'react';
+import { ComponentPropsWithoutRef } from 'react';
 
-interface ClassName {
-  className: string;
-}
+import { ComponentClasses } from './types';
 
-interface BadgeProps {
+interface BadgeProps extends ComponentPropsWithoutRef<'div'> {
   label: string;
 }
 
-type ComponentClasses<Props extends string> = Record<Props, ClassName>;
-type ComponentProps = React.HTMLAttributes<HTMLDivElement> & BadgeProps & PropsWithChildren;
-type Badge = React.FC<ComponentProps> & ComponentClasses<'default'>;
+type Badge = React.FC<BadgeProps> & ComponentClasses<'default'>;
 
 export const Badge: Badge = ({ children, label, ...props }) => {
   return (

--- a/reactant/components/Breadcrumbs.tsx
+++ b/reactant/components/Breadcrumbs.tsx
@@ -1,18 +1,14 @@
-import { PropsWithChildren } from 'react';
+import { ComponentPropsWithoutRef } from 'react';
 
 import { Link } from './Link';
+import { ComponentClasses } from './types';
 
-interface ClassName {
-  className: string;
-}
-
-type BreadcrumbsClasses<Props extends string> = Record<Props, ClassName>;
-type BreadcrumbsProps = React.HTMLAttributes<HTMLUListElement>;
+type BreadcrumbsProps = ComponentPropsWithoutRef<'ul'>;
 type Breadcrumbs = React.FC<BreadcrumbsProps> &
-  BreadcrumbsClasses<'default'> & {
-    Item: React.FC<ItemProps> & ItemClasses<'default'>;
-    Path: React.FC<PathProps> & PathClasses<'default'> & PathClasses<'lastItem'>;
-    Divider: React.FC<DividerProps> & DividerClasses<'default'>;
+  ComponentClasses<'default'> & {
+    Item: React.FC<ItemProps> & ComponentClasses<'default'>;
+    Path: React.FC<PathProps> & ComponentClasses<'default' | 'lastItem'>;
+    Divider: React.FC<DividerProps> & ComponentClasses<'default'>;
   };
 
 export const Breadcrumbs: Breadcrumbs = ({ children, ...props }) => {
@@ -27,8 +23,7 @@ Breadcrumbs.default = {
   className: 'flex items-center flex-wrap m-0 p-0 md:container md:mx-auto',
 };
 
-type ItemClasses<Props extends string> = Record<Props, ClassName>;
-type ItemProps = React.HTMLAttributes<HTMLLIElement> & PropsWithChildren;
+type ItemProps = ComponentPropsWithoutRef<'li'>;
 
 const Item: Breadcrumbs['Item'] = ({ children, ...props }) => {
   return <li {...props}>{children}</li>;
@@ -40,12 +35,7 @@ Item.default = {
 
 Breadcrumbs.Item = Item;
 
-interface PathProp {
-  href?: string;
-}
-
-type PathClasses<Props extends string> = Record<Props, ClassName>;
-type PathProps = React.AnchorHTMLAttributes<HTMLAnchorElement> & PathProp & PropsWithChildren;
+type PathProps = ComponentPropsWithoutRef<'a'>;
 
 const Path: Breadcrumbs['Path'] = ({ children, href, ...props }) => {
   return (
@@ -65,8 +55,7 @@ Path.lastItem = {
 
 Breadcrumbs.Path = Path;
 
-type DividerClasses<Props extends string> = Record<Props, ClassName>;
-type DividerProps = React.HTMLAttributes<HTMLSpanElement> & PropsWithChildren;
+type DividerProps = ComponentPropsWithoutRef<'span'>;
 
 const Divider: Breadcrumbs['Divider'] = ({ children, ...props }) => {
   return <span {...props}>{children}</span>;

--- a/reactant/components/Button.tsx
+++ b/reactant/components/Button.tsx
@@ -1,16 +1,12 @@
-import { PropsWithChildren } from 'react';
+import { ComponentPropsWithoutRef } from 'react';
 
-interface ClassName {
-  className: string;
-}
+import { ComponentClasses } from './types';
 
-type ComponentClasses<Union extends string> = Record<Union, ClassName>;
-
-type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & PropsWithChildren;
+type ButtonProps = ComponentPropsWithoutRef<'button'>;
 
 type Button = React.FC<ButtonProps> &
   ComponentClasses<'primary' | 'secondary' | 'subtle' | 'iconOnly'> & {
-    Icon: { className: string };
+    Icon: ComponentClasses<'default'>;
   };
 
 export const Button: Button = ({ children, ...props }) => {
@@ -42,5 +38,7 @@ Button.iconOnly = {
 };
 
 Button.Icon = {
-  className: 'mr-3',
+  default: {
+    className: 'mr-3',
+  },
 };

--- a/reactant/components/Input.tsx
+++ b/reactant/components/Input.tsx
@@ -1,24 +1,13 @@
-import React, { createContext, PropsWithChildren, useContext, useId } from 'react';
+import React, { ComponentPropsWithoutRef, createContext, useContext, useId } from 'react';
+
+import { ComponentClasses } from './types';
 
 const FormGroupAccessibilityContext = createContext<{ id: string | undefined }>({ id: undefined });
 
-interface ClassName {
-  className: string;
-}
-
-type ComponentClasses<Union extends string> = Record<Union, ClassName>;
-
-type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+type InputProps = ComponentPropsWithoutRef<'input'>;
 type Input = React.FC<InputProps> &
   ComponentClasses<'default'> & {
-    Icon: {
-      default: {
-        className: string;
-      };
-      position: {
-        className: string;
-      };
-    };
+    Icon: ComponentClasses<'default' | 'position'>;
   };
 
 export const Input: Input = ({ children, id, className, ...props }) => {
@@ -46,7 +35,7 @@ Input.Icon = {
   },
 };
 
-type LabelProps = React.HTMLAttributes<HTMLLabelElement> & PropsWithChildren;
+type LabelProps = ComponentPropsWithoutRef<'label'>;
 type Label = React.FC<LabelProps> & ComponentClasses<'default' | 'left' | 'top'>;
 
 export const Label: Label = ({ children, id, ...props }) => {
@@ -71,7 +60,7 @@ Label.top = {
   className: 'flex mb-2',
 };
 
-type FormGroupProps = React.HTMLAttributes<HTMLDivElement> & PropsWithChildren;
+type FormGroupProps = ComponentPropsWithoutRef<'div'>;
 type FormGroup = React.FC<FormGroupProps>;
 
 export const FormGroup: FormGroup = ({ children, ...props }) => {

--- a/reactant/components/Link.tsx
+++ b/reactant/components/Link.tsx
@@ -1,14 +1,11 @@
-import { PropsWithChildren } from 'react';
+import { ComponentPropsWithoutRef } from 'react';
 
-interface ClassName {
-  className: string;
-}
+import { ComponentClasses } from './types';
 
-type ComponentClasses<Union extends string> = Record<Union, ClassName>;
-type LinkProps = React.AnchorHTMLAttributes<HTMLAnchorElement> & PropsWithChildren;
+type LinkProps = ComponentPropsWithoutRef<'a'>;
 type Link = React.FC<LinkProps> &
   ComponentClasses<'text' | 'iconOnly'> & {
-    Icon: { className?: string };
+    Icon: ComponentClasses<'default'>;
   };
 
 export const Link: Link = ({ children, href, ...props }) => {
@@ -22,10 +19,14 @@ export const Link: Link = ({ children, href, ...props }) => {
 Link.text = {
   className: 'flex flex-row items-center text-base font-normal hover:text-[#053FB0]',
 };
+
 Link.iconOnly = {
   className: 'flex flex-row items-center text-base font-normal hover:text-[#053FB0]',
 };
+
 Link.Icon = {
-  className:
-    'inline-block h-6 w-6 fill-black stroke-black hover:fill-[#053FB0] hover:stroke-[#053FB0]',
+  default: {
+    className:
+      'inline-block h-6 w-6 fill-black stroke-black hover:fill-[#053FB0] hover:stroke-[#053FB0]',
+  },
 };

--- a/reactant/components/Pagination.tsx
+++ b/reactant/components/Pagination.tsx
@@ -1,17 +1,13 @@
-import { PropsWithChildren } from 'react';
+import { ComponentPropsWithoutRef } from 'react';
 
-interface ClassName {
-  className: string;
-}
+import { ComponentClasses } from './types';
 
-type ComponentProps<Props, VariantKey extends string> = React.FC<Props> &
-  Record<VariantKey, ClassName>;
-
-type PaginationProps = React.HTMLAttributes<HTMLDivElement> & PropsWithChildren;
-type Pagination = ComponentProps<PaginationProps, 'default'> & {
-  NextPage?: { className: string };
-  PrevPage?: { className: string };
-};
+type PaginationProps = ComponentPropsWithoutRef<'div'>;
+type Pagination = React.FC<PaginationProps> &
+  ComponentClasses<'default'> & {
+    NextPage: ComponentClasses<'default'>;
+    PrevPage: ComponentClasses<'default'>;
+  };
 
 export const Pagination: Pagination = ({ children, ...props }) => {
   return <div {...props}>{children}</div>;
@@ -20,9 +16,15 @@ export const Pagination: Pagination = ({ children, ...props }) => {
 Pagination.default = {
   className: 'flex flex-row justify-center items-center gap-2 mt-11 mb-14',
 };
+
 Pagination.NextPage = {
-  className: 'fill-none stroke-black hover:stroke-[#053FB0] cursor-pointer m-3',
+  default: {
+    className: 'fill-none stroke-black hover:stroke-[#053FB0] cursor-pointer m-3',
+  },
 };
+
 Pagination.PrevPage = {
-  className: 'fill-none stroke-black hover:stroke-[#053FB0] cursor-pointer m-3',
+  default: {
+    className: 'fill-none stroke-black hover:stroke-[#053FB0] cursor-pointer m-3',
+  },
 };

--- a/reactant/components/ProducTile.tsx
+++ b/reactant/components/ProducTile.tsx
@@ -1,25 +1,20 @@
-import { PropsWithChildren } from 'react';
+import { ComponentPropsWithoutRef } from 'react';
 
-interface ClassName {
-  className: string;
-}
+import { ComponentClasses } from './types';
 
-type ComponentProps<Props, VariantKey extends string> = React.FC<Props> &
-  Record<VariantKey, ClassName>;
-
-type PProps = React.HTMLAttributes<HTMLParagraphElement> & PropsWithChildren;
-type P = ComponentProps<PProps, 'default'>;
+type PProps = ComponentPropsWithoutRef<'p'>;
+type P = React.FC<PProps> & ComponentClasses<'default'>;
 
 export const P: P = ({ children, ...props }) => {
   return <p {...props}>{children}</p>;
 };
 
 P.default = {
-  className: 'leading-7 text-base ',
+  className: 'leading-7 text-base',
 };
 
-type H3Props = React.HTMLAttributes<HTMLHeadingElement> & PropsWithChildren;
-type H3 = ComponentProps<H3Props, 'default'>;
+type H3Props = ComponentPropsWithoutRef<'h3'>;
+type H3 = React.FC<H3Props> & ComponentClasses<'default'>;
 
 export const H3: H3 = ({ children, ...props }) => {
   return <h3 {...props}>{children}</h3>;
@@ -29,44 +24,9 @@ H3.default = {
   className: 'font-bold leading-6 text-xl',
 };
 
-interface ProductPrice {
-  prices: {
-    price: {
-      formatted: string;
-    } | null;
-  };
-}
+type FigureProps = ComponentPropsWithoutRef<'figure'>;
 
-type ProductPriceProps = React.HTMLAttributes<HTMLDivElement> & ProductPrice;
-type ProductPriceComponent = ComponentProps<ProductPriceProps, 'default'>;
-
-export const ProductPrice: ProductPriceComponent = ({ prices }) => (
-  <div className={ProductPrice.default.className}>
-    <p className="text-base">{prices.price?.formatted}</p>
-  </div>
-);
-
-ProductPrice.default = {
-  className: 'card-text relative py-1',
-};
-
-type FigureProps = React.HTMLAttributes<HTMLElement> & PropsWithChildren;
-type Figure = ComponentProps<FigureProps, 'default'>;
-
-type FigCaptionProps = React.HTMLAttributes<HTMLElement> & PropsWithChildren;
-type FigCaption = ComponentProps<FigCaptionProps, 'default'>;
-
-type BodyProps = React.HTMLAttributes<HTMLDivElement> & PropsWithChildren;
-type Body = ComponentProps<BodyProps, 'default'>;
-
-type ProductTileProps = React.HTMLAttributes<HTMLElement> & PropsWithChildren;
-type ProductTile = ComponentProps<ProductTileProps, 'default'> & {
-  Figure: Figure;
-  FigCaption: FigCaption;
-  Body: Body;
-};
-
-const Figure: Figure = ({ children, ...props }) => {
+const Figure: ProductTile['Figure'] = ({ children, ...props }) => {
   return <figure {...props}>{children}</figure>;
 };
 
@@ -74,8 +34,10 @@ Figure.default = {
   className: 'group/cardFigure mt-0 overflow-hidden p-0.5 relative bg-white mb-0',
 };
 
-const FigCaption: FigCaption = ({ children, ...props }) => {
-  return <figure {...props}>{children}</figure>;
+type FigCaptionProps = ComponentPropsWithoutRef<'figcaption'>;
+
+const FigCaption: ProductTile['FigCaption'] = ({ children, ...props }) => {
+  return <figcaption {...props}>{children}</figcaption>;
 };
 
 FigCaption.default = {
@@ -83,13 +45,23 @@ FigCaption.default = {
     'absolute hidden inset-0 w-full m-0 py-6 text-center group-hover/cardFigure:inline-flex flex-col justify-end',
 };
 
-const Body: Body = ({ children, ...props }) => {
+type BodyProps = ComponentPropsWithoutRef<'div'>;
+
+const Body: ProductTile['Body'] = ({ children, ...props }) => {
   return <div {...props}>{children}</div>;
 };
 
 Body.default = {
   className: 'group/cardBody',
 };
+
+type ProductTileProps = ComponentPropsWithoutRef<'article'>;
+type ProductTile = React.FC<ProductTileProps> &
+  ComponentClasses<'default'> & {
+    Figure: React.FC<FigureProps> & ComponentClasses<'default'>;
+    FigCaption: React.FC<FigCaptionProps> & ComponentClasses<'default'>;
+    Body: React.FC<BodyProps> & ComponentClasses<'default'>;
+  };
 
 export const ProductTile: ProductTile = ({ children, ...props }) => {
   return <article {...props}>{children}</article>;
@@ -98,6 +70,7 @@ export const ProductTile: ProductTile = ({ children, ...props }) => {
 ProductTile.default = {
   className: 'flex flex-col justify-start bg-transparent p-0 min-h-[430px]',
 };
+
 ProductTile.Figure = Figure;
 ProductTile.FigCaption = FigCaption;
 ProductTile.Body = Body;

--- a/reactant/components/Rating.tsx
+++ b/reactant/components/Rating.tsx
@@ -1,41 +1,36 @@
-import React from 'react';
+import React, { ComponentPropsWithoutRef } from 'react';
 
 import { EmptyStarIcon } from '../icons/stars/EmptyStar';
 import { FilledStarIcon } from '../icons/stars/FilledStar';
 import { HalfFilledStarIcon } from '../icons/stars/HalfFilledStar';
 
-interface ClassName {
-  className: string;
-}
+import { ComponentClasses } from './types';
 
-type ComponentProps<Props, VariantKey extends string> = React.FC<Props> &
-  Record<VariantKey, ClassName>;
-
-interface Rating {
+interface RatingProps extends ComponentPropsWithoutRef<'span'> {
   value: number | null;
 }
 
-type RatingProps = React.HTMLAttributes<HTMLImageElement> & Rating;
-type RatingComponent = ComponentProps<RatingProps, 'default'> & {
-  Icon: { className: string };
-};
+type Rating = React.FC<RatingProps> &
+  ComponentClasses<'default'> & {
+    Icon: ComponentClasses<'default'>;
+  };
 
 const MAX_RATING = 5;
 const roundHalf = (num: number) => {
   return Math.round(num * 2) / 2;
 };
 
-export const Rating: RatingComponent = ({ value, ...props }) => {
+export const Rating: Rating = ({ value, ...props }) => {
   const stars: React.ReactElement[] = [];
   const rating = value ? roundHalf(value) : 0;
 
   for (let i = 1; i <= MAX_RATING; i += 1) {
     if (rating - i >= 0) {
-      stars.push(<FilledStarIcon className={Rating.Icon.className} key={i} />);
+      stars.push(<FilledStarIcon className={Rating.Icon.default.className} key={i} />);
     } else if (rating - i > -1) {
-      stars.push(<HalfFilledStarIcon className={Rating.Icon.className} key={i} />);
+      stars.push(<HalfFilledStarIcon className={Rating.Icon.default.className} key={i} />);
     } else {
-      stars.push(<EmptyStarIcon className={Rating.Icon.className} key={i} />);
+      stars.push(<EmptyStarIcon className={Rating.Icon.default.className} key={i} />);
     }
   }
 
@@ -51,5 +46,7 @@ Rating.default = {
 };
 
 Rating.Icon = {
-  className: 'fill-[#053FB0] stroke-none',
+  default: {
+    className: 'fill-[#053FB0] stroke-none',
+  },
 };

--- a/reactant/components/Swatch.tsx
+++ b/reactant/components/Swatch.tsx
@@ -1,50 +1,48 @@
-import { createContext, PropsWithChildren, useContext, useId } from 'react';
+import { ComponentPropsWithoutRef, createContext, useContext, useId } from 'react';
 
-interface ClassName {
-  className: string;
-}
+import { ComponentClasses } from './types';
 
 const SwatchAccessibilityContext = createContext<{ id: string | undefined }>({ id: undefined });
 
-type ComponentProps<Props, VariantKey extends string> = React.FC<Props> &
-  Record<VariantKey, ClassName>;
-
-type SwatchGroupProps = React.HTMLAttributes<HTMLDivElement> & PropsWithChildren;
-type SwatchGroup = ComponentProps<SwatchGroupProps, 'default'> & {
-  Label: ClassName;
-};
+type SwatchGroupProps = ComponentPropsWithoutRef<'div'>;
+type SwatchGroup = React.FC<SwatchGroupProps> &
+  ComponentClasses<'default'> & {
+    Label: React.FC<SwatchGroupLabelProps> & ComponentClasses<'default'>;
+  };
 
 export const SwatchGroup: SwatchGroup = ({ children, ...props }) => {
-  return <div {...props}>{children}</div>;
+  return (
+    <div role="radiogroup" {...props}>
+      {children}
+    </div>
+  );
 };
 
 SwatchGroup.default = {
   className: 'flex flex-row flex-wrap justify-start items-center gap-3 pt-3 pb-2',
 };
-SwatchGroup.Label = {
+
+type SwatchGroupLabelProps = ComponentPropsWithoutRef<'label'>;
+
+const SwatchGroupLabel: SwatchGroup['Label'] = ({ children, ...props }) => {
+  return <label {...props}>{children}</label>;
+};
+
+SwatchGroupLabel.default = {
   className:
     'basis-full inline-flex flex-row justify-start items-center gap-2 font-semibold h-6 my-1',
 };
 
-type LabelProps = React.HTMLAttributes<HTMLLabelElement> & PropsWithChildren;
-type Label = React.FC<LabelProps> & { className?: string };
+SwatchGroup.Label = SwatchGroupLabel;
 
-export const Label: Label = ({ children, ...props }) => {
-  return <label {...props}>{children}</label>;
-};
+type SwatchProps = ComponentPropsWithoutRef<'div'>;
 
-type SwatchProps = React.HTMLAttributes<HTMLDivElement> & PropsWithChildren;
-type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
-type SwatchLabelProps = React.HTMLAttributes<HTMLLabelElement> & PropsWithChildren;
-type SwatchVariantProps = React.HTMLAttributes<HTMLSpanElement> & {
-  variantColor: string;
-} & PropsWithChildren;
-
-type Swatch = ComponentProps<SwatchProps, 'default'> & {
-  Input: React.FC<InputProps> & Record<'default', ClassName>;
-  Label: React.FC<SwatchLabelProps> & Record<'default', ClassName>;
-  Variant: React.FC<SwatchVariantProps> & Record<'default', ClassName>;
-};
+type Swatch = React.FC<SwatchProps> &
+  ComponentClasses<'default'> & {
+    Input: React.FC<InputProps> & ComponentClasses<'default'>;
+    Label: React.FC<SwatchLabelProps> & ComponentClasses<'default'>;
+    Variant: React.FC<SwatchVariantProps> & ComponentClasses<'default'>;
+  };
 
 export const Swatch: Swatch = ({ children, ...props }) => {
   const id = useId();
@@ -60,11 +58,15 @@ Swatch.default = {
   className: 'relative',
 };
 
+type InputProps = ComponentPropsWithoutRef<'input'>;
+
 const SwatchInput: Swatch['Input'] = ({ id, name, ...props }) => {
   const { id: swatchId } = useContext(SwatchAccessibilityContext);
 
-  return <input id={id ?? swatchId} name={name ?? id} {...props} />;
+  return <input id={id ?? swatchId} name={name ?? id} type="radio" {...props} />;
 };
+
+type SwatchLabelProps = ComponentPropsWithoutRef<'label'>;
 
 const SwatchLabel: Swatch['Label'] = ({ children, id, ...props }) => {
   const { id: swatchId } = useContext(SwatchAccessibilityContext);
@@ -75,6 +77,11 @@ const SwatchLabel: Swatch['Label'] = ({ children, id, ...props }) => {
     </label>
   );
 };
+
+interface SwatchVariantProps extends ComponentPropsWithoutRef<'span'> {
+  variantColor: string;
+}
+
 const SwatchVariant: Swatch['Variant'] = ({ children, variantColor, ...props }) => {
   return (
     <span
@@ -87,6 +94,7 @@ const SwatchVariant: Swatch['Variant'] = ({ children, variantColor, ...props }) 
 SwatchInput.default = {
   className: 'absolute top-0.5 left-0.5 outline-none sr-only peer/input',
 };
+
 SwatchLabel.default = {
   className:
     'border-2 border-solid border-[#CFD8DC] cursor-pointer inline-flex flex-row items-stretch justify-evenly text-[0px] h-6 w-6 p-0.5 hover:border-2 hover:border-solid hover:border-[#053FB0] peer-checked/input:outline-[#053fb033] peer-checked/input:outline peer-checked/input:outline-4 peer-focus/input:outline-[#053fb033] peer-focus/input:outline-3 peer-focus/input:outline peer-disabled/input:border-2 peer-disabled/input:border-solid peer-disabled/input:border-[#F1F3F5] peer-disabled/input:pointer-events-none',

--- a/reactant/components/types.ts
+++ b/reactant/components/types.ts
@@ -1,0 +1,5 @@
+interface ClassName {
+  className: string;
+}
+
+export type ComponentClasses<Union extends string> = Record<Union, ClassName>;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -133,10 +133,14 @@ export const Footer = ({ brands, categoryTree, settings }: FooterProps) => {
                 {socialMediaLinks.map((link) => (
                   <li key={link.name}>
                     <Link className={Link.iconOnly.className}>
-                      {link.name === 'Facebook' && <FacebookIcon className={Link.Icon.className} />}
-                      {link.name === 'Twitter' && <TwitterIcon className={Link.Icon.className} />}
+                      {link.name === 'Facebook' && (
+                        <FacebookIcon className={Link.Icon.default.className} />
+                      )}
+                      {link.name === 'Twitter' && (
+                        <TwitterIcon className={Link.Icon.default.className} />
+                      )}
                       {link.name === 'Pinterest' && (
-                        <PinterestIcon className={Link.Icon.className} />
+                        <PinterestIcon className={Link.Icon.default.className} />
                       )}
                     </Link>
                   </li>

--- a/src/components/ProductTiles.tsx
+++ b/src/components/ProductTiles.tsx
@@ -183,7 +183,6 @@ export const ProductTiles = ({
                         <SwatchGroup
                           className={SwatchGroup.default.className}
                           key={options.entityId}
-                          role="radiogroup"
                         >
                           {options.values.edges.map(({ node: variant }) => (
                             <Swatch className={Swatch.default.className} key={variant.entityId}>

--- a/src/pages/category/[cid].tsx
+++ b/src/pages/category/[cid].tsx
@@ -313,12 +313,12 @@ export default function CategoryPage({
                   <Link
                     href={`${category.path}?first=9&before=${search.searchProducts.products.pageInfo.startCursor}`}
                   >
-                    <ChevronLeftIcon className={Pagination.PrevPage?.className} />
+                    <ChevronLeftIcon className={Pagination.PrevPage.default.className} />
                   </Link>
                   <Link
                     href={`${category.path}?page=9&after=${search.searchProducts.products.pageInfo.endCursor}`}
                   >
-                    <ChevronRightIcon className={Pagination.NextPage?.className} />
+                    <ChevronRightIcon className={Pagination.NextPage.default.className} />
                   </Link>
                 </Pagination>
               )}

--- a/src/pages/product/[pid].tsx
+++ b/src/pages/product/[pid].tsx
@@ -8,7 +8,7 @@ import { Breadcrumbs } from '../../../reactant/components/Breadcrumbs';
 import { Button } from '../../../reactant/components/Button';
 import { Link } from '../../../reactant/components/Link';
 import { Rating } from '../../../reactant/components/Rating';
-import { Label, Swatch, SwatchGroup } from '../../../reactant/components/Swatch';
+import { Swatch, SwatchGroup } from '../../../reactant/components/Swatch';
 import { CartIcon } from '../../../reactant/icons/Cart';
 import { DividerIcon } from '../../../reactant/icons/Divider';
 import { HeartIcon } from '../../../reactant/icons/Heart';
@@ -573,12 +573,11 @@ export default function ProductPage({ brands, categoryTree, product, settings }:
                         <SwatchGroup
                           className={SwatchGroup.default.className}
                           key={swatch.node.entityId}
-                          role="radiogroup"
                         >
                           <>
-                            <Label className={SwatchGroup.Label.className}>
+                            <SwatchGroup.Label className={SwatchGroup.Label.default.className}>
                               <span>{swatch.node.displayName}</span>
-                            </Label>
+                            </SwatchGroup.Label>
                             {swatch.node.values.edges.map((variant) => {
                               return (
                                 <Swatch
@@ -599,7 +598,6 @@ export default function ProductPage({ brands, categoryTree, product, settings }:
                                     className={Swatch.Input.default.className}
                                     name={`${variant.node.entityId}`}
                                     onClick={() => onSwatchClick(variant.node.entityId)}
-                                    type="radio"
                                     value={variant.node.entityId}
                                   />
                                 </Swatch>
@@ -627,12 +625,12 @@ export default function ProductPage({ brands, categoryTree, product, settings }:
                     <button className="w-[44px]">-</button>
                   </div>
                 </div>
-                <div className="grid grid-cols-2 gap-x-4 flex justify-between mb-12">
+                <div className="grid grid-cols-2 gap-x-4 justify-between mb-12">
                   <Button className={`${Button.primary.className} col-span-1`}>
-                    <CartIcon className={Button.Icon.className} /> Add to cart
+                    <CartIcon className={Button.Icon.default.className} /> Add to cart
                   </Button>
                   <Button className={`${Button.secondary.className} col-span-1`}>
-                    <HeartIcon className={Button.Icon.className} /> Save to wishlist
+                    <HeartIcon className={Button.Icon.default.className} /> Save to wishlist
                   </Button>
                 </div>
               </form>


### PR DESCRIPTION
## What/Why?

We had a couple of different ways to type the Reactant components, so this cleans up some of the types/components to be more consistent which each other.

- Exports `ComponentClasses` out of a `type.ts` folder to share across components.
- Instead of doing `React.HTMLAttributes<HTMLElement> & PropsWithChildren`, it's switched over to using generics instead, e.g. `PropsWithChildren<React.HTMLAttributes<HTMLElement>>`
- Child components, e.g. `Button.Icon` will now have a `default` member on them, in case we want to add "variants" later on.