### PR TITLE
fix: footer categories urls

### DIFF
--- a/apps/core/src/app/components/Footer/FooterMenus/CategoryFooterMenu.tsx
+++ b/apps/core/src/app/components/Footer/FooterMenus/CategoryFooterMenu.tsx
@@ -5,9 +5,15 @@ import { BaseFooterMenu } from './BaseFooterMenu';
 export const CategoryFooterMenu = async () => {
   const categoryTree = await getCategoryTree();
 
-  if (!categoryTree.length) {
+  // Temp workaround until we have the middleware that converts paths to real urls
+  const items = categoryTree.map((item) => ({
+    ...item,
+    path: `/category/${item.entityId}`,
+  }));
+
+  if (!items.length) {
     return null;
   }
 
-  return <BaseFooterMenu items={categoryTree} title="Categories" />;
+  return <BaseFooterMenu items={items} title="Categories" />;
 };


### PR DESCRIPTION
## What/Why?
We are currently using the `category.path` which looks like `/bath`. But we don't have the middleware that translates to our internal routing, so for now, to get the links working adding a workaround that uses entity id.

PS: The middleware code was done for the POC and we can port it over:
 https://github.com/bigcommerce/catalyst/blob/main-poc/src/middleware.ts