### PR TITLE
feat: add to cart spinner

### DIFF
--- a/apps/core/src/app/product/[slug]/AddToCart.tsx
+++ b/apps/core/src/app/product/[slug]/AddToCart.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { Button } from '@bigcommerce/reactant/Button';
+import { ShoppingCart, Loader2 as Spinner } from 'lucide-react';
+import { experimental_useFormStatus as useFormStatus } from 'react-dom';
+
+import { handleAddToCart } from './_actions/addToCart';
+
+interface Props {
+  productId: number;
+}
+
+const AddToCartButton = () => {
+  const { pending } = useFormStatus();
+
+  const status = pending ? 'pending' : 'idle';
+
+  return (
+    <Button disabled={pending} type="submit">
+      {status === 'idle' && (
+        <>
+          <ShoppingCart aria-hidden="true" className="mx-2" />
+          <span>Add to Cart</span>
+        </>
+      )}
+
+      {status === 'pending' && (
+        <>
+          <Spinner aria-hidden="true" className="animate-spin" />
+          <span className="sr-only">Processing...</span>
+        </>
+      )}
+    </Button>
+  );
+};
+
+export const AddToCart = ({ productId }: Props) => {
+  return (
+    <form action={() => handleAddToCart(productId)} className="w-full">
+      <AddToCartButton />
+    </form>
+  );
+};

--- a/apps/core/src/app/product/[slug]/_actions/addToCart.ts
+++ b/apps/core/src/app/product/[slug]/_actions/addToCart.ts
@@ -1,0 +1,45 @@
+'use server';
+
+import { addCartLineItem, createCart } from '@bigcommerce/catalyst-client';
+import { revalidateTag } from 'next/cache';
+import { cookies } from 'next/headers';
+
+export async function handleAddToCart(productEntityId: number) {
+  const cartId = cookies().get('cartId')?.value;
+
+  if (cartId) {
+    await addCartLineItem(cartId, {
+      lineItems: [
+        {
+          productEntityId,
+          quantity: 1,
+        },
+      ],
+    });
+
+    revalidateTag('cart');
+
+    return;
+  }
+
+  // Create cart
+  const cart = await createCart([
+    {
+      productEntityId,
+      quantity: 1,
+    },
+  ]);
+
+  if (cart) {
+    cookies().set({
+      name: 'cartId',
+      value: cart.entityId,
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: true,
+      path: '/',
+    });
+  }
+
+  revalidateTag('cart');
+}

--- a/apps/core/src/app/product/[slug]/page.tsx
+++ b/apps/core/src/app/product/[slug]/page.tsx
@@ -1,18 +1,15 @@
-import { addCartLineItem, createCart, getProduct } from '@bigcommerce/catalyst-client';
+import { getProduct } from '@bigcommerce/catalyst-client';
 import { Button } from '@bigcommerce/reactant/Button';
-import { Heart, ShoppingCart } from 'lucide-react';
-import { revalidateTag } from 'next/cache';
-import { cookies } from 'next/headers';
+import { Heart } from 'lucide-react';
 import { notFound } from 'next/navigation';
 import { Suspense } from 'react';
 
+import { AddToCart } from './AddToCart';
 import { BreadCrumbs } from './Breadcrumbs';
 import { Gallery } from './Gallery';
 import { Reviews } from './Reviews';
 import { ReviewSummary } from './ReviewSummary';
 
-// import { Variants } from './Variants';
-//
 const currencyFormatter = new Intl.NumberFormat('en-US', {
   style: 'currency',
   currency: 'USD',
@@ -27,49 +24,6 @@ export default async function Product({ params }: { params: { slug: string } }) 
   if (!product) {
     return notFound();
   }
-
-  const handleAddToCart = async () => {
-    'use server';
-
-    const cartId = cookies().get('cartId')?.value;
-
-    if (cartId) {
-      await addCartLineItem(cartId, {
-        lineItems: [
-          {
-            productEntityId: productId,
-            quantity: 1,
-          },
-        ],
-      });
-
-      revalidateTag('cart');
-      // revalidatePath('/cart');
-
-      return;
-    }
-
-    // Create cart
-    const cart = await createCart([
-      {
-        productEntityId: productId,
-        quantity: 1,
-      },
-    ]);
-
-    if (cart) {
-      cookies().set({
-        name: 'cartId',
-        value: cart.entityId,
-        httpOnly: true,
-        sameSite: 'lax',
-        secure: true,
-        path: '/',
-      });
-    }
-
-    revalidateTag('cart');
-  };
 
   return (
     <>
@@ -94,12 +48,7 @@ export default async function Product({ params }: { params: { slug: string } }) 
           )}
 
           <div className="my-7 flex gap-4">
-            <form action={handleAddToCart} className="w-full">
-              <Button type="submit">
-                <ShoppingCart aria-hidden="true" className="mx-2" />
-                Add to Cart
-              </Button>
-            </form>
+            <AddToCart productId={productId} />
 
             {/* NOT IMPLEMENTED YET */}
             <div className="w-full">


### PR DESCRIPTION
## What/Why?
Moved the `AddToCart` component to a client component, this way we can use `useFormStatus` to get the state of the form and show a spinner when the form is being submitted.

Moved the `addToCart` action to its own file under `_actions/`

https://github.com/bigcommerce/catalyst/assets/2752665/5098695a-5445-4f1e-ba48-5112547b15da
