### PR TITLE
feat(reactant): CATALYST-30 create Tag component

### DIFF
--- a/apps/docs/stories/Tag.stories.tsx
+++ b/apps/docs/stories/Tag.stories.tsx
@@ -1,0 +1,35 @@
+import { Tag, TagAction, TagContent, TagProps } from '@bigcommerce/reactant/Tag';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof Tag> = {
+  component: Tag,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Tag>;
+
+export const BasicExample: Story = {
+  args: {
+    children: 'Tag',
+  },
+  render: ({ children }: TagProps) => (
+    <Tag>
+      <TagContent>{children}</TagContent>
+      {/* eslint-disable-next-line no-alert */}
+      <TagAction onClick={() => alert('Clicked')} />
+    </Tag>
+  ),
+};
+
+export const NoActionExample: Story = {
+  args: {
+    children: 'Tag',
+  },
+  render: ({ children }: TagProps) => (
+    <Tag>
+      <TagContent>{children}</TagContent>
+    </Tag>
+  ),
+};

--- a/packages/reactant/src/components/Tag/Tag.tsx
+++ b/packages/reactant/src/components/Tag/Tag.tsx
@@ -1,0 +1,56 @@
+import { X } from 'lucide-react';
+import { ComponentPropsWithRef, ElementRef, forwardRef } from 'react';
+
+import { cs } from '../../utils/cs';
+
+export type TagProps = ComponentPropsWithRef<'div'>;
+
+const Tag = forwardRef<ElementRef<'div'>, TagProps>(({ className, ...props }, ref) => {
+  return (
+    <div
+      className={cs(
+        'inline-flex h-[40px] flex-row items-center whitespace-nowrap bg-gray-100',
+        className,
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+
+Tag.displayName = 'Tag';
+
+export type TagContentProps = ComponentPropsWithRef<'span'>;
+
+const TagContent = forwardRef<ElementRef<'span'>, TagContentProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <span className={cs('pl-4 pr-2 font-semibold only:px-4', className)} ref={ref} {...props} />
+    );
+  },
+);
+
+TagContent.displayName = 'TagContent';
+
+export type TagActionProps = ComponentPropsWithRef<'button'>;
+
+const TagAction = forwardRef<ElementRef<'button'>, TagActionProps>(
+  ({ className, children, ...props }, ref) => {
+    return (
+      <button
+        className={cs(
+          'box-content inline-flex h-8 w-8 items-center justify-center p-1 hover:bg-blue-primary/10 focus:outline-none focus:ring-4 focus:ring-inset focus:ring-blue-primary/20',
+        )}
+        ref={ref}
+        type="button"
+        {...props}
+      >
+        {children || <X className="h-4 w-4" />}
+      </button>
+    );
+  },
+);
+
+TagAction.displayName = 'TagAction';
+
+export { Tag, TagContent, TagAction };

--- a/packages/reactant/src/components/Tag/index.ts
+++ b/packages/reactant/src/components/Tag/index.ts
@@ -1,0 +1,3 @@
+'use client';
+
+export * from './Tag';


### PR DESCRIPTION
## What/Why?
Creates a tag components that will be used to show active filters on the category page:

| PLP | Designs |
| - | - |
| <img src="https://github.com/bigcommerce/catalyst/assets/10539418/19cb7a88-a1eb-4e65-a62e-b089e1d6f8bb" width="400" /> | <img src="https://github.com/bigcommerce/catalyst/assets/10539418/dc9c2b0c-b7d7-44be-acb1-30c1a1e5c6c5" width="400" /> |


## Testing

https://github.com/bigcommerce/catalyst/assets/10539418/5e10ee82-efd4-4c95-9417-8dee4a4eb9ed
