### PR TITLE
feat: CATALYST-30 add facets and category args to search query

### DIFF
--- a/.vscode/settings.example.json
+++ b/.vscode/settings.example.json
@@ -3,5 +3,5 @@
   "eslint.workingDirectories": [
     { "pattern": "apps/*/" },
     { "pattern": "packages/*/" }
-  ],
+  ]
 }


### PR DESCRIPTION
## What/Why?
- Adds `categoryEntityId` and `categoryEntityIds` to the product search query and makes the `searchTerm` optional. These arguments are optional in GraphQL so wanted to add/reflect what the API consumes.
- Adds facets to the `getProductSearchResults` query as we will need them in the category/search pages.

## Testing
Rendered UI with the pulled in facets:
![Screenshot 2023-08-03 at 10 41 48](https://github.com/bigcommerce/catalyst/assets/10539418/cf773e87-1060-4b93-9390-e2ad65a89a4a)
