### PR TITLE
fix: use h2 in titles to accessibility

### DIFF
--- a/apps/core/src/app/page.tsx
+++ b/apps/core/src/app/page.tsx
@@ -1,5 +1,6 @@
 import { cs } from '@bigcommerce/reactant/cs';
 import { ReactNode } from 'react';
+
 import client from '~/client';
 
 import { Hero } from './components/Hero';
@@ -10,7 +11,7 @@ const ProductList = ({ children }: { children: ReactNode }) => (
 );
 
 const ProductListName = ({ children }: { children: ReactNode }) => (
-  <h3 className={cs('mb-10 text-center text-h3 sm:text-left')}>{children}</h3>
+  <h2 className={cs('mb-10 text-center text-h3 sm:text-left')}>{children}</h2>
 );
 
 const ProductListGrid = ({ children }: { children: ReactNode }) => (


### PR DESCRIPTION
## What/Why?
Use `h2` instead of `h3` to follow the accesible flow of headings and get 100% accessibility lighthouse score.

## Testing
![Screenshot 2023-07-25 at 2 39 06 PM](https://github.com/bigcommerce/catalyst/assets/196129/344f4447-09d5-46a4-ac62-968927ade4c4)
