### PR TITLE
feat(core): CATALYST-30 render subcategories in the PLP page

### DIFF
--- a/apps/core/src/app/category/[slug]/SubCategories.tsx
+++ b/apps/core/src/app/category/[slug]/SubCategories.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link';
+
+import client from '~/client';
+
+interface Props {
+  categoryId: number;
+}
+
+export async function SubCategories({ categoryId }: Props) {
+  const [categoryTree] = await client.getCategoryTree(categoryId);
+
+  if (!categoryTree?.children.length) {
+    return null;
+  }
+
+  return (
+    <div>
+      <h3 className="mb-3 text-h5">Categories</h3>
+
+      <ul className="flex flex-col gap-4 text-base">
+        {categoryTree.children.map((category) => (
+          <li key={category.entityId}>
+            <Link href={`/category/${category.entityId}`}>{category.name}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/core/src/app/category/[slug]/page.tsx
+++ b/apps/core/src/app/category/[slug]/page.tsx
@@ -10,6 +10,7 @@ import client from '~/client';
 import { Breadcrumbs } from './Breadcrumbs';
 import { fetchCategory, PublicSearchParamsSchema } from './fetchCategory';
 import { SortBy } from './SortBy';
+import { SubCategories } from './SubCategories';
 
 interface Props {
   params: {
@@ -63,21 +64,13 @@ export default async function Category({ params, searchParams }: Props) {
         </div>
       </div>
 
-      <div className="pt-6 sm:grid sm:grid-cols-3 lg:gap-x-8 xl:grid-cols-4">
+      <div className="sm:grid sm:grid-cols-3 lg:gap-x-8 xl:grid-cols-4">
         <aside aria-labelledby="filters-heading" className="flex flex-col gap-6">
           <h2 className="sr-only" id="filters-heading">
             Filters
           </h2>
 
-          <div>
-            <h3 className="mb-3 text-h5">Categories</h3>
-
-            <ul className="flex flex-col gap-4 text-base">
-              <li>Category 1</li>
-              <li>Category 2</li>
-              <li>Category 3</li>
-            </ul>
-          </div>
+          <SubCategories categoryId={categoryId} />
 
           <div>
             <h3 className="mb-3 text-h5">Brand</h3>

--- a/packages/client/src/queries/getCategoryTree.ts
+++ b/packages/client/src/queries/getCategoryTree.ts
@@ -3,6 +3,7 @@ import { generateQueryOp, QueryGenqlSelection, QueryResult } from '../generated'
 
 export const getCategoryTree = async <T>(
   customFetch: <U>(data: FetcherInput) => Promise<BigCommerceResponse<U>>,
+  rootEntityId?: number,
   config: T = {} as T,
 ) => {
   const Category = {
@@ -14,6 +15,9 @@ export const getCategoryTree = async <T>(
   const query = {
     site: {
       categoryTree: {
+        __args: {
+          rootEntityId,
+        },
         ...Category,
         children: {
           ...Category,


### PR DESCRIPTION
## What/Why?
Renders the subcategories within the PLP page.

## Testing

https://github.com/bigcommerce/catalyst/assets/10539418/84716ca7-2e4d-4670-ab0e-46c08abda057


