### PR TITLE
chore(ci): HEADLESS-00 add max-warnings 0 to eslint

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -43,7 +43,7 @@ jobs:
         run: npm ci
 
       - name: Lint
-        run: npm run lint
+        run: npm run lint -- --max-warnings 0
 
       - name: Typecheck
         run: tsc --noEmit

--- a/src/session.ts
+++ b/src/session.ts
@@ -59,7 +59,7 @@ export async function sessionMiddleware(request: NextRequest) {
     // if we have a valid session and expiry, and it expires in less than 1 day, update TTL
     session.expiry = ttlForSession(now);
     await session.save();
-  } else if (session.expiry - now <= 0){
+  } else if (session.expiry - now <= 0) {
     // If we have a valid session cookie, but the internal session ttl has expired, destroy it and generate a new one
     session.destroy();
 


### PR DESCRIPTION
## What/why?

Adds the `--max-warnings 0` flag to the eslint command in CI to throw if any warnings are not dealt with. This prevents some stylistic warnings from merging onto master, which one is resolved in this PR.

## Testing/proof
:x: https://github.com/bigcommerce/catalyst/actions/runs/4632522012/jobs/8196677953?pr=48
✅ https://github.com/bigcommerce/catalyst/actions/runs/4632533910/jobs/8196706442?pr=48