### PR TITLE
feat(catalyst): BCTHEME-1662 add counter component

### DIFF
--- a/lib/reactant/components/Button.tsx
+++ b/lib/reactant/components/Button.tsx
@@ -2,9 +2,9 @@ import { ComponentPropsWithoutRef } from 'react';
 
 import { ComponentClasses } from './types';
 
-type ButtonProps = ComponentPropsWithoutRef<'button'>;
+export type ButtonProps = ComponentPropsWithoutRef<'button'>;
 
-type Button = React.FC<ButtonProps> &
+export type Button = React.FC<ButtonProps> &
   ComponentClasses<'primary' | 'secondary' | 'subtle' | 'iconOnly'> & {
     Icon: ComponentClasses<'default'>;
   };
@@ -34,7 +34,7 @@ Button.subtle = {
 };
 
 Button.iconOnly = {
-  className: '!px-3',
+  className: 'px-3',
 };
 
 Button.Icon = {

--- a/lib/reactant/components/Counter.tsx
+++ b/lib/reactant/components/Counter.tsx
@@ -1,0 +1,50 @@
+import React, { ComponentPropsWithoutRef } from 'react';
+
+import { Button, Button as CounterButtonType } from '@reactant/components/Button';
+import { Label as CounterLabelType, Input, Label } from '@reactant/components/Input';
+import { ComponentClasses } from '@reactant/components/types';
+
+type CounterProps = ComponentPropsWithoutRef<'div'>;
+type CounterWrapperProps = ComponentPropsWithoutRef<'div'>;
+type CounterInputProps = ComponentPropsWithoutRef<'input'>;
+type Counter = React.FC<CounterProps> & {
+  Button: CounterButtonType;
+  Input: React.FC<CounterInputProps> & ComponentClasses<'default'>;
+  Label: CounterLabelType;
+  Wrapper: React.FC<CounterWrapperProps> & ComponentClasses<'container' | 'focus'>;
+};
+
+const CounterWrapper: Counter['Wrapper'] = ({ children, ...props }) => {
+  return <div {...props}>{children}</div>;
+};
+
+CounterWrapper.container = {
+  className: 'inline-flex item-center border-2 border-[#CFD8DC]',
+};
+CounterWrapper.focus = {
+  className: 'border-[#053FB0] outline outline-offset-0 outline-4 outline-[#cdd8ef]',
+};
+
+const CounterLabel: Counter['Label'] = Label;
+const CounterInput: Counter['Input'] = Input;
+const CounterButton: Counter['Button'] = Button;
+
+CounterInput.default = {
+  className:
+    'inline-flex relative group/input-wrapper [&_input]:w-8 [&_input]:h-11 [&_input]:px-0 [&_input]:mx-0.5 [&_input]:text-base [&_input]:font-semibold [&_input]:text-center [&_input]:border-0 [&_input]:block [&_input:focus]:border-none [&_input:focus]:outline-none [&_input:focus]:outline-offset-0 [&_input:focus]:outline-0 [&_input:focus]:outline-none',
+};
+
+CounterButton.Icon = {
+  default: {
+    className: 'focus:outline focus:-outline-offset-8 focus:outline-4 focus:outline-[#cdd8ef]',
+  },
+};
+
+export const Counter: Counter = ({ children, ...props }) => {
+  return <div {...props}>{children}</div>;
+};
+
+Counter.Wrapper = CounterWrapper;
+Counter.Label = CounterLabel;
+Counter.Input = CounterInput;
+Counter.Button = CounterButton;

--- a/lib/reactant/components/Input.tsx
+++ b/lib/reactant/components/Input.tsx
@@ -36,7 +36,7 @@ Input.Icon = {
 };
 
 type LabelProps = ComponentPropsWithoutRef<'label'>;
-type Label = React.FC<LabelProps> & ComponentClasses<'default' | 'left' | 'top'>;
+export type Label = React.FC<LabelProps> & ComponentClasses<'default' | 'left' | 'top'>;
 
 export const Label: Label = ({ children, id, ...props }) => {
   const { id: formGroupId } = useContext(FormGroupAccessibilityContext);

--- a/src/components/Counter.tsx
+++ b/src/components/Counter.tsx
@@ -1,0 +1,109 @@
+import React, { ChangeEvent, ComponentPropsWithoutRef, KeyboardEvent, useState } from 'react';
+
+import { Counter as ReactantCounter } from '@reactant/components/Counter';
+import { FormGroup } from '@reactant/components/Input';
+
+interface CounterProps extends ComponentPropsWithoutRef<'div'> {
+  counterLabel?: string;
+  icons: {
+    DecreaseIcon: React.FC<React.ComponentPropsWithoutRef<'svg'>>;
+    IncreaseIcon: React.FC<React.ComponentPropsWithoutRef<'svg'>>;
+  };
+  initValue: number;
+}
+
+type Counter = React.FC<CounterProps>;
+
+export const Counter: Counter = ({ counterLabel, icons, initValue }) => {
+  const [currValue, setValue] = useState<number>(initValue);
+  const [focus, setFocus] = useState(false);
+  const { DecreaseIcon, IncreaseIcon } = icons;
+  const STEP = 1;
+
+  const handleChange = (
+    event: ChangeEvent<HTMLInputElement> & {
+      target: HTMLInputElement;
+    },
+  ) => {
+    const { value } = event.target;
+
+    if (Number.isNaN(parseFloat(value))) {
+      return setValue(0);
+    }
+
+    if (parseFloat(value) < 0) {
+      return setValue(0);
+    }
+
+    setValue(parseFloat(value));
+  };
+  const handleIncrease = () => {
+    return setValue(Math.round(currValue + STEP));
+  };
+  const handleDecrease = () => {
+    if (currValue - STEP < 0) {
+      return;
+    }
+
+    return setValue(Math.round(currValue - STEP));
+  };
+  const handleKeyPress = (event: KeyboardEvent) => {
+    switch (event.key) {
+      case 'ArrowUp':
+        handleIncrease();
+        break;
+
+      case 'ArrowDown':
+        handleDecrease();
+        break;
+
+      case 'Escape':
+        setValue(currValue);
+        break;
+
+      default:
+        break;
+    }
+  };
+  const handleFocus = () => setFocus(true);
+  const handleBlur = () => setFocus(false);
+
+  return (
+    <ReactantCounter>
+      {Boolean(counterLabel) && (
+        <ReactantCounter.Label className={`${ReactantCounter.Label.top.className} font-semibold`}>
+          {counterLabel}
+        </ReactantCounter.Label>
+      )}
+      <ReactantCounter.Wrapper
+        className={`${ReactantCounter.Wrapper.container.className} ${
+          focus ? ReactantCounter.Wrapper.focus.className : ''
+        }`}
+      >
+        <ReactantCounter.Button
+          className={`${ReactantCounter.Button.iconOnly.className} !px-2 my-0.5 ${ReactantCounter.Button.Icon.default.className}`}
+          onClick={handleDecrease}
+        >
+          <DecreaseIcon className="inline-block h-6 w-6 fill-black stroke-black" key="onOpen" />
+        </ReactantCounter.Button>
+        <FormGroup>
+          <ReactantCounter.Input
+            className={ReactantCounter.Input.default.className}
+            onBlur={handleBlur}
+            onChange={handleChange}
+            onFocus={handleFocus}
+            onKeyDown={handleKeyPress}
+            type="text"
+            value={currValue}
+          />
+        </FormGroup>
+        <ReactantCounter.Button
+          className={`${ReactantCounter.Button.iconOnly.className} !px-2 my-0.5 ${ReactantCounter.Button.Icon.default.className}`}
+          onClick={handleIncrease}
+        >
+          <IncreaseIcon className="inline-block h-6 w-6 fill-black stroke-black" key="onOpen" />
+        </ReactantCounter.Button>
+      </ReactantCounter.Wrapper>
+    </ReactantCounter>
+  );
+};

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer components {
+    input::-webkit-inner-spin-button {
+        -webkit-appearance: none;
+    }
+}


### PR DESCRIPTION
## What/Why?
This PR adds Counter component that can be used in PDP, Cart pages.

**Usage:**
```
<Counter
    counterLabel="Quantity:"
    icons={{ DecreaseIcon: ChevronDownIcon, IncreaseIcon: ChevronUpIcon }}
    initValue={100}
  />
```

## Testing

https://user-images.githubusercontent.com/67792608/235690364-d318cb38-69e0-41d4-bdf3-b59af25a00b7.mov


