### PR TITLE
chore(docs): remove next js eslint config

### DIFF
--- a/apps/docs/.eslintrc.cjs
+++ b/apps/docs/.eslintrc.cjs
@@ -6,13 +6,11 @@ const config = {
   extends: [
     '@bigcommerce/catalyst/base',
     '@bigcommerce/catalyst/react',
-    '@bigcommerce/catalyst/next',
     '@bigcommerce/catalyst/prettier',
     'plugin:storybook/recommended',
   ],
   rules: {
     '@typescript-eslint/naming-convention': 'off',
-    '@next/next/no-html-link-for-pages': 'off',
     'no-underscore-dangle': [
       'error',
       {


### PR DESCRIPTION
## What/Why?
Removes the `/apps/docs` Next.js eslint config, since storybook isn't next. We've been getting a couple of issues when trying to use normal `<img />` elements.
