### PR TITLE
feat(reactant): CATALYST-30 add Sheet component

### DIFF
--- a/apps/docs/stories/Sheet.stories.tsx
+++ b/apps/docs/stories/Sheet.stories.tsx
@@ -1,0 +1,109 @@
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetOverlay,
+  SheetTitle,
+  SheetTrigger,
+} from '@bigcommerce/reactant/Sheet';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof Sheet> = {
+  component: Sheet,
+  tags: ['autodocs'],
+  argTypes: {
+    side: { control: 'select', options: ['top', 'right', 'bottom', 'left'] },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Sheet>;
+
+const Content = () => (
+  <>
+    <h3 className="mb-2 text-h5">Categories</h3>
+
+    <ul className="flex flex-col">
+      <li>
+        <a className="block py-2" href="#gucci">
+          Gucci
+        </a>
+      </li>
+      <li>
+        <a className="block py-2" href="#versace">
+          Versace
+        </a>
+      </li>
+      <li>
+        <a className="block py-2" href="#ralph-lauren">
+          Ralph Lauren
+        </a>
+      </li>
+    </ul>
+  </>
+);
+
+export const Basic: Story = {
+  args: {
+    side: 'left',
+  },
+  render: ({ side }) => (
+    <Sheet>
+      <SheetTrigger asChild>
+        <button className="mx-auto block rounded-sm border p-2">Open</button>
+      </SheetTrigger>
+      <SheetContent side={side}>
+        <SheetHeader>
+          <SheetTitle>Filters</SheetTitle>
+          <SheetClose />
+        </SheetHeader>
+        <Content />
+      </SheetContent>
+    </Sheet>
+  ),
+};
+
+export const WithOverlay: Story = {
+  render: () => (
+    <Sheet>
+      <SheetTrigger asChild>
+        <button className="mx-auto block rounded-sm border p-2">Open</button>
+      </SheetTrigger>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>Sheet w/ Overlay</SheetTitle>
+          <SheetClose />
+        </SheetHeader>
+        <p>
+          The overlay can add a backdrop to the sheet to obfuscate the view to the user interface.
+        </p>
+      </SheetContent>
+      <SheetOverlay />
+    </Sheet>
+  ),
+};
+
+export const WithFooter: Story = {
+  render: () => (
+    <Sheet>
+      <SheetTrigger asChild>
+        <button className="mx-auto block rounded-sm border p-2">Open</button>
+      </SheetTrigger>
+      <SheetContent side="right">
+        <SheetHeader>
+          <SheetTitle>Sheet w/ Footer</SheetTitle>
+          <SheetClose />
+        </SheetHeader>
+        <p>The footer allows you to pass add custom actions and controls.</p>
+        <SheetFooter>
+          <SheetClose asChild>
+            <button className="rounded-sm border p-2">Apply</button>
+          </SheetClose>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  ),
+};

--- a/packages/reactant/package.json
+++ b/packages/reactant/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-checkbox": "^1.0.4",
+    "@radix-ui/react-dialog": "^1.0.4",
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-navigation-menu": "^1.1.2",
     "@radix-ui/react-radio-group": "^1.1.3",
@@ -63,6 +64,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "tailwindcss": "^3.2.4",
+    "tailwindcss-animate": "^1.0.6",
     "tsup": "^6.7.0",
     "typescript": "^5.1.3"
   }

--- a/packages/reactant/src/components/Sheet/Sheet.tsx
+++ b/packages/reactant/src/components/Sheet/Sheet.tsx
@@ -1,0 +1,122 @@
+import * as SheetPrimitive from '@radix-ui/react-dialog';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { X } from 'lucide-react';
+import { ComponentPropsWithoutRef, ElementRef, forwardRef, HTMLAttributes } from 'react';
+
+import { cs } from '../../utils/cs';
+
+const Sheet = SheetPrimitive.Root;
+
+const SheetTrigger = SheetPrimitive.Trigger;
+
+type SheetCloseProps = ComponentPropsWithoutRef<typeof SheetPrimitive.Close>;
+
+const SheetClose = forwardRef<ElementRef<typeof SheetPrimitive.Close>, SheetCloseProps>(
+  ({ children, ...props }, ref) => (
+    <SheetPrimitive.Close ref={ref} {...props}>
+      {children || (
+        <X className="h-6 w-6">
+          <title>Close</title>
+        </X>
+      )}
+    </SheetPrimitive.Close>
+  ),
+);
+
+SheetClose.displayName = SheetPrimitive.Close.displayName;
+
+const SheetPortal = ({ className, ...props }: SheetPrimitive.DialogPortalProps) => (
+  <SheetPrimitive.Portal className={cs(className)} {...props} />
+);
+
+SheetPortal.displayName = SheetPrimitive.Portal.displayName;
+
+const SheetOverlay = forwardRef<
+  ElementRef<typeof SheetPrimitive.Overlay>,
+  ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cs(
+      'fixed inset-0 z-50 bg-white/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
+
+const sheetVariants = cva(
+  'fixed z-50 gap-4 bg-white p-6 md:p-10 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+  {
+    variants: {
+      side: {
+        top: 'inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top',
+        bottom:
+          'inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
+        left: 'inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm',
+        right:
+          'inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm',
+      },
+    },
+    defaultVariants: {
+      side: 'left',
+    },
+  },
+);
+
+export interface SheetContentProps
+  extends ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {}
+
+const SheetContent = forwardRef<ElementRef<typeof SheetPrimitive.Content>, SheetContentProps>(
+  ({ side = 'left', className, children, ...props }, ref) => (
+    <SheetPortal>
+      <SheetPrimitive.Content
+        className={cs(sheetVariants({ side }), className)}
+        ref={ref}
+        {...props}
+      >
+        {children}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  ),
+);
+
+SheetContent.displayName = SheetPrimitive.Content.displayName;
+
+const SheetHeader = ({ className, ...props }: HTMLAttributes<HTMLDivElement>) => (
+  <div className={cs('mb-6 flex flex-row items-center justify-between', className)} {...props} />
+);
+
+SheetHeader.displayName = 'SheetHeader';
+
+const SheetFooter = ({ className, ...props }: HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cs('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
+    {...props}
+  />
+);
+
+SheetFooter.displayName = 'SheetFooter';
+
+const SheetTitle = forwardRef<
+  ElementRef<typeof SheetPrimitive.Title>,
+  ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title className={cs('text-h4', className)} ref={ref} {...props} />
+));
+
+SheetTitle.displayName = SheetPrimitive.Title.displayName;
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetOverlay,
+};

--- a/packages/reactant/src/components/Sheet/index.ts
+++ b/packages/reactant/src/components/Sheet/index.ts
@@ -1,0 +1,3 @@
+'use client';
+
+export * from './Sheet';

--- a/packages/reactant/tailwind.config.js
+++ b/packages/reactant/tailwind.config.js
@@ -77,7 +77,7 @@ const config = {
   },
   // @ts-ignore
   // eslint-disable-next-line global-require
-  plugins: [require('tailwindcss-radix')()],
+  plugins: [require('tailwindcss-radix')(), require('tailwindcss-animate')],
 };
 
 module.exports = config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -381,6 +381,9 @@ importers:
       '@radix-ui/react-checkbox':
         specifier: ^1.0.4
         version: 1.0.4(@types/react-dom@18.2.4)(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-dialog':
+        specifier: ^1.0.4
+        version: 1.0.4(@types/react-dom@18.2.4)(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-label':
         specifier: ^2.0.2
         version: 2.0.2(@types/react-dom@18.2.4)(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0)
@@ -451,6 +454,9 @@ importers:
       tailwindcss:
         specifier: ^3.2.4
         version: 3.2.4(postcss@8.4.21)
+      tailwindcss-animate:
+        specifier: ^1.0.6
+        version: 1.0.6(tailwindcss@3.2.4)
       tsup:
         specifier: ^6.7.0
         version: 6.7.0(postcss@8.4.21)(typescript@5.1.3)
@@ -3816,6 +3822,40 @@ packages:
       '@babel/runtime': 7.22.3
       '@types/react': 18.2.8
       react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-dialog@1.0.4(@types/react-dom@18.2.4)(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-hJtRy/jPULGQZceSAP2Re6/4NpKo8im6V8P2hUqZsdFiSL8l35kYsw3qbRI6Ay5mQd2+wlLqje770eq+RJ3yZg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.3
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.8)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.8)(react@18.2.0)
+      '@radix-ui/react-dismissable-layer': 1.0.4(@types/react-dom@18.2.4)(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-focus-guards': 1.0.1(@types/react@18.2.8)(react@18.2.0)
+      '@radix-ui/react-focus-scope': 1.0.3(@types/react-dom@18.2.4)(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.2.8)(react@18.2.0)
+      '@radix-ui/react-portal': 1.0.3(@types/react-dom@18.2.4)(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.2.4)(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.4)(@types/react@18.2.8)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.8)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.8)(react@18.2.0)
+      '@types/react': 18.2.8
+      '@types/react-dom': 18.2.4
+      aria-hidden: 1.2.3
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-remove-scroll: 2.5.5(@types/react@18.2.8)(react@18.2.0)
     dev: false
 
   /@radix-ui/react-direction@1.0.0(react@18.2.0):
@@ -11674,6 +11714,14 @@ packages:
   /tailwind-merge@1.12.0:
     resolution: {integrity: sha512-Y17eDp7FtN1+JJ4OY0Bqv9OA41O+MS8c1Iyr3T6JFLnOgLg3EvcyMKZAnQ8AGyvB5Nxm3t9Xb5Mhe139m8QT/g==}
     dev: false
+
+  /tailwindcss-animate@1.0.6(tailwindcss@3.2.4):
+    resolution: {integrity: sha512-4WigSGMvbl3gCCact62ZvOngA+PRqhAn7si3TQ3/ZuPuQZcIEtVap+ENSXbzWhpojKB8CpvnIsrwBu8/RnHtuw==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders'
+    dependencies:
+      tailwindcss: 3.2.4(postcss@8.4.21)
+    dev: true
 
   /tailwindcss-radix@2.8.0:
     resolution: {integrity: sha512-1k1UfoIYgVyBl13FKwwoKavjnJ5VEaUClCTAsgz3VLquN4ay/lyaMPzkbqD71sACDs2fRGImytAUlMb4TzOt1A==}


### PR DESCRIPTION
## What/Why?
- Adds the `Sheet` component.
- Adds the `tailwind-animate` library which adds a collection of animations for our components.

## Testing

https://github.com/bigcommerce/catalyst/assets/10539418/7f47fdb7-e6e5-432b-8b62-8ec0b89b5792
