### PR TITLE
refactor: use product card everywhere

### DIFF
--- a/apps/core/src/app/category/[slug]/page.tsx
+++ b/apps/core/src/app/category/[slug]/page.tsx
@@ -1,8 +1,9 @@
 import { getCategory } from '@bigcommerce/catalyst-client';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import Image from 'next/image';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+
+import { ProductCard } from 'src/app/components/ProductCard';
 
 interface Props {
   params: {
@@ -72,32 +73,7 @@ export default async function Category({ params, searchParams }: Props) {
 
           <div className="grid grid-cols-1 gap-y-4 sm:grid-cols-2 sm:gap-x-6 sm:gap-y-10 lg:gap-x-8 xl:grid-cols-3">
             {products.map((product) => (
-              <div className="group relative flex flex-col overflow-hidden" key={product.entityId}>
-                <div className="group-hover:opacity-75">
-                  <Image
-                    alt={product.defaultImage?.altText ?? product.name}
-                    className="h-full w-full object-cover object-center sm:h-full sm:w-full"
-                    height={300}
-                    src={product.defaultImage?.url ?? ''}
-                    width={300}
-                  />
-                </div>
-
-                <div className="flex flex-1 flex-col space-y-2 p-4">
-                  {product.brand && <p className="text-base text-gray-500">{product.brand.name}</p>}
-
-                  <h3 className="text-h5">
-                    <Link href={`/product/${product.entityId}`}>
-                      <span aria-hidden="true" className="absolute inset-0" />
-                      {product.name}
-                    </Link>
-                  </h3>
-
-                  <div className="flex flex-1 flex-col justify-end">
-                    <p className="text-base">${product.prices?.price.value}</p>
-                  </div>
-                </div>
-              </div>
+              <ProductCard key={product.entityId} product={product} />
             ))}
           </div>
 

--- a/apps/core/src/app/components/ProductCard/index.tsx
+++ b/apps/core/src/app/components/ProductCard/index.tsx
@@ -1,0 +1,55 @@
+import {
+  ProductCardImage,
+  ProductCardInfo,
+  ProductCardInfoBrandName,
+  ProductCardInfoPrice,
+  ProductCardInfoProductName,
+  ProductCard as ReactantProductCard,
+} from '@bigcommerce/reactant/ProductCard';
+import Image from 'next/image';
+import Link from 'next/link';
+
+interface Product {
+  entityId: number;
+  name: string;
+  defaultImage?: {
+    altText?: string;
+    url: string;
+  };
+  brand?: {
+    name: string;
+  };
+  prices?: {
+    price?: {
+      value?: number;
+    };
+  };
+}
+
+interface ProductCardProps {
+  product: Product;
+}
+
+export const ProductCard = ({ product }: ProductCardProps) => (
+  <ReactantProductCard key={product.entityId}>
+    <ProductCardImage>
+      <Image
+        alt={product.defaultImage?.altText ?? product.name}
+        className="h-full w-full object-contain object-center sm:h-full sm:w-full"
+        height={300}
+        src={product.defaultImage?.url ?? ''}
+        width={300}
+      />
+    </ProductCardImage>
+    <ProductCardInfo>
+      {product.brand && <ProductCardInfoBrandName>{product.brand.name}</ProductCardInfoBrandName>}
+      <ProductCardInfoProductName>
+        <Link href={`/product/${product.entityId}`}>
+          <span aria-hidden="true" className="absolute inset-0" />
+          {product.name}
+        </Link>
+      </ProductCardInfoProductName>
+      <ProductCardInfoPrice>${product.prices?.price?.value}</ProductCardInfoPrice>
+    </ProductCardInfo>
+  </ReactantProductCard>
+);

--- a/apps/core/src/app/page.tsx
+++ b/apps/core/src/app/page.tsx
@@ -1,48 +1,8 @@
 import { getBestSellingProducts, getFeaturedProducts } from '@bigcommerce/catalyst-client';
 import { cs } from '@bigcommerce/reactant/cs';
-import {
-  ProductCardBadge,
-  ProductCardImage,
-  ProductCardInfo,
-  ProductCardInfoBrandName,
-  ProductCardInfoPrice,
-  ProductCardInfoProductName,
-  ProductCard as ReactantProductCard,
-} from '@bigcommerce/reactant/ProductCard';
-import Image from 'next/image';
-import Link from 'next/link';
 import { ReactNode } from 'react';
 
-type FeaturedProduct = Awaited<ReturnType<typeof getFeaturedProducts>>[number];
-type BestSellingProduct = Awaited<ReturnType<typeof getBestSellingProducts>>[number];
-
-interface ProductCardProps {
-  product: FeaturedProduct | BestSellingProduct;
-}
-
-const ProductCard = ({ product }: ProductCardProps) => (
-  <ReactantProductCard key={product.entityId}>
-    <ProductCardImage>
-      <Image
-        alt={product.defaultImage?.altText ?? product.name}
-        className="h-full w-full object-contain object-center sm:h-full sm:w-full"
-        height={300}
-        src={product.defaultImage?.url ?? ''}
-        width={300}
-      />
-    </ProductCardImage>
-    <ProductCardInfo>
-      {product.brand && <ProductCardInfoBrandName>{product.brand.name}</ProductCardInfoBrandName>}
-      <ProductCardInfoProductName>
-        <Link href={`/product/${product.entityId}`}>
-          <span aria-hidden="true" className="absolute inset-0" />
-          {product.name}
-        </Link>
-      </ProductCardInfoProductName>
-      <ProductCardInfoPrice>${product.price?.value}</ProductCardInfoPrice>
-    </ProductCardInfo>
-  </ReactantProductCard>
-);
+import { ProductCard } from './components/ProductCard';
 
 const ProductList = ({ children }: { children: ReactNode }) => (
   <section className={cs('mb-10')}>{children}</section>

--- a/apps/core/src/app/search/page.tsx
+++ b/apps/core/src/app/search/page.tsx
@@ -1,7 +1,8 @@
 import { getProductSearchResults } from '@bigcommerce/catalyst-client';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import Image from 'next/image';
 import Link from 'next/link';
+
+import { ProductCard } from '../components/ProductCard';
 
 import { SearchForm } from './SearchForm';
 
@@ -65,32 +66,7 @@ export default async function Search({ searchParams }: Props) {
 
           <div className="grid grid-cols-1 gap-y-4 sm:grid-cols-2 sm:gap-x-6 sm:gap-y-10 lg:gap-x-8 xl:grid-cols-4">
             {products.map((product) => (
-              <div className="group relative flex flex-col overflow-hidden" key={product.entityId}>
-                <div className="group-hover:opacity-75">
-                  <Image
-                    alt={product.defaultImage?.altText ?? product.name}
-                    className="h-full w-full object-cover object-center sm:h-full sm:w-full"
-                    height={300}
-                    src={product.defaultImage?.url ?? ''}
-                    width={300}
-                  />
-                </div>
-
-                <div className="flex flex-1 flex-col space-y-2 p-4">
-                  {product.brand && <p className="text-base text-gray-500">{product.brand.name}</p>}
-
-                  <h3 className="text-h5">
-                    <Link href={`/product/${product.entityId}`}>
-                      <span aria-hidden="true" className="absolute inset-0" />
-                      {product.name}
-                    </Link>
-                  </h3>
-
-                  <div className="flex flex-1 flex-col justify-end">
-                    <p className="text-base">${product.prices?.price.value}</p>
-                  </div>
-                </div>
-              </div>
+              <ProductCard key={product.entityId} product={product} />
             ))}
           </div>
 

--- a/packages/client/src/queries/getBestSellingProducts.ts
+++ b/packages/client/src/queries/getBestSellingProducts.ts
@@ -45,12 +45,5 @@ export const getBestSellingProducts = async ({
     },
   });
 
-  return removeEdgesAndNodes(site.bestSellingProducts).map((product) => {
-    const { prices, ...rest } = product;
-
-    return {
-      ...rest,
-      price: prices?.price,
-    };
-  });
+  return removeEdgesAndNodes(site.bestSellingProducts);
 };

--- a/packages/client/src/queries/getFeaturedProducts.ts
+++ b/packages/client/src/queries/getFeaturedProducts.ts
@@ -48,12 +48,5 @@ export const getFeaturedProducts = async ({
 
   const { site } = await client.query(query);
 
-  return removeEdgesAndNodes(site.featuredProducts).map((product) => {
-    const { prices, ...rest } = product;
-
-    return {
-      ...rest,
-      price: prices?.price,
-    };
-  });
+  return removeEdgesAndNodes(site.featuredProducts);
 };


### PR DESCRIPTION
## What/Why?
Create a `ProductCard` under core and reuse it on home / search / category:

Home:

![euGArYfJ](https://github.com/bigcommerce/catalyst/assets/2752665/aaca4521-0643-4f5d-9fa5-7d044371f303)


Category:

![4aJ8Dcme](https://github.com/bigcommerce/catalyst/assets/2752665/b316cc6b-be3e-4ecd-aea1-0bbefd4a4c1d)

Search:

![UfK2HfBp](https://github.com/bigcommerce/catalyst/assets/2752665/71bdde3e-8d85-4a50-9ead-cbcd24b9d917)
