### PR TITLE
wip(reactant): CATALYST-20 create linked list carousel component

### DIFF
--- a/apps/docs/stories/CarouselLinkedList.stories.tsx
+++ b/apps/docs/stories/CarouselLinkedList.stories.tsx
@@ -1,0 +1,123 @@
+import { Button } from '@bigcommerce/reactant/Button';
+import { CarouselLinkedList, CarouselLinkedListItem } from '@bigcommerce/reactant/Carousel';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof CarouselLinkedList> = {
+  component: CarouselLinkedList,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof CarouselLinkedList>;
+
+export const OneSlide: Story = {
+  render: () => (
+    <CarouselLinkedList>
+      <CarouselLinkedListItem className="flex flex-col justify-center bg-gray-100 p-12 duration-700">
+        <h1 className="text-h1">25% Off Sale</h1>
+        <p className="max-w-[548px] pt-4">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
+          ut labore et dolore magna aliqua. Ut enim ad minim veniam.
+        </p>
+        <Button asChild className="mt-10 w-[141px]">
+          <a href="/#">Shop now</a>
+        </Button>
+      </CarouselLinkedListItem>
+    </CarouselLinkedList>
+  ),
+};
+
+export const TwoSlides: Story = {
+  render: () => (
+    <div>
+      <CarouselLinkedList>
+        <CarouselLinkedListItem className="flex flex-col justify-center bg-gray-100 p-12 duration-700">
+          <h1 className="text-h1">25% Off Sale</h1>
+          <p className="max-w-[548px] pt-4">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
+          </p>
+          <Button asChild className="mt-10 w-[141px]">
+            <a href="/#">Shop now</a>
+          </Button>
+        </CarouselLinkedListItem>
+        <CarouselLinkedListItem className="flex flex-col justify-center bg-gray-100 p-12 duration-700">
+          <h1 className="text-h1">Great Deals</h1>
+          <p className="max-w-[548px] pt-4">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
+          </p>
+          <Button asChild className="mt-10 w-[141px]">
+            <a href="/#">Shop now</a>
+          </Button>
+        </CarouselLinkedListItem>
+      </CarouselLinkedList>
+    </div>
+  ),
+};
+
+export const ThreeSlides: Story = {
+  render: () => (
+    <div>
+      <CarouselLinkedList>
+        <CarouselLinkedListItem className="flex flex-col justify-center bg-gray-100 p-12 duration-700">
+          <h1 className="text-h1">25% Off Sale</h1>
+          <p className="max-w-[548px] pt-4">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
+          </p>
+          <Button asChild className="mt-10 w-[141px]">
+            <a href="/#">Shop now</a>
+          </Button>
+        </CarouselLinkedListItem>
+        <CarouselLinkedListItem className="flex flex-col justify-center bg-gray-100 p-12 duration-700">
+          <h1 className="text-h1">Great Deals</h1>
+          <p className="max-w-[548px] pt-4">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
+          </p>
+          <Button asChild className="mt-10 w-[141px]">
+            <a href="/#">Shop now</a>
+          </Button>
+        </CarouselLinkedListItem>
+        <CarouselLinkedListItem className="flex flex-col justify-center bg-gray-100 p-12 duration-700">
+          <h1 className="text-h1">Low Prices</h1>
+          <p className="max-w-[548px] pt-4">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
+          </p>
+          <Button asChild className="mt-10 w-[141px]">
+            <a href="/#">Shop now</a>
+          </Button>
+        </CarouselLinkedListItem>
+      </CarouselLinkedList>
+    </div>
+  ),
+};
+
+const mocked = new Array(100).fill(undefined).map((_, index) => index);
+
+export const OneHundredSlides: Story = {
+  render: () => (
+    <div>
+      <CarouselLinkedList>
+        {mocked.map((item) => (
+          <CarouselLinkedListItem
+            className="flex flex-col justify-center bg-gray-100 p-12 duration-700"
+            key={item}
+          >
+            <h1 className="text-h1">{item + 1}% Off Sale</h1>
+            <p className="max-w-[548px] pt-4">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+              incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
+            </p>
+            <Button asChild className="mt-10 w-[141px]">
+              <a href="/#">Shop now</a>
+            </Button>
+          </CarouselLinkedListItem>
+        ))}
+      </CarouselLinkedList>
+    </div>
+  ),
+};

--- a/packages/reactant/src/components/Carousel/CarouselLinkedList.tsx
+++ b/packages/reactant/src/components/Carousel/CarouselLinkedList.tsx
@@ -1,0 +1,138 @@
+import { ArrowLeft, ArrowRight, Pause, Play } from 'lucide-react';
+import {
+  Children,
+  cloneElement,
+  ComponentPropsWithRef,
+  ElementRef,
+  forwardRef,
+  isValidElement,
+  ReactElement,
+  useEffect,
+  useReducer,
+  useState,
+} from 'react';
+
+import { cs } from '../../utils/cs';
+
+import { LinkedList, Node } from './LinkedList';
+
+export interface CarouselLinkedListItemProps extends ComponentPropsWithRef<'li'> {
+  inert?: boolean;
+}
+
+export const CarouselLinkedListItem = forwardRef<ElementRef<'li'>, CarouselLinkedListItemProps>(
+  ({ className, children, inert }, ref) => {
+    return (
+      <li
+        className={cs('absolute h-full w-full transform transition-all', className)}
+        // @ts-expect-error https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60822
+        inert={inert ? 'true' : null}
+        ref={ref}
+      >
+        {children}
+      </li>
+    );
+  },
+);
+
+interface CarouselLinkedListProps extends ComponentPropsWithRef<'ul'> {
+  interval?: number;
+  children:
+    | ReactElement<CarouselLinkedListItemProps>
+    | Array<ReactElement<CarouselLinkedListItemProps>>;
+}
+
+export const CarouselLinkedList = forwardRef<ElementRef<'ul'>, CarouselLinkedListProps>(
+  ({ children, className, interval = 10_000 }, ref) => {
+    const [paused, togglePause] = useReducer((state: boolean) => !state, false);
+    const [hoverPaused, setHoverPaused] = useState(false);
+    const [current, setCurrent] = useState<Node<ReactElement<CarouselLinkedListItemProps>> | null>(
+      null,
+    );
+
+    useEffect(() => {
+      const valid = Children.toArray(children).filter(
+        (child): child is ReactElement<CarouselLinkedListItemProps> =>
+          isValidElement<CarouselLinkedListItemProps>(child) &&
+          typeof child !== 'string' &&
+          typeof child !== 'number',
+      );
+
+      const linkedList = new LinkedList();
+
+      Children.map(valid, (child) => linkedList.append(child));
+
+      setCurrent(linkedList.head);
+    }, [children]);
+
+    useEffect(() => {
+      const intervalId = setInterval(() => {
+        if (!paused && !hoverPaused && Children.count(children) > 1 && current) {
+          setCurrent(current.next);
+        }
+      }, interval);
+
+      return () => {
+        clearInterval(intervalId);
+      };
+    }, [hoverPaused, interval, paused, children, current]);
+
+    if (!current) return <ul>!current</ul>;
+    if (!current.prev) return <ul>!current.prev</ul>;
+    if (!current.next) return <ul>!current.next</ul>;
+
+    const left = cloneElement(current.prev.data, {
+      className: cs(current.prev.data.props.className, 'z-10 -translate-x-full'),
+      inert: true,
+    });
+    const middle = cloneElement(current.data, {
+      className: cs(current.data.props.className, 'z-20 translate-x-0'),
+    });
+    const right = cloneElement(current.next.data, {
+      className: cs(current.next.data.props.className, 'z-10 translate-x-full'),
+      inert: true,
+    });
+
+    return (
+      <ul
+        className={cs(
+          'relative inset-0 h-[640px] overflow-hidden md:h-[508px] lg:h-[600px]',
+          className,
+        )}
+        onBlur={() => setHoverPaused(false)}
+        onFocus={() => setHoverPaused(true)}
+        onMouseEnter={() => setHoverPaused(true)}
+        onMouseLeave={() => setHoverPaused(false)}
+        ref={ref}
+      >
+        {[left, middle, right]}
+
+        {Children.count(children) > 1 && (
+          <ul className="absolute bottom-12 left-12 z-30 flex gap-8">
+            <li>
+              <button className="p-1" onClick={() => togglePause()}>
+                {paused ? <Play /> : <Pause />}
+              </button>
+            </li>
+
+            <li>
+              <button className="p-1" onClick={() => setCurrent(current.prev)}>
+                <ArrowLeft />
+              </button>
+            </li>
+
+            <li aria-atomic="true" aria-live="polite" className="p-1 font-semibold">
+              ? of ?
+            </li>
+
+            <li>
+              <button className="p-1" onClick={() => setCurrent(current.next)}>
+                <ArrowRight />
+              </button>
+            </li>
+          </ul>
+        )}
+      </ul>
+    );
+  },
+);

--- a/packages/reactant/src/components/Carousel/LinkedList.ts
+++ b/packages/reactant/src/components/Carousel/LinkedList.ts
@@ -1,0 +1,43 @@
+/* eslint-disable max-classes-per-file */
+import { ReactElement } from 'react';
+
+import { CarouselLinkedListItemProps } from './CarouselLinkedList';
+
+export class Node<T> {
+  data: T;
+  next: Node<T> | null = null;
+  prev: Node<T> | null = null;
+
+  constructor(data: T) {
+    this.data = data;
+  }
+}
+
+export class LinkedList {
+  head: Node<ReactElement<CarouselLinkedListItemProps>> | null = null;
+
+  append(data: ReactElement<CarouselLinkedListItemProps>) {
+    const node = new Node(data);
+
+    if (!this.head) {
+      this.head = node;
+      this.head.next = node;
+      this.head.prev = node;
+    } else {
+      let temp = this.head;
+
+      while (temp.next !== this.head) {
+        if (temp.next) {
+          temp = temp.next;
+        }
+      }
+
+      const newSlide = new Node(data);
+
+      temp.next = newSlide;
+      this.head.prev = newSlide;
+      newSlide.next = this.head;
+      newSlide.prev = temp;
+    }
+  }
+}

--- a/packages/reactant/src/components/Carousel/index.ts
+++ b/packages/reactant/src/components/Carousel/index.ts
@@ -1,0 +1,3 @@
+'use client';
+
+export * from './CarouselLinkedList';


### PR DESCRIPTION
## What/Why?
⚠️ **WIP:** A proof of concept to test whether creating `<CarouselItem />`'s as nodes in a circular doubly linked list allows for a cleaner `<Carousel />` implementation.

### DONE:
- [x] `<CarouselLinkedList />` slideshow works with 4 or more `<CarouselLinkedListItems />`

### WIP:
- [ ] `<CarouselLinkedList />` slideshow does not work with 3 or less `<CarouselLinkedListItems />`
- [ ] Each node in the linked list needs to be aware of its original index in the `children` array. This is to enable us to render the `1/3`, `2/3`, etc. indicator between the left and right navigation buttons.

## Testing
⚠️ WIP - See Storybook for now.