### PR TITLE
feat: STRF-10937 genql script to regenerate types, queries and mutations

### DIFF
--- a/packages/client/.env.example
+++ b/packages/client/.env.example
@@ -1,0 +1,9 @@
+# Shared env vars, used by all apps and api client
+BIGCOMMERCE_STORE_HASH=
+BIGCOMMERCE_STOREFRONT_DOMAIN="https://store-{storeHash}.mybigcommerce.com"
+BIGCOMMERCE_ACCESS_TOKEN=
+BIGCOMMERCE_CUSTOMER_IMPERSONATION_TOKEN=
+BIGCOMMERCE_CDN_HOSTNAME="*.bigcommerce.com"
+
+# with-makeswift specific env vars
+MAKESWIFT_SITE_API_KEY=

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -1,0 +1,14 @@
+# packages/client
+
+## How to section
+
+### How to use graphql types generation?
+
+Required env variables in .env.local:
+
+- BIGCOMMERCE_STORE_HASH
+- BIGCOMMERCE_CUSTOMER_IMPERSONATION_TOKEN
+
+Run `pnpm run gen-types`
+
+Note: don't use createClient from  `./src/generated/index.ts` (or better remove it)

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -9,7 +9,9 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "check-types": "tsc --noEmit",
-    "lint": "eslint . --ext .ts,.js,.cjs --max-warnings 0"
+    "lint": "eslint . --ext .ts,.js,.cjs --max-warnings 0",
+    "lint-fix": "eslint . --ext .ts,.js,.cjs --fix",
+    "gen-types": "dotenv -e .env.local -- node scripts/types.js"
   },
   "files": [
     "dist"
@@ -18,9 +20,10 @@
     "@bigcommerce/catalyst-configs": "workspace:^",
     "@bigcommerce/eslint-config": "^2.7.0",
     "@bigcommerce/eslint-config-catalyst": "workspace:^",
-    "@genql/cli": "^6.0.0",
+    "@genql/cli": "^4.0.4",
     "@types/node": "^18.13.00",
     "eslint": "^8.33.0",
+    "dotenv-cli": "^7.2.1",
     "prettier": "^2.8.8",
     "tsup": "^6.7.0",
     "typescript": "^5.1.3"

--- a/packages/client/scripts/types.js
+++ b/packages/client/scripts/types.js
@@ -1,0 +1,49 @@
+const { generate } = require('@genql/cli');
+const path = require('path');
+
+const getSecrets = () => {
+  const storeHash = process.env.BIGCOMMERCE_STORE_HASH;
+
+  if (!storeHash) {
+    throw new Error('Missing store hash');
+  }
+
+  const token = process.env.BIGCOMMERCE_CUSTOMER_IMPERSONATION_TOKEN;
+
+  if (!token) {
+    throw new Error('Missing customer impersonation token');
+  }
+
+  return {
+    storeHash,
+    token,
+  };
+};
+
+const run = async () => {
+  try {
+    const { storeHash, token } = getSecrets();
+
+    await generate({
+      endpoint: `https://store-${storeHash}.mybigcommerce.com/graphql`,
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      output: path.join(__dirname, '../src/generated'),
+      scalarTypes: {
+        DateTime: 'string',
+        Long: 'number',
+        BigDecimal: 'number',
+      },
+      sortProperties: true,
+    });
+    // eslint-disable-next-line no-console
+    console.log('ok');
+    process.exit();
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.log(e);
+  }
+};
+
+run();

--- a/packages/client/src/generated/index.ts
+++ b/packages/client/src/generated/index.ts
@@ -7,9 +7,11 @@ import type {
 } from './schema'
 import {
   linkTypeMap,
+  createClient as createClientOriginal,
   generateGraphqlOperation,
   type FieldsSelection,
   type GraphqlOperation,
+  type ClientOptions,
   GenqlError,
 } from './runtime'
 export type { FieldsSelection } from './runtime'

--- a/packages/client/src/generated/schema.graphql
+++ b/packages/client/src/generated/schema.graphql
@@ -22,6 +22,48 @@ type AddCartLineItemsResult {
   cart: Cart
 }
 
+"""Add checkout billing address data object"""
+input AddCheckoutBillingAddressDataInput {
+  """The checkout billing address"""
+  address: CheckoutAddressInput!
+}
+
+"""Add checkout billing address input object"""
+input AddCheckoutBillingAddressInput {
+  """The checkout id"""
+  checkoutEntityId: String!
+
+  """Add checkout billing address data object"""
+  data: AddCheckoutBillingAddressDataInput!
+}
+
+"""Add checkout billing address result"""
+type AddCheckoutBillingAddressResult {
+  """The Checkout that is updated as a result of mutation."""
+  checkout: Checkout
+}
+
+"""Add checkout shipping consignments data object"""
+input AddCheckoutShippingConsignmentsDataInput {
+  """The list of shipping consignments"""
+  consignments: [CheckoutShippingConsignmentInput!]!
+}
+
+"""Add checkout shipping consignments input object"""
+input AddCheckoutShippingConsignmentsInput {
+  """The checkout id"""
+  checkoutEntityId: String!
+
+  """Add checkout shipping consignments data object"""
+  data: AddCheckoutShippingConsignmentsDataInput!
+}
+
+"""Apply checkout shipping consignments result"""
+type AddCheckoutShippingConsignmentsResult {
+  """The Checkout that is updated as a result of mutation."""
+  checkout: Checkout
+}
+
 """Add wishlist items input object"""
 input AddWishlistItemsInput {
   """The wishlist id"""
@@ -61,6 +103,48 @@ type AggregatedInventory {
   Indicates a threshold low-stock level. This can be 'null' if the inventory warning level is not set or if the store's Inventory Settings disable displaying stock levels on the storefront.
   """
   warningLevel: Int!
+}
+
+"""Apply checkout coupon data object"""
+input ApplyCheckoutCouponDataInput {
+  """The checkout coupon code"""
+  couponCode: String!
+}
+
+"""Apply checkout coupon input object"""
+input ApplyCheckoutCouponInput {
+  """The checkout id"""
+  checkoutEntityId: String!
+
+  """Apply checkout coupon data object"""
+  data: ApplyCheckoutCouponDataInput!
+}
+
+"""Apply checkout coupon result"""
+type ApplyCheckoutCouponResult {
+  """The Checkout that is updated as a result of mutation."""
+  checkout: Checkout
+}
+
+"""Apply checkout spam protection data object"""
+input ApplyCheckoutSpamProtectionDataInput {
+  """The checkout spam protection token"""
+  token: String!
+}
+
+"""Apply checkout spam protection input object"""
+input ApplyCheckoutSpamProtectionInput {
+  """The checkout id"""
+  checkoutEntityId: String!
+
+  """Apply checkout spam protection data object"""
+  data: ApplyCheckoutSpamProtectionDataInput!
+}
+
+"""Apply checkout spam protection result"""
+type ApplyCheckoutSpamProtectionResult {
+  """The Checkout that is updated as a result of mutation."""
+  checkout: Checkout
 }
 
 """Assign cart to the customer input object."""
@@ -447,6 +531,9 @@ type Breadcrumb {
 
   """Name of the category."""
   name: String!
+
+  """Path to the category."""
+  path: String!
 }
 
 """A connection to a list of items."""
@@ -1422,16 +1509,626 @@ type CheckboxOption implements CatalogProductOption {
   label: String!
 }
 
+"""The checkout."""
+type Checkout implements Node {
+  """Billing address information."""
+  billingAddress: CheckoutBillingAddress
+
+  """Cart associated with the checkout."""
+  cart: Cart
+
+  """Coupons applied at checkout level."""
+  coupons: [CheckoutCoupon!]!
+
+  """Time when the checkout was created."""
+  createdAt: DateTimeExtended!
+
+  """
+  Shopper's message provided as details for the order to be created from the checkout.
+  """
+  customerMessage: String
+
+  """Checkout ID."""
+  entityId: String!
+
+  """Gift wrapping cost for all items, including or excluding tax."""
+  giftWrappingCostTotal: Money
+
+  """
+  The total payable amount, before applying any store credit or gift certificate.
+  """
+  grandTotal: Money
+
+  """Handling cost for all consignments including or excluding tax."""
+  handlingCostTotal: Money
+
+  """The ID of an object"""
+  id: ID!
+
+  """Order associated with the checkout."""
+  order: Order
+
+  """GrandTotal subtract the store-credit amount."""
+  outstandingBalance: Money
+
+  """List of promotions"""
+  promotions: [CheckoutPromotion!]!
+
+  """List of shipping consignments."""
+  shippingConsignments: [CheckoutShippingConsignment!]
+
+  """Total shipping cost before any discounts are applied."""
+  shippingCostTotal: Money
+
+  """
+  Subtotal of the checkout before applying item-level discounts. Tax inclusive based on the store settings.
+  """
+  subtotal: Money
+
+  """Total amount of taxes applied."""
+  taxTotal: Money
+
+  """List of taxes applied."""
+  taxes: [CheckoutTax!]
+
+  """Time when the checkout was last updated."""
+  updatedAt: DateTimeExtended!
+}
+
+"""Checkout address."""
+interface CheckoutAddress {
+  """Address line 1."""
+  address1: String
+
+  """Address line 2."""
+  address2: String
+
+  """Name of the city."""
+  city: String
+
+  """Company name."""
+  company: String
+
+  """Country code."""
+  countryCode: String!
+
+  """List of custom fields."""
+  customFields: [CheckoutAddressCustomField!]!
+
+  """Email address."""
+  email: String
+
+  """The first name."""
+  firstName: String
+
+  """The last name."""
+  lastName: String
+
+  """Phone number."""
+  phone: String
+
+  """Postal code."""
+  postalCode: String
+
+  """State or province."""
+  stateOrProvince: String
+
+  """Code of the state or province."""
+  stateOrProvinceCode: String
+}
+
+"""Checkboxes custom field."""
+type CheckoutAddressCheckboxesCustomField implements CheckoutAddressCustomField {
+  """Custom field ID."""
+  entityId: Int!
+
+  """List of custom field value IDs."""
+  valueEntityIds: [Int!]!
+}
+
+"""Checkout address checkboxes custom field input object"""
+input CheckoutAddressCheckboxesCustomFieldInput {
+  """The custom field ID."""
+  fieldEntityId: Int!
+
+  """List of custom field value IDs."""
+  fieldValueEntityIds: [Int!]!
+}
+
+"""Custom field of the checkout address."""
+interface CheckoutAddressCustomField {
+  """Custom field ID."""
+  entityId: Int!
+}
+
+"""Checkout address custom field input object"""
+input CheckoutAddressCustomFieldInput {
+  """List of checkboxes custom fields."""
+  checkboxes: [CheckoutAddressCheckboxesCustomFieldInput!]
+
+  """List of date custom fields."""
+  dates: [CheckoutAddressDateCustomFieldInput!]
+
+  """List of multiple choice custom fields."""
+  multipleChoices: [CheckoutAddressMultipleChoiceCustomFieldInput!]
+
+  """List of number custom fields."""
+  numbers: [CheckoutAddressNumberCustomFieldInput!]
+
+  """List of password custom fields."""
+  passwords: [CheckoutAddressPasswordCustomFieldInput!]
+
+  """List of text custom fields."""
+  texts: [CheckoutAddressTextCustomFieldInput!]
+}
+
+"""Date custom field."""
+type CheckoutAddressDateCustomField implements CheckoutAddressCustomField {
+  """Date value."""
+  date: DateTimeExtended!
+
+  """Custom field ID."""
+  entityId: Int!
+}
+
+"""Checkout address date custom field input object"""
+input CheckoutAddressDateCustomFieldInput {
+  """Date value."""
+  date: DateTime!
+
+  """The custom field ID."""
+  fieldEntityId: Int!
+}
+
+"""Checkout address input object"""
+input CheckoutAddressInput {
+  """Address line 1"""
+  address1: String
+
+  """Address line 2"""
+  address2: String
+
+  """Name of the city"""
+  city: String
+
+  """Company name"""
+  company: String
+
+  """Country code"""
+  countryCode: String!
+
+  """List of custom fields"""
+  customFields: CheckoutAddressCustomFieldInput
+
+  """Email address"""
+  email: String
+
+  """The first name"""
+  firstName: String
+
+  """The last name"""
+  lastName: String
+
+  """Phone number"""
+  phone: String
+
+  """Postal code"""
+  postalCode: String
+
+  """Should we save this address?"""
+  shouldSaveAddress: Boolean!
+
+  """State or province"""
+  stateOrProvince: String
+
+  """Code of the state or province"""
+  stateOrProvinceCode: String
+}
+
+"""Multiple choice custom field."""
+type CheckoutAddressMultipleChoiceCustomField implements CheckoutAddressCustomField {
+  """Custom field ID."""
+  entityId: Int!
+
+  """Custom field value ID."""
+  valueEntityId: Int!
+}
+
+"""Checkout address multiple choice custom field input object"""
+input CheckoutAddressMultipleChoiceCustomFieldInput {
+  """The custom field ID."""
+  fieldEntityId: Int!
+
+  """The custom field value ID."""
+  fieldValueEntityId: Int!
+}
+
+"""Number custom field."""
+type CheckoutAddressNumberCustomField implements CheckoutAddressCustomField {
+  """Custom field ID."""
+  entityId: Int!
+
+  """Number value."""
+  number: Float!
+}
+
+"""Checkout address number custom field input object"""
+input CheckoutAddressNumberCustomFieldInput {
+  """The custom field ID."""
+  fieldEntityId: Int!
+
+  """Number value."""
+  number: Float!
+}
+
+"""Password custom field."""
+type CheckoutAddressPasswordCustomField implements CheckoutAddressCustomField {
+  """Custom field ID."""
+  entityId: Int!
+
+  """Password value."""
+  password: String!
+}
+
+"""Checkout address password custom field input object"""
+input CheckoutAddressPasswordCustomFieldInput {
+  """The custom field ID."""
+  fieldEntityId: Int!
+
+  """Password value."""
+  password: String!
+}
+
+"""Checkout address text custom field input object"""
+input CheckoutAddressTextCustomFieldInput {
+  """The custom field ID."""
+  fieldEntityId: Int!
+
+  """Text value."""
+  text: String!
+}
+
+"""Text custom field."""
+type CheckoutAddressTextFieldCustomField implements CheckoutAddressCustomField {
+  """Custom field ID."""
+  entityId: Int!
+
+  """Text value."""
+  text: String!
+}
+
+"""Available shipping option."""
+type CheckoutAvailableShippingOption {
+  """Shipping option cost."""
+  cost: Money!
+
+  """Shipping option description."""
+  description: String!
+
+  """Shipping option ID."""
+  entityId: String!
+
+  """Shipping option image URL."""
+  imageUrl: String
+
+  """Is this shipping method the recommended shipping option or not."""
+  isRecommended: Boolean!
+
+  """An estimate of the arrival time."""
+  transitTime: String
+
+  """Shipping option type. Flat rate, UPS, etc."""
+  type: String!
+}
+
+"""Checkboxes billing address."""
+type CheckoutBillingAddress implements CheckoutAddress {
+  """Address line 1."""
+  address1: String
+
+  """Address line 2."""
+  address2: String
+
+  """Name of the city."""
+  city: String
+
+  """Company name."""
+  company: String
+
+  """Country code."""
+  countryCode: String!
+
+  """List of custom fields."""
+  customFields: [CheckoutAddressCustomField!]!
+
+  """Email address."""
+  email: String
+
+  """Billing address ID."""
+  entityId: String!
+
+  """The first name."""
+  firstName: String
+
+  """The last name."""
+  lastName: String
+
+  """Phone number."""
+  phone: String
+
+  """Postal code."""
+  postalCode: String
+
+  """State or province."""
+  stateOrProvince: String
+
+  """Code of the state or province."""
+  stateOrProvinceCode: String
+}
+
+"""Checkboxes consignment address."""
+type CheckoutConsignmentAddress implements CheckoutAddress {
+  """Address line 1."""
+  address1: String
+
+  """Address line 2."""
+  address2: String
+
+  """Name of the city."""
+  city: String
+
+  """Company name."""
+  company: String
+
+  """Country code."""
+  countryCode: String!
+
+  """List of custom fields."""
+  customFields: [CheckoutAddressCustomField!]!
+
+  """Email address."""
+  email: String
+
+  """The first name."""
+  firstName: String
+
+  """The last name."""
+  lastName: String
+
+  """Phone number."""
+  phone: String
+
+  """Postal code."""
+  postalCode: String
+
+  """State or province."""
+  stateOrProvince: String
+
+  """Code of the state or province."""
+  stateOrProvinceCode: String
+}
+
+"""Checkout consignment line item input object"""
+input CheckoutConsignmentLineItemInput {
+  """The line item id"""
+  lineItemEntityId: String!
+
+  """The total number of consignment line items"""
+  quantity: Int!
+}
+
+"""The checkout coupon."""
+type CheckoutCoupon {
+  """The coupon code."""
+  code: String!
+
+  """The coupon type."""
+  couponType: CouponType
+
+  """The discounted amount applied within a given context."""
+  discountedAmount: Money!
+
+  """The coupon ID."""
+  entityId: Int!
+}
+
+"""Checkout mutations"""
+type CheckoutMutations {
+  """Creates a checkout billing address."""
+  addCheckoutBillingAddress(
+    """Add checkout billing address input object"""
+    input: AddCheckoutBillingAddressInput!
+  ): AddCheckoutBillingAddressResult
+
+  """Creates a checkout shipping consignments."""
+  addCheckoutShippingConsignments(
+    """Apply checkout shipping consignments input object"""
+    input: AddCheckoutShippingConsignmentsInput!
+  ): AddCheckoutShippingConsignmentsResult
+
+  """Applies a checkout coupon."""
+  applyCheckoutCoupon(
+    """Apply checkout coupon input object"""
+    input: ApplyCheckoutCouponInput!
+  ): ApplyCheckoutCouponResult
+
+  """Applies a checkout spam protection."""
+  applyCheckoutSpamProtection(
+    """Apply checkout spam protection input object"""
+    input: ApplyCheckoutSpamProtectionInput!
+  ): ApplyCheckoutSpamProtectionResult
+
+  """Completes the checkout."""
+  completeCheckout(
+    """Complete checkout input object"""
+    input: CompleteCheckoutInput!
+  ): CompleteCheckoutResult
+
+  """Deletes a checkout consignment."""
+  deleteCheckoutConsignment(
+    """Delete checkout consignment input object"""
+    input: DeleteCheckoutConsignmentInput!
+  ): DeleteCheckoutConsignmentResult
+
+  """Selects a checkout shipping option."""
+  selectCheckoutShippingOption(
+    """Select checkout shipping option input object"""
+    input: SelectCheckoutShippingOptionInput!
+  ): SelectCheckoutShippingOptionResult
+
+  """Unapply a checkout coupon."""
+  unapplyCheckoutCoupon(
+    """Unapply checkout coupon input object"""
+    input: UnapplyCheckoutCouponInput!
+  ): UnapplyCheckoutCouponResult
+
+  """Update a checkout billing address."""
+  updateCheckoutBillingAddress(
+    """Update checkout billing address input object"""
+    input: UpdateCheckoutBillingAddressInput!
+  ): UpdateCheckoutBillingAddressResult
+
+  """Updates a checkout customer message."""
+  updateCheckoutCustomerMessage(
+    """Update checkout customer message input object"""
+    input: UpdateCheckoutCustomerMessageInput!
+  ): UpdateCheckoutCustomerMessageResult
+
+  """Updates a checkout shipping consignments."""
+  updateCheckoutShippingConsignment(
+    """Update checkout shipping consignment input object"""
+    input: UpdateCheckoutShippingConsignmentInput!
+  ): UpdateCheckoutShippingConsignmentResult
+}
+
+"""The checkout promotion"""
+type CheckoutPromotion {
+  """The checkout promotion banners."""
+  banners: [CheckoutPromotionBanner!]!
+}
+
+"""The checkout promotion banner"""
+type CheckoutPromotionBanner {
+  """The checkout promotion banner ID."""
+  entityId: Int!
+
+  """The list of the locations where the banner will display."""
+  locations: [CheckoutPromotionBannerLocation!]!
+
+  """Text of the banner."""
+  text: String!
+
+  """Type of the banner."""
+  type: CheckoutPromotionBannerType!
+}
+
+"""Checkout promotion banner location."""
+enum CheckoutPromotionBannerLocation {
+  CART_PAGE
+  CHECKOUT_PAGE
+  HOME_PAGE
+  PRODUCT_PAGE
+}
+
+"""Checkout promotion banner type."""
+enum CheckoutPromotionBannerType {
+  APPLIED
+  ELIGIBLE
+  PROMOTION
+  UPSELL
+}
+
+"""Selected shipping option."""
+type CheckoutSelectedShippingOption {
+  """Shipping option cost."""
+  cost: Money!
+
+  """Shipping option description."""
+  description: String!
+
+  """Shipping option ID."""
+  entityId: String!
+
+  """Shipping option image URL."""
+  imageUrl: String
+
+  """An estimate of the arrival time."""
+  transitTime: String
+
+  """Shipping option type. Flat rate, UPS, etc."""
+  type: String!
+}
+
 """Checkout settings."""
 type CheckoutSettings {
   """Indicates whether ReCaptcha is enabled on checkout."""
   reCaptchaEnabled: Boolean!
 }
 
+"""Checkout shipping consignment."""
+type CheckoutShippingConsignment {
+  """Shipping consignment address."""
+  address: CheckoutConsignmentAddress!
+
+  """List of available shipping options."""
+  availableShippingOptions: [CheckoutAvailableShippingOption!]
+
+  """List of coupons applied to this shipping consignment."""
+  coupons: [CheckoutCoupon!]
+
+  """Shipping consignment ID."""
+  entityId: String!
+
+  """The handling cost of shipping for the consignment."""
+  handlingCost: Money
+
+  """List of line item IDs for the consignment."""
+  lineItemIds: [String!]!
+
+  """Selected shipping option."""
+  selectedShippingOption: CheckoutSelectedShippingOption
+
+  """The shipping cost for the consignment."""
+  shippingCost: Money
+}
+
+"""Checkout shipping consignments input object"""
+input CheckoutShippingConsignmentInput {
+  """Shipping consignment address."""
+  address: CheckoutAddressInput!
+
+  """List of line items for the consignment."""
+  lineItems: [CheckoutConsignmentLineItemInput!]!
+}
+
+"""The checkout."""
+type CheckoutTax {
+  """Tax amount."""
+  amount: Money!
+
+  """Name of the tax."""
+  name: String!
+}
+
 """Additional information about the collection."""
 type CollectionInfo {
   """Total items in the collection despite pagination."""
   totalItems: Long
+}
+
+"""Complete checkout input object"""
+input CompleteCheckoutInput {
+  """The checkout id"""
+  checkoutEntityId: String!
+}
+
+"""Complete checkout result"""
+type CompleteCheckoutResult {
+  """The Order ID created as a result of the checkout."""
+  orderEntityId: Int
+
+  """The access token to be used to complete a payment."""
+  paymentAccessToken: String
 }
 
 """Contact field"""
@@ -1530,6 +2227,16 @@ type Content {
     """Rendered regions filter by page type and id."""
     entityPageType: EntityPageType!
   ): RenderedRegionsByPageType!
+}
+
+"""The coupon type."""
+enum CouponType {
+  FREE_SHIPPING
+  PERCENTAGE_DISCOUNT
+  PER_ITEM_DISCOUNT
+  PER_TOTAL_DISCOUNT
+  PROMOTION
+  SHIPPING_DISCOUNT
 }
 
 """Create cart input object"""
@@ -1811,6 +2518,21 @@ type DeleteCartLineItemResult {
 type DeleteCartResult {
   """The ID of the Cart that is deleted as a result of mutation."""
   deletedCartEntityId: String
+}
+
+"""Delete checkout consignment input object"""
+input DeleteCheckoutConsignmentInput {
+  """The checkout id"""
+  checkoutEntityId: String!
+
+  """The consignment id"""
+  consignmentEntityId: String!
+}
+
+"""Delete checkout consignment result"""
+type DeleteCheckoutConsignmentResult {
+  """The Checkout that is updated as a result of mutation."""
+  checkout: Checkout
 }
 
 """Delete wishlist items input object"""
@@ -2406,6 +3128,9 @@ type Mutation {
   """The Cart mutations."""
   cart: CartMutations!
 
+  """The Checkout mutations."""
+  checkout: CheckoutMutations!
+
   """Customer login"""
   login(
     """An email of the customer."""
@@ -2580,6 +3305,12 @@ input OptionValueId {
 
   """A variant value id filter."""
   valueEntityId: Int!
+}
+
+"""The order."""
+type Order {
+  """Order ID."""
+  entityId: Int!
 }
 
 """Other Filter"""
@@ -3006,6 +3737,9 @@ type ProductAttributeSearchFilter implements SearchProductFilter {
 
   """Indicates whether to display product count next to the filter."""
   displayProductCount: Boolean!
+
+  """Filter name for building filter URLs"""
+  filterName: String!
 
   """Indicates whether filter is collapsed by default."""
   isCollapsedByDefault: Boolean!
@@ -3637,6 +4371,30 @@ type SearchQueries {
   ): SearchProducts!
 }
 
+"""Select checkout shipping option input data object"""
+input SelectCheckoutShippingOptionDataInput {
+  """The shipping option id"""
+  shippingOptionEntityId: String!
+}
+
+"""Select checkout shipping option input object"""
+input SelectCheckoutShippingOptionInput {
+  """The checkout id"""
+  checkoutEntityId: String!
+
+  """The consignment id"""
+  consignmentEntityId: String!
+
+  """Select checkout shipping option data object"""
+  data: SelectCheckoutShippingOptionDataInput!
+}
+
+"""Select checkout shipping option result"""
+type SelectCheckoutShippingOptionResult {
+  """The Checkout that is updated as a result of mutation."""
+  checkout: Checkout
+}
+
 """Seo Details"""
 type SeoDetails {
   """Meta description."""
@@ -3772,6 +4530,12 @@ type Site {
     """
     rootEntityId: Int
   ): [CategoryTreeItem!]!
+
+  """The checkout of the current customer."""
+  checkout(
+    """Checkout ID."""
+    entityId: String
+  ): Checkout
 
   """The page content."""
   content: Content!
@@ -4044,6 +4808,27 @@ type TextFieldOption implements CatalogProductOption {
   minLength: Int
 }
 
+"""Unapply checkout coupon data object"""
+input UnapplyCheckoutCouponDataInput {
+  """The checkout coupon code"""
+  couponCode: String!
+}
+
+"""Unapply checkout coupon input object"""
+input UnapplyCheckoutCouponInput {
+  """The checkout id"""
+  checkoutEntityId: String!
+
+  """Unapply checkout coupon data object"""
+  data: UnapplyCheckoutCouponDataInput!
+}
+
+"""Unapply checkout coupon result"""
+type UnapplyCheckoutCouponResult {
+  """The Checkout that is updated as a result of mutation."""
+  checkout: Checkout
+}
+
 """Unassign cart from the customer input object."""
 input UnassignCartFromCustomerInput {
   """The cart id."""
@@ -4102,6 +4887,75 @@ input UpdateCartLineItemInput {
 type UpdateCartLineItemResult {
   """The Cart that is updated as a result of mutation."""
   cart: Cart
+}
+
+"""Update checkout billing address data object"""
+input UpdateCheckoutBillingAddressDataInput {
+  """The checkout billing address"""
+  address: CheckoutAddressInput!
+}
+
+"""Update checkout billing address input object"""
+input UpdateCheckoutBillingAddressInput {
+  """The address id"""
+  addressEntityId: String!
+
+  """The checkout id"""
+  checkoutEntityId: String!
+
+  """Update checkout billing address data object"""
+  data: UpdateCheckoutBillingAddressDataInput!
+}
+
+"""Update checkout billing address result"""
+type UpdateCheckoutBillingAddressResult {
+  """The Checkout that is updated as a result of mutation."""
+  checkout: Checkout
+}
+
+"""Update checkout customer message data object"""
+input UpdateCheckoutCustomerMessageDataInput {
+  """The checkout customer message"""
+  message: String!
+}
+
+"""Update checkout customer message input object"""
+input UpdateCheckoutCustomerMessageInput {
+  """The checkout id"""
+  checkoutEntityId: String!
+
+  """Update checkout customer message data object"""
+  data: UpdateCheckoutCustomerMessageDataInput!
+}
+
+"""Update checkout customer message result"""
+type UpdateCheckoutCustomerMessageResult {
+  """The Checkout that is updated as a result of mutation."""
+  checkout: Checkout
+}
+
+"""Update checkout shipping consignment data object"""
+input UpdateCheckoutShippingConsignmentDataInput {
+  """Checkout shipping consignment input object"""
+  consignment: CheckoutShippingConsignmentInput!
+}
+
+"""Update checkout shipping consignment input object"""
+input UpdateCheckoutShippingConsignmentInput {
+  """The checkout id"""
+  checkoutEntityId: String!
+
+  """The consignment id"""
+  consignmentEntityId: String!
+
+  """Update checkout shipping consignment data object"""
+  data: UpdateCheckoutShippingConsignmentDataInput!
+}
+
+"""Update checkout shipping consignment result"""
+type UpdateCheckoutShippingConsignmentResult {
+  """The Checkout that is updated as a result of mutation."""
+  checkout: Checkout
 }
 
 """Update wishlist input object"""

--- a/packages/client/src/generated/schema.ts
+++ b/packages/client/src/generated/schema.ts
@@ -23,6 +23,22 @@ export interface AddCartLineItemsResult {
 }
 
 
+/** Add checkout billing address result */
+export interface AddCheckoutBillingAddressResult {
+    /** The Checkout that is updated as a result of mutation. */
+    checkout?: (Checkout | null)
+    __typename: 'AddCheckoutBillingAddressResult'
+}
+
+
+/** Apply checkout shipping consignments result */
+export interface AddCheckoutShippingConsignmentsResult {
+    /** The Checkout that is updated as a result of mutation. */
+    checkout?: (Checkout | null)
+    __typename: 'AddCheckoutShippingConsignmentsResult'
+}
+
+
 /** Add wishlist items */
 export interface AddWishlistItemsResult {
     /** The wishlist */
@@ -48,6 +64,22 @@ export interface AggregatedInventory {
     /** Indicates a threshold low-stock level. This can be 'null' if the inventory warning level is not set or if the store's Inventory Settings disable displaying stock levels on the storefront. */
     warningLevel: Scalars['Int']
     __typename: 'AggregatedInventory'
+}
+
+
+/** Apply checkout coupon result */
+export interface ApplyCheckoutCouponResult {
+    /** The Checkout that is updated as a result of mutation. */
+    checkout?: (Checkout | null)
+    __typename: 'ApplyCheckoutCouponResult'
+}
+
+
+/** Apply checkout spam protection result */
+export interface ApplyCheckoutSpamProtectionResult {
+    /** The Checkout that is updated as a result of mutation. */
+    checkout?: (Checkout | null)
+    __typename: 'ApplyCheckoutSpamProtectionResult'
 }
 
 
@@ -348,6 +380,8 @@ export interface Breadcrumb {
     entityId: Scalars['Int']
     /** Name of the category. */
     name: Scalars['String']
+    /** Path to the category. */
+    path: Scalars['String']
     __typename: 'Breadcrumb'
 }
 
@@ -947,6 +981,294 @@ export interface CheckboxOption {
 }
 
 
+/** The checkout. */
+export interface Checkout {
+    /** Billing address information. */
+    billingAddress?: (CheckoutBillingAddress | null)
+    /** Cart associated with the checkout. */
+    cart?: (Cart | null)
+    /** Coupons applied at checkout level. */
+    coupons: CheckoutCoupon[]
+    /** Time when the checkout was created. */
+    createdAt: DateTimeExtended
+    /** Shopper's message provided as details for the order to be created from the checkout. */
+    customerMessage?: (Scalars['String'] | null)
+    /** Checkout ID. */
+    entityId: Scalars['String']
+    /** Gift wrapping cost for all items, including or excluding tax. */
+    giftWrappingCostTotal?: (Money | null)
+    /** The total payable amount, before applying any store credit or gift certificate. */
+    grandTotal?: (Money | null)
+    /** Handling cost for all consignments including or excluding tax. */
+    handlingCostTotal?: (Money | null)
+    /** The ID of an object */
+    id: Scalars['ID']
+    /** Order associated with the checkout. */
+    order?: (Order | null)
+    /** GrandTotal subtract the store-credit amount. */
+    outstandingBalance?: (Money | null)
+    /** List of promotions */
+    promotions: CheckoutPromotion[]
+    /** List of shipping consignments. */
+    shippingConsignments?: (CheckoutShippingConsignment[] | null)
+    /** Total shipping cost before any discounts are applied. */
+    shippingCostTotal?: (Money | null)
+    /** Subtotal of the checkout before applying item-level discounts. Tax inclusive based on the store settings. */
+    subtotal?: (Money | null)
+    /** Total amount of taxes applied. */
+    taxTotal?: (Money | null)
+    /** List of taxes applied. */
+    taxes?: (CheckoutTax[] | null)
+    /** Time when the checkout was last updated. */
+    updatedAt: DateTimeExtended
+    __typename: 'Checkout'
+}
+
+
+/** Checkout address. */
+export type CheckoutAddress = (CheckoutBillingAddress | CheckoutConsignmentAddress) & { __isUnion?: true }
+
+
+/** Checkboxes custom field. */
+export interface CheckoutAddressCheckboxesCustomField {
+    /** Custom field ID. */
+    entityId: Scalars['Int']
+    /** List of custom field value IDs. */
+    valueEntityIds: Scalars['Int'][]
+    __typename: 'CheckoutAddressCheckboxesCustomField'
+}
+
+
+/** Custom field of the checkout address. */
+export type CheckoutAddressCustomField = (CheckoutAddressCheckboxesCustomField | CheckoutAddressDateCustomField | CheckoutAddressMultipleChoiceCustomField | CheckoutAddressNumberCustomField | CheckoutAddressPasswordCustomField | CheckoutAddressTextFieldCustomField) & { __isUnion?: true }
+
+
+/** Date custom field. */
+export interface CheckoutAddressDateCustomField {
+    /** Date value. */
+    date: DateTimeExtended
+    /** Custom field ID. */
+    entityId: Scalars['Int']
+    __typename: 'CheckoutAddressDateCustomField'
+}
+
+
+/** Multiple choice custom field. */
+export interface CheckoutAddressMultipleChoiceCustomField {
+    /** Custom field ID. */
+    entityId: Scalars['Int']
+    /** Custom field value ID. */
+    valueEntityId: Scalars['Int']
+    __typename: 'CheckoutAddressMultipleChoiceCustomField'
+}
+
+
+/** Number custom field. */
+export interface CheckoutAddressNumberCustomField {
+    /** Custom field ID. */
+    entityId: Scalars['Int']
+    /** Number value. */
+    number: Scalars['Float']
+    __typename: 'CheckoutAddressNumberCustomField'
+}
+
+
+/** Password custom field. */
+export interface CheckoutAddressPasswordCustomField {
+    /** Custom field ID. */
+    entityId: Scalars['Int']
+    /** Password value. */
+    password: Scalars['String']
+    __typename: 'CheckoutAddressPasswordCustomField'
+}
+
+
+/** Text custom field. */
+export interface CheckoutAddressTextFieldCustomField {
+    /** Custom field ID. */
+    entityId: Scalars['Int']
+    /** Text value. */
+    text: Scalars['String']
+    __typename: 'CheckoutAddressTextFieldCustomField'
+}
+
+
+/** Available shipping option. */
+export interface CheckoutAvailableShippingOption {
+    /** Shipping option cost. */
+    cost: Money
+    /** Shipping option description. */
+    description: Scalars['String']
+    /** Shipping option ID. */
+    entityId: Scalars['String']
+    /** Shipping option image URL. */
+    imageUrl?: (Scalars['String'] | null)
+    /** Is this shipping method the recommended shipping option or not. */
+    isRecommended: Scalars['Boolean']
+    /** An estimate of the arrival time. */
+    transitTime?: (Scalars['String'] | null)
+    /** Shipping option type. Flat rate, UPS, etc. */
+    type: Scalars['String']
+    __typename: 'CheckoutAvailableShippingOption'
+}
+
+
+/** Checkboxes billing address. */
+export interface CheckoutBillingAddress {
+    /** Address line 1. */
+    address1?: (Scalars['String'] | null)
+    /** Address line 2. */
+    address2?: (Scalars['String'] | null)
+    /** Name of the city. */
+    city?: (Scalars['String'] | null)
+    /** Company name. */
+    company?: (Scalars['String'] | null)
+    /** Country code. */
+    countryCode: Scalars['String']
+    /** List of custom fields. */
+    customFields: CheckoutAddressCustomField[]
+    /** Email address. */
+    email?: (Scalars['String'] | null)
+    /** Billing address ID. */
+    entityId: Scalars['String']
+    /** The first name. */
+    firstName?: (Scalars['String'] | null)
+    /** The last name. */
+    lastName?: (Scalars['String'] | null)
+    /** Phone number. */
+    phone?: (Scalars['String'] | null)
+    /** Postal code. */
+    postalCode?: (Scalars['String'] | null)
+    /** State or province. */
+    stateOrProvince?: (Scalars['String'] | null)
+    /** Code of the state or province. */
+    stateOrProvinceCode?: (Scalars['String'] | null)
+    __typename: 'CheckoutBillingAddress'
+}
+
+
+/** Checkboxes consignment address. */
+export interface CheckoutConsignmentAddress {
+    /** Address line 1. */
+    address1?: (Scalars['String'] | null)
+    /** Address line 2. */
+    address2?: (Scalars['String'] | null)
+    /** Name of the city. */
+    city?: (Scalars['String'] | null)
+    /** Company name. */
+    company?: (Scalars['String'] | null)
+    /** Country code. */
+    countryCode: Scalars['String']
+    /** List of custom fields. */
+    customFields: CheckoutAddressCustomField[]
+    /** Email address. */
+    email?: (Scalars['String'] | null)
+    /** The first name. */
+    firstName?: (Scalars['String'] | null)
+    /** The last name. */
+    lastName?: (Scalars['String'] | null)
+    /** Phone number. */
+    phone?: (Scalars['String'] | null)
+    /** Postal code. */
+    postalCode?: (Scalars['String'] | null)
+    /** State or province. */
+    stateOrProvince?: (Scalars['String'] | null)
+    /** Code of the state or province. */
+    stateOrProvinceCode?: (Scalars['String'] | null)
+    __typename: 'CheckoutConsignmentAddress'
+}
+
+
+/** The checkout coupon. */
+export interface CheckoutCoupon {
+    /** The coupon code. */
+    code: Scalars['String']
+    /** The coupon type. */
+    couponType?: (CouponType | null)
+    /** The discounted amount applied within a given context. */
+    discountedAmount: Money
+    /** The coupon ID. */
+    entityId: Scalars['Int']
+    __typename: 'CheckoutCoupon'
+}
+
+
+/** Checkout mutations */
+export interface CheckoutMutations {
+    /** Creates a checkout billing address. */
+    addCheckoutBillingAddress?: (AddCheckoutBillingAddressResult | null)
+    /** Creates a checkout shipping consignments. */
+    addCheckoutShippingConsignments?: (AddCheckoutShippingConsignmentsResult | null)
+    /** Applies a checkout coupon. */
+    applyCheckoutCoupon?: (ApplyCheckoutCouponResult | null)
+    /** Applies a checkout spam protection. */
+    applyCheckoutSpamProtection?: (ApplyCheckoutSpamProtectionResult | null)
+    /** Completes the checkout. */
+    completeCheckout?: (CompleteCheckoutResult | null)
+    /** Deletes a checkout consignment. */
+    deleteCheckoutConsignment?: (DeleteCheckoutConsignmentResult | null)
+    /** Selects a checkout shipping option. */
+    selectCheckoutShippingOption?: (SelectCheckoutShippingOptionResult | null)
+    /** Unapply a checkout coupon. */
+    unapplyCheckoutCoupon?: (UnapplyCheckoutCouponResult | null)
+    /** Update a checkout billing address. */
+    updateCheckoutBillingAddress?: (UpdateCheckoutBillingAddressResult | null)
+    /** Updates a checkout customer message. */
+    updateCheckoutCustomerMessage?: (UpdateCheckoutCustomerMessageResult | null)
+    /** Updates a checkout shipping consignments. */
+    updateCheckoutShippingConsignment?: (UpdateCheckoutShippingConsignmentResult | null)
+    __typename: 'CheckoutMutations'
+}
+
+
+/** The checkout promotion */
+export interface CheckoutPromotion {
+    /** The checkout promotion banners. */
+    banners: CheckoutPromotionBanner[]
+    __typename: 'CheckoutPromotion'
+}
+
+
+/** The checkout promotion banner */
+export interface CheckoutPromotionBanner {
+    /** The checkout promotion banner ID. */
+    entityId: Scalars['Int']
+    /** The list of the locations where the banner will display. */
+    locations: CheckoutPromotionBannerLocation[]
+    /** Text of the banner. */
+    text: Scalars['String']
+    /** Type of the banner. */
+    type: CheckoutPromotionBannerType
+    __typename: 'CheckoutPromotionBanner'
+}
+
+
+/** Checkout promotion banner location. */
+export type CheckoutPromotionBannerLocation = 'CART_PAGE' | 'CHECKOUT_PAGE' | 'HOME_PAGE' | 'PRODUCT_PAGE'
+
+
+/** Checkout promotion banner type. */
+export type CheckoutPromotionBannerType = 'APPLIED' | 'ELIGIBLE' | 'PROMOTION' | 'UPSELL'
+
+
+/** Selected shipping option. */
+export interface CheckoutSelectedShippingOption {
+    /** Shipping option cost. */
+    cost: Money
+    /** Shipping option description. */
+    description: Scalars['String']
+    /** Shipping option ID. */
+    entityId: Scalars['String']
+    /** Shipping option image URL. */
+    imageUrl?: (Scalars['String'] | null)
+    /** An estimate of the arrival time. */
+    transitTime?: (Scalars['String'] | null)
+    /** Shipping option type. Flat rate, UPS, etc. */
+    type: Scalars['String']
+    __typename: 'CheckoutSelectedShippingOption'
+}
+
+
 /** Checkout settings. */
 export interface CheckoutSettings {
     /** Indicates whether ReCaptcha is enabled on checkout. */
@@ -955,11 +1277,53 @@ export interface CheckoutSettings {
 }
 
 
+/** Checkout shipping consignment. */
+export interface CheckoutShippingConsignment {
+    /** Shipping consignment address. */
+    address: CheckoutConsignmentAddress
+    /** List of available shipping options. */
+    availableShippingOptions?: (CheckoutAvailableShippingOption[] | null)
+    /** List of coupons applied to this shipping consignment. */
+    coupons?: (CheckoutCoupon[] | null)
+    /** Shipping consignment ID. */
+    entityId: Scalars['String']
+    /** The handling cost of shipping for the consignment. */
+    handlingCost?: (Money | null)
+    /** List of line item IDs for the consignment. */
+    lineItemIds: Scalars['String'][]
+    /** Selected shipping option. */
+    selectedShippingOption?: (CheckoutSelectedShippingOption | null)
+    /** The shipping cost for the consignment. */
+    shippingCost?: (Money | null)
+    __typename: 'CheckoutShippingConsignment'
+}
+
+
+/** The checkout. */
+export interface CheckoutTax {
+    /** Tax amount. */
+    amount: Money
+    /** Name of the tax. */
+    name: Scalars['String']
+    __typename: 'CheckoutTax'
+}
+
+
 /** Additional information about the collection. */
 export interface CollectionInfo {
     /** Total items in the collection despite pagination. */
     totalItems?: (Scalars['Long'] | null)
     __typename: 'CollectionInfo'
+}
+
+
+/** Complete checkout result */
+export interface CompleteCheckoutResult {
+    /** The Order ID created as a result of the checkout. */
+    orderEntityId?: (Scalars['Int'] | null)
+    /** The access token to be used to complete a payment. */
+    paymentAccessToken?: (Scalars['String'] | null)
+    __typename: 'CompleteCheckoutResult'
 }
 
 
@@ -1023,6 +1387,10 @@ export interface Content {
     renderedRegionsByPageTypeAndEntityId: RenderedRegionsByPageType
     __typename: 'Content'
 }
+
+
+/** The coupon type. */
+export type CouponType = 'FREE_SHIPPING' | 'PERCENTAGE_DISCOUNT' | 'PER_ITEM_DISCOUNT' | 'PER_TOTAL_DISCOUNT' | 'PROMOTION' | 'SHIPPING_DISCOUNT'
 
 
 /** Create cart result */
@@ -1236,6 +1604,14 @@ export interface DeleteCartResult {
     /** The ID of the Cart that is deleted as a result of mutation. */
     deletedCartEntityId?: (Scalars['String'] | null)
     __typename: 'DeleteCartResult'
+}
+
+
+/** Delete checkout consignment result */
+export interface DeleteCheckoutConsignmentResult {
+    /** The Checkout that is updated as a result of mutation. */
+    checkout?: (Checkout | null)
+    __typename: 'DeleteCheckoutConsignmentResult'
 }
 
 
@@ -1716,6 +2092,8 @@ export interface MultipleChoiceOptionValue {
 export interface Mutation {
     /** The Cart mutations. */
     cart: CartMutations
+    /** The Checkout mutations. */
+    checkout: CheckoutMutations
     /** Customer login */
     login: LoginResult
     /** Customer logout */
@@ -1727,7 +2105,7 @@ export interface Mutation {
 
 
 /** An object with an ID */
-export type Node = (Banner | Blog | BlogPost | Brand | Cart | Category | ContactPage | NormalPage | Product | RawHtmlPage | Variant) & { __isUnion?: true }
+export type Node = (Banner | Blog | BlogPost | Brand | Cart | Category | Checkout | ContactPage | NormalPage | Product | RawHtmlPage | Variant) & { __isUnion?: true }
 
 
 /** A normal page. */
@@ -1853,6 +2231,14 @@ export interface OptionValueEdge {
     /** The item at the end of the edge. */
     node: ProductOptionValue
     __typename: 'OptionValueEdge'
+}
+
+
+/** The order. */
+export interface Order {
+    /** Order ID. */
+    entityId: Scalars['Int']
+    __typename: 'Order'
 }
 
 
@@ -2128,6 +2514,8 @@ export interface ProductAttributeSearchFilter {
     attributes: ProductAttributeSearchFilterItemConnection
     /** Indicates whether to display product count next to the filter. */
     displayProductCount: Scalars['Boolean']
+    /** Filter name for building filter URLs */
+    filterName: Scalars['String']
     /** Indicates whether filter is collapsed by default. */
     isCollapsedByDefault: Scalars['Boolean']
     /** Display name for the filter. */
@@ -2597,6 +2985,14 @@ export interface SearchQueries {
 }
 
 
+/** Select checkout shipping option result */
+export interface SelectCheckoutShippingOptionResult {
+    /** The Checkout that is updated as a result of mutation. */
+    checkout?: (Checkout | null)
+    __typename: 'SelectCheckoutShippingOptionResult'
+}
+
+
 /** Seo Details */
 export interface SeoDetails {
     /** Meta description. */
@@ -2690,6 +3086,8 @@ export interface Site {
     category?: (Category | null)
     /** A tree of categories. */
     categoryTree: CategoryTreeItem[]
+    /** The checkout of the current customer. */
+    checkout?: (Checkout | null)
     /** The page content. */
     content: Content
     /** Store Currencies. */
@@ -2866,6 +3264,14 @@ export interface TextFieldOption {
 }
 
 
+/** Unapply checkout coupon result */
+export interface UnapplyCheckoutCouponResult {
+    /** The Checkout that is updated as a result of mutation. */
+    checkout?: (Checkout | null)
+    __typename: 'UnapplyCheckoutCouponResult'
+}
+
+
 /** Unassign cart from the customer result. */
 export interface UnassignCartFromCustomerResult {
     /** The Cart that is updated as a result of mutation. */
@@ -2887,6 +3293,30 @@ export interface UpdateCartLineItemResult {
     /** The Cart that is updated as a result of mutation. */
     cart?: (Cart | null)
     __typename: 'UpdateCartLineItemResult'
+}
+
+
+/** Update checkout billing address result */
+export interface UpdateCheckoutBillingAddressResult {
+    /** The Checkout that is updated as a result of mutation. */
+    checkout?: (Checkout | null)
+    __typename: 'UpdateCheckoutBillingAddressResult'
+}
+
+
+/** Update checkout customer message result */
+export interface UpdateCheckoutCustomerMessageResult {
+    /** The Checkout that is updated as a result of mutation. */
+    checkout?: (Checkout | null)
+    __typename: 'UpdateCheckoutCustomerMessageResult'
+}
+
+
+/** Update checkout shipping consignment result */
+export interface UpdateCheckoutShippingConsignmentResult {
+    /** The Checkout that is updated as a result of mutation. */
+    checkout?: (Checkout | null)
+    __typename: 'UpdateCheckoutShippingConsignmentResult'
 }
 
 
@@ -3113,6 +3543,52 @@ export interface AddCartLineItemsResultGenqlSelection{
 }
 
 
+/** Add checkout billing address data object */
+export interface AddCheckoutBillingAddressDataInput {
+/** The checkout billing address */
+address: CheckoutAddressInput}
+
+
+/** Add checkout billing address input object */
+export interface AddCheckoutBillingAddressInput {
+/** The checkout id */
+checkoutEntityId: Scalars['String'],
+/** Add checkout billing address data object */
+data: AddCheckoutBillingAddressDataInput}
+
+
+/** Add checkout billing address result */
+export interface AddCheckoutBillingAddressResultGenqlSelection{
+    /** The Checkout that is updated as a result of mutation. */
+    checkout?: CheckoutGenqlSelection
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
+/** Add checkout shipping consignments data object */
+export interface AddCheckoutShippingConsignmentsDataInput {
+/** The list of shipping consignments */
+consignments: CheckoutShippingConsignmentInput[]}
+
+
+/** Add checkout shipping consignments input object */
+export interface AddCheckoutShippingConsignmentsInput {
+/** The checkout id */
+checkoutEntityId: Scalars['String'],
+/** Add checkout shipping consignments data object */
+data: AddCheckoutShippingConsignmentsDataInput}
+
+
+/** Apply checkout shipping consignments result */
+export interface AddCheckoutShippingConsignmentsResultGenqlSelection{
+    /** The Checkout that is updated as a result of mutation. */
+    checkout?: CheckoutGenqlSelection
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
 /** Add wishlist items input object */
 export interface AddWishlistItemsInput {
 /** The wishlist id */
@@ -3147,6 +3623,52 @@ export interface AggregatedInventoryGenqlSelection{
     availableToSell?: boolean | number
     /** Indicates a threshold low-stock level. This can be 'null' if the inventory warning level is not set or if the store's Inventory Settings disable displaying stock levels on the storefront. */
     warningLevel?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
+/** Apply checkout coupon data object */
+export interface ApplyCheckoutCouponDataInput {
+/** The checkout coupon code */
+couponCode: Scalars['String']}
+
+
+/** Apply checkout coupon input object */
+export interface ApplyCheckoutCouponInput {
+/** The checkout id */
+checkoutEntityId: Scalars['String'],
+/** Apply checkout coupon data object */
+data: ApplyCheckoutCouponDataInput}
+
+
+/** Apply checkout coupon result */
+export interface ApplyCheckoutCouponResultGenqlSelection{
+    /** The Checkout that is updated as a result of mutation. */
+    checkout?: CheckoutGenqlSelection
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
+/** Apply checkout spam protection data object */
+export interface ApplyCheckoutSpamProtectionDataInput {
+/** The checkout spam protection token */
+token: Scalars['String']}
+
+
+/** Apply checkout spam protection input object */
+export interface ApplyCheckoutSpamProtectionInput {
+/** The checkout id */
+checkoutEntityId: Scalars['String'],
+/** Apply checkout spam protection data object */
+data: ApplyCheckoutSpamProtectionDataInput}
+
+
+/** Apply checkout spam protection result */
+export interface ApplyCheckoutSpamProtectionResultGenqlSelection{
+    /** The Checkout that is updated as a result of mutation. */
+    checkout?: CheckoutGenqlSelection
     __typename?: boolean | number
     __scalar?: boolean | number
 }
@@ -3497,6 +4019,8 @@ export interface BreadcrumbGenqlSelection{
     entityId?: boolean | number
     /** Name of the category. */
     name?: boolean | number
+    /** Path to the category. */
+    path?: boolean | number
     __typename?: boolean | number
     __scalar?: boolean | number
 }
@@ -4325,6 +4849,469 @@ export interface CheckboxOptionGenqlSelection{
 }
 
 
+/** The checkout. */
+export interface CheckoutGenqlSelection{
+    /** Billing address information. */
+    billingAddress?: CheckoutBillingAddressGenqlSelection
+    /** Cart associated with the checkout. */
+    cart?: CartGenqlSelection
+    /** Coupons applied at checkout level. */
+    coupons?: CheckoutCouponGenqlSelection
+    /** Time when the checkout was created. */
+    createdAt?: DateTimeExtendedGenqlSelection
+    /** Shopper's message provided as details for the order to be created from the checkout. */
+    customerMessage?: boolean | number
+    /** Checkout ID. */
+    entityId?: boolean | number
+    /** Gift wrapping cost for all items, including or excluding tax. */
+    giftWrappingCostTotal?: MoneyGenqlSelection
+    /** The total payable amount, before applying any store credit or gift certificate. */
+    grandTotal?: MoneyGenqlSelection
+    /** Handling cost for all consignments including or excluding tax. */
+    handlingCostTotal?: MoneyGenqlSelection
+    /** The ID of an object */
+    id?: boolean | number
+    /** Order associated with the checkout. */
+    order?: OrderGenqlSelection
+    /** GrandTotal subtract the store-credit amount. */
+    outstandingBalance?: MoneyGenqlSelection
+    /** List of promotions */
+    promotions?: CheckoutPromotionGenqlSelection
+    /** List of shipping consignments. */
+    shippingConsignments?: CheckoutShippingConsignmentGenqlSelection
+    /** Total shipping cost before any discounts are applied. */
+    shippingCostTotal?: MoneyGenqlSelection
+    /** Subtotal of the checkout before applying item-level discounts. Tax inclusive based on the store settings. */
+    subtotal?: MoneyGenqlSelection
+    /** Total amount of taxes applied. */
+    taxTotal?: MoneyGenqlSelection
+    /** List of taxes applied. */
+    taxes?: CheckoutTaxGenqlSelection
+    /** Time when the checkout was last updated. */
+    updatedAt?: DateTimeExtendedGenqlSelection
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
+/** Checkout address. */
+export interface CheckoutAddressGenqlSelection{
+    /** Address line 1. */
+    address1?: boolean | number
+    /** Address line 2. */
+    address2?: boolean | number
+    /** Name of the city. */
+    city?: boolean | number
+    /** Company name. */
+    company?: boolean | number
+    /** Country code. */
+    countryCode?: boolean | number
+    /** List of custom fields. */
+    customFields?: CheckoutAddressCustomFieldGenqlSelection
+    /** Email address. */
+    email?: boolean | number
+    /** The first name. */
+    firstName?: boolean | number
+    /** The last name. */
+    lastName?: boolean | number
+    /** Phone number. */
+    phone?: boolean | number
+    /** Postal code. */
+    postalCode?: boolean | number
+    /** State or province. */
+    stateOrProvince?: boolean | number
+    /** Code of the state or province. */
+    stateOrProvinceCode?: boolean | number
+    on_CheckoutBillingAddress?: CheckoutBillingAddressGenqlSelection
+    on_CheckoutConsignmentAddress?: CheckoutConsignmentAddressGenqlSelection
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
+/** Checkboxes custom field. */
+export interface CheckoutAddressCheckboxesCustomFieldGenqlSelection{
+    /** Custom field ID. */
+    entityId?: boolean | number
+    /** List of custom field value IDs. */
+    valueEntityIds?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
+/** Checkout address checkboxes custom field input object */
+export interface CheckoutAddressCheckboxesCustomFieldInput {
+/** The custom field ID. */
+fieldEntityId: Scalars['Int'],
+/** List of custom field value IDs. */
+fieldValueEntityIds: Scalars['Int'][]}
+
+
+/** Custom field of the checkout address. */
+export interface CheckoutAddressCustomFieldGenqlSelection{
+    /** Custom field ID. */
+    entityId?: boolean | number
+    on_CheckoutAddressCheckboxesCustomField?: CheckoutAddressCheckboxesCustomFieldGenqlSelection
+    on_CheckoutAddressDateCustomField?: CheckoutAddressDateCustomFieldGenqlSelection
+    on_CheckoutAddressMultipleChoiceCustomField?: CheckoutAddressMultipleChoiceCustomFieldGenqlSelection
+    on_CheckoutAddressNumberCustomField?: CheckoutAddressNumberCustomFieldGenqlSelection
+    on_CheckoutAddressPasswordCustomField?: CheckoutAddressPasswordCustomFieldGenqlSelection
+    on_CheckoutAddressTextFieldCustomField?: CheckoutAddressTextFieldCustomFieldGenqlSelection
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
+/** Checkout address custom field input object */
+export interface CheckoutAddressCustomFieldInput {
+/** List of checkboxes custom fields. */
+checkboxes?: (CheckoutAddressCheckboxesCustomFieldInput[] | null),
+/** List of date custom fields. */
+dates?: (CheckoutAddressDateCustomFieldInput[] | null),
+/** List of multiple choice custom fields. */
+multipleChoices?: (CheckoutAddressMultipleChoiceCustomFieldInput[] | null),
+/** List of number custom fields. */
+numbers?: (CheckoutAddressNumberCustomFieldInput[] | null),
+/** List of password custom fields. */
+passwords?: (CheckoutAddressPasswordCustomFieldInput[] | null),
+/** List of text custom fields. */
+texts?: (CheckoutAddressTextCustomFieldInput[] | null)}
+
+
+/** Date custom field. */
+export interface CheckoutAddressDateCustomFieldGenqlSelection{
+    /** Date value. */
+    date?: DateTimeExtendedGenqlSelection
+    /** Custom field ID. */
+    entityId?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
+/** Checkout address date custom field input object */
+export interface CheckoutAddressDateCustomFieldInput {
+/** Date value. */
+date: Scalars['DateTime'],
+/** The custom field ID. */
+fieldEntityId: Scalars['Int']}
+
+
+/** Checkout address input object */
+export interface CheckoutAddressInput {
+/** Address line 1 */
+address1?: (Scalars['String'] | null),
+/** Address line 2 */
+address2?: (Scalars['String'] | null),
+/** Name of the city */
+city?: (Scalars['String'] | null),
+/** Company name */
+company?: (Scalars['String'] | null),
+/** Country code */
+countryCode: Scalars['String'],
+/** List of custom fields */
+customFields?: (CheckoutAddressCustomFieldInput | null),
+/** Email address */
+email?: (Scalars['String'] | null),
+/** The first name */
+firstName?: (Scalars['String'] | null),
+/** The last name */
+lastName?: (Scalars['String'] | null),
+/** Phone number */
+phone?: (Scalars['String'] | null),
+/** Postal code */
+postalCode?: (Scalars['String'] | null),
+/** Should we save this address? */
+shouldSaveAddress: Scalars['Boolean'],
+/** State or province */
+stateOrProvince?: (Scalars['String'] | null),
+/** Code of the state or province */
+stateOrProvinceCode?: (Scalars['String'] | null)}
+
+
+/** Multiple choice custom field. */
+export interface CheckoutAddressMultipleChoiceCustomFieldGenqlSelection{
+    /** Custom field ID. */
+    entityId?: boolean | number
+    /** Custom field value ID. */
+    valueEntityId?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
+/** Checkout address multiple choice custom field input object */
+export interface CheckoutAddressMultipleChoiceCustomFieldInput {
+/** The custom field ID. */
+fieldEntityId: Scalars['Int'],
+/** The custom field value ID. */
+fieldValueEntityId: Scalars['Int']}
+
+
+/** Number custom field. */
+export interface CheckoutAddressNumberCustomFieldGenqlSelection{
+    /** Custom field ID. */
+    entityId?: boolean | number
+    /** Number value. */
+    number?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
+/** Checkout address number custom field input object */
+export interface CheckoutAddressNumberCustomFieldInput {
+/** The custom field ID. */
+fieldEntityId: Scalars['Int'],
+/** Number value. */
+number: Scalars['Float']}
+
+
+/** Password custom field. */
+export interface CheckoutAddressPasswordCustomFieldGenqlSelection{
+    /** Custom field ID. */
+    entityId?: boolean | number
+    /** Password value. */
+    password?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
+/** Checkout address password custom field input object */
+export interface CheckoutAddressPasswordCustomFieldInput {
+/** The custom field ID. */
+fieldEntityId: Scalars['Int'],
+/** Password value. */
+password: Scalars['String']}
+
+
+/** Checkout address text custom field input object */
+export interface CheckoutAddressTextCustomFieldInput {
+/** The custom field ID. */
+fieldEntityId: Scalars['Int'],
+/** Text value. */
+text: Scalars['String']}
+
+
+/** Text custom field. */
+export interface CheckoutAddressTextFieldCustomFieldGenqlSelection{
+    /** Custom field ID. */
+    entityId?: boolean | number
+    /** Text value. */
+    text?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
+/** Available shipping option. */
+export interface CheckoutAvailableShippingOptionGenqlSelection{
+    /** Shipping option cost. */
+    cost?: MoneyGenqlSelection
+    /** Shipping option description. */
+    description?: boolean | number
+    /** Shipping option ID. */
+    entityId?: boolean | number
+    /** Shipping option image URL. */
+    imageUrl?: boolean | number
+    /** Is this shipping method the recommended shipping option or not. */
+    isRecommended?: boolean | number
+    /** An estimate of the arrival time. */
+    transitTime?: boolean | number
+    /** Shipping option type. Flat rate, UPS, etc. */
+    type?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
+/** Checkboxes billing address. */
+export interface CheckoutBillingAddressGenqlSelection{
+    /** Address line 1. */
+    address1?: boolean | number
+    /** Address line 2. */
+    address2?: boolean | number
+    /** Name of the city. */
+    city?: boolean | number
+    /** Company name. */
+    company?: boolean | number
+    /** Country code. */
+    countryCode?: boolean | number
+    /** List of custom fields. */
+    customFields?: CheckoutAddressCustomFieldGenqlSelection
+    /** Email address. */
+    email?: boolean | number
+    /** Billing address ID. */
+    entityId?: boolean | number
+    /** The first name. */
+    firstName?: boolean | number
+    /** The last name. */
+    lastName?: boolean | number
+    /** Phone number. */
+    phone?: boolean | number
+    /** Postal code. */
+    postalCode?: boolean | number
+    /** State or province. */
+    stateOrProvince?: boolean | number
+    /** Code of the state or province. */
+    stateOrProvinceCode?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
+/** Checkboxes consignment address. */
+export interface CheckoutConsignmentAddressGenqlSelection{
+    /** Address line 1. */
+    address1?: boolean | number
+    /** Address line 2. */
+    address2?: boolean | number
+    /** Name of the city. */
+    city?: boolean | number
+    /** Company name. */
+    company?: boolean | number
+    /** Country code. */
+    countryCode?: boolean | number
+    /** List of custom fields. */
+    customFields?: CheckoutAddressCustomFieldGenqlSelection
+    /** Email address. */
+    email?: boolean | number
+    /** The first name. */
+    firstName?: boolean | number
+    /** The last name. */
+    lastName?: boolean | number
+    /** Phone number. */
+    phone?: boolean | number
+    /** Postal code. */
+    postalCode?: boolean | number
+    /** State or province. */
+    stateOrProvince?: boolean | number
+    /** Code of the state or province. */
+    stateOrProvinceCode?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
+/** Checkout consignment line item input object */
+export interface CheckoutConsignmentLineItemInput {
+/** The line item id */
+lineItemEntityId: Scalars['String'],
+/** The total number of consignment line items */
+quantity: Scalars['Int']}
+
+
+/** The checkout coupon. */
+export interface CheckoutCouponGenqlSelection{
+    /** The coupon code. */
+    code?: boolean | number
+    /** The coupon type. */
+    couponType?: boolean | number
+    /** The discounted amount applied within a given context. */
+    discountedAmount?: MoneyGenqlSelection
+    /** The coupon ID. */
+    entityId?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
+/** Checkout mutations */
+export interface CheckoutMutationsGenqlSelection{
+    /** Creates a checkout billing address. */
+    addCheckoutBillingAddress?: (AddCheckoutBillingAddressResultGenqlSelection & { __args: {
+    /** Add checkout billing address input object */
+    input: AddCheckoutBillingAddressInput} })
+    /** Creates a checkout shipping consignments. */
+    addCheckoutShippingConsignments?: (AddCheckoutShippingConsignmentsResultGenqlSelection & { __args: {
+    /** Apply checkout shipping consignments input object */
+    input: AddCheckoutShippingConsignmentsInput} })
+    /** Applies a checkout coupon. */
+    applyCheckoutCoupon?: (ApplyCheckoutCouponResultGenqlSelection & { __args: {
+    /** Apply checkout coupon input object */
+    input: ApplyCheckoutCouponInput} })
+    /** Applies a checkout spam protection. */
+    applyCheckoutSpamProtection?: (ApplyCheckoutSpamProtectionResultGenqlSelection & { __args: {
+    /** Apply checkout spam protection input object */
+    input: ApplyCheckoutSpamProtectionInput} })
+    /** Completes the checkout. */
+    completeCheckout?: (CompleteCheckoutResultGenqlSelection & { __args: {
+    /** Complete checkout input object */
+    input: CompleteCheckoutInput} })
+    /** Deletes a checkout consignment. */
+    deleteCheckoutConsignment?: (DeleteCheckoutConsignmentResultGenqlSelection & { __args: {
+    /** Delete checkout consignment input object */
+    input: DeleteCheckoutConsignmentInput} })
+    /** Selects a checkout shipping option. */
+    selectCheckoutShippingOption?: (SelectCheckoutShippingOptionResultGenqlSelection & { __args: {
+    /** Select checkout shipping option input object */
+    input: SelectCheckoutShippingOptionInput} })
+    /** Unapply a checkout coupon. */
+    unapplyCheckoutCoupon?: (UnapplyCheckoutCouponResultGenqlSelection & { __args: {
+    /** Unapply checkout coupon input object */
+    input: UnapplyCheckoutCouponInput} })
+    /** Update a checkout billing address. */
+    updateCheckoutBillingAddress?: (UpdateCheckoutBillingAddressResultGenqlSelection & { __args: {
+    /** Update checkout billing address input object */
+    input: UpdateCheckoutBillingAddressInput} })
+    /** Updates a checkout customer message. */
+    updateCheckoutCustomerMessage?: (UpdateCheckoutCustomerMessageResultGenqlSelection & { __args: {
+    /** Update checkout customer message input object */
+    input: UpdateCheckoutCustomerMessageInput} })
+    /** Updates a checkout shipping consignments. */
+    updateCheckoutShippingConsignment?: (UpdateCheckoutShippingConsignmentResultGenqlSelection & { __args: {
+    /** Update checkout shipping consignment input object */
+    input: UpdateCheckoutShippingConsignmentInput} })
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
+/** The checkout promotion */
+export interface CheckoutPromotionGenqlSelection{
+    /** The checkout promotion banners. */
+    banners?: CheckoutPromotionBannerGenqlSelection
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
+/** The checkout promotion banner */
+export interface CheckoutPromotionBannerGenqlSelection{
+    /** The checkout promotion banner ID. */
+    entityId?: boolean | number
+    /** The list of the locations where the banner will display. */
+    locations?: boolean | number
+    /** Text of the banner. */
+    text?: boolean | number
+    /** Type of the banner. */
+    type?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
+/** Selected shipping option. */
+export interface CheckoutSelectedShippingOptionGenqlSelection{
+    /** Shipping option cost. */
+    cost?: MoneyGenqlSelection
+    /** Shipping option description. */
+    description?: boolean | number
+    /** Shipping option ID. */
+    entityId?: boolean | number
+    /** Shipping option image URL. */
+    imageUrl?: boolean | number
+    /** An estimate of the arrival time. */
+    transitTime?: boolean | number
+    /** Shipping option type. Flat rate, UPS, etc. */
+    type?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
 /** Checkout settings. */
 export interface CheckoutSettingsGenqlSelection{
     /** Indicates whether ReCaptcha is enabled on checkout. */
@@ -4334,10 +5321,69 @@ export interface CheckoutSettingsGenqlSelection{
 }
 
 
+/** Checkout shipping consignment. */
+export interface CheckoutShippingConsignmentGenqlSelection{
+    /** Shipping consignment address. */
+    address?: CheckoutConsignmentAddressGenqlSelection
+    /** List of available shipping options. */
+    availableShippingOptions?: CheckoutAvailableShippingOptionGenqlSelection
+    /** List of coupons applied to this shipping consignment. */
+    coupons?: CheckoutCouponGenqlSelection
+    /** Shipping consignment ID. */
+    entityId?: boolean | number
+    /** The handling cost of shipping for the consignment. */
+    handlingCost?: MoneyGenqlSelection
+    /** List of line item IDs for the consignment. */
+    lineItemIds?: boolean | number
+    /** Selected shipping option. */
+    selectedShippingOption?: CheckoutSelectedShippingOptionGenqlSelection
+    /** The shipping cost for the consignment. */
+    shippingCost?: MoneyGenqlSelection
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
+/** Checkout shipping consignments input object */
+export interface CheckoutShippingConsignmentInput {
+/** Shipping consignment address. */
+address: CheckoutAddressInput,
+/** List of line items for the consignment. */
+lineItems: CheckoutConsignmentLineItemInput[]}
+
+
+/** The checkout. */
+export interface CheckoutTaxGenqlSelection{
+    /** Tax amount. */
+    amount?: MoneyGenqlSelection
+    /** Name of the tax. */
+    name?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
 /** Additional information about the collection. */
 export interface CollectionInfoGenqlSelection{
     /** Total items in the collection despite pagination. */
     totalItems?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
+/** Complete checkout input object */
+export interface CompleteCheckoutInput {
+/** The checkout id */
+checkoutEntityId: Scalars['String']}
+
+
+/** Complete checkout result */
+export interface CompleteCheckoutResultGenqlSelection{
+    /** The Order ID created as a result of the checkout. */
+    orderEntityId?: boolean | number
+    /** The access token to be used to complete a payment. */
+    paymentAccessToken?: boolean | number
     __typename?: boolean | number
     __scalar?: boolean | number
 }
@@ -4681,6 +5727,23 @@ export interface DeleteCartLineItemResultGenqlSelection{
 export interface DeleteCartResultGenqlSelection{
     /** The ID of the Cart that is deleted as a result of mutation. */
     deletedCartEntityId?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
+/** Delete checkout consignment input object */
+export interface DeleteCheckoutConsignmentInput {
+/** The checkout id */
+checkoutEntityId: Scalars['String'],
+/** The consignment id */
+consignmentEntityId: Scalars['String']}
+
+
+/** Delete checkout consignment result */
+export interface DeleteCheckoutConsignmentResultGenqlSelection{
+    /** The Checkout that is updated as a result of mutation. */
+    checkout?: CheckoutGenqlSelection
     __typename?: boolean | number
     __scalar?: boolean | number
 }
@@ -5230,6 +6293,8 @@ export interface MultipleChoiceOptionValueGenqlSelection{
 export interface MutationGenqlSelection{
     /** The Cart mutations. */
     cart?: CartMutationsGenqlSelection
+    /** The Checkout mutations. */
+    checkout?: CheckoutMutationsGenqlSelection
     /** Customer login */
     login?: (LoginResultGenqlSelection & { __args: {
     /** An email of the customer. */
@@ -5255,6 +6320,7 @@ export interface NodeGenqlSelection{
     on_Brand?: BrandGenqlSelection
     on_Cart?: CartGenqlSelection
     on_Category?: CategoryGenqlSelection
+    on_Checkout?: CheckoutGenqlSelection
     on_ContactPage?: ContactPageGenqlSelection
     on_NormalPage?: NormalPageGenqlSelection
     on_Product?: ProductGenqlSelection
@@ -5403,6 +6469,15 @@ export interface OptionValueId {
 optionEntityId: Scalars['Int'],
 /** A variant value id filter. */
 valueEntityId: Scalars['Int']}
+
+
+/** The order. */
+export interface OrderGenqlSelection{
+    /** Order ID. */
+    entityId?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
 
 
 /** Other Filter */
@@ -5720,6 +6795,8 @@ export interface ProductAttributeSearchFilterGenqlSelection{
     attributes?: (ProductAttributeSearchFilterItemConnectionGenqlSelection & { __args?: {after?: (Scalars['String'] | null), before?: (Scalars['String'] | null), first?: (Scalars['Int'] | null), last?: (Scalars['Int'] | null)} })
     /** Indicates whether to display product count next to the filter. */
     displayProductCount?: boolean | number
+    /** Filter name for building filter URLs */
+    filterName?: boolean | number
     /** Indicates whether filter is collapsed by default. */
     isCollapsedByDefault?: boolean | number
     /** Display name for the filter. */
@@ -6297,6 +7374,31 @@ export interface SearchQueriesGenqlSelection{
 }
 
 
+/** Select checkout shipping option input data object */
+export interface SelectCheckoutShippingOptionDataInput {
+/** The shipping option id */
+shippingOptionEntityId: Scalars['String']}
+
+
+/** Select checkout shipping option input object */
+export interface SelectCheckoutShippingOptionInput {
+/** The checkout id */
+checkoutEntityId: Scalars['String'],
+/** The consignment id */
+consignmentEntityId: Scalars['String'],
+/** Select checkout shipping option data object */
+data: SelectCheckoutShippingOptionDataInput}
+
+
+/** Select checkout shipping option result */
+export interface SelectCheckoutShippingOptionResultGenqlSelection{
+    /** The Checkout that is updated as a result of mutation. */
+    checkout?: CheckoutGenqlSelection
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
 /** Seo Details */
 export interface SeoDetailsGenqlSelection{
     /** Meta description. */
@@ -6407,6 +7509,10 @@ export interface SiteGenqlSelection{
     categoryTree?: (CategoryTreeItemGenqlSelection & { __args?: {
     /** A root category ID to be used to load the tree starting from a particular branch. If not supplied, starts at the top of the tree. */
     rootEntityId?: (Scalars['Int'] | null)} })
+    /** The checkout of the current customer. */
+    checkout?: (CheckoutGenqlSelection & { __args?: {
+    /** Checkout ID. */
+    entityId?: (Scalars['String'] | null)} })
     /** The page content. */
     content?: ContentGenqlSelection
     /** Store Currencies. */
@@ -6619,6 +7725,29 @@ export interface TextFieldOptionGenqlSelection{
 }
 
 
+/** Unapply checkout coupon data object */
+export interface UnapplyCheckoutCouponDataInput {
+/** The checkout coupon code */
+couponCode: Scalars['String']}
+
+
+/** Unapply checkout coupon input object */
+export interface UnapplyCheckoutCouponInput {
+/** The checkout id */
+checkoutEntityId: Scalars['String'],
+/** Unapply checkout coupon data object */
+data: UnapplyCheckoutCouponDataInput}
+
+
+/** Unapply checkout coupon result */
+export interface UnapplyCheckoutCouponResultGenqlSelection{
+    /** The Checkout that is updated as a result of mutation. */
+    checkout?: CheckoutGenqlSelection
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
 /** Unassign cart from the customer input object. */
 export interface UnassignCartFromCustomerInput {
 /** The cart id. */
@@ -6679,6 +7808,79 @@ lineItemEntityId: Scalars['String']}
 export interface UpdateCartLineItemResultGenqlSelection{
     /** The Cart that is updated as a result of mutation. */
     cart?: CartGenqlSelection
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
+/** Update checkout billing address data object */
+export interface UpdateCheckoutBillingAddressDataInput {
+/** The checkout billing address */
+address: CheckoutAddressInput}
+
+
+/** Update checkout billing address input object */
+export interface UpdateCheckoutBillingAddressInput {
+/** The address id */
+addressEntityId: Scalars['String'],
+/** The checkout id */
+checkoutEntityId: Scalars['String'],
+/** Update checkout billing address data object */
+data: UpdateCheckoutBillingAddressDataInput}
+
+
+/** Update checkout billing address result */
+export interface UpdateCheckoutBillingAddressResultGenqlSelection{
+    /** The Checkout that is updated as a result of mutation. */
+    checkout?: CheckoutGenqlSelection
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
+/** Update checkout customer message data object */
+export interface UpdateCheckoutCustomerMessageDataInput {
+/** The checkout customer message */
+message: Scalars['String']}
+
+
+/** Update checkout customer message input object */
+export interface UpdateCheckoutCustomerMessageInput {
+/** The checkout id */
+checkoutEntityId: Scalars['String'],
+/** Update checkout customer message data object */
+data: UpdateCheckoutCustomerMessageDataInput}
+
+
+/** Update checkout customer message result */
+export interface UpdateCheckoutCustomerMessageResultGenqlSelection{
+    /** The Checkout that is updated as a result of mutation. */
+    checkout?: CheckoutGenqlSelection
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
+/** Update checkout shipping consignment data object */
+export interface UpdateCheckoutShippingConsignmentDataInput {
+/** Checkout shipping consignment input object */
+consignment: CheckoutShippingConsignmentInput}
+
+
+/** Update checkout shipping consignment input object */
+export interface UpdateCheckoutShippingConsignmentInput {
+/** The checkout id */
+checkoutEntityId: Scalars['String'],
+/** The consignment id */
+consignmentEntityId: Scalars['String'],
+/** Update checkout shipping consignment data object */
+data: UpdateCheckoutShippingConsignmentDataInput}
+
+
+/** Update checkout shipping consignment result */
+export interface UpdateCheckoutShippingConsignmentResultGenqlSelection{
+    /** The Checkout that is updated as a result of mutation. */
+    checkout?: CheckoutGenqlSelection
     __typename?: boolean | number
     __scalar?: boolean | number
 }
@@ -6975,6 +8177,22 @@ name?: (Scalars['String'] | null)}
     
 
 
+    const AddCheckoutBillingAddressResult_possibleTypes: string[] = ['AddCheckoutBillingAddressResult']
+    export const isAddCheckoutBillingAddressResult = (obj?: { __typename?: any } | null): obj is AddCheckoutBillingAddressResult => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isAddCheckoutBillingAddressResult"')
+      return AddCheckoutBillingAddressResult_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const AddCheckoutShippingConsignmentsResult_possibleTypes: string[] = ['AddCheckoutShippingConsignmentsResult']
+    export const isAddCheckoutShippingConsignmentsResult = (obj?: { __typename?: any } | null): obj is AddCheckoutShippingConsignmentsResult => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isAddCheckoutShippingConsignmentsResult"')
+      return AddCheckoutShippingConsignmentsResult_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
     const AddWishlistItemsResult_possibleTypes: string[] = ['AddWishlistItemsResult']
     export const isAddWishlistItemsResult = (obj?: { __typename?: any } | null): obj is AddWishlistItemsResult => {
       if (!obj?.__typename) throw new Error('__typename is missing in "isAddWishlistItemsResult"')
@@ -6995,6 +8213,22 @@ name?: (Scalars['String'] | null)}
     export const isAggregatedInventory = (obj?: { __typename?: any } | null): obj is AggregatedInventory => {
       if (!obj?.__typename) throw new Error('__typename is missing in "isAggregatedInventory"')
       return AggregatedInventory_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const ApplyCheckoutCouponResult_possibleTypes: string[] = ['ApplyCheckoutCouponResult']
+    export const isApplyCheckoutCouponResult = (obj?: { __typename?: any } | null): obj is ApplyCheckoutCouponResult => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isApplyCheckoutCouponResult"')
+      return ApplyCheckoutCouponResult_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const ApplyCheckoutSpamProtectionResult_possibleTypes: string[] = ['ApplyCheckoutSpamProtectionResult']
+    export const isApplyCheckoutSpamProtectionResult = (obj?: { __typename?: any } | null): obj is ApplyCheckoutSpamProtectionResult => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isApplyCheckoutSpamProtectionResult"')
+      return ApplyCheckoutSpamProtectionResult_possibleTypes.includes(obj.__typename)
     }
     
 
@@ -7487,6 +8721,142 @@ name?: (Scalars['String'] | null)}
     
 
 
+    const Checkout_possibleTypes: string[] = ['Checkout']
+    export const isCheckout = (obj?: { __typename?: any } | null): obj is Checkout => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isCheckout"')
+      return Checkout_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const CheckoutAddress_possibleTypes: string[] = ['CheckoutBillingAddress','CheckoutConsignmentAddress']
+    export const isCheckoutAddress = (obj?: { __typename?: any } | null): obj is CheckoutAddress => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isCheckoutAddress"')
+      return CheckoutAddress_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const CheckoutAddressCheckboxesCustomField_possibleTypes: string[] = ['CheckoutAddressCheckboxesCustomField']
+    export const isCheckoutAddressCheckboxesCustomField = (obj?: { __typename?: any } | null): obj is CheckoutAddressCheckboxesCustomField => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isCheckoutAddressCheckboxesCustomField"')
+      return CheckoutAddressCheckboxesCustomField_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const CheckoutAddressCustomField_possibleTypes: string[] = ['CheckoutAddressCheckboxesCustomField','CheckoutAddressDateCustomField','CheckoutAddressMultipleChoiceCustomField','CheckoutAddressNumberCustomField','CheckoutAddressPasswordCustomField','CheckoutAddressTextFieldCustomField']
+    export const isCheckoutAddressCustomField = (obj?: { __typename?: any } | null): obj is CheckoutAddressCustomField => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isCheckoutAddressCustomField"')
+      return CheckoutAddressCustomField_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const CheckoutAddressDateCustomField_possibleTypes: string[] = ['CheckoutAddressDateCustomField']
+    export const isCheckoutAddressDateCustomField = (obj?: { __typename?: any } | null): obj is CheckoutAddressDateCustomField => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isCheckoutAddressDateCustomField"')
+      return CheckoutAddressDateCustomField_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const CheckoutAddressMultipleChoiceCustomField_possibleTypes: string[] = ['CheckoutAddressMultipleChoiceCustomField']
+    export const isCheckoutAddressMultipleChoiceCustomField = (obj?: { __typename?: any } | null): obj is CheckoutAddressMultipleChoiceCustomField => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isCheckoutAddressMultipleChoiceCustomField"')
+      return CheckoutAddressMultipleChoiceCustomField_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const CheckoutAddressNumberCustomField_possibleTypes: string[] = ['CheckoutAddressNumberCustomField']
+    export const isCheckoutAddressNumberCustomField = (obj?: { __typename?: any } | null): obj is CheckoutAddressNumberCustomField => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isCheckoutAddressNumberCustomField"')
+      return CheckoutAddressNumberCustomField_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const CheckoutAddressPasswordCustomField_possibleTypes: string[] = ['CheckoutAddressPasswordCustomField']
+    export const isCheckoutAddressPasswordCustomField = (obj?: { __typename?: any } | null): obj is CheckoutAddressPasswordCustomField => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isCheckoutAddressPasswordCustomField"')
+      return CheckoutAddressPasswordCustomField_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const CheckoutAddressTextFieldCustomField_possibleTypes: string[] = ['CheckoutAddressTextFieldCustomField']
+    export const isCheckoutAddressTextFieldCustomField = (obj?: { __typename?: any } | null): obj is CheckoutAddressTextFieldCustomField => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isCheckoutAddressTextFieldCustomField"')
+      return CheckoutAddressTextFieldCustomField_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const CheckoutAvailableShippingOption_possibleTypes: string[] = ['CheckoutAvailableShippingOption']
+    export const isCheckoutAvailableShippingOption = (obj?: { __typename?: any } | null): obj is CheckoutAvailableShippingOption => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isCheckoutAvailableShippingOption"')
+      return CheckoutAvailableShippingOption_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const CheckoutBillingAddress_possibleTypes: string[] = ['CheckoutBillingAddress']
+    export const isCheckoutBillingAddress = (obj?: { __typename?: any } | null): obj is CheckoutBillingAddress => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isCheckoutBillingAddress"')
+      return CheckoutBillingAddress_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const CheckoutConsignmentAddress_possibleTypes: string[] = ['CheckoutConsignmentAddress']
+    export const isCheckoutConsignmentAddress = (obj?: { __typename?: any } | null): obj is CheckoutConsignmentAddress => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isCheckoutConsignmentAddress"')
+      return CheckoutConsignmentAddress_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const CheckoutCoupon_possibleTypes: string[] = ['CheckoutCoupon']
+    export const isCheckoutCoupon = (obj?: { __typename?: any } | null): obj is CheckoutCoupon => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isCheckoutCoupon"')
+      return CheckoutCoupon_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const CheckoutMutations_possibleTypes: string[] = ['CheckoutMutations']
+    export const isCheckoutMutations = (obj?: { __typename?: any } | null): obj is CheckoutMutations => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isCheckoutMutations"')
+      return CheckoutMutations_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const CheckoutPromotion_possibleTypes: string[] = ['CheckoutPromotion']
+    export const isCheckoutPromotion = (obj?: { __typename?: any } | null): obj is CheckoutPromotion => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isCheckoutPromotion"')
+      return CheckoutPromotion_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const CheckoutPromotionBanner_possibleTypes: string[] = ['CheckoutPromotionBanner']
+    export const isCheckoutPromotionBanner = (obj?: { __typename?: any } | null): obj is CheckoutPromotionBanner => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isCheckoutPromotionBanner"')
+      return CheckoutPromotionBanner_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const CheckoutSelectedShippingOption_possibleTypes: string[] = ['CheckoutSelectedShippingOption']
+    export const isCheckoutSelectedShippingOption = (obj?: { __typename?: any } | null): obj is CheckoutSelectedShippingOption => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isCheckoutSelectedShippingOption"')
+      return CheckoutSelectedShippingOption_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
     const CheckoutSettings_possibleTypes: string[] = ['CheckoutSettings']
     export const isCheckoutSettings = (obj?: { __typename?: any } | null): obj is CheckoutSettings => {
       if (!obj?.__typename) throw new Error('__typename is missing in "isCheckoutSettings"')
@@ -7495,10 +8865,34 @@ name?: (Scalars['String'] | null)}
     
 
 
+    const CheckoutShippingConsignment_possibleTypes: string[] = ['CheckoutShippingConsignment']
+    export const isCheckoutShippingConsignment = (obj?: { __typename?: any } | null): obj is CheckoutShippingConsignment => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isCheckoutShippingConsignment"')
+      return CheckoutShippingConsignment_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const CheckoutTax_possibleTypes: string[] = ['CheckoutTax']
+    export const isCheckoutTax = (obj?: { __typename?: any } | null): obj is CheckoutTax => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isCheckoutTax"')
+      return CheckoutTax_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
     const CollectionInfo_possibleTypes: string[] = ['CollectionInfo']
     export const isCollectionInfo = (obj?: { __typename?: any } | null): obj is CollectionInfo => {
       if (!obj?.__typename) throw new Error('__typename is missing in "isCollectionInfo"')
       return CollectionInfo_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const CompleteCheckoutResult_possibleTypes: string[] = ['CompleteCheckoutResult']
+    export const isCompleteCheckoutResult = (obj?: { __typename?: any } | null): obj is CompleteCheckoutResult => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isCompleteCheckoutResult"')
+      return CompleteCheckoutResult_possibleTypes.includes(obj.__typename)
     }
     
 
@@ -7651,6 +9045,14 @@ name?: (Scalars['String'] | null)}
     export const isDeleteCartResult = (obj?: { __typename?: any } | null): obj is DeleteCartResult => {
       if (!obj?.__typename) throw new Error('__typename is missing in "isDeleteCartResult"')
       return DeleteCartResult_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const DeleteCheckoutConsignmentResult_possibleTypes: string[] = ['DeleteCheckoutConsignmentResult']
+    export const isDeleteCheckoutConsignmentResult = (obj?: { __typename?: any } | null): obj is DeleteCheckoutConsignmentResult => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isDeleteCheckoutConsignmentResult"')
+      return DeleteCheckoutConsignmentResult_possibleTypes.includes(obj.__typename)
     }
     
 
@@ -7927,7 +9329,7 @@ name?: (Scalars['String'] | null)}
     
 
 
-    const Node_possibleTypes: string[] = ['Banner','Blog','BlogPost','Brand','Cart','Category','ContactPage','NormalPage','Product','RawHtmlPage','Variant']
+    const Node_possibleTypes: string[] = ['Banner','Blog','BlogPost','Brand','Cart','Category','Checkout','ContactPage','NormalPage','Product','RawHtmlPage','Variant']
     export const isNode = (obj?: { __typename?: any } | null): obj is Node => {
       if (!obj?.__typename) throw new Error('__typename is missing in "isNode"')
       return Node_possibleTypes.includes(obj.__typename)
@@ -7995,6 +9397,14 @@ name?: (Scalars['String'] | null)}
     export const isOptionValueEdge = (obj?: { __typename?: any } | null): obj is OptionValueEdge => {
       if (!obj?.__typename) throw new Error('__typename is missing in "isOptionValueEdge"')
       return OptionValueEdge_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const Order_possibleTypes: string[] = ['Order']
+    export const isOrder = (obj?: { __typename?: any } | null): obj is Order => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isOrder"')
+      return Order_possibleTypes.includes(obj.__typename)
     }
     
 
@@ -8431,6 +9841,14 @@ name?: (Scalars['String'] | null)}
     
 
 
+    const SelectCheckoutShippingOptionResult_possibleTypes: string[] = ['SelectCheckoutShippingOptionResult']
+    export const isSelectCheckoutShippingOptionResult = (obj?: { __typename?: any } | null): obj is SelectCheckoutShippingOptionResult => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isSelectCheckoutShippingOptionResult"')
+      return SelectCheckoutShippingOptionResult_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
     const SeoDetails_possibleTypes: string[] = ['SeoDetails']
     export const isSeoDetails = (obj?: { __typename?: any } | null): obj is SeoDetails => {
       if (!obj?.__typename) throw new Error('__typename is missing in "isSeoDetails"')
@@ -8575,6 +9993,14 @@ name?: (Scalars['String'] | null)}
     
 
 
+    const UnapplyCheckoutCouponResult_possibleTypes: string[] = ['UnapplyCheckoutCouponResult']
+    export const isUnapplyCheckoutCouponResult = (obj?: { __typename?: any } | null): obj is UnapplyCheckoutCouponResult => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isUnapplyCheckoutCouponResult"')
+      return UnapplyCheckoutCouponResult_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
     const UnassignCartFromCustomerResult_possibleTypes: string[] = ['UnassignCartFromCustomerResult']
     export const isUnassignCartFromCustomerResult = (obj?: { __typename?: any } | null): obj is UnassignCartFromCustomerResult => {
       if (!obj?.__typename) throw new Error('__typename is missing in "isUnassignCartFromCustomerResult"')
@@ -8595,6 +10021,30 @@ name?: (Scalars['String'] | null)}
     export const isUpdateCartLineItemResult = (obj?: { __typename?: any } | null): obj is UpdateCartLineItemResult => {
       if (!obj?.__typename) throw new Error('__typename is missing in "isUpdateCartLineItemResult"')
       return UpdateCartLineItemResult_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const UpdateCheckoutBillingAddressResult_possibleTypes: string[] = ['UpdateCheckoutBillingAddressResult']
+    export const isUpdateCheckoutBillingAddressResult = (obj?: { __typename?: any } | null): obj is UpdateCheckoutBillingAddressResult => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isUpdateCheckoutBillingAddressResult"')
+      return UpdateCheckoutBillingAddressResult_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const UpdateCheckoutCustomerMessageResult_possibleTypes: string[] = ['UpdateCheckoutCustomerMessageResult']
+    export const isUpdateCheckoutCustomerMessageResult = (obj?: { __typename?: any } | null): obj is UpdateCheckoutCustomerMessageResult => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isUpdateCheckoutCustomerMessageResult"')
+      return UpdateCheckoutCustomerMessageResult_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const UpdateCheckoutShippingConsignmentResult_possibleTypes: string[] = ['UpdateCheckoutShippingConsignmentResult']
+    export const isUpdateCheckoutShippingConsignmentResult = (obj?: { __typename?: any } | null): obj is UpdateCheckoutShippingConsignmentResult => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isUpdateCheckoutShippingConsignmentResult"')
+      return UpdateCheckoutShippingConsignmentResult_possibleTypes.includes(obj.__typename)
     }
     
 
@@ -8734,6 +10184,29 @@ export const enumCategoryProductSort = {
    LOWEST_PRICE: 'LOWEST_PRICE' as const,
    NEWEST: 'NEWEST' as const,
    Z_TO_A: 'Z_TO_A' as const
+}
+
+export const enumCheckoutPromotionBannerLocation = {
+   CART_PAGE: 'CART_PAGE' as const,
+   CHECKOUT_PAGE: 'CHECKOUT_PAGE' as const,
+   HOME_PAGE: 'HOME_PAGE' as const,
+   PRODUCT_PAGE: 'PRODUCT_PAGE' as const
+}
+
+export const enumCheckoutPromotionBannerType = {
+   APPLIED: 'APPLIED' as const,
+   ELIGIBLE: 'ELIGIBLE' as const,
+   PROMOTION: 'PROMOTION' as const,
+   UPSELL: 'UPSELL' as const
+}
+
+export const enumCouponType = {
+   FREE_SHIPPING: 'FREE_SHIPPING' as const,
+   PERCENTAGE_DISCOUNT: 'PERCENTAGE_DISCOUNT' as const,
+   PER_ITEM_DISCOUNT: 'PER_ITEM_DISCOUNT' as const,
+   PER_TOTAL_DISCOUNT: 'PER_TOTAL_DISCOUNT' as const,
+   PROMOTION: 'PROMOTION' as const,
+   SHIPPING_DISCOUNT: 'SHIPPING_DISCOUNT' as const
 }
 
 export const enumCurrencySymbolPosition = {

--- a/packages/client/src/generated/types.ts
+++ b/packages/client/src/generated/types.ts
@@ -1,999 +1,1113 @@
 export default {
     "scalars": [
-        13,
-        15,
-        22,
-        49,
-        78,
-        99,
-        107,
-        120,
+        25,
+        27,
+        34,
+        61,
+        90,
         123,
-        127,
-        131,
-        139,
-        140,
-        141,
-        147,
-        165,
-        174,
-        190,
-        192,
-        202,
-        207,
-        233,
-        243,
-        248,
-        249,
-        255,
-        273,
-        285,
-        286,
-        287
+        124,
+        136,
+        145,
+        153,
+        168,
+        171,
+        175,
+        179,
+        187,
+        188,
+        189,
+        195,
+        213,
+        223,
+        239,
+        241,
+        251,
+        256,
+        282,
+        295,
+        300,
+        301,
+        307,
+        337,
+        349,
+        350,
+        351
     ],
     "types": {
         "AddCartLineItemsDataInput": {
             "giftCertificates": [
-                44
+                56
             ],
             "lineItems": [
-                51
+                63
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "AddCartLineItemsInput": {
             "cartEntityId": [
-                249
+                301
             ],
             "data": [
                 0
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "AddCartLineItemsResult": {
             "cart": [
-                39
+                51
             ],
             "__typename": [
-                249
+                301
+            ]
+        },
+        "AddCheckoutBillingAddressDataInput": {
+            "address": [
+                106
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "AddCheckoutBillingAddressInput": {
+            "checkoutEntityId": [
+                301
+            ],
+            "data": [
+                3
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "AddCheckoutBillingAddressResult": {
+            "checkout": [
+                98
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "AddCheckoutShippingConsignmentsDataInput": {
+            "consignments": [
+                128
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "AddCheckoutShippingConsignmentsInput": {
+            "checkoutEntityId": [
+                301
+            ],
+            "data": [
+                6
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "AddCheckoutShippingConsignmentsResult": {
+            "checkout": [
+                98
+            ],
+            "__typename": [
+                301
             ]
         },
         "AddWishlistItemsInput": {
             "entityId": [
-                131
+                179
             ],
             "items": [
-                282
+                346
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "AddWishlistItemsResult": {
             "result": [
-                275
+                339
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "Aggregated": {
             "availableToSell": [
-                147
+                195
             ],
             "warningLevel": [
-                131
+                179
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "AggregatedInventory": {
             "availableToSell": [
-                131
+                179
             ],
             "warningLevel": [
-                131
+                179
             ],
             "__typename": [
-                249
+                301
+            ]
+        },
+        "ApplyCheckoutCouponDataInput": {
+            "couponCode": [
+                301
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "ApplyCheckoutCouponInput": {
+            "checkoutEntityId": [
+                301
+            ],
+            "data": [
+                13
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "ApplyCheckoutCouponResult": {
+            "checkout": [
+                98
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "ApplyCheckoutSpamProtectionDataInput": {
+            "token": [
+                301
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "ApplyCheckoutSpamProtectionInput": {
+            "checkoutEntityId": [
+                301
+            ],
+            "data": [
+                16
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "ApplyCheckoutSpamProtectionResult": {
+            "checkout": [
+                98
+            ],
+            "__typename": [
+                301
             ]
         },
         "AssignCartToCustomerInput": {
             "cartEntityId": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "AssignCartToCustomerResult": {
             "cart": [
-                39
+                51
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "Author": {
             "name": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "Banner": {
             "content": [
-                249
+                301
             ],
             "entityId": [
-                147
+                195
             ],
             "id": [
-                127
+                175
             ],
             "location": [
-                13
+                25
             ],
             "name": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "BannerConnection": {
             "edges": [
-                12
+                24
             ],
             "pageInfo": [
-                173
+                222
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "BannerEdge": {
             "cursor": [
-                249
+                301
             ],
             "node": [
-                10
+                22
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "BannerLocation": {},
         "Banners": {
             "brandPage": [
-                26,
+                38,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "brandEntityId": [
-                        131,
+                        179,
                         "Int!"
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "categoryPage": [
-                76,
+                88,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "categoryEntityId": [
-                        131,
+                        179,
                         "Int!"
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "homePage": [
-                11,
+                23,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "searchPage": [
-                11,
+                23,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "BigDecimal": {},
         "Blog": {
             "description": [
-                249
+                301
             ],
             "id": [
-                127
+                175
             ],
             "isVisibleInNavigation": [
-                22
+                34
             ],
             "name": [
-                249
+                301
             ],
             "path": [
-                249
+                301
             ],
             "post": [
-                18,
+                30,
                 {
                     "entityId": [
-                        131,
+                        179,
                         "Int!"
                     ]
                 }
             ],
             "posts": [
-                19,
+                31,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "filters": [
-                        21
+                        33
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "last": [
-                        131
+                        179
                     ],
                     "sort": [
-                        287
+                        351
                     ]
                 }
             ],
             "renderedRegions": [
-                221
+                270
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "BlogIndexPage": {
             "entityId": [
-                131
+                179
             ],
             "isVisibleInNavigation": [
-                22
+                34
             ],
             "name": [
-                249
+                301
             ],
             "parentEntityId": [
-                131
+                179
             ],
             "path": [
-                249
+                301
             ],
             "renderedRegions": [
-                221
+                270
             ],
             "seo": [
-                235
+                287
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "BlogPost": {
             "author": [
-                249
+                301
             ],
             "entityId": [
-                131
+                179
             ],
             "htmlBody": [
-                249
+                301
             ],
             "id": [
-                127
+                175
             ],
             "name": [
-                249
+                301
             ],
             "path": [
-                249
+                301
             ],
             "plainTextSummary": [
-                249,
+                301,
                 {
                     "characterLimit": [
-                        131
+                        179
                     ]
                 }
             ],
             "publishedDate": [
-                108
+                154
             ],
             "renderedRegions": [
-                221
+                270
             ],
             "seo": [
-                235
+                287
             ],
             "tags": [
-                249
+                301
             ],
             "thumbnailImage": [
-                128
+                176
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "BlogPostConnection": {
             "collectionInfo": [
-                87
+                130
             ],
             "edges": [
-                20
+                32
             ],
             "pageInfo": [
-                173
+                222
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "BlogPostEdge": {
             "cursor": [
-                249
+                301
             ],
             "node": [
-                18
+                30
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "BlogPostsFiltersInput": {
             "entityIds": [
-                131
+                179
             ],
             "tags": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "Boolean": {},
         "Brand": {
             "defaultImage": [
-                128
+                176
             ],
             "entityId": [
-                131
+                179
             ],
             "id": [
-                127
+                175
             ],
             "metaDesc": [
-                249
+                301
             ],
             "metaKeywords": [
-                249
+                301
             ],
             "metafields": [
-                149,
+                197,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "keys": [
-                        249,
+                        301,
                         "[String!]"
                     ],
                     "last": [
-                        131
+                        179
                     ],
                     "namespace": [
-                        249,
+                        301,
                         "String!"
                     ]
                 }
             ],
             "name": [
-                249
+                301
             ],
             "pageTitle": [
-                249
+                301
             ],
             "path": [
-                249
+                301
             ],
             "products": [
-                193,
+                242,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "hideOutOfStock": [
-                        22
+                        34
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "searchKeywords": [
-                249
+                301
             ],
             "seo": [
-                235
+                287
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "BrandConnection": {
             "edges": [
-                25
+                37
             ],
             "pageInfo": [
-                173
+                222
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "BrandEdge": {
             "cursor": [
-                249
+                301
             ],
             "node": [
-                23
+                35
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "BrandPageBannerConnection": {
             "edges": [
-                27
+                39
             ],
             "pageInfo": [
-                173
+                222
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "BrandPageBannerEdge": {
             "cursor": [
-                249
+                301
             ],
             "node": [
-                10
+                22
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "BrandSearchFilter": {
             "brands": [
-                30,
+                42,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "displayProductCount": [
-                22
+                34
             ],
             "isCollapsedByDefault": [
-                22
+                34
             ],
             "name": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "BrandSearchFilterItem": {
             "entityId": [
-                131
+                179
             ],
             "isSelected": [
-                22
+                34
             ],
             "name": [
-                249
+                301
             ],
             "productCount": [
-                131
+                179
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "BrandSearchFilterItemConnection": {
             "edges": [
-                31
+                43
             ],
             "pageInfo": [
-                173
+                222
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "BrandSearchFilterItemEdge": {
             "cursor": [
-                249
+                301
             ],
             "node": [
-                29
+                41
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "Breadcrumb": {
             "entityId": [
-                131
+                179
             ],
             "name": [
-                249
+                301
+            ],
+            "path": [
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "BreadcrumbConnection": {
             "edges": [
-                34
+                46
             ],
             "pageInfo": [
-                173
+                222
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "BreadcrumbEdge": {
             "cursor": [
-                249
+                301
             ],
             "node": [
-                32
+                44
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "BulkPricingFixedPriceDiscount": {
             "maximumQuantity": [
-                131
+                179
             ],
             "minimumQuantity": [
-                131
+                179
             ],
             "price": [
-                15
+                27
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "BulkPricingPercentageDiscount": {
             "maximumQuantity": [
-                131
+                179
             ],
             "minimumQuantity": [
-                131
+                179
             ],
             "percentOff": [
-                15
+                27
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "BulkPricingRelativePriceDiscount": {
             "maximumQuantity": [
-                131
+                179
             ],
             "minimumQuantity": [
-                131
+                179
             ],
             "priceAdjustment": [
-                15
+                27
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "BulkPricingTier": {
             "maximumQuantity": [
-                131
+                179
             ],
             "minimumQuantity": [
-                131
+                179
             ],
             "on_BulkPricingFixedPriceDiscount": [
-                35
+                47
             ],
             "on_BulkPricingPercentageDiscount": [
-                36
+                48
             ],
             "on_BulkPricingRelativePriceDiscount": [
-                37
+                49
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "Cart": {
             "amount": [
-                152
+                200
             ],
             "baseAmount": [
-                152
+                200
             ],
             "createdAt": [
-                108
+                154
             ],
             "currencyCode": [
-                249
+                301
             ],
             "discountedAmount": [
-                152
+                200
             ],
             "discounts": [
-                42
+                54
             ],
             "entityId": [
-                249
+                301
             ],
             "id": [
-                127
+                175
             ],
             "isTaxIncluded": [
-                22
+                34
             ],
             "lineItems": [
-                52
+                64
             ],
             "locale": [
-                249
+                301
             ],
             "updatedAt": [
-                108
+                154
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CartCustomItem": {
             "entityId": [
-                249
+                301
             ],
             "extendedListPrice": [
-                152
+                200
             ],
             "listPrice": [
-                152
+                200
             ],
             "name": [
-                249
+                301
             ],
             "quantity": [
-                131
+                179
             ],
             "sku": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CartDigitalItem": {
             "brand": [
-                249
+                301
             ],
             "couponAmount": [
-                152
+                200
             ],
             "discountedAmount": [
-                152
+                200
             ],
             "discounts": [
-                42
+                54
             ],
             "entityId": [
-                249
+                301
             ],
             "extendedListPrice": [
-                152
+                200
             ],
             "extendedSalePrice": [
-                152
+                200
             ],
             "imageUrl": [
-                249
+                301
             ],
             "isTaxable": [
-                22
+                34
             ],
             "listPrice": [
-                152
+                200
             ],
             "name": [
-                249
+                301
             ],
             "originalPrice": [
-                152
+                200
             ],
             "parentEntityId": [
-                249
+                301
             ],
             "productEntityId": [
-                131
+                179
             ],
             "quantity": [
-                131
+                179
             ],
             "salePrice": [
-                152
+                200
             ],
             "selectedOptions": [
-                66
+                78
             ],
             "sku": [
-                249
+                301
             ],
             "url": [
-                249
+                301
             ],
             "variantEntityId": [
-                131
+                179
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CartDiscount": {
             "discountedAmount": [
-                152
+                200
             ],
             "entityId": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CartGiftCertificate": {
             "amount": [
-                152
+                200
             ],
             "entityId": [
-                249
+                301
             ],
             "isTaxable": [
-                22
+                34
             ],
             "message": [
-                249
+                301
             ],
             "name": [
-                249
+                301
             ],
             "recipient": [
-                45
+                57
             ],
             "sender": [
-                47
+                59
             ],
             "theme": [
-                49
+                61
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CartGiftCertificateInput": {
             "amount": [
-                15
+                27
             ],
             "message": [
-                249
+                301
             ],
             "name": [
-                249
+                301
             ],
             "quantity": [
-                131
+                179
             ],
             "recipient": [
-                46
+                58
             ],
             "sender": [
-                48
+                60
             ],
             "theme": [
-                49
+                61
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CartGiftCertificateRecipient": {
             "email": [
-                249
+                301
             ],
             "name": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CartGiftCertificateRecipientInput": {
             "email": [
-                249
+                301
             ],
             "name": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CartGiftCertificateSender": {
             "email": [
-                249
+                301
             ],
             "name": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CartGiftCertificateSenderInput": {
             "email": [
-                249
+                301
             ],
             "name": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CartGiftCertificateTheme": {},
         "CartGiftWrapping": {
             "amount": [
-                152
+                200
             ],
             "message": [
-                249
+                301
             ],
             "name": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CartLineItemInput": {
             "productEntityId": [
-                131
+                179
             ],
             "quantity": [
-                131
+                179
             ],
             "selectedOptions": [
-                67
+                79
             ],
             "variantEntityId": [
-                131
+                179
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CartLineItems": {
             "customItems": [
-                40
+                52
             ],
             "digitalItems": [
-                41
+                53
             ],
             "giftCertificates": [
-                43
+                55
             ],
             "physicalItems": [
-                54
+                66
             ],
             "totalQuantity": [
-                131
+                179
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CartMutations": {
@@ -1007,1697 +1121,2426 @@ export default {
                 }
             ],
             "assignCartToCustomer": [
-                8,
+                20,
                 {
                     "input": [
-                        7,
+                        19,
                         "AssignCartToCustomerInput!"
                     ]
                 }
             ],
             "createCart": [
-                92,
+                138,
                 {
                     "input": [
-                        91,
+                        137,
                         "CreateCartInput!"
                     ]
                 }
             ],
             "deleteCart": [
-                112,
+                158,
                 {
                     "input": [
-                        109,
+                        155,
                         "DeleteCartInput!"
                     ]
                 }
             ],
             "deleteCartLineItem": [
-                111,
+                157,
                 {
                     "input": [
-                        110,
+                        156,
                         "DeleteCartLineItemInput!"
                     ]
                 }
             ],
             "unassignCartFromCustomer": [
-                258,
+                313,
                 {
                     "input": [
-                        257,
+                        312,
                         "UnassignCartFromCustomerInput!"
                     ]
                 }
             ],
             "updateCartCurrency": [
-                261,
+                316,
                 {
                     "input": [
-                        260,
+                        315,
                         "UpdateCartCurrencyInput!"
                     ]
                 }
             ],
             "updateCartLineItem": [
-                264,
+                319,
                 {
                     "input": [
-                        263,
+                        318,
                         "UpdateCartLineItemInput!"
                     ]
                 }
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CartPhysicalItem": {
             "brand": [
-                249
+                301
             ],
             "couponAmount": [
-                152
+                200
             ],
             "discountedAmount": [
-                152
+                200
             ],
             "discounts": [
-                42
+                54
             ],
             "entityId": [
-                249
+                301
             ],
             "extendedListPrice": [
-                152
+                200
             ],
             "extendedSalePrice": [
-                152
+                200
             ],
             "giftWrapping": [
-                50
+                62
             ],
             "imageUrl": [
-                249
+                301
             ],
             "isShippingRequired": [
-                22
+                34
             ],
             "isTaxable": [
-                22
+                34
             ],
             "listPrice": [
-                152
+                200
             ],
             "name": [
-                249
+                301
             ],
             "originalPrice": [
-                152
+                200
             ],
             "parentEntityId": [
-                249
+                301
             ],
             "productEntityId": [
-                131
+                179
             ],
             "quantity": [
-                131
+                179
             ],
             "salePrice": [
-                152
+                200
             ],
             "selectedOptions": [
-                66
+                78
             ],
             "sku": [
-                249
+                301
             ],
             "url": [
-                249
+                301
             ],
             "variantEntityId": [
-                131
+                179
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CartSelectedCheckboxOption": {
             "entityId": [
-                131
+                179
             ],
             "name": [
-                249
+                301
             ],
             "value": [
-                249
+                301
             ],
             "valueEntityId": [
-                131
+                179
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CartSelectedCheckboxOptionInput": {
             "optionEntityId": [
-                131
+                179
             ],
             "optionValueEntityId": [
-                131
+                179
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CartSelectedDateFieldOption": {
             "date": [
-                108
+                154
             ],
             "entityId": [
-                131
+                179
             ],
             "name": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CartSelectedDateFieldOptionInput": {
             "date": [
-                107
+                153
             ],
             "optionEntityId": [
-                131
+                179
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CartSelectedFileUploadOption": {
             "entityId": [
-                131
+                179
             ],
             "fileName": [
-                249
+                301
             ],
             "name": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CartSelectedMultiLineTextFieldOption": {
             "entityId": [
-                131
+                179
             ],
             "name": [
-                249
+                301
             ],
             "text": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CartSelectedMultiLineTextFieldOptionInput": {
             "optionEntityId": [
-                131
+                179
             ],
             "text": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CartSelectedMultipleChoiceOption": {
             "entityId": [
-                131
+                179
             ],
             "name": [
-                249
+                301
             ],
             "value": [
-                249
+                301
             ],
             "valueEntityId": [
-                131
+                179
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CartSelectedMultipleChoiceOptionInput": {
             "optionEntityId": [
-                131
+                179
             ],
             "optionValueEntityId": [
-                131
+                179
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CartSelectedNumberFieldOption": {
             "entityId": [
-                131
+                179
             ],
             "name": [
-                249
+                301
             ],
             "number": [
-                123
+                171
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CartSelectedNumberFieldOptionInput": {
             "number": [
-                123
+                171
             ],
             "optionEntityId": [
-                131
+                179
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CartSelectedOption": {
             "entityId": [
-                131
+                179
             ],
             "name": [
-                249
+                301
             ],
             "on_CartSelectedCheckboxOption": [
-                55
+                67
             ],
             "on_CartSelectedDateFieldOption": [
-                57
+                69
             ],
             "on_CartSelectedFileUploadOption": [
-                59
+                71
             ],
             "on_CartSelectedMultiLineTextFieldOption": [
-                60
+                72
             ],
             "on_CartSelectedMultipleChoiceOption": [
-                62
+                74
             ],
             "on_CartSelectedNumberFieldOption": [
-                64
+                76
             ],
             "on_CartSelectedTextFieldOption": [
-                68
+                80
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CartSelectedOptionsInput": {
             "checkboxes": [
-                56
+                68
             ],
             "dateFields": [
-                58
+                70
             ],
             "multiLineTextFields": [
-                61
+                73
             ],
             "multipleChoices": [
-                63
+                75
             ],
             "numberFields": [
-                65
+                77
             ],
             "textFields": [
-                69
+                81
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CartSelectedTextFieldOption": {
             "entityId": [
-                131
+                179
             ],
             "name": [
-                249
+                301
             ],
             "text": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CartSelectedTextFieldOptionInput": {
             "optionEntityId": [
-                131
+                179
             ],
             "text": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "Catalog": {
             "productComparisonsEnabled": [
-                22
+                34
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CatalogProductOption": {
             "displayName": [
-                249
+                301
             ],
             "entityId": [
-                131
+                179
             ],
             "isRequired": [
-                22
+                34
             ],
             "isVariantOption": [
-                22
+                34
             ],
             "on_CheckboxOption": [
-                85
+                97
             ],
             "on_DateFieldOption": [
-                106
+                152
             ],
             "on_FileUploadFieldOption": [
-                122
+                170
             ],
             "on_MultiLineTextFieldOption": [
-                154
+                202
             ],
             "on_MultipleChoiceOption": [
-                155
+                203
             ],
             "on_NumberFieldOption": [
-                160
+                208
             ],
             "on_TextFieldOption": [
-                256
+                308
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CatalogProductOptionValue": {
             "entityId": [
-                131
+                179
             ],
             "isDefault": [
-                22
+                34
             ],
             "isSelected": [
-                22
+                34
             ],
             "label": [
-                249
+                301
             ],
             "on_MultipleChoiceOptionValue": [
-                156
+                204
             ],
             "on_ProductPickListOptionValue": [
-                203
+                252
             ],
             "on_SwatchOptionValue": [
-                253
+                305
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "Category": {
             "breadcrumbs": [
-                33,
+                45,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "depth": [
-                        131,
+                        179,
                         "Int!"
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "defaultImage": [
-                128
+                176
             ],
             "defaultProductSort": [
-                78
+                90
             ],
             "description": [
-                249
+                301
             ],
             "entityId": [
-                131
+                179
             ],
             "id": [
-                127
+                175
             ],
             "metafields": [
-                149,
+                197,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "keys": [
-                        249,
+                        301,
                         "[String!]"
                     ],
                     "last": [
-                        131
+                        179
                     ],
                     "namespace": [
-                        249,
+                        301,
                         "String!"
                     ]
                 }
             ],
             "name": [
-                249
+                301
             ],
             "path": [
-                249
+                301
             ],
             "products": [
-                193,
+                242,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "hideOutOfStock": [
-                        22
+                        34
                     ],
                     "last": [
-                        131
+                        179
                     ],
                     "sortBy": [
-                        78
+                        90
                     ]
                 }
             ],
             "seo": [
-                235
+                287
             ],
             "shopByPriceRanges": [
-                237,
+                289,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "currencyCode": [
-                        286
+                        350
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "includeTax": [
-                        22
+                        34
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CategoryConnection": {
             "edges": [
-                75
+                87
             ],
             "pageInfo": [
-                173
+                222
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CategoryEdge": {
             "cursor": [
-                249
+                301
             ],
             "node": [
-                73
+                85
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CategoryPageBannerConnection": {
             "edges": [
-                77
+                89
             ],
             "pageInfo": [
-                173
+                222
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CategoryPageBannerEdge": {
             "cursor": [
-                249
+                301
             ],
             "node": [
-                10
+                22
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CategoryProductSort": {},
         "CategorySearchFilter": {
             "categories": [
-                81,
+                93,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "displayProductCount": [
-                22
+                34
             ],
             "isCollapsedByDefault": [
-                22
+                34
             ],
             "name": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CategorySearchFilterItem": {
             "entityId": [
-                131
+                179
             ],
             "isSelected": [
-                22
+                34
             ],
             "name": [
-                249
+                301
             ],
             "productCount": [
-                131
+                179
             ],
             "subCategories": [
-                251,
+                303,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CategorySearchFilterItemConnection": {
             "edges": [
-                82
+                94
             ],
             "pageInfo": [
-                173
+                222
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CategorySearchFilterItemEdge": {
             "cursor": [
-                249
+                301
             ],
             "node": [
-                80
+                92
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CategoryTreeItem": {
             "children": [
-                83
+                95
             ],
             "description": [
-                249
+                301
             ],
             "entityId": [
-                131
+                179
             ],
             "hasChildren": [
-                22
+                34
             ],
             "image": [
-                128
+                176
             ],
             "name": [
-                249
+                301
             ],
             "path": [
-                249
+                301
             ],
             "productCount": [
-                131
+                179
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "Channel": {
             "entityId": [
-                147
+                195
             ],
             "metafields": [
-                149,
+                197,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "keys": [
-                        249,
+                        301,
                         "[String!]"
                     ],
                     "last": [
-                        131
+                        179
                     ],
                     "namespace": [
-                        249,
+                        301,
                         "String!"
                     ]
                 }
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CheckboxOption": {
             "checkedByDefault": [
-                22
+                34
             ],
             "displayName": [
-                249
+                301
             ],
             "entityId": [
-                131
+                179
             ],
             "isRequired": [
-                22
+                34
             ],
             "isVariantOption": [
-                22
+                34
             ],
             "label": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
+            ]
+        },
+        "Checkout": {
+            "billingAddress": [
+                116
+            ],
+            "cart": [
+                51
+            ],
+            "coupons": [
+                119
+            ],
+            "createdAt": [
+                154
+            ],
+            "customerMessage": [
+                301
+            ],
+            "entityId": [
+                301
+            ],
+            "giftWrappingCostTotal": [
+                200
+            ],
+            "grandTotal": [
+                200
+            ],
+            "handlingCostTotal": [
+                200
+            ],
+            "id": [
+                175
+            ],
+            "order": [
+                217
+            ],
+            "outstandingBalance": [
+                200
+            ],
+            "promotions": [
+                121
+            ],
+            "shippingConsignments": [
+                127
+            ],
+            "shippingCostTotal": [
+                200
+            ],
+            "subtotal": [
+                200
+            ],
+            "taxTotal": [
+                200
+            ],
+            "taxes": [
+                129
+            ],
+            "updatedAt": [
+                154
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "CheckoutAddress": {
+            "address1": [
+                301
+            ],
+            "address2": [
+                301
+            ],
+            "city": [
+                301
+            ],
+            "company": [
+                301
+            ],
+            "countryCode": [
+                301
+            ],
+            "customFields": [
+                102
+            ],
+            "email": [
+                301
+            ],
+            "firstName": [
+                301
+            ],
+            "lastName": [
+                301
+            ],
+            "phone": [
+                301
+            ],
+            "postalCode": [
+                301
+            ],
+            "stateOrProvince": [
+                301
+            ],
+            "stateOrProvinceCode": [
+                301
+            ],
+            "on_CheckoutBillingAddress": [
+                116
+            ],
+            "on_CheckoutConsignmentAddress": [
+                117
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "CheckoutAddressCheckboxesCustomField": {
+            "entityId": [
+                179
+            ],
+            "valueEntityIds": [
+                179
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "CheckoutAddressCheckboxesCustomFieldInput": {
+            "fieldEntityId": [
+                179
+            ],
+            "fieldValueEntityIds": [
+                179
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "CheckoutAddressCustomField": {
+            "entityId": [
+                179
+            ],
+            "on_CheckoutAddressCheckboxesCustomField": [
+                100
+            ],
+            "on_CheckoutAddressDateCustomField": [
+                104
+            ],
+            "on_CheckoutAddressMultipleChoiceCustomField": [
+                107
+            ],
+            "on_CheckoutAddressNumberCustomField": [
+                109
+            ],
+            "on_CheckoutAddressPasswordCustomField": [
+                111
+            ],
+            "on_CheckoutAddressTextFieldCustomField": [
+                114
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "CheckoutAddressCustomFieldInput": {
+            "checkboxes": [
+                101
+            ],
+            "dates": [
+                105
+            ],
+            "multipleChoices": [
+                108
+            ],
+            "numbers": [
+                110
+            ],
+            "passwords": [
+                112
+            ],
+            "texts": [
+                113
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "CheckoutAddressDateCustomField": {
+            "date": [
+                154
+            ],
+            "entityId": [
+                179
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "CheckoutAddressDateCustomFieldInput": {
+            "date": [
+                153
+            ],
+            "fieldEntityId": [
+                179
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "CheckoutAddressInput": {
+            "address1": [
+                301
+            ],
+            "address2": [
+                301
+            ],
+            "city": [
+                301
+            ],
+            "company": [
+                301
+            ],
+            "countryCode": [
+                301
+            ],
+            "customFields": [
+                103
+            ],
+            "email": [
+                301
+            ],
+            "firstName": [
+                301
+            ],
+            "lastName": [
+                301
+            ],
+            "phone": [
+                301
+            ],
+            "postalCode": [
+                301
+            ],
+            "shouldSaveAddress": [
+                34
+            ],
+            "stateOrProvince": [
+                301
+            ],
+            "stateOrProvinceCode": [
+                301
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "CheckoutAddressMultipleChoiceCustomField": {
+            "entityId": [
+                179
+            ],
+            "valueEntityId": [
+                179
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "CheckoutAddressMultipleChoiceCustomFieldInput": {
+            "fieldEntityId": [
+                179
+            ],
+            "fieldValueEntityId": [
+                179
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "CheckoutAddressNumberCustomField": {
+            "entityId": [
+                179
+            ],
+            "number": [
+                171
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "CheckoutAddressNumberCustomFieldInput": {
+            "fieldEntityId": [
+                179
+            ],
+            "number": [
+                171
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "CheckoutAddressPasswordCustomField": {
+            "entityId": [
+                179
+            ],
+            "password": [
+                301
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "CheckoutAddressPasswordCustomFieldInput": {
+            "fieldEntityId": [
+                179
+            ],
+            "password": [
+                301
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "CheckoutAddressTextCustomFieldInput": {
+            "fieldEntityId": [
+                179
+            ],
+            "text": [
+                301
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "CheckoutAddressTextFieldCustomField": {
+            "entityId": [
+                179
+            ],
+            "text": [
+                301
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "CheckoutAvailableShippingOption": {
+            "cost": [
+                200
+            ],
+            "description": [
+                301
+            ],
+            "entityId": [
+                301
+            ],
+            "imageUrl": [
+                301
+            ],
+            "isRecommended": [
+                34
+            ],
+            "transitTime": [
+                301
+            ],
+            "type": [
+                301
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "CheckoutBillingAddress": {
+            "address1": [
+                301
+            ],
+            "address2": [
+                301
+            ],
+            "city": [
+                301
+            ],
+            "company": [
+                301
+            ],
+            "countryCode": [
+                301
+            ],
+            "customFields": [
+                102
+            ],
+            "email": [
+                301
+            ],
+            "entityId": [
+                301
+            ],
+            "firstName": [
+                301
+            ],
+            "lastName": [
+                301
+            ],
+            "phone": [
+                301
+            ],
+            "postalCode": [
+                301
+            ],
+            "stateOrProvince": [
+                301
+            ],
+            "stateOrProvinceCode": [
+                301
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "CheckoutConsignmentAddress": {
+            "address1": [
+                301
+            ],
+            "address2": [
+                301
+            ],
+            "city": [
+                301
+            ],
+            "company": [
+                301
+            ],
+            "countryCode": [
+                301
+            ],
+            "customFields": [
+                102
+            ],
+            "email": [
+                301
+            ],
+            "firstName": [
+                301
+            ],
+            "lastName": [
+                301
+            ],
+            "phone": [
+                301
+            ],
+            "postalCode": [
+                301
+            ],
+            "stateOrProvince": [
+                301
+            ],
+            "stateOrProvinceCode": [
+                301
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "CheckoutConsignmentLineItemInput": {
+            "lineItemEntityId": [
+                301
+            ],
+            "quantity": [
+                179
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "CheckoutCoupon": {
+            "code": [
+                301
+            ],
+            "couponType": [
+                136
+            ],
+            "discountedAmount": [
+                200
+            ],
+            "entityId": [
+                179
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "CheckoutMutations": {
+            "addCheckoutBillingAddress": [
+                5,
+                {
+                    "input": [
+                        4,
+                        "AddCheckoutBillingAddressInput!"
+                    ]
+                }
+            ],
+            "addCheckoutShippingConsignments": [
+                8,
+                {
+                    "input": [
+                        7,
+                        "AddCheckoutShippingConsignmentsInput!"
+                    ]
+                }
+            ],
+            "applyCheckoutCoupon": [
+                15,
+                {
+                    "input": [
+                        14,
+                        "ApplyCheckoutCouponInput!"
+                    ]
+                }
+            ],
+            "applyCheckoutSpamProtection": [
+                18,
+                {
+                    "input": [
+                        17,
+                        "ApplyCheckoutSpamProtectionInput!"
+                    ]
+                }
+            ],
+            "completeCheckout": [
+                132,
+                {
+                    "input": [
+                        131,
+                        "CompleteCheckoutInput!"
+                    ]
+                }
+            ],
+            "deleteCheckoutConsignment": [
+                160,
+                {
+                    "input": [
+                        159,
+                        "DeleteCheckoutConsignmentInput!"
+                    ]
+                }
+            ],
+            "selectCheckoutShippingOption": [
+                286,
+                {
+                    "input": [
+                        285,
+                        "SelectCheckoutShippingOptionInput!"
+                    ]
+                }
+            ],
+            "unapplyCheckoutCoupon": [
+                311,
+                {
+                    "input": [
+                        310,
+                        "UnapplyCheckoutCouponInput!"
+                    ]
+                }
+            ],
+            "updateCheckoutBillingAddress": [
+                322,
+                {
+                    "input": [
+                        321,
+                        "UpdateCheckoutBillingAddressInput!"
+                    ]
+                }
+            ],
+            "updateCheckoutCustomerMessage": [
+                325,
+                {
+                    "input": [
+                        324,
+                        "UpdateCheckoutCustomerMessageInput!"
+                    ]
+                }
+            ],
+            "updateCheckoutShippingConsignment": [
+                328,
+                {
+                    "input": [
+                        327,
+                        "UpdateCheckoutShippingConsignmentInput!"
+                    ]
+                }
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "CheckoutPromotion": {
+            "banners": [
+                122
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "CheckoutPromotionBanner": {
+            "entityId": [
+                179
+            ],
+            "locations": [
+                123
+            ],
+            "text": [
+                301
+            ],
+            "type": [
+                124
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "CheckoutPromotionBannerLocation": {},
+        "CheckoutPromotionBannerType": {},
+        "CheckoutSelectedShippingOption": {
+            "cost": [
+                200
+            ],
+            "description": [
+                301
+            ],
+            "entityId": [
+                301
+            ],
+            "imageUrl": [
+                301
+            ],
+            "transitTime": [
+                301
+            ],
+            "type": [
+                301
+            ],
+            "__typename": [
+                301
             ]
         },
         "CheckoutSettings": {
             "reCaptchaEnabled": [
-                22
+                34
             ],
             "__typename": [
-                249
+                301
+            ]
+        },
+        "CheckoutShippingConsignment": {
+            "address": [
+                117
+            ],
+            "availableShippingOptions": [
+                115
+            ],
+            "coupons": [
+                119
+            ],
+            "entityId": [
+                301
+            ],
+            "handlingCost": [
+                200
+            ],
+            "lineItemIds": [
+                301
+            ],
+            "selectedShippingOption": [
+                125
+            ],
+            "shippingCost": [
+                200
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "CheckoutShippingConsignmentInput": {
+            "address": [
+                106
+            ],
+            "lineItems": [
+                118
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "CheckoutTax": {
+            "amount": [
+                200
+            ],
+            "name": [
+                301
+            ],
+            "__typename": [
+                301
             ]
         },
         "CollectionInfo": {
             "totalItems": [
-                147
+                195
             ],
             "__typename": [
-                249
+                301
+            ]
+        },
+        "CompleteCheckoutInput": {
+            "checkoutEntityId": [
+                301
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "CompleteCheckoutResult": {
+            "orderEntityId": [
+                179
+            ],
+            "paymentAccessToken": [
+                301
+            ],
+            "__typename": [
+                301
             ]
         },
         "ContactField": {
             "address": [
-                249
+                301
             ],
             "addressType": [
-                249
+                301
             ],
             "country": [
-                249
+                301
             ],
             "email": [
-                249
+                301
             ],
             "phone": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "ContactPage": {
             "contactFields": [
-                249
+                301
             ],
             "entityId": [
-                131
+                179
             ],
             "htmlBody": [
-                249
+                301
             ],
             "id": [
-                127
+                175
             ],
             "isVisibleInNavigation": [
-                22
+                34
             ],
             "name": [
-                249
+                301
             ],
             "parentEntityId": [
-                131
+                179
             ],
             "path": [
-                249
+                301
             ],
             "plainTextSummary": [
-                249,
+                301,
                 {
                     "characterLimit": [
-                        131
+                        179
                     ]
                 }
             ],
             "renderedRegions": [
-                221
+                270
             ],
             "seo": [
-                235
+                287
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "Content": {
             "banners": [
-                14
+                26
             ],
             "blog": [
-                16
+                28
             ],
             "page": [
-                272,
+                336,
                 {
                     "entityId": [
-                        131,
+                        179,
                         "Int!"
                     ]
                 }
             ],
             "pages": [
-                171,
+                220,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "filters": [
-                        274
+                        338
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "renderedRegionsByPageType": [
-                221,
+                270,
                 {
                     "pageType": [
-                        174,
+                        223,
                         "PageType!"
                     ]
                 }
             ],
             "renderedRegionsByPageTypeAndEntityId": [
-                221,
+                270,
                 {
                     "entityId": [
-                        147,
+                        195,
                         "Long!"
                     ],
                     "entityPageType": [
-                        120,
+                        168,
                         "EntityPageType!"
                     ]
                 }
             ],
             "__typename": [
-                249
+                301
             ]
         },
+        "CouponType": {},
         "CreateCartInput": {
             "currencyCode": [
-                249
+                301
             ],
             "giftCertificates": [
-                44
+                56
             ],
             "lineItems": [
-                51
+                63
             ],
             "locale": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CreateCartResult": {
             "cart": [
-                39
+                51
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CreateWishlistInput": {
             "isPublic": [
-                22
+                34
             ],
             "items": [
-                282
+                346
             ],
             "name": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CreateWishlistResult": {
             "result": [
-                275
+                339
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "Currency": {
             "code": [
-                286
+                350
             ],
             "display": [
-                97
+                143
             ],
             "entityId": [
-                131
+                179
             ],
             "exchangeRate": [
-                123
+                171
             ],
             "flagImage": [
-                249
+                301
             ],
             "isActive": [
-                22
+                34
             ],
             "isTransactional": [
-                22
+                34
             ],
             "name": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CurrencyConnection": {
             "edges": [
-                98
+                144
             ],
             "pageInfo": [
-                173
+                222
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CurrencyDisplay": {
             "decimalPlaces": [
-                131
+                179
             ],
             "decimalToken": [
-                249
+                301
             ],
             "symbol": [
-                249
+                301
             ],
             "symbolPlacement": [
-                99
+                145
             ],
             "thousandsToken": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CurrencyEdge": {
             "cursor": [
-                249
+                301
             ],
             "node": [
-                95
+                141
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CurrencySymbolPosition": {},
         "CustomField": {
             "entityId": [
-                131
+                179
             ],
             "name": [
-                249
+                301
             ],
             "value": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CustomFieldConnection": {
             "edges": [
-                102
+                148
             ],
             "pageInfo": [
-                173
+                222
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CustomFieldEdge": {
             "cursor": [
-                249
+                301
             ],
             "node": [
-                100
+                146
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "Customer": {
             "addressCount": [
-                131
+                179
             ],
             "attributeCount": [
-                131
+                179
             ],
             "attributes": [
-                105
+                151
             ],
             "company": [
-                249
+                301
             ],
             "customerGroupId": [
-                131
+                179
             ],
             "email": [
-                249
+                301
             ],
             "entityId": [
-                131
+                179
             ],
             "firstName": [
-                249
+                301
             ],
             "lastName": [
-                249
+                301
             ],
             "notes": [
-                249
+                301
             ],
             "phone": [
-                249
+                301
             ],
             "storeCredit": [
-                152
+                200
             ],
             "taxExemptCategory": [
-                249
+                301
             ],
             "wishlists": [
-                276,
+                340,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "filters": [
-                        278
+                        342
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CustomerAttribute": {
             "entityId": [
-                131
+                179
             ],
             "name": [
-                249
+                301
             ],
             "value": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "CustomerAttributes": {
             "attribute": [
-                104,
+                150,
                 {
                     "entityId": [
-                        131,
+                        179,
                         "Int!"
                     ]
                 }
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "DateFieldOption": {
             "defaultValue": [
-                107
+                153
             ],
             "displayName": [
-                249
+                301
             ],
             "earliest": [
-                107
+                153
             ],
             "entityId": [
-                131
+                179
             ],
             "isRequired": [
-                22
+                34
             ],
             "isVariantOption": [
-                22
+                34
             ],
             "latest": [
-                107
+                153
             ],
             "limitDateBy": [
-                140
+                188
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "DateTime": {},
         "DateTimeExtended": {
             "utc": [
-                107
+                153
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "DeleteCartInput": {
             "cartEntityId": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "DeleteCartLineItemInput": {
             "cartEntityId": [
-                249
+                301
             ],
             "lineItemEntityId": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "DeleteCartLineItemResult": {
             "cart": [
-                39
+                51
             ],
             "deletedCartEntityId": [
-                249
+                301
             ],
             "deletedLineItemEntityId": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "DeleteCartResult": {
             "deletedCartEntityId": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
+            ]
+        },
+        "DeleteCheckoutConsignmentInput": {
+            "checkoutEntityId": [
+                301
+            ],
+            "consignmentEntityId": [
+                301
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "DeleteCheckoutConsignmentResult": {
+            "checkout": [
+                98
+            ],
+            "__typename": [
+                301
             ]
         },
         "DeleteWishlistItemsInput": {
             "entityId": [
-                131
+                179
             ],
             "itemEntityIds": [
-                131
+                179
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "DeleteWishlistItemsResult": {
             "result": [
-                275
+                339
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "DeleteWishlistResult": {
             "result": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "DeleteWishlistsInput": {
             "entityIds": [
-                131
+                179
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "DisplayField": {
             "extendedDateFormat": [
-                249
+                301
             ],
             "shortDateFormat": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "Distance": {
             "lengthUnit": [
-                139
+                187
             ],
             "value": [
-                123
+                171
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "DistanceFilter": {
             "latitude": [
-                123
+                171
             ],
             "lengthUnit": [
-                139
+                187
             ],
             "longitude": [
-                123
+                171
             ],
             "radius": [
-                123
+                171
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "EntityPageType": {},
         "ExternalLinkPage": {
             "entityId": [
-                131
+                179
             ],
             "isVisibleInNavigation": [
-                22
+                34
             ],
             "link": [
-                249
+                301
             ],
             "name": [
-                249
+                301
             ],
             "parentEntityId": [
-                131
+                179
             ],
             "seo": [
-                235
+                287
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "FileUploadFieldOption": {
             "displayName": [
-                249
+                301
             ],
             "entityId": [
-                131
+                179
             ],
             "fileTypes": [
-                249
+                301
             ],
             "isRequired": [
-                22
+                34
             ],
             "isVariantOption": [
-                22
+                34
             ],
             "maxFileSize": [
-                131
+                179
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "Float": {},
         "GiftWrapping": {
             "allowComments": [
-                22
+                34
             ],
             "entityId": [
-                131
+                179
             ],
             "name": [
-                249
+                301
             ],
             "previewImageUrl": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "GiftWrappingConnection": {
             "edges": [
-                126
+                174
             ],
             "pageInfo": [
-                173
+                222
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "GiftWrappingEdge": {
             "cursor": [
-                249
+                301
             ],
             "node": [
-                124
+                172
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "ID": {},
         "Image": {
             "altText": [
-                249
+                301
             ],
             "isDefault": [
-                22
+                34
             ],
             "url": [
-                249,
+                301,
                 {
                     "height": [
-                        131
+                        179
                     ],
                     "width": [
-                        131,
+                        179,
                         "Int!"
                     ]
                 }
             ],
             "urlOriginal": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "ImageConnection": {
             "edges": [
-                130
+                178
             ],
             "pageInfo": [
-                173
+                222
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "ImageEdge": {
             "cursor": [
-                249
+                301
             ],
             "node": [
-                128
+                176
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "Int": {},
         "Inventory": {
             "locations": [
-                136,
+                184,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "cities": [
-                        249,
+                        301,
                         "[String!]"
                     ],
                     "codes": [
-                        249,
+                        301,
                         "[String!]"
                     ],
                     "countryCodes": [
-                        285,
+                        349,
                         "[countryCode!]"
                     ],
                     "distanceFilter": [
-                        119
+                        167
                     ],
                     "entityIds": [
-                        131,
+                        179,
                         "[Int!]"
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "last": [
-                        131
+                        179
                     ],
                     "serviceTypeIds": [
-                        249,
+                        301,
                         "[String!]"
                     ],
                     "states": [
-                        249,
+                        301,
                         "[String!]"
                     ],
                     "typeIds": [
-                        249,
+                        301,
                         "[String!]"
                     ]
                 }
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "InventoryAddress": {
             "address1": [
-                249
+                301
             ],
             "address2": [
-                249
+                301
             ],
             "city": [
-                249
+                301
             ],
             "code": [
-                249
+                301
             ],
             "countryCode": [
-                249
+                301
             ],
             "description": [
-                249
+                301
             ],
             "email": [
-                249
+                301
             ],
             "entityId": [
-                131
+                179
             ],
             "label": [
-                249
+                301
             ],
             "latitude": [
-                123
+                171
             ],
             "longitude": [
-                123
+                171
             ],
             "phone": [
-                249
+                301
             ],
             "postalCode": [
-                249
+                301
             ],
             "stateOrProvince": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "InventoryByLocations": {
             "availableToSell": [
-                147
+                195
             ],
             "isInStock": [
-                22
+                34
             ],
             "locationDistance": [
-                118
+                166
             ],
             "locationEntityCode": [
-                249
+                301
             ],
             "locationEntityId": [
-                147
+                195
             ],
             "locationEntityServiceTypeIds": [
-                249
+                301
             ],
             "locationEntityTypeId": [
-                249
+                301
             ],
             "warningLevel": [
-                131
+                179
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "InventoryLocation": {
             "address": [
-                133
+                181
             ],
             "blackoutHours": [
-                242
+                294
             ],
             "code": [
-                249
+                301
             ],
             "description": [
-                249
+                301
             ],
             "distance": [
-                118
+                166
             ],
             "entityId": [
-                131
+                179
             ],
             "label": [
-                249
+                301
             ],
             "metafields": [
-                149,
+                197,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "keys": [
-                        249,
+                        301,
                         "[String!]"
                     ],
                     "last": [
-                        131
+                        179
                     ],
                     "namespace": [
-                        249,
+                        301,
                         "String!"
                     ]
                 }
             ],
             "operatingHours": [
-                162
+                210
             ],
             "serviceTypeIds": [
-                249
+                301
             ],
             "specialHours": [
-                242
+                294
             ],
             "timeZone": [
-                249
+                301
             ],
             "typeId": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "InventoryLocationConnection": {
             "edges": [
-                137
+                185
             ],
             "pageInfo": [
-                173
+                222
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "InventoryLocationEdge": {
             "cursor": [
-                249
+                301
             ],
             "node": [
-                135
+                183
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "InventorySettings": {
             "defaultOutOfStockMessage": [
-                249
+                301
             ],
             "hideInProductFiltering": [
-                22
+                34
             ],
             "optionOutOfStockBehavior": [
-                165
+                213
             ],
             "productOutOfStockBehavior": [
-                202
+                251
             ],
             "showOutOfStockMessage": [
-                22
+                34
             ],
             "showPreOrderStockLevels": [
-                22
+                34
             ],
             "stockLevelDisplay": [
-                243
+                295
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "LengthUnit": {},
@@ -2705,2758 +3548,2927 @@ export default {
         "LimitInputBy": {},
         "LocationConnection": {
             "edges": [
-                143
+                191
             ],
             "pageInfo": [
-                173
+                222
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "LocationEdge": {
             "cursor": [
-                249
+                301
             ],
             "node": [
-                134
+                182
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "LoginResult": {
             "customer": [
-                103
+                149
             ],
             "result": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "LogoField": {
             "image": [
-                128
+                176
             ],
             "title": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "LogoutResult": {
             "result": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "Long": {},
         "Measurement": {
             "unit": [
-                249
+                301
             ],
             "value": [
-                123
+                171
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "MetafieldConnection": {
             "edges": [
-                150
+                198
             ],
             "pageInfo": [
-                173
+                222
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "MetafieldEdge": {
             "cursor": [
-                249
-            ],
-            "node": [
-                151
-            ],
-            "__typename": [
-                249
-            ]
-        },
-        "Metafields": {
-            "entityId": [
-                131
-            ],
-            "id": [
-                127
-            ],
-            "key": [
-                249
-            ],
-            "value": [
-                249
-            ],
-            "__typename": [
-                249
-            ]
-        },
-        "Money": {
-            "currencyCode": [
-                249
-            ],
-            "formatted": [
-                249
-            ],
-            "value": [
-                15
-            ],
-            "__typename": [
-                249
-            ]
-        },
-        "MoneyRange": {
-            "max": [
-                152
-            ],
-            "min": [
-                152
-            ],
-            "__typename": [
-                249
-            ]
-        },
-        "MultiLineTextFieldOption": {
-            "defaultValue": [
-                249
-            ],
-            "displayName": [
-                249
-            ],
-            "entityId": [
-                131
-            ],
-            "isRequired": [
-                22
-            ],
-            "isVariantOption": [
-                22
-            ],
-            "maxLength": [
-                131
-            ],
-            "maxLines": [
-                131
-            ],
-            "minLength": [
-                131
-            ],
-            "__typename": [
-                249
-            ]
-        },
-        "MultipleChoiceOption": {
-            "displayName": [
-                249
-            ],
-            "displayStyle": [
-                249
-            ],
-            "entityId": [
-                131
-            ],
-            "isRequired": [
-                22
-            ],
-            "isVariantOption": [
-                22
-            ],
-            "values": [
-                200,
-                {
-                    "after": [
-                        249
-                    ],
-                    "before": [
-                        249
-                    ],
-                    "first": [
-                        131
-                    ],
-                    "last": [
-                        131
-                    ]
-                }
-            ],
-            "__typename": [
-                249
-            ]
-        },
-        "MultipleChoiceOptionValue": {
-            "entityId": [
-                131
-            ],
-            "isDefault": [
-                22
-            ],
-            "isSelected": [
-                22
-            ],
-            "label": [
-                249
-            ],
-            "__typename": [
-                249
-            ]
-        },
-        "Mutation": {
-            "cart": [
-                53
-            ],
-            "login": [
-                144,
-                {
-                    "email": [
-                        249,
-                        "String!"
-                    ],
-                    "password": [
-                        249,
-                        "String!"
-                    ]
-                }
-            ],
-            "logout": [
-                146
-            ],
-            "wishlist": [
-                283
-            ],
-            "__typename": [
-                249
-            ]
-        },
-        "Node": {
-            "id": [
-                127
-            ],
-            "on_Banner": [
-                10
-            ],
-            "on_Blog": [
-                16
-            ],
-            "on_BlogPost": [
-                18
-            ],
-            "on_Brand": [
-                23
-            ],
-            "on_Cart": [
-                39
-            ],
-            "on_Category": [
-                73
-            ],
-            "on_ContactPage": [
-                89
-            ],
-            "on_NormalPage": [
-                159
-            ],
-            "on_Product": [
-                183
-            ],
-            "on_RawHtmlPage": [
-                216
-            ],
-            "on_Variant": [
-                268
-            ],
-            "__typename": [
-                249
-            ]
-        },
-        "NormalPage": {
-            "entityId": [
-                131
-            ],
-            "htmlBody": [
-                249
-            ],
-            "id": [
-                127
-            ],
-            "isVisibleInNavigation": [
-                22
-            ],
-            "name": [
-                249
-            ],
-            "parentEntityId": [
-                131
-            ],
-            "path": [
-                249
-            ],
-            "plainTextSummary": [
-                249,
-                {
-                    "characterLimit": [
-                        131
-                    ]
-                }
-            ],
-            "renderedRegions": [
-                221
-            ],
-            "seo": [
-                235
-            ],
-            "__typename": [
-                249
-            ]
-        },
-        "NumberFieldOption": {
-            "defaultValue": [
-                123
-            ],
-            "displayName": [
-                249
-            ],
-            "entityId": [
-                131
-            ],
-            "highest": [
-                123
-            ],
-            "isIntegerOnly": [
-                22
-            ],
-            "isRequired": [
-                22
-            ],
-            "isVariantOption": [
-                22
-            ],
-            "limitNumberBy": [
-                141
-            ],
-            "lowest": [
-                123
-            ],
-            "__typename": [
-                249
-            ]
-        },
-        "OperatingDay": {
-            "closing": [
-                249
-            ],
-            "open": [
-                22
-            ],
-            "opening": [
-                249
-            ],
-            "__typename": [
-                249
-            ]
-        },
-        "OperatingHours": {
-            "friday": [
-                161
-            ],
-            "monday": [
-                161
-            ],
-            "saturday": [
-                161
-            ],
-            "sunday": [
-                161
-            ],
-            "thursday": [
-                161
-            ],
-            "tuesday": [
-                161
-            ],
-            "wednesday": [
-                161
-            ],
-            "__typename": [
-                249
-            ]
-        },
-        "OptionConnection": {
-            "edges": [
-                164
-            ],
-            "pageInfo": [
-                173
-            ],
-            "__typename": [
-                249
-            ]
-        },
-        "OptionEdge": {
-            "cursor": [
-                249
-            ],
-            "node": [
-                196
-            ],
-            "__typename": [
-                249
-            ]
-        },
-        "OptionOutOfStockBehavior": {},
-        "OptionValueConnection": {
-            "edges": [
-                167
-            ],
-            "pageInfo": [
-                173
-            ],
-            "__typename": [
-                249
-            ]
-        },
-        "OptionValueEdge": {
-            "cursor": [
-                249
+                301
             ],
             "node": [
                 199
             ],
             "__typename": [
-                249
+                301
+            ]
+        },
+        "Metafields": {
+            "entityId": [
+                179
+            ],
+            "id": [
+                175
+            ],
+            "key": [
+                301
+            ],
+            "value": [
+                301
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "Money": {
+            "currencyCode": [
+                301
+            ],
+            "formatted": [
+                301
+            ],
+            "value": [
+                27
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "MoneyRange": {
+            "max": [
+                200
+            ],
+            "min": [
+                200
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "MultiLineTextFieldOption": {
+            "defaultValue": [
+                301
+            ],
+            "displayName": [
+                301
+            ],
+            "entityId": [
+                179
+            ],
+            "isRequired": [
+                34
+            ],
+            "isVariantOption": [
+                34
+            ],
+            "maxLength": [
+                179
+            ],
+            "maxLines": [
+                179
+            ],
+            "minLength": [
+                179
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "MultipleChoiceOption": {
+            "displayName": [
+                301
+            ],
+            "displayStyle": [
+                301
+            ],
+            "entityId": [
+                179
+            ],
+            "isRequired": [
+                34
+            ],
+            "isVariantOption": [
+                34
+            ],
+            "values": [
+                249,
+                {
+                    "after": [
+                        301
+                    ],
+                    "before": [
+                        301
+                    ],
+                    "first": [
+                        179
+                    ],
+                    "last": [
+                        179
+                    ]
+                }
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "MultipleChoiceOptionValue": {
+            "entityId": [
+                179
+            ],
+            "isDefault": [
+                34
+            ],
+            "isSelected": [
+                34
+            ],
+            "label": [
+                301
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "Mutation": {
+            "cart": [
+                65
+            ],
+            "checkout": [
+                120
+            ],
+            "login": [
+                192,
+                {
+                    "email": [
+                        301,
+                        "String!"
+                    ],
+                    "password": [
+                        301,
+                        "String!"
+                    ]
+                }
+            ],
+            "logout": [
+                194
+            ],
+            "wishlist": [
+                347
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "Node": {
+            "id": [
+                175
+            ],
+            "on_Banner": [
+                22
+            ],
+            "on_Blog": [
+                28
+            ],
+            "on_BlogPost": [
+                30
+            ],
+            "on_Brand": [
+                35
+            ],
+            "on_Cart": [
+                51
+            ],
+            "on_Category": [
+                85
+            ],
+            "on_Checkout": [
+                98
+            ],
+            "on_ContactPage": [
+                134
+            ],
+            "on_NormalPage": [
+                207
+            ],
+            "on_Product": [
+                232
+            ],
+            "on_RawHtmlPage": [
+                265
+            ],
+            "on_Variant": [
+                332
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "NormalPage": {
+            "entityId": [
+                179
+            ],
+            "htmlBody": [
+                301
+            ],
+            "id": [
+                175
+            ],
+            "isVisibleInNavigation": [
+                34
+            ],
+            "name": [
+                301
+            ],
+            "parentEntityId": [
+                179
+            ],
+            "path": [
+                301
+            ],
+            "plainTextSummary": [
+                301,
+                {
+                    "characterLimit": [
+                        179
+                    ]
+                }
+            ],
+            "renderedRegions": [
+                270
+            ],
+            "seo": [
+                287
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "NumberFieldOption": {
+            "defaultValue": [
+                171
+            ],
+            "displayName": [
+                301
+            ],
+            "entityId": [
+                179
+            ],
+            "highest": [
+                171
+            ],
+            "isIntegerOnly": [
+                34
+            ],
+            "isRequired": [
+                34
+            ],
+            "isVariantOption": [
+                34
+            ],
+            "limitNumberBy": [
+                189
+            ],
+            "lowest": [
+                171
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "OperatingDay": {
+            "closing": [
+                301
+            ],
+            "open": [
+                34
+            ],
+            "opening": [
+                301
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "OperatingHours": {
+            "friday": [
+                209
+            ],
+            "monday": [
+                209
+            ],
+            "saturday": [
+                209
+            ],
+            "sunday": [
+                209
+            ],
+            "thursday": [
+                209
+            ],
+            "tuesday": [
+                209
+            ],
+            "wednesday": [
+                209
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "OptionConnection": {
+            "edges": [
+                212
+            ],
+            "pageInfo": [
+                222
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "OptionEdge": {
+            "cursor": [
+                301
+            ],
+            "node": [
+                245
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "OptionOutOfStockBehavior": {},
+        "OptionValueConnection": {
+            "edges": [
+                215
+            ],
+            "pageInfo": [
+                222
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "OptionValueEdge": {
+            "cursor": [
+                301
+            ],
+            "node": [
+                248
+            ],
+            "__typename": [
+                301
             ]
         },
         "OptionValueId": {
             "optionEntityId": [
-                131
+                179
             ],
             "valueEntityId": [
-                131
+                179
             ],
             "__typename": [
-                249
+                301
+            ]
+        },
+        "Order": {
+            "entityId": [
+                179
+            ],
+            "__typename": [
+                301
             ]
         },
         "OtherSearchFilter": {
             "displayProductCount": [
-                22
+                34
             ],
             "freeShipping": [
-                170
+                219
             ],
             "isCollapsedByDefault": [
-                22
+                34
             ],
             "isFeatured": [
-                170
+                219
             ],
             "isInStock": [
-                170
+                219
             ],
             "name": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "OtherSearchFilterItem": {
             "isSelected": [
-                22
+                34
             ],
             "productCount": [
-                131
+                179
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "PageConnection": {
             "edges": [
-                172
+                221
             ],
             "pageInfo": [
-                173
+                222
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "PageEdge": {
             "cursor": [
-                249
+                301
             ],
             "node": [
-                272
+                336
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "PageInfo": {
             "endCursor": [
-                249
+                301
             ],
             "hasNextPage": [
-                22
+                34
             ],
             "hasPreviousPage": [
-                22
+                34
             ],
             "startCursor": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "PageType": {},
         "PopularBrandConnection": {
             "edges": [
-                176
+                225
             ],
             "pageInfo": [
-                173
+                222
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "PopularBrandEdge": {
             "cursor": [
-                249
+                301
             ],
             "node": [
-                177
+                226
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "PopularBrandType": {
             "count": [
-                131
+                179
             ],
             "entityId": [
-                131
+                179
             ],
             "name": [
-                249
+                301
             ],
             "path": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "PriceRanges": {
             "priceRange": [
-                153
+                201
             ],
             "retailPriceRange": [
-                153
+                201
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "PriceSearchFilter": {
             "isCollapsedByDefault": [
-                22
+                34
             ],
             "name": [
-                249
+                301
             ],
             "selected": [
-                181
+                230
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "PriceSearchFilterInput": {
             "maxPrice": [
-                123
+                171
             ],
             "minPrice": [
-                123
+                171
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "PriceSearchFilterItem": {
             "maxPrice": [
-                123
+                171
             ],
             "minPrice": [
-                123
+                171
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "Prices": {
             "basePrice": [
-                152
+                200
             ],
             "bulkPricing": [
-                38
+                50
             ],
             "mapPrice": [
-                152
+                200
             ],
             "price": [
-                152
+                200
             ],
             "priceRange": [
-                153
+                201
             ],
             "retailPrice": [
-                152
+                200
             ],
             "retailPriceRange": [
-                153
+                201
             ],
             "salePrice": [
-                152
+                200
             ],
             "saved": [
-                152
+                200
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "Product": {
             "addToCartUrl": [
-                249
+                301
             ],
             "addToWishlistUrl": [
-                249
+                301
             ],
             "availability": [
-                249
+                301
             ],
             "availabilityDescription": [
-                249
+                301
             ],
             "availabilityV2": [
-                189
+                238
             ],
             "brand": [
-                23
+                35
             ],
             "categories": [
-                74,
+                86,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "condition": [
-                192
+                241
             ],
             "createdAt": [
-                108
+                154
             ],
             "customFields": [
-                101,
+                147,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "last": [
-                        131
+                        179
                     ],
                     "names": [
-                        249,
+                        301,
                         "[String!]"
                     ]
                 }
             ],
             "defaultImage": [
-                128
+                176
             ],
             "depth": [
-                148
+                196
             ],
             "description": [
-                249
+                301
             ],
             "entityId": [
-                131
+                179
             ],
             "giftWrappingOptions": [
-                125,
+                173,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "gtin": [
-                249
+                301
             ],
             "height": [
-                148
+                196
             ],
             "id": [
-                127
+                175
             ],
             "images": [
-                129,
+                177,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "inventory": [
-                195
+                244
             ],
             "maxPurchaseQuantity": [
-                131
+                179
             ],
             "metafields": [
-                149,
+                197,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "keys": [
-                        249,
+                        301,
                         "[String!]"
                     ],
                     "last": [
-                        131
+                        179
                     ],
                     "namespace": [
-                        249,
+                        301,
                         "String!"
                     ]
                 }
             ],
             "minPurchaseQuantity": [
-                131
+                179
             ],
             "mpn": [
-                249
+                301
             ],
             "name": [
-                249
+                301
             ],
             "options": [
-                163,
+                211,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "path": [
-                249
+                301
             ],
             "plainTextDescription": [
-                249,
+                301,
                 {
                     "characterLimit": [
-                        131
+                        179
                     ]
                 }
             ],
             "priceRanges": [
-                178,
+                227,
                 {
                     "includeTax": [
-                        22
+                        34
                     ]
                 }
             ],
             "prices": [
-                182,
+                231,
                 {
                     "currencyCode": [
-                        286
+                        350
                     ],
                     "includeTax": [
-                        22
+                        34
                     ]
                 }
             ],
             "productOptions": [
-                197,
+                246,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "relatedProducts": [
-                219,
+                268,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "hideOutOfStock": [
-                        22
+                        34
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "reviewSummary": [
-                225
+                274
             ],
             "reviews": [
-                223,
+                272,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "filters": [
-                        205
+                        254
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "last": [
-                        131
+                        179
                     ],
                     "sort": [
-                        207
+                        256
                     ]
                 }
             ],
             "seo": [
-                235
+                287
             ],
             "showCartAction": [
-                22
+                34
             ],
             "sku": [
-                249
+                301
             ],
             "type": [
-                249
+                301
             ],
             "upc": [
-                249
+                301
             ],
             "variants": [
-                269,
+                333,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "entityIds": [
-                        131,
+                        179,
                         "[Int!]"
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "isPurchasable": [
-                        22
+                        34
                     ],
                     "last": [
-                        131
+                        179
                     ],
                     "optionValueIds": [
-                        168,
+                        216,
                         "[OptionValueId!]"
                     ]
                 }
             ],
             "warranty": [
-                249
+                301
             ],
             "weight": [
-                148
+                196
             ],
             "width": [
-                148
+                196
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "ProductAttributeSearchFilter": {
             "attributes": [
-                187,
+                236,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "displayProductCount": [
-                22
+                34
+            ],
+            "filterName": [
+                301
             ],
             "isCollapsedByDefault": [
-                22
+                34
             ],
             "name": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "ProductAttributeSearchFilterInput": {
             "attribute": [
-                249
+                301
             ],
             "values": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "ProductAttributeSearchFilterItem": {
             "isSelected": [
-                22
+                34
             ],
             "productCount": [
-                131
+                179
             ],
             "value": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "ProductAttributeSearchFilterItemConnection": {
             "edges": [
-                188
+                237
             ],
             "pageInfo": [
-                173
+                222
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "ProductAttributeSearchFilterItemEdge": {
             "cursor": [
-                249
+                301
             ],
             "node": [
-                186
+                235
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "ProductAvailability": {
             "description": [
-                249
+                301
             ],
             "status": [
-                190
+                239
             ],
             "on_ProductAvailable": [
-                191
+                240
             ],
             "on_ProductPreOrder": [
-                204
+                253
             ],
             "on_ProductUnavailable": [
-                208
+                257
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "ProductAvailabilityStatus": {},
         "ProductAvailable": {
             "description": [
-                249
+                301
             ],
             "status": [
-                190
+                239
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "ProductConditionType": {},
         "ProductConnection": {
             "collectionInfo": [
-                87
+                130
             ],
             "edges": [
-                194
+                243
             ],
             "pageInfo": [
-                173
+                222
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "ProductEdge": {
             "cursor": [
-                249
+                301
             ],
             "node": [
-                183
+                232
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "ProductInventory": {
             "aggregated": [
-                6
+                12
             ],
             "hasVariantInventory": [
-                22
+                34
             ],
             "isInStock": [
-                22
+                34
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "ProductOption": {
             "displayName": [
-                249
+                301
             ],
             "entityId": [
-                131
+                179
             ],
             "isRequired": [
-                22
+                34
             ],
             "values": [
-                166,
+                214,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "ProductOptionConnection": {
             "edges": [
-                198
+                247
             ],
             "pageInfo": [
-                173
+                222
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "ProductOptionEdge": {
             "cursor": [
-                249
+                301
             ],
             "node": [
-                71
+                83
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "ProductOptionValue": {
             "entityId": [
-                131
+                179
             ],
             "label": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "ProductOptionValueConnection": {
             "edges": [
-                201
+                250
             ],
             "pageInfo": [
-                173
+                222
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "ProductOptionValueEdge": {
             "cursor": [
-                249
+                301
             ],
             "node": [
-                72
+                84
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "ProductOutOfStockBehavior": {},
         "ProductPickListOptionValue": {
             "defaultImage": [
-                128
+                176
             ],
             "entityId": [
-                131
+                179
             ],
             "isDefault": [
-                22
+                34
             ],
             "isSelected": [
-                22
+                34
             ],
             "label": [
-                249
+                301
             ],
             "productId": [
-                131
+                179
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "ProductPreOrder": {
             "description": [
-                249
+                301
             ],
             "message": [
-                249
+                301
             ],
             "status": [
-                190
+                239
             ],
             "willBeReleasedAt": [
-                108
+                154
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "ProductReviewsFiltersInput": {
             "rating": [
-                206
+                255
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "ProductReviewsRatingFilterInput": {
             "maxRating": [
-                131
+                179
             ],
             "minRating": [
-                131
+                179
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "ProductReviewsSortInput": {},
         "ProductUnavailable": {
             "description": [
-                249
+                301
             ],
             "message": [
-                249
+                301
             ],
             "status": [
-                190
+                239
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "PublicWishlist": {
             "entityId": [
-                131
+                179
             ],
             "items": [
-                280,
+                344,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "hideOutOfStock": [
-                        22
+                        34
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "name": [
-                249
+                301
             ],
             "token": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "Query": {
             "channel": [
-                84
+                96
             ],
             "customer": [
-                103
+                149
             ],
             "inventory": [
-                132
+                180
             ],
             "node": [
-                158,
+                206,
                 {
                     "id": [
-                        127,
+                        175,
                         "ID!"
                     ]
                 }
             ],
             "site": [
-                240
+                292
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "RatingSearchFilter": {
             "isCollapsedByDefault": [
-                22
+                34
             ],
             "name": [
-                249
+                301
             ],
             "ratings": [
-                214,
+                263,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "RatingSearchFilterInput": {
             "maxRating": [
-                123
+                171
             ],
             "minRating": [
-                123
+                171
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "RatingSearchFilterItem": {
             "isSelected": [
-                22
+                34
             ],
             "productCount": [
-                131
+                179
             ],
             "value": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "RatingSearchFilterItemConnection": {
             "edges": [
-                215
+                264
             ],
             "pageInfo": [
-                173
+                222
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "RatingSearchFilterItemEdge": {
             "cursor": [
-                249
+                301
             ],
             "node": [
-                213
+                262
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "RawHtmlPage": {
             "entityId": [
-                131
+                179
             ],
             "htmlBody": [
-                249
+                301
             ],
             "id": [
-                127
+                175
             ],
             "isVisibleInNavigation": [
-                22
+                34
             ],
             "name": [
-                249
+                301
             ],
             "parentEntityId": [
-                131
+                179
             ],
             "path": [
-                249
+                301
             ],
             "plainTextSummary": [
-                249,
+                301,
                 {
                     "characterLimit": [
-                        131
+                        179
                     ]
                 }
             ],
             "seo": [
-                235
+                287
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "ReCaptchaSettings": {
             "siteKey": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "Region": {
             "html": [
-                249
+                301
             ],
             "name": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "RelatedProductsConnection": {
             "edges": [
-                220
+                269
             ],
             "pageInfo": [
-                173
+                222
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "RelatedProductsEdge": {
             "cursor": [
-                249
+                301
             ],
             "node": [
-                183
+                232
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "RenderedRegionsByPageType": {
             "regions": [
-                218
+                267
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "Review": {
             "author": [
-                9
+                21
             ],
             "createdAt": [
-                108
+                154
             ],
             "entityId": [
-                147
+                195
             ],
             "rating": [
-                131
+                179
             ],
             "text": [
-                249
+                301
             ],
             "title": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "ReviewConnection": {
             "edges": [
-                224
+                273
             ],
             "pageInfo": [
-                173
+                222
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "ReviewEdge": {
             "cursor": [
-                249
+                301
             ],
             "node": [
-                222
+                271
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "Reviews": {
             "averageRating": [
-                123
+                171
             ],
             "numberOfReviews": [
-                131
+                179
             ],
             "summationOfRatings": [
-                131
+                179
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "Route": {
             "node": [
-                158
+                206
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "Search": {
             "productFilteringEnabled": [
-                22
+                34
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "SearchProductFilter": {
             "isCollapsedByDefault": [
-                22
+                34
             ],
             "name": [
-                249
+                301
             ],
             "on_BrandSearchFilter": [
-                28
+                40
             ],
             "on_CategorySearchFilter": [
-                79
+                91
             ],
             "on_OtherSearchFilter": [
-                169
+                218
             ],
             "on_PriceSearchFilter": [
-                179
+                228
             ],
             "on_ProductAttributeSearchFilter": [
-                184
+                233
             ],
             "on_RatingSearchFilter": [
-                211
+                260
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "SearchProductFilterConnection": {
             "edges": [
-                230
+                279
             ],
             "pageInfo": [
-                173
+                222
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "SearchProductFilterEdge": {
             "cursor": [
-                249
+                301
             ],
             "node": [
-                228
+                277
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "SearchProducts": {
             "filters": [
-                229,
+                278,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "products": [
-                193,
+                242,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ]
                 }
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "SearchProductsFiltersInput": {
             "brandEntityIds": [
-                131
+                179
             ],
             "categoryEntityId": [
-                131
+                179
             ],
             "categoryEntityIds": [
-                131
+                179
             ],
             "hideOutOfStock": [
-                22
+                34
             ],
             "isFeatured": [
-                22
+                34
             ],
             "isFreeShipping": [
-                22
+                34
             ],
             "price": [
-                180
+                229
             ],
             "productAttributes": [
-                185
+                234
             ],
             "rating": [
-                212
+                261
             ],
             "searchSubCategories": [
-                22
+                34
             ],
             "searchTerm": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "SearchProductsSortInput": {},
         "SearchQueries": {
             "searchProducts": [
-                231,
+                280,
                 {
                     "filters": [
-                        232,
+                        281,
                         "SearchProductsFiltersInput!"
                     ],
                     "sort": [
-                        233
+                        282
                     ]
                 }
             ],
             "__typename": [
-                249
+                301
+            ]
+        },
+        "SelectCheckoutShippingOptionDataInput": {
+            "shippingOptionEntityId": [
+                301
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "SelectCheckoutShippingOptionInput": {
+            "checkoutEntityId": [
+                301
+            ],
+            "consignmentEntityId": [
+                301
+            ],
+            "data": [
+                284
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "SelectCheckoutShippingOptionResult": {
+            "checkout": [
+                98
+            ],
+            "__typename": [
+                301
             ]
         },
         "SeoDetails": {
             "metaDescription": [
-                249
+                301
             ],
             "metaKeywords": [
-                249
+                301
             ],
             "pageTitle": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "Settings": {
             "channelId": [
-                147
+                195
             ],
             "checkout": [
-                86
+                126
             ],
             "contact": [
-                88
+                133
             ],
             "display": [
-                117
+                165
             ],
             "inventory": [
-                138
+                186
             ],
             "logo": [
-                145
+                193
             ],
             "logoV2": [
-                245
+                297
             ],
             "reCaptcha": [
-                217
+                266
             ],
             "search": [
-                227
+                276
             ],
             "socialMediaLinks": [
-                241
+                293
             ],
             "status": [
-                248
+                300
             ],
             "storeHash": [
-                249
+                301
             ],
             "storeName": [
-                249
+                301
             ],
             "storefront": [
-                247
+                299
             ],
             "tax": [
-                254
+                306
             ],
             "url": [
-                267
+                331
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "ShopByPriceConnection": {
             "edges": [
-                238
+                290
             ],
             "pageInfo": [
-                173
+                222
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "ShopByPriceEdge": {
             "cursor": [
-                249
+                301
             ],
             "node": [
-                239
+                291
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "ShopByPriceRange": {
             "ranges": [
-                153
+                201
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "Site": {
             "bestSellingProducts": [
-                193,
+                242,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "hideOutOfStock": [
-                        22
+                        34
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "brands": [
-                24,
+                36,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "entityIds": [
-                        131,
+                        179,
                         "[Int!]"
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "last": [
-                        131
+                        179
                     ],
                     "productEntityIds": [
-                        131,
+                        179,
                         "[Int!]"
                     ]
                 }
             ],
             "cart": [
-                39,
+                51,
                 {
                     "entityId": [
-                        249
+                        301
                     ]
                 }
             ],
             "category": [
-                73,
+                85,
                 {
                     "entityId": [
-                        131,
+                        179,
                         "Int!"
                     ]
                 }
             ],
             "categoryTree": [
-                83,
+                95,
                 {
                     "rootEntityId": [
-                        131
+                        179
+                    ]
+                }
+            ],
+            "checkout": [
+                98,
+                {
+                    "entityId": [
+                        301
                     ]
                 }
             ],
             "content": [
-                90
+                135
             ],
             "currencies": [
-                96,
+                142,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "currency": [
-                95,
+                141,
                 {
                     "currencyCode": [
-                        286,
+                        350,
                         "currencyCode!"
                     ]
                 }
             ],
             "featuredProducts": [
-                193,
+                242,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "hideOutOfStock": [
-                        22
+                        34
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "newestProducts": [
-                193,
+                242,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "hideOutOfStock": [
-                        22
+                        34
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "popularBrands": [
-                175,
+                224,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "product": [
-                183,
+                232,
                 {
                     "entityId": [
-                        131
+                        179
                     ],
                     "id": [
-                        127
+                        175
                     ],
                     "optionValueIds": [
-                        168,
+                        216,
                         "[OptionValueId!]"
                     ],
                     "sku": [
-                        249
+                        301
                     ],
                     "useDefaultOptionSelections": [
-                        22
+                        34
                     ],
                     "variantEntityId": [
-                        131
+                        179
                     ]
                 }
             ],
             "products": [
-                193,
+                242,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "entityIds": [
-                        131,
+                        179,
                         "[Int!]"
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "hideOutOfStock": [
-                        22
+                        34
                     ],
                     "ids": [
-                        127,
+                        175,
                         "[ID!]"
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "publicWishlist": [
-                209,
+                258,
                 {
                     "token": [
-                        249,
+                        301,
                         "String!"
                     ]
                 }
             ],
             "route": [
-                226,
+                275,
                 {
                     "path": [
-                        249,
+                        301,
                         "String!"
                     ]
                 }
             ],
             "search": [
-                234
+                283
             ],
             "settings": [
-                236
+                288
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "SocialMediaLink": {
             "name": [
-                249
+                301
             ],
             "url": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "SpecialHour": {
             "closing": [
-                107
+                153
             ],
             "label": [
-                249
+                301
             ],
             "open": [
-                22
+                34
             ],
             "opening": [
-                107
+                153
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "StockLevelDisplay": {},
         "StoreImageLogo": {
             "image": [
-                128
+                176
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "StoreLogo": {
             "on_StoreImageLogo": [
-                244
+                296
             ],
             "on_StoreTextLogo": [
-                246
+                298
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "StoreTextLogo": {
             "text": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "Storefront": {
             "catalog": [
-                70
+                82
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "StorefrontStatusType": {},
         "String": {},
         "SubCategorySearchFilterItem": {
             "entityId": [
-                131
+                179
             ],
             "isSelected": [
-                22
+                34
             ],
             "name": [
-                249
+                301
             ],
             "productCount": [
-                131
+                179
             ],
             "subCategories": [
-                251,
+                303,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "SubCategorySearchFilterItemConnection": {
             "edges": [
-                252
+                304
             ],
             "pageInfo": [
-                173
+                222
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "SubCategorySearchFilterItemEdge": {
             "cursor": [
-                249
+                301
             ],
             "node": [
-                250
+                302
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "SwatchOptionValue": {
             "entityId": [
-                131
+                179
             ],
             "hexColors": [
-                249
+                301
             ],
             "imageUrl": [
-                249,
+                301,
                 {
                     "height": [
-                        131
+                        179
                     ],
                     "width": [
-                        131,
+                        179,
                         "Int!"
                     ]
                 }
             ],
             "isDefault": [
-                22
+                34
             ],
             "isSelected": [
-                22
+                34
             ],
             "label": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "TaxDisplaySettings": {
             "pdp": [
-                255
+                307
             ],
             "plp": [
-                255
+                307
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "TaxPriceDisplay": {},
         "TextFieldOption": {
             "defaultValue": [
-                249
+                301
             ],
             "displayName": [
-                249
+                301
             ],
             "entityId": [
-                131
+                179
             ],
             "isRequired": [
-                22
+                34
             ],
             "isVariantOption": [
-                22
+                34
             ],
             "maxLength": [
-                131
+                179
             ],
             "minLength": [
-                131
+                179
             ],
             "__typename": [
-                249
+                301
+            ]
+        },
+        "UnapplyCheckoutCouponDataInput": {
+            "couponCode": [
+                301
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "UnapplyCheckoutCouponInput": {
+            "checkoutEntityId": [
+                301
+            ],
+            "data": [
+                309
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "UnapplyCheckoutCouponResult": {
+            "checkout": [
+                98
+            ],
+            "__typename": [
+                301
             ]
         },
         "UnassignCartFromCustomerInput": {
             "cartEntityId": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "UnassignCartFromCustomerResult": {
             "cart": [
-                39
+                51
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "UpdateCartCurrencyDataInput": {
             "currencyCode": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "UpdateCartCurrencyInput": {
             "cartEntityId": [
-                249
+                301
             ],
             "data": [
-                259
+                314
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "UpdateCartCurrencyResult": {
             "cart": [
-                39
+                51
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "UpdateCartLineItemDataInput": {
             "giftCertificate": [
-                44
+                56
             ],
             "lineItem": [
-                51
+                63
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "UpdateCartLineItemInput": {
             "cartEntityId": [
-                249
+                301
             ],
             "data": [
-                262
+                317
             ],
             "lineItemEntityId": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "UpdateCartLineItemResult": {
             "cart": [
-                39
+                51
             ],
             "__typename": [
-                249
+                301
+            ]
+        },
+        "UpdateCheckoutBillingAddressDataInput": {
+            "address": [
+                106
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "UpdateCheckoutBillingAddressInput": {
+            "addressEntityId": [
+                301
+            ],
+            "checkoutEntityId": [
+                301
+            ],
+            "data": [
+                320
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "UpdateCheckoutBillingAddressResult": {
+            "checkout": [
+                98
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "UpdateCheckoutCustomerMessageDataInput": {
+            "message": [
+                301
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "UpdateCheckoutCustomerMessageInput": {
+            "checkoutEntityId": [
+                301
+            ],
+            "data": [
+                323
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "UpdateCheckoutCustomerMessageResult": {
+            "checkout": [
+                98
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "UpdateCheckoutShippingConsignmentDataInput": {
+            "consignment": [
+                128
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "UpdateCheckoutShippingConsignmentInput": {
+            "checkoutEntityId": [
+                301
+            ],
+            "consignmentEntityId": [
+                301
+            ],
+            "data": [
+                326
+            ],
+            "__typename": [
+                301
+            ]
+        },
+        "UpdateCheckoutShippingConsignmentResult": {
+            "checkout": [
+                98
+            ],
+            "__typename": [
+                301
             ]
         },
         "UpdateWishlistInput": {
             "data": [
-                284
+                348
             ],
             "entityId": [
-                131
+                179
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "UpdateWishlistResult": {
             "result": [
-                275
+                339
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "UrlField": {
             "cdnUrl": [
-                249
+                301
             ],
             "checkoutUrl": [
-                249
+                301
             ],
             "vanityUrl": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "Variant": {
             "defaultImage": [
-                128
+                176
             ],
             "depth": [
-                148
+                196
             ],
             "entityId": [
-                131
+                179
             ],
             "gtin": [
-                249
+                301
             ],
             "height": [
-                148
+                196
             ],
             "id": [
-                127
+                175
             ],
             "inventory": [
-                271
+                335
             ],
             "isPurchasable": [
-                22
+                34
             ],
             "metafields": [
-                149,
+                197,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "keys": [
-                        249,
+                        301,
                         "[String!]"
                     ],
                     "last": [
-                        131
+                        179
                     ],
                     "namespace": [
-                        249,
+                        301,
                         "String!"
                     ]
                 }
             ],
             "mpn": [
-                249
+                301
             ],
             "options": [
-                163,
+                211,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "prices": [
-                182,
+                231,
                 {
                     "currencyCode": [
-                        286
+                        350
                     ],
                     "includeTax": [
-                        22
+                        34
                     ]
                 }
             ],
             "productOptions": [
-                197,
+                246,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "sku": [
-                249
+                301
             ],
             "upc": [
-                249
+                301
             ],
             "weight": [
-                148
+                196
             ],
             "width": [
-                148
+                196
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "VariantConnection": {
             "edges": [
-                270
+                334
             ],
             "pageInfo": [
-                173
+                222
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "VariantEdge": {
             "cursor": [
-                249
+                301
             ],
             "node": [
-                268
+                332
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "VariantInventory": {
             "aggregated": [
-                5
+                11
             ],
             "byLocation": [
-                142,
+                190,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "distanceFilter": [
-                        119
+                        167
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "last": [
-                        131
+                        179
                     ],
                     "locationEntityCodes": [
-                        249,
+                        301,
                         "[String!]"
                     ],
                     "locationEntityIds": [
-                        131,
+                        179,
                         "[Int!]"
                     ],
                     "locationEntityServiceTypeIds": [
-                        249,
+                        301,
                         "[String!]"
                     ],
                     "locationEntityTypeIds": [
-                        249,
+                        301,
                         "[String!]"
                     ]
                 }
             ],
             "isInStock": [
-                22
+                34
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "WebPage": {
             "entityId": [
-                131
+                179
             ],
             "isVisibleInNavigation": [
-                22
+                34
             ],
             "name": [
-                249
+                301
             ],
             "parentEntityId": [
-                131
+                179
             ],
             "seo": [
-                235
+                287
             ],
             "on_BlogIndexPage": [
-                17
+                29
             ],
             "on_ContactPage": [
-                89
+                134
             ],
             "on_ExternalLinkPage": [
-                121
+                169
             ],
             "on_NormalPage": [
-                159
+                207
             ],
             "on_RawHtmlPage": [
-                216
+                265
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "WebPageType": {},
         "WebPagesFiltersInput": {
             "entityIds": [
-                131
+                179
             ],
             "isVisibleInNavigation": [
-                22
+                34
             ],
             "pageType": [
-                273
+                337
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "Wishlist": {
             "entityId": [
-                131
+                179
             ],
             "isPublic": [
-                22
+                34
             ],
             "items": [
-                280,
+                344,
                 {
                     "after": [
-                        249
+                        301
                     ],
                     "before": [
-                        249
+                        301
                     ],
                     "first": [
-                        131
+                        179
                     ],
                     "hideOutOfStock": [
-                        22
+                        34
                     ],
                     "last": [
-                        131
+                        179
                     ]
                 }
             ],
             "name": [
-                249
+                301
             ],
             "token": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "WishlistConnection": {
             "edges": [
-                277
+                341
             ],
             "pageInfo": [
-                173
+                222
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "WishlistEdge": {
             "cursor": [
-                249
+                301
             ],
             "node": [
-                275
+                339
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "WishlistFiltersInput": {
             "entityIds": [
-                131
+                179
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "WishlistItem": {
             "entityId": [
-                131
+                179
             ],
             "product": [
-                183
+                232
             ],
             "productEntityId": [
-                131
+                179
             ],
             "variantEntityId": [
-                131
+                179
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "WishlistItemConnection": {
             "edges": [
-                281
+                345
             ],
             "pageInfo": [
-                173
+                222
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "WishlistItemEdge": {
             "cursor": [
-                249
+                301
             ],
             "node": [
-                279
+                343
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "WishlistItemInput": {
             "productEntityId": [
-                131
+                179
             ],
             "variantEntityId": [
-                131
+                179
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "WishlistMutations": {
             "addWishlistItems": [
-                4,
+                10,
                 {
                     "input": [
-                        3,
+                        9,
                         "AddWishlistItemsInput!"
                     ]
                 }
             ],
             "createWishlist": [
-                94,
+                140,
                 {
                     "input": [
-                        93,
+                        139,
                         "CreateWishlistInput!"
                     ]
                 }
             ],
             "deleteWishlistItems": [
-                114,
+                162,
                 {
                     "input": [
-                        113,
+                        161,
                         "DeleteWishlistItemsInput!"
                     ]
                 }
             ],
             "deleteWishlists": [
-                115,
+                163,
                 {
                     "input": [
-                        116,
+                        164,
                         "DeleteWishlistsInput!"
                     ]
                 }
             ],
             "updateWishlist": [
-                266,
+                330,
                 {
                     "input": [
-                        265,
+                        329,
                         "UpdateWishlistInput!"
                     ]
                 }
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "WishlistUpdateDataInput": {
             "isPublic": [
-                22
+                34
             ],
             "name": [
-                249
+                301
             ],
             "__typename": [
-                249
+                301
             ]
         },
         "countryCode": {},

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,1 +1,3 @@
 export { createClient } from './client';
+export { generateQueryOp, generateMutationOp, type QueryResult } from './generated/index';
+export * from './generated/schema';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -294,11 +294,14 @@ importers:
         specifier: workspace:^
         version: link:../eslint-config-catalyst
       '@genql/cli':
-        specifier: ^6.0.0
-        version: 6.0.0
+        specifier: ^4.0.4
+        version: 4.0.4
       '@types/node':
         specifier: ^18.13.00
         version: 18.13.0
+      dotenv-cli:
+        specifier: ^7.2.1
+        version: 7.2.1
       eslint:
         specifier: ^8.33.0
         version: 8.33.0
@@ -2959,8 +2962,8 @@ packages:
   /@fal-works/esbuild-plugin-global-externals@2.1.2:
     resolution: {integrity: sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ==}
 
-  /@genql/cli@6.0.0:
-    resolution: {integrity: sha512-CL7udS5eIZjL6YabT3RU3Vhus2Dtb0qtU95hyaBadrO7aj+TZQqmeABOVOzBWcWDErZOGHVNd8JqgQ1Ww4pUCw==}
+  /@genql/cli@4.0.4:
+    resolution: {integrity: sha512-I8ZcHVWQaMHJhHrE9CGU2H162zM9y6zhxIZV8bgMZZq1B0jpMV1OoD+G6rVJM2yx3QyLBqPZMA7YlHryVk72Ew==}
     hasBin: true
     dependencies:
       '@graphql-tools/graphql-file-loader': 7.5.17(graphql@16.6.0)


### PR DESCRIPTION
## What/Why?
Run `node scripts/types` or  `pnpm gen-types`.

Note: We would also need to create a store for deployments (publishing), that will update types (or apply another strategy)
## Testing

<img width="960" alt="Screenshot 2023-06-29 at 17 59 39" src="https://github.com/bigcommerce/catalyst/assets/68893868/2397bb56-6175-4779-9056-9e41b209ffeb">
