### PR TITLE
feat(reactant): add RectangleList component

### DIFF
--- a/apps/docs/stories/RectangleList.stories.tsx
+++ b/apps/docs/stories/RectangleList.stories.tsx
@@ -1,0 +1,49 @@
+import {
+  RectangleList,
+  RectangleListGroup,
+  RectangleListItem,
+  RectangleListLabel,
+} from '@bigcommerce/reactant/RectangleList';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof RectangleList> = {
+  component: RectangleList,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof RectangleList>;
+
+const mockedData = {
+  entityId: 100,
+  displayName: 'Size',
+  values: [
+    { entityId: 1, label: 'XS' },
+    { entityId: 2, label: 'S' },
+    { entityId: 3, label: 'M' },
+    { entityId: 4, label: 'L' },
+    { entityId: 5, label: 'XL' },
+  ],
+};
+
+export const Basic: Story = {
+  render: () => (
+    <RectangleList>
+      <RectangleListLabel>{mockedData.displayName}</RectangleListLabel>
+      <RectangleListGroup>
+        {mockedData.values.map(({ label, entityId }) => (
+          <RectangleListItem
+            href="#"
+            isActive={entityId === 2}
+            isDisabled={entityId === 3}
+            key={entityId}
+            title={`${mockedData.displayName} ${label}`}
+          >
+            {label}
+          </RectangleListItem>
+        ))}
+      </RectangleListGroup>
+    </RectangleList>
+  ),
+};

--- a/packages/reactant/src/components/RectangleList/RectangleList.tsx
+++ b/packages/reactant/src/components/RectangleList/RectangleList.tsx
@@ -1,0 +1,69 @@
+import { Slot } from '@radix-ui/react-slot';
+import { ComponentPropsWithRef, ElementRef, forwardRef } from 'react';
+
+import { cs } from '../../utils/cs';
+
+export const RectangleList = forwardRef<ElementRef<'dl'>, ComponentPropsWithRef<'dl'>>(
+  ({ children, className, ...props }, ref) => (
+    <dl className={cs(className)} ref={ref} {...props}>
+      {children}
+    </dl>
+  ),
+);
+
+export const RectangleListLabel = forwardRef<ElementRef<'dt'>, ComponentPropsWithRef<'dt'>>(
+  ({ className, children, ...props }, ref) => (
+    <dt className={cs('my-2 h-6 font-semibold', className)} ref={ref} {...props}>
+      {children}
+    </dt>
+  ),
+);
+
+export const RectangleListGroup = forwardRef<ElementRef<'dd'>, ComponentPropsWithRef<'dd'>>(
+  ({ className, ...props }, ref) => (
+    <dd className={cs('flex flex-wrap gap-4', className)} ref={ref} {...props} />
+  ),
+);
+
+interface RectangleListItemProps extends ComponentPropsWithRef<'a'> {
+  asChild?: boolean;
+  isActive?: boolean;
+  isDisabled?: boolean;
+}
+
+export const RectangleListItem = forwardRef<ElementRef<'a'>, RectangleListItemProps>(
+  (
+    { asChild = false, className, children, isActive = false, isDisabled = false, href, ...props },
+    ref,
+  ) => {
+    const Comp = asChild ? Slot : 'a';
+
+    return isDisabled ? (
+      <Comp
+        aria-disabled="true"
+        className={cs(
+          'cursor-not-allowed border-2 border-gray-100 py-2.5 px-6 font-semibold text-gray-400 hover:border-gray-100',
+          className,
+        )}
+        ref={ref}
+        role="link"
+        {...props}
+      >
+        {children}
+      </Comp>
+    ) : (
+      <Comp
+        className={cs(
+          'focus:ring-primary-blue/20 border-2 border-gray-200 py-2.5 px-6 font-semibold hover:border-blue-primary focus:outline-none focus:ring-4',
+          isActive && 'border-blue-primary',
+          className,
+        )}
+        href={href}
+        ref={ref}
+        {...props}
+      >
+        {children}
+      </Comp>
+    );
+  },
+);

--- a/packages/reactant/src/components/RectangleList/index.ts
+++ b/packages/reactant/src/components/RectangleList/index.ts
@@ -1,0 +1,1 @@
+export * from './RectangleList';


### PR DESCRIPTION
## What/Why?
Add `RectangleList` component.

This component will render each `RectangleListItem` as an `a` tag, since the idea will be that we will use url params to control what option is selected.

When disabled, other than adding disabled styling, I also add the `role="link"` prop, add `aria-disabled`, and remove `href`. This seems to be the right way[ to "disable" an href element](https://w3c.github.io/html-aria/#el-a).

## Screens
![Screenshot 2023-08-04 at 2 26 32 PM](https://github.com/bigcommerce/catalyst/assets/196129/ce5bba72-d751-4a1d-bd36-75de32e65009)

## Testing
WIP