### PR TITLE
feat(core): CATALYST-35 add route structure for compare page

### DIFF
--- a/apps/core/src/app/compare/[...productIds]/page.tsx
+++ b/apps/core/src/app/compare/[...productIds]/page.tsx
@@ -1,0 +1,5 @@
+export default function Compare({ params }: { params: { productIds: string[] } }) {
+  const productIds = params.productIds;
+
+  return <h1 className="text-h2">Comparing {productIds.length} products</h1>;
+}


### PR DESCRIPTION
## What/Why?
Hoping to get approval on the route structure (and implications) for the Product Comparison page. 

## Testing
Page available in Vercel preview deployment at `/compare[/1/2/3]`