### PR TITLE
feat(core): CATALYST-30 sort products via query params

### DIFF
--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -19,7 +19,8 @@
     "react-dom": "^18.2.0",
     "server-only": "^0.0.1",
     "sharp": "^0.32.1",
-    "tailwind-merge": "^1.12.0"
+    "tailwind-merge": "^1.12.0",
+    "zod": "^3.21.4"
   },
   "devDependencies": {
     "@bigcommerce/catalyst-configs": "workspace:^",

--- a/apps/core/src/app/category/[slug]/fetchCategory.ts
+++ b/apps/core/src/app/category/[slug]/fetchCategory.ts
@@ -1,22 +1,64 @@
+import { SearchProductsSortInput } from '@bigcommerce/catalyst-client';
 import { cache } from 'react';
+import z from 'zod';
 
 import client from '~/client';
 
-export interface FetchCategoryParams {
-  categoryId: number;
-  limit?: number;
-  after?: string;
-  before?: string;
-}
+const searchProductsSortInput: SearchProductsSortInput[] = [
+  'A_TO_Z',
+  'BEST_REVIEWED',
+  'BEST_SELLING',
+  'FEATURED',
+  'HIGHEST_PRICE',
+  'LOWEST_PRICE',
+  'NEWEST',
+  'RELEVANCE',
+  'Z_TO_A',
+];
+
+export const PrivateSearchParamsSchema = z
+  .object({
+    searchTerm: z.string().optional(),
+    categoryEntityId: z.number().optional(),
+    limit: z.number().optional(),
+    before: z.string().optional(),
+    after: z.string().optional(),
+    sort: z
+      .string()
+      .toUpperCase()
+      .refine<SearchProductsSortInput>((value): value is SearchProductsSortInput =>
+        Boolean(searchProductsSortInput.find((input) => input === value)),
+      )
+      .optional(),
+  })
+  .passthrough();
+
+export const PublicSearchParamsSchema = z.preprocess((searchParams) => {
+  const validatedRecord = z.record(z.unknown()).parse(searchParams);
+
+  const { categoryId, ...rest } = validatedRecord;
+
+  return {
+    categoryEntityId: categoryId,
+    ...rest,
+  };
+}, PrivateSearchParamsSchema);
 
 export const fetchCategory = cache(
   // We need to make sure the reference passed into this function is the same if we want it to be memoized.
-  async ({ categoryId, limit = 4, after, before }: FetchCategoryParams) => {
+  async ({
+    categoryEntityId,
+    limit = 4,
+    after,
+    before,
+    sort,
+  }: z.infer<typeof PrivateSearchParamsSchema>) => {
     return client.getProductSearchResults({
-      categoryEntityId: categoryId,
+      categoryEntityId,
       limit,
       after,
       before,
+      sort,
     });
   },
 );

--- a/apps/core/src/app/category/[slug]/page.tsx
+++ b/apps/core/src/app/category/[slug]/page.tsx
@@ -8,7 +8,7 @@ import { ProductCard } from 'src/app/components/ProductCard';
 import client from '~/client';
 
 import { Breadcrumbs } from './Breadcrumbs';
-import { fetchCategory } from './fetchCategory';
+import { fetchCategory, PublicSearchParamsSchema } from './fetchCategory';
 
 interface Props {
   params: {
@@ -20,14 +20,9 @@ interface Props {
 export default async function Category({ params, searchParams }: Props) {
   const categoryId = Number(params.slug);
 
-  // Eventually we'll want to have a utility parse the query params for the page and map them to the appropriate graphql filters.
-  const after = typeof searchParams.after === 'string' ? searchParams.after : undefined;
-  const before = typeof searchParams.before === 'string' ? searchParams.before : undefined;
-  const limit = typeof searchParams.limit === 'string' ? Number(searchParams.limit) : undefined;
+  const parsedParams = PublicSearchParamsSchema.parse({ categoryId, ...searchParams });
 
-  const fetchCategoryParams = { categoryId, limit, after, before };
-
-  const search = await fetchCategory(fetchCategoryParams);
+  const search = await fetchCategory(parsedParams);
 
   // We will only need a partial of this query to fetch the category name and breadcrumbs.
   // The rest of the arguments are useless at this point.

--- a/packages/client/src/queries/getProductSearchResults.ts
+++ b/packages/client/src/queries/getProductSearchResults.ts
@@ -1,5 +1,10 @@
 import { BigCommerceResponse, FetcherInput } from '../fetcher';
-import { generateQueryOp, QueryGenqlSelection, QueryResult } from '../generated';
+import {
+  generateQueryOp,
+  QueryGenqlSelection,
+  QueryResult,
+  SearchProductsSortInput,
+} from '../generated';
 import { removeEdgesAndNodes } from '../utils/removeEdgesAndNodes';
 
 export interface ProductSearch {
@@ -9,11 +14,20 @@ export interface ProductSearch {
   limit?: number;
   before?: string;
   after?: string;
+  sort?: SearchProductsSortInput;
 }
 
 export const getProductSearchResults = async <T>(
   customFetch: <U>(data: FetcherInput) => Promise<BigCommerceResponse<U>>,
-  { searchTerm, categoryEntityId, categoryEntityIds, limit = 9, before, after }: ProductSearch,
+  {
+    searchTerm,
+    categoryEntityId,
+    categoryEntityIds,
+    limit = 9,
+    before,
+    after,
+    sort,
+  }: ProductSearch,
   config: T = {} as T,
 ) => {
   const paginationArgs = before ? { last: limit, before } : { first: limit, after };
@@ -28,6 +42,7 @@ export const getProductSearchResults = async <T>(
               categoryEntityId,
               categoryEntityIds,
             },
+            sort,
           },
           products: {
             __args: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       tailwind-merge:
         specifier: ^1.12.0
         version: 1.12.0
+      zod:
+        specifier: ^3.21.4
+        version: 3.21.4
     devDependencies:
       '@bigcommerce/catalyst-configs':
         specifier: workspace:^


### PR DESCRIPTION
## What/Why?
Adds the ability to sort products via query params. This is pre-work before hooking up the dropdown.

## Testing

https://github.com/bigcommerce/catalyst/assets/10539418/a5ce4091-1756-49a7-8614-b52faf9194df

