### PR TITLE
feat(core): CATALYST-30 hook up product sort to sort dropdown

### DIFF
--- a/apps/core/src/app/category/[slug]/SortBy.tsx
+++ b/apps/core/src/app/category/[slug]/SortBy.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { Select, SelectContent, SelectItem } from '@bigcommerce/reactant/Select';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+
+export function SortBy() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const value = searchParams.get('sort') ?? 'featured';
+
+  const onSort = (sortValue: string) => {
+    const params = new URLSearchParams(searchParams);
+
+    params.set('sort', sortValue);
+
+    return router.push(`${pathname}?${params.toString()}`);
+  };
+
+  return (
+    <Select
+      className="order-2 min-w-[224px] md:order-3 md:w-auto"
+      onValueChange={onSort}
+      value={value}
+    >
+      <SelectContent>
+        <SelectItem value="featured">Featured items</SelectItem>
+        <SelectItem value="newest">Newest items</SelectItem>
+        <SelectItem value="best_selling">Best selling</SelectItem>
+        <SelectItem value="a_to_z">A to Z</SelectItem>
+        <SelectItem value="z_to_a">Z to A</SelectItem>
+        <SelectItem value="best_reviewed">By review</SelectItem>
+        <SelectItem value="lowest_price">Price: ascending</SelectItem>
+        <SelectItem value="highest_price">Price: descending</SelectItem>
+        <SelectItem value="relevance">Relevance</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+}

--- a/apps/core/src/app/category/[slug]/page.tsx
+++ b/apps/core/src/app/category/[slug]/page.tsx
@@ -1,14 +1,15 @@
 import { Button } from '@bigcommerce/reactant/Button';
-import { Select, SelectContent, SelectItem } from '@bigcommerce/reactant/Select';
 import { ChevronLeft, ChevronRight, Filter } from 'lucide-react';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import { Suspense } from 'react';
 
 import { ProductCard } from 'src/app/components/ProductCard';
 import client from '~/client';
 
 import { Breadcrumbs } from './Breadcrumbs';
 import { fetchCategory, PublicSearchParamsSchema } from './fetchCategory';
+import { SortBy } from './SortBy';
 
 interface Props {
   params: {
@@ -50,19 +51,10 @@ export default async function Category({ params, searchParams }: Props) {
             <Filter className="mr-3" /> <span>Show Filters</span>
           </Button>
           <div className="flex w-full flex-col items-start gap-4 md:flex-row md:items-center md:justify-end md:gap-6">
-            <Select className="order-2 min-w-[224px] md:order-3 md:w-auto" defaultValue="featured">
-              <SelectContent>
-                <SelectItem value="featured">Featured items</SelectItem>
-                <SelectItem value="newest">Newest items</SelectItem>
-                <SelectItem value="best_selling">Best selling</SelectItem>
-                <SelectItem value="a_to_z">A to Z</SelectItem>
-                <SelectItem value="z_to_a">Z to A</SelectItem>
-                <SelectItem value="best_reviewed">By review</SelectItem>
-                <SelectItem value="lowest_price">Price: ascending</SelectItem>
-                <SelectItem value="highest_price">Price: descending</SelectItem>
-                <SelectItem value="relevance">Relevance</SelectItem>
-              </SelectContent>
-            </Select>
+            {/* This suspense boundary allows everything above it to be statically rendered */}
+            <Suspense>
+              <SortBy />
+            </Suspense>
             <div className="order-3 py-4 text-base font-semibold md:order-2 md:py-0">
               {/* TODO: Plural vs. singular items */}
               {search.products.collectionInfo?.totalItems} items


### PR DESCRIPTION
## What/Why?
Hook up the product sort filtering, via the query params, with the sort by dropdown.

## Testing

### Selecting items from the dropdown

https://github.com/bigcommerce/catalyst/assets/10539418/3dba116e-69bf-4f5f-ba9b-2aca135fd497

### Navigating backwards

https://github.com/bigcommerce/catalyst/assets/10539418/be9b5768-90a5-46c8-943a-a29a07446b23