### PR TITLE
fix(create-catalyst): remove build script pointing to non-existent entry

### DIFF
--- a/packages/create-catalyst/package.json
+++ b/packages/create-catalyst/package.json
@@ -8,7 +8,6 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup",
     "check-types": "tsc --noEmit",
     "lint": "eslint . --max-warnings 0"
   },


### PR DESCRIPTION
## What/Why?
Running `pnpm run dev` from root results in:
```
@bigcommerce/create-catalyst:build: > @bigcommerce/create-catalyst@0.1.0 build /Users/matt.volk/code/catalyst/packages/create-catalyst
@bigcommerce/create-catalyst:build: > tsup
@bigcommerce/create-catalyst:build: 
@bigcommerce/create-catalyst:build: Cannot find src/index.ts
@bigcommerce/create-catalyst:build:  ELIFECYCLE  Command failed with exit code 1.
@bigcommerce/create-catalyst:build: ERROR: command finished with error: command (/Users/matt.volk/code/catalyst/packages/create-catalyst) pnpm run build exited (1)
```

**Reason:** The `build` script in `packages/create-catalyst/package.json` runs `tsup` which is looking for a `package/create-catalyst/package.json/src/index.ts` file, which does not yet exist.

## Testing
Check out this branch, run `pnpm run dev` from repository root, confirm no errors thrown from `create-catalyst`