### PR TITLE
fix(reactant): HEADLESS-00 update tailwind content glob

### DIFF
--- a/commit-validation.json
+++ b/commit-validation.json
@@ -3,6 +3,7 @@
     "ci",
     "deps",
     "client",
-    "catalyst"
+    "catalyst",
+    "reactant"
   ]
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ['./src/**/*.{ts,tsx}', './reactant/**/*.{ts,tsx}'],
+  content: ['./src/**/*.{ts,tsx}', './lib/**/*.{ts,tsx}'],
   theme: {
     extend: {
       fontFamily: {


### PR DESCRIPTION
## What/Why?
Styles using the JIT engine from Tailwind were not being compiled. In #52 I forgot to change this config value when changing the import locations around. This updates the config to the new path glob.

## Testing
Swatches and buttons now render correctly
![Screenshot 2023-04-25 at 11 11 42](https://user-images.githubusercontent.com/10539418/234322264-8ac9c5b4-34ff-492c-8411-eb7085245e2b.png)

![Screenshot 2023-04-25 at 11 08 18](https://user-images.githubusercontent.com/10539418/234322038-ca28a17a-a2e5-4a4b-afa8-d1265d46fe0c.png)
