### PR TITLE
feat(reactant): add swatch component

### DIFF
--- a/apps/docs/stories/Swatch.stories.tsx
+++ b/apps/docs/stories/Swatch.stories.tsx
@@ -1,0 +1,154 @@
+import {
+  Swatch,
+  SwatchGroup,
+  SwatchGroupLabel,
+  SwatchInput,
+  SwatchLabel,
+  SwatchPreview,
+  SwatchVariant,
+} from '@bigcommerce/reactant/Swatch';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Fragment } from 'react';
+
+const meta: Meta<typeof Swatch> = {
+  component: Swatch,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Swatch>;
+
+const mockedData = [
+  {
+    entityId: 295,
+    displayName: 'Color',
+    isRequired: true,
+    __typename: 'MultipleChoiceOption',
+    displayStyle: 'Swatch',
+    values: [
+      { entityId: 462, label: 'Red', isDefault: false, hexColors: ['#FF001E'], imageUrl: null },
+      { entityId: 463, label: 'Blue', isDefault: false, hexColors: ['#2700FF'], imageUrl: null },
+      { entityId: 464, label: 'Green', isDefault: true, hexColors: ['#14FF00'], imageUrl: null },
+      {
+        entityId: 465,
+        label: 'Grey-ish',
+        isDefault: false,
+        hexColors: ['#3D3E57', '#BA5B5B'],
+        imageUrl: null,
+      },
+    ],
+  },
+];
+
+const focusHandler = (
+  e: MouseEvent & {
+    target: HTMLElement;
+  },
+) => {
+  const swatchInput = e.target.parentElement?.nextSibling;
+
+  if (swatchInput) {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    (swatchInput as HTMLInputElement).focus();
+  }
+};
+
+/**
+ * Swatch has 3 main children: `SwatchInput`, `SwatchLabel`, `SwatchLabel`.
+ * Please pay attention, children order matters since sibling combinator `peer` is being used for styling inside components.
+ * More details [here](https://tailwindcss.com/docs/hover-focus-and-other-states#styling-based-on-sibling-state).
+ */
+export const BasicSwatch: Story = {
+  render: () => (
+    <div className="mb-32">
+      <Swatch onClick={focusHandler}>
+        <SwatchInput aria-label="Blue" />
+        <SwatchLabel title="Blue">
+          <SwatchVariant variantColor="#053FB0" />
+        </SwatchLabel>
+        <SwatchPreview variantColor="#053FB0" />
+      </Swatch>
+    </div>
+  ),
+};
+
+export const DisabledSwatch: Story = {
+  render: () => (
+    <div className="mb-32 flex gap-3">
+      <Swatch onClick={focusHandler}>
+        <SwatchInput aria-label="Blue" />
+        <SwatchLabel title="Blue">
+          <SwatchVariant variantColor="#3071EF" />
+        </SwatchLabel>
+        <SwatchPreview variantColor="#3071EF" />
+      </Swatch>
+      <Swatch key="disabled" onClick={focusHandler}>
+        <SwatchInput disabled />
+        <SwatchLabel title="disabled">
+          <SwatchVariant />
+        </SwatchLabel>
+      </Swatch>
+    </div>
+  ),
+};
+
+export const NoneSwatch: Story = {
+  render: () => (
+    <div className="mb-32 flex gap-3">
+      <Swatch>
+        <SwatchInput aria-label="Blue" />
+        <SwatchLabel title="Blue">
+          <SwatchVariant variantColor="#3071EF" />
+        </SwatchLabel>
+        <SwatchPreview variantColor="#3071EF" />
+      </Swatch>
+      <Swatch onClick={focusHandler}>
+        <SwatchInput />
+        <SwatchLabel title="None">
+          <SwatchVariant variant="none" />
+        </SwatchLabel>
+      </Swatch>
+    </div>
+  ),
+};
+
+/**
+ * Swatch can be used in group with additional group label.
+ */
+export const SwatchGroupExample: Story = {
+  render: () => (
+    <SwatchGroup className="mb-32 flex gap-3">
+      {mockedData.map(({ displayName, displayStyle, entityId, values }) => {
+        if (displayStyle === 'Swatch') {
+          return (
+            <Fragment key={entityId}>
+              <SwatchGroupLabel>Product {displayName}:</SwatchGroupLabel>
+              {values.map(({ entityId: id, label, hexColors }) => {
+                const swatchId = id.toString();
+
+                return (
+                  <Swatch key={swatchId}>
+                    <SwatchInput aria-label={label} name={swatchId} value={swatchId} />
+                    <SwatchLabel id={swatchId} title={label}>
+                      <SwatchVariant variantColor={hexColors[0]} />
+                    </SwatchLabel>
+                    <SwatchPreview variantColor={hexColors[0]} />
+                  </Swatch>
+                );
+              })}
+              <Swatch key="disabled">
+                <SwatchInput disabled />
+                <SwatchLabel title="disabled">
+                  <SwatchVariant />
+                </SwatchLabel>
+              </Swatch>
+            </Fragment>
+          );
+        }
+
+        return null;
+      })}
+    </SwatchGroup>
+  ),
+};

--- a/packages/reactant/src/components/Swatch/Swatch.tsx
+++ b/packages/reactant/src/components/Swatch/Swatch.tsx
@@ -1,0 +1,146 @@
+import {
+  ComponentPropsWithRef,
+  createContext,
+  ElementRef,
+  forwardRef,
+  useContext,
+  useId,
+} from 'react';
+
+import { cs } from '../../utils/cs';
+import { Label } from '../Label';
+
+const SwatchAccessibilityContext = createContext<{ id: string | undefined }>({ id: undefined });
+
+export const SwatchGroup = forwardRef<ElementRef<'div'>, ComponentPropsWithRef<'div'>>(
+  ({ children, className, ...props }, ref) => {
+    return (
+      <div
+        className={cs('flex flex-wrap items-center gap-3 pt-3 pb-2', className)}
+        ref={ref}
+        role="radiogroup"
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+
+export const SwatchGroupLabel = ({
+  className,
+  children,
+  ...props
+}: ComponentPropsWithRef<'label'>) => {
+  return (
+    <Label
+      className={cs('my-1 inline-flex h-6 basis-full items-center gap-2 font-semibold', className)}
+      {...props}
+    >
+      {children}
+    </Label>
+  );
+};
+
+export const SwatchInput = forwardRef<ElementRef<'input'>, ComponentPropsWithRef<'input'>>(
+  ({ className, id, name, ...props }, ref) => {
+    const { id: swatchId } = useContext(SwatchAccessibilityContext);
+
+    return (
+      <input
+        className={cs('peer sr-only top-px left-px', className)}
+        id={id?.toString() ?? swatchId}
+        name={name || id || swatchId}
+        ref={ref}
+        type="radio"
+        {...props}
+      />
+    );
+  },
+);
+
+export const SwatchLabel = ({
+  className,
+  children,
+  id,
+  ...props
+}: ComponentPropsWithRef<'label'>) => {
+  const { id: swatchId } = useContext(SwatchAccessibilityContext);
+
+  return (
+    <Label
+      className={cs(
+        'peer/preview peer-focus:ring-primary-blue/20 inline-flex cursor-pointer justify-evenly border-2 border-gray-200 p-1 text-[0px] hover:border-blue-primary peer-checked:border-blue-primary peer-focus:ring-4 peer-disabled:cursor-default peer-disabled:border-gray-100',
+        className,
+      )}
+      htmlFor={id ?? swatchId}
+      {...props}
+    >
+      {children}
+    </Label>
+  );
+};
+
+interface SwatchVariantProps extends ComponentPropsWithRef<'span'> {
+  variantColor?: string;
+  variant?: 'default' | 'none';
+}
+
+const swatchVariants = {
+  none: 'inline-block relative border border-gray-200 border-solid overflow-hidden',
+};
+
+export const SwatchVariant = forwardRef<ElementRef<'span'>, SwatchVariantProps>(
+  ({ children, className, variant = 'default', variantColor, ...props }, ref) => {
+    return variant === 'default' ? (
+      <span
+        className={cs('h-9 w-9 bg-gray-100', className)}
+        ref={ref}
+        {...props}
+        style={{ backgroundColor: variantColor, backgroundImage: `url(${variantColor ?? ''})` }}
+      />
+    ) : (
+      <span className={cs('h-9 w-9', swatchVariants.none, className)} ref={ref} {...props}>
+        <span className="border-red absolute -left-px -top-[2px] inline-block w-[51px] origin-top-left rotate-45 border-t-2 border-solid" />
+      </span>
+    );
+  },
+);
+
+interface SwatchPreviewProps extends ComponentPropsWithRef<'div'> {
+  variantColor: string;
+}
+
+export const SwatchPreview = forwardRef<ElementRef<'div'>, SwatchPreviewProps>(
+  ({ className, variantColor, ...props }, ref) => {
+    return (
+      <div
+        className={cs(
+          'absolute top-14 left-0 hidden items-stretch justify-evenly border-2 border-solid border-gray-200 py-[7px] px-[6px] peer-hover/preview:flex',
+          className,
+        )}
+        ref={ref}
+        {...props}
+      >
+        <span
+          className={cs('inline-flex h-[126px] w-[126px] bg-gray-100')}
+          style={{ backgroundColor: variantColor, backgroundImage: `url(${variantColor})` }}
+        />
+      </div>
+    );
+  },
+);
+
+export const Swatch = forwardRef<ElementRef<'div'>, ComponentPropsWithRef<'div'>>(
+  ({ children, className, ...props }, ref) => {
+    const id = useId();
+
+    return (
+      <SwatchAccessibilityContext.Provider value={{ id }}>
+        <div className={cs('relative', className)} ref={ref} {...props}>
+          {children}
+        </div>
+      </SwatchAccessibilityContext.Provider>
+    );
+  },
+);

--- a/packages/reactant/src/components/Swatch/index.ts
+++ b/packages/reactant/src/components/Swatch/index.ts
@@ -1,0 +1,1 @@
+export * from './Swatch';


### PR DESCRIPTION
## What/Why?
This PR adds Swatch component to Reactant Lib.

### Usage
```
<Swatch onClick={focusHandler}>
  <SwatchInput aria-label="your-label" />
  <SwatchLabel title="your-label">
    <SwatchVariant variantColor="#3071EF" />
  </SwatchLabel>
  <SwatchPreview variantColor="#3071EF" />
</Swatch>
```

## Testing
Locally tested

https://github.com/bigcommerce/catalyst/assets/67792608/84ec4857-9976-4260-96bd-52198f01cf95

