### PR TITLE
feat(core): CATALYST-30 consume query params into PLP page

### DIFF
--- a/apps/core/src/app/category/[slug]/fetchCategory.ts
+++ b/apps/core/src/app/category/[slug]/fetchCategory.ts
@@ -1,10 +1,24 @@
-import { SearchProductsSortInput } from '@bigcommerce/catalyst-client';
+import { SearchProductsFiltersInput, SearchProductsSortInput } from '@bigcommerce/catalyst-client';
 import { cache } from 'react';
 import z from 'zod';
 
 import client from '~/client';
 
-const searchProductsSortInput: SearchProductsSortInput[] = [
+const SearchParamSchema = z.union([z.string(), z.array(z.string()), z.undefined()]);
+
+const SearchParamToArray = SearchParamSchema.transform((value) => {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    return [value];
+  }
+
+  return undefined;
+});
+
+const PrivateSortParam = z.enum([
   'A_TO_Z',
   'BEST_REVIEWED',
   'BEST_SELLING',
@@ -14,51 +28,143 @@ const searchProductsSortInput: SearchProductsSortInput[] = [
   'NEWEST',
   'RELEVANCE',
   'Z_TO_A',
-];
+]) satisfies z.ZodType<SearchProductsSortInput>;
 
-export const PrivateSearchParamsSchema = z
+const PublicSortParam = z.string().toUpperCase().pipe(PrivateSortParam);
+
+const SearchProductsFiltersInputSchema = z.object({
+  brandEntityIds: z.array(z.number()).optional(),
+  categoryEntityId: z.number().optional(),
+  categoryEntityIds: z.array(z.number()).optional(),
+  hideOutOfStock: z.boolean().optional(),
+  isFeatured: z.boolean().optional(),
+  isFreeShipping: z.boolean().optional(),
+  price: z
+    .object({
+      maxPrice: z.number().optional(),
+      minPrice: z.number().optional(),
+    })
+    .optional(),
+  productAttributes: z
+    .array(
+      z.object({
+        attribute: z.string(),
+        values: z.array(z.string()),
+      }),
+    )
+    .optional(),
+  rating: z
+    .object({
+      maxRating: z.number().optional(),
+      minRating: z.number().optional(),
+    })
+    .optional(),
+  searchSubCategories: z.boolean().optional(),
+  searchTerm: z.string().optional(),
+}) satisfies z.ZodType<SearchProductsFiltersInput>;
+
+const PrivateSearchParamsSchema = z.object({
+  after: z.string().optional(),
+  before: z.string().optional(),
+  limit: z.number().optional(),
+  sort: PrivateSortParam.optional(),
+  filters: SearchProductsFiltersInputSchema.optional(),
+});
+
+const PublicSearchParamsSchema = z
   .object({
-    searchTerm: z.string().optional(),
-    categoryEntityId: z.number().optional(),
-    limit: z.number().optional(),
-    before: z.string().optional(),
     after: z.string().optional(),
-    sort: z
-      .string()
-      .toUpperCase()
-      .refine<SearchProductsSortInput>((value): value is SearchProductsSortInput =>
-        Boolean(searchProductsSortInput.find((input) => input === value)),
-      )
-      .optional(),
+    before: z.string().optional(),
+    brand: SearchParamToArray.transform((value) => value?.map(Number)),
+    categoryId: z.number(),
+    isFeatured: z.coerce.boolean().optional(),
+    limit: z.coerce.number().optional(),
+    minPrice: z.coerce.number().optional(),
+    maxPrice: z.coerce.number().optional(),
+    minRating: z.coerce.number().optional(),
+    maxRating: z.coerce.number().optional(),
+    sort: PublicSortParam.optional(),
+    // In the future we should support more stock filters, e.g. out of stock, low stock, etc.
+    stock: SearchParamToArray.transform((value) =>
+      value?.filter((stock) => z.enum(['in_stock']).safeParse(stock).success),
+    ),
+    // In the future we should support more shipping filters, e.g. 2 day shipping, same day, etc.
+    shipping: SearchParamToArray.transform((value) =>
+      value?.filter((stock) => z.enum(['free_shipping']).safeParse(stock).success),
+    ),
   })
-  .passthrough();
+  .catchall(SearchParamToArray);
 
-export const PublicSearchParamsSchema = z.preprocess((searchParams) => {
-  const validatedRecord = z.record(z.unknown()).parse(searchParams);
+export const PublicToPrivateParams = PublicSearchParamsSchema.transform((publicParams) => {
+  const { after, before, limit, sort, ...filters } = publicParams;
 
-  const { categoryId, ...rest } = validatedRecord;
+  const {
+    brand,
+    categoryId,
+    isFeatured,
+    minPrice,
+    maxPrice,
+    minRating,
+    maxRating,
+    shipping,
+    stock,
+    // There is a bug in Next.js that is adding the path params to the searchParams. We need to filter out the slug params for now.
+    // https://github.com/vercel/next.js/issues/51802
+    slug,
+    ...additionalParams
+  } = filters;
+
+  // Assuming the rest of the params are product attributes for now. We need to see if we can get the GQL endpoint to ingore unknown params.
+  const productAttributes = Object.entries(additionalParams).map(([attribute, values]) => ({
+    attribute,
+    values,
+  }));
 
   return {
-    categoryEntityId: categoryId,
-    ...rest,
+    after,
+    before,
+    limit,
+    sort,
+    filters: {
+      brandEntityIds: brand,
+      categoryEntityId: categoryId,
+      hideOutOfStock: stock?.includes('in_stock'),
+      isFreeShipping: shipping?.includes('free_shipping'),
+      isFeatured,
+      price:
+        minPrice || maxPrice
+          ? {
+              maxPrice,
+              minPrice,
+            }
+          : undefined,
+      productAttributes: productAttributes.length ? productAttributes : undefined,
+      rating:
+        minRating || maxRating
+          ? {
+              maxRating,
+              minRating,
+            }
+          : undefined,
+    },
   };
-}, PrivateSearchParamsSchema);
+}).pipe(PrivateSearchParamsSchema);
 
 export const fetchCategory = cache(
   // We need to make sure the reference passed into this function is the same if we want it to be memoized.
   async ({
-    categoryEntityId,
-    limit = 4,
     after,
     before,
+    limit = 9,
     sort,
+    filters,
   }: z.infer<typeof PrivateSearchParamsSchema>) => {
     return client.getProductSearchResults({
-      categoryEntityId,
-      limit,
       after,
       before,
+      limit,
       sort,
+      filters,
     });
   },
 );

--- a/apps/core/src/app/category/[slug]/page.tsx
+++ b/apps/core/src/app/category/[slug]/page.tsx
@@ -8,7 +8,7 @@ import { ProductCard } from 'src/app/components/ProductCard';
 import client from '~/client';
 
 import { Breadcrumbs } from './Breadcrumbs';
-import { fetchCategory, PublicSearchParamsSchema } from './fetchCategory';
+import { fetchCategory, PublicToPrivateParams } from './fetchCategory';
 import { SortBy } from './SortBy';
 import { SubCategories } from './SubCategories';
 
@@ -22,9 +22,9 @@ interface Props {
 export default async function Category({ params, searchParams }: Props) {
   const categoryId = Number(params.slug);
 
-  const parsedParams = PublicSearchParamsSchema.parse({ categoryId, ...searchParams });
+  const privateParams = PublicToPrivateParams.parse({ categoryId, ...searchParams });
 
-  const search = await fetchCategory(parsedParams);
+  const search = await fetchCategory(privateParams);
 
   // We will only need a partial of this query to fetch the category name and breadcrumbs.
   // The rest of the arguments are useless at this point.

--- a/apps/core/src/app/search/page.tsx
+++ b/apps/core/src/app/search/page.tsx
@@ -26,7 +26,9 @@ export default async function Search({ searchParams }: Props) {
   }
 
   const productSearchResults = await client.getProductSearchResults({
-    searchTerm,
+    filters: {
+      searchTerm,
+    },
     limit: 4,
     after,
     before,

--- a/packages/client/src/queries/getProductSearchResults.ts
+++ b/packages/client/src/queries/getProductSearchResults.ts
@@ -3,31 +3,22 @@ import {
   generateQueryOp,
   QueryGenqlSelection,
   QueryResult,
+  SearchProductsFiltersInput,
   SearchProductsSortInput,
 } from '../generated';
 import { removeEdgesAndNodes } from '../utils/removeEdgesAndNodes';
 
 export interface ProductSearch {
-  searchTerm?: string;
-  categoryEntityId?: number;
-  categoryEntityIds?: number[];
   limit?: number;
   before?: string;
   after?: string;
   sort?: SearchProductsSortInput;
+  filters?: SearchProductsFiltersInput;
 }
 
 export const getProductSearchResults = async <T>(
   customFetch: <U>(data: FetcherInput) => Promise<BigCommerceResponse<U>>,
-  {
-    searchTerm,
-    categoryEntityId,
-    categoryEntityIds,
-    limit = 9,
-    before,
-    after,
-    sort,
-  }: ProductSearch,
+  { limit = 9, before, after, sort, filters = {} }: ProductSearch,
   config: T = {} as T,
 ) => {
   const paginationArgs = before ? { last: limit, before } : { first: limit, after };
@@ -37,11 +28,7 @@ export const getProductSearchResults = async <T>(
       search: {
         searchProducts: {
           __args: {
-            filters: {
-              searchTerm,
-              categoryEntityId,
-              categoryEntityIds,
-            },
+            filters,
             sort,
           },
           products: {
@@ -158,10 +145,6 @@ export const getProductSearchResults = async <T>(
   const searchResults = site.search.searchProducts;
 
   return {
-    filters: {
-      searchTerm,
-      ...paginationArgs,
-    },
     facets: {
       items: removeEdgesAndNodes(searchResults.filters).map((node) => {
         switch (node.__typename) {


### PR DESCRIPTION
## What/Why?

In order for shoppers to use filtering we needed to define a schema for filtering off of. This schema will enable merchants to define what they want in query params and can map them to the appropriate filters (and allow them to customize some of the search functionality). For the shopper, they need to see something "pretty" and we need to map those "pretty" values to be consumed into the GraphQL API. Here is a list of what the public facing params are and what GraphQL Input they map too:
| Public Param | GraphQL Input | Notes |
| - | - | - |
| <pre style="white-space: nowrap;">?brand=37&brand=36</pre> | <pre style="white-space: nowrap;">brandEntityIds: [37, 36]</pre> | |
| <pre style="white-space: nowrap;">?isFeatured=<any></pre> | <pre style="white-space: nowrap;">isFeatured</pre> | This theoretically could be deprecated in Catalyst |
| <pre style="white-space: nowrap;">?minPrice=5&maxPrice=10</pre> | <pre style="white-space: nowrap;">pricing: { minPrice: 5, maxPrice: 10 }</pre> | Cornerstone only allowed you to filter price by requiring both min and max pricing. This now enables filtering by either or. |
| <pre style="white-space: nowrap;">?minRating=0&maxRating=5</pre> | <pre style="white-space: nowrap;">rating: { minRating: 0, maxRating: 5 }</pre> | Cornerstone only enabled only min rating. This now enables filtering by either max or min ratings. |
| <pre style="white-space: nowrap;">?stock=in_stock</pre> | <pre style="white-space: nowrap;">hideInStock: stock === 'in_stock'</pre> | Enabled future stock options if we introduce any. |
| <pre style="white-space: nowrap;">?shipping=free_shipping</pre> | <pre style="white-space: nowrap;">isFreeShipping: shipping === 'free_shipping'</pre> | Enabled future shipping options if we introduce any. |

For now, all other query params are treated as product attribute filters, however our GraphQL API doesn't filter out unknown attributes. If you add `?gucci=dream` to the params the list will come up blank as it filters it out. I created a ticket to address this:
https://bigcommercecloud.atlassian.net/browse/STRF-11126

## Testing

`http://localhost:3000/category/23?limit=11&minRating=0&maxRating=5&minPrice=10&maxPrice=200&isFeatured=1&sort=lowest_price`

![screencapture-localhost-3000-category-23-2023-08-16-16_16_12](https://github.com/bigcommerce/catalyst/assets/10539418/92b308d4-e537-4ed0-b54b-d0def044b99b)
