### PR TITLE
feat(core): CATALYST-30 add display refinements for selected facets

### DIFF
--- a/apps/core/src/app/category/[slug]/RefineBy.tsx
+++ b/apps/core/src/app/category/[slug]/RefineBy.tsx
@@ -1,0 +1,117 @@
+import { Tag, TagAction, TagContent } from '@bigcommerce/reactant/Tag';
+import z from 'zod';
+
+import { fetchCategory, PublicSearchParamsSchema } from './fetchCategory';
+
+interface Props {
+  facets: Awaited<ReturnType<typeof fetchCategory>>['facets'];
+}
+
+interface FacetProps<Key extends string> {
+  key: Key;
+  display_name: string;
+  value: string;
+}
+
+const publicParamKeys = PublicSearchParamsSchema.keyof();
+
+type PublicParamKeys = z.infer<typeof publicParamKeys>;
+
+const mapFacetsToRefinements = (facets: Props['facets']) =>
+  facets.items
+    .map<Array<FacetProps<PublicParamKeys | string>>>((facet) => {
+      switch (facet.__typename) {
+        case 'BrandSearchFilter':
+          return facet.brands
+            .filter((brand) => brand.isSelected)
+            .map<FacetProps<PublicParamKeys>>(({ name, entityId }) => ({
+              key: 'brand',
+              display_name: name,
+              value: String(entityId),
+            }));
+
+        case 'RatingSearchFilter':
+          return facet.ratings
+            .filter((rating) => rating.isSelected)
+            .map<FacetProps<PublicParamKeys>>(({ value }) => ({
+              key: 'minRating',
+              display_name: `Rating ${value} & up`,
+              value,
+            }));
+
+        case 'ProductAttributeSearchFilter':
+          return facet.attributes
+            .filter(({ isSelected }) => isSelected)
+            .map<FacetProps<string>>(({ value }) => {
+              return {
+                key: facet.filterName,
+                display_name: value,
+                value,
+              };
+            });
+
+        case 'OtherSearchFilter': {
+          const { freeShipping, isFeatured, isInStock } = facet;
+
+          const shipping: FacetProps<PublicParamKeys> | undefined = freeShipping?.isSelected
+            ? {
+                key: 'shipping',
+                display_name: 'Free Shipping',
+                value: 'free_shipping',
+              }
+            : undefined;
+
+          const stock: FacetProps<PublicParamKeys> | undefined = isInStock?.isSelected
+            ? {
+                key: 'stock',
+                display_name: 'In Stock',
+                value: 'in_stock',
+              }
+            : undefined;
+
+          const featured: FacetProps<PublicParamKeys> | undefined = isFeatured?.isSelected
+            ? {
+                key: 'isFeatured',
+                display_name: 'Is Featured',
+                value: '1',
+              }
+            : undefined;
+
+          return [shipping, stock, featured].filter(
+            (props): props is FacetProps<PublicParamKeys> => props !== undefined,
+          );
+        }
+
+        default:
+          return [];
+      }
+    })
+    .flat();
+
+export const RefineBy = ({ facets }: Props) => {
+  const refinements = mapFacetsToRefinements(facets);
+
+  if (!refinements.length) {
+    return null;
+  }
+
+  return (
+    <div>
+      <div className="flex flex-row items-center justify-between pb-2">
+        <h3 className="text-h5">Refine by</h3>
+        {/* TODO: Make subtle variant */}
+        <button className="font-semibold text-blue-primary">Clear all</button>
+      </div>
+      <ul className="mb-4 flex flex-row flex-wrap gap-2 py-2">
+        {refinements.map((param) => (
+          <li key={`${param.key}-${param.value}`}>
+            <Tag>
+              <TagContent>{param.display_name}</TagContent>
+              <TagAction />
+            </Tag>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};

--- a/apps/core/src/app/category/[slug]/fetchCategory.ts
+++ b/apps/core/src/app/category/[slug]/fetchCategory.ts
@@ -71,7 +71,7 @@ const PrivateSearchParamsSchema = z.object({
   filters: SearchProductsFiltersInputSchema.optional(),
 });
 
-const PublicSearchParamsSchema = z
+export const PublicSearchParamsSchema = z
   .object({
     after: z.string().optional(),
     before: z.string().optional(),

--- a/apps/core/src/app/category/[slug]/page.tsx
+++ b/apps/core/src/app/category/[slug]/page.tsx
@@ -2,13 +2,13 @@ import { Button } from '@bigcommerce/reactant/Button';
 import { ChevronLeft, ChevronRight, Filter } from 'lucide-react';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
-import { Suspense } from 'react';
 
 import { ProductCard } from 'src/app/components/ProductCard';
 import client from '~/client';
 
 import { Breadcrumbs } from './Breadcrumbs';
 import { fetchCategory, PublicToPrivateParams } from './fetchCategory';
+import { RefineBy } from './RefineBy';
 import { SortBy } from './SortBy';
 import { SubCategories } from './SubCategories';
 
@@ -52,10 +52,7 @@ export default async function Category({ params, searchParams }: Props) {
             <Filter className="mr-3" /> <span>Show Filters</span>
           </Button>
           <div className="flex w-full flex-col items-start gap-4 md:flex-row md:items-center md:justify-end md:gap-6">
-            {/* This suspense boundary allows everything above it to be statically rendered */}
-            <Suspense>
-              <SortBy />
-            </Suspense>
+            <SortBy />
             <div className="order-3 py-4 text-base font-semibold md:order-2 md:py-0">
               {/* TODO: Plural vs. singular items */}
               {search.products.collectionInfo?.totalItems} items
@@ -71,6 +68,8 @@ export default async function Category({ params, searchParams }: Props) {
           </h2>
 
           <SubCategories categoryId={categoryId} />
+
+          <RefineBy facets={search.facets} />
 
           <div>
             <h3 className="mb-3 text-h5">Brand</h3>


### PR DESCRIPTION
## What/Why?
Adds a *display only* refinement component that consumes the facets that are selected and renders them nicely. I will be hooking up the removal logic in a separate PR.

## Testing
| | Screenshot | Notes |
| - | - | - |
| No refinements | ![Screenshot 2023-08-17 at 11 25 18](https://github.com/bigcommerce/catalyst/assets/10539418/ec0421c7-e02e-445f-a882-95cbaaed1a8e) | |
| Free shipping | ![Screenshot 2023-08-17 at 11 25 31](https://github.com/bigcommerce/catalyst/assets/10539418/305a1de8-6720-4cd2-b59b-a29fb8ab2d96) | |
| Is featured | ![Screenshot 2023-08-17 at 11 26 25](https://github.com/bigcommerce/catalyst/assets/10539418/93e4a74c-ba23-4963-9e15-e6785307afcc) | |
| In stock | ![Screenshot 2023-08-17 at 11 26 09](https://github.com/bigcommerce/catalyst/assets/10539418/542ac94b-274e-4a80-9fae-06a02feb5e59) | |
| Rating | ![Screenshot 2023-08-17 at 11 25 46](https://github.com/bigcommerce/catalyst/assets/10539418/581622fa-16e4-4a77-89ad-3e8d865bdf9e) | |
| Product attributes | ![Screenshot 2023-08-17 at 11 25 58](https://github.com/bigcommerce/catalyst/assets/10539418/0aad4e82-f464-47b6-a5c1-ace550deb568) | |
| Multiple refinements | ![Screenshot 2023-08-17 at 11 30 09](https://github.com/bigcommerce/catalyst/assets/10539418/be504bec-3dbf-4c2a-b334-6bb445588c76) | We have since removed the pricing refinements. |





