### PR TITLE
feat(core): add related products to PDP

### DIFF
--- a/apps/core/src/app/product/[slug]/page.tsx
+++ b/apps/core/src/app/product/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import { OptionValueId } from '@bigcommerce/catalyst-client';
 import { Button } from '@bigcommerce/reactant/Button';
 import { Counter } from '@bigcommerce/reactant/Counter';
 import { Label } from '@bigcommerce/reactant/Label';
@@ -151,14 +152,16 @@ const ProductDescriptionAndReviews = ({
   );
 };
 
-const RelatedProducts = ({
-  product,
+const RelatedProducts = async ({
+  productId,
+  optionValueIds,
 }: {
-  product: Awaited<ReturnType<typeof client.getProduct>>;
+  productId: number;
+  optionValueIds: OptionValueId[];
 }) => {
-  assertNonNullable(product);
+  const relatedProducts = await client.getRelatedProducts({ productId, optionValueIds });
 
-  if (!product.relatedProducts.length) {
+  if (!relatedProducts || !relatedProducts.length) {
     return null;
   }
 
@@ -166,7 +169,7 @@ const RelatedProducts = ({
     <>
       <h2 className="text-h3">Related Products</h2>
       <div className="mb-14 mt-9 grid grid-cols-2 gap-6 md:grid-cols-4 lg:mt-10 lg:gap-8">
-        {product.relatedProducts.map((relatedProduct) => (
+        {relatedProducts.map((relatedProduct) => (
           <ProductCard key={relatedProduct.entityId} product={relatedProduct} />
         ))}
       </div>
@@ -203,7 +206,10 @@ export default async function Product({
         <ProductDetails product={product} />
         <ProductDescriptionAndReviews product={product} />
       </div>
-      <RelatedProducts product={product} />
+
+      <Suspense fallback="Loading...">
+        <RelatedProducts optionValueIds={optionValueIds} productId={productId} />
+      </Suspense>
     </>
   );
 }

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -16,6 +16,7 @@ import { getFeaturedProducts } from './queries/getFeaturedProducts';
 import { getProduct } from './queries/getProduct';
 import { getProductReviews } from './queries/getProductReviews';
 import { getProductSearchResults } from './queries/getProductSearchResults';
+import { getRelatedProducts } from './queries/getRelatedProducts';
 import { getStoreSettings } from './queries/getStoreSettings';
 
 type OmitFirstInTuple<T extends unknown[]> = T extends [unknown, ...infer U] ? U : [];
@@ -63,6 +64,10 @@ class Client<CustomRequestInit extends RequestInit = RequestInit> {
     ...args: PublicParams<typeof getProductSearchResults<CustomRequestInit>>
   ) {
     return getProductSearchResults(this.fetch, ...args);
+  }
+
+  getRelatedProducts(...args: PublicParams<typeof getRelatedProducts<CustomRequestInit>>) {
+    return getRelatedProducts(this.fetch, ...args);
   }
 
   getStoreSettings(...args: PublicParams<typeof getStoreSettings<CustomRequestInit>>) {

--- a/packages/client/src/queries/getProduct.ts
+++ b/packages/client/src/queries/getProduct.ts
@@ -54,7 +54,6 @@ const reshapeProduct = (product: Product) => {
     categories: reshapeProductCategories(product.categories),
     images: removeEdgesAndNodes(product.images),
     productOptions: reshapeProductOptions(product.productOptions),
-    relatedProducts: removeEdgesAndNodes(product.relatedProducts),
   };
 };
 
@@ -160,27 +159,6 @@ async function internalGetProduct<T>(
         minPurchaseQuantity: true,
         maxPurchaseQuantity: true,
         condition: true,
-        relatedProducts: {
-          __args: { first: 4 },
-          edges: {
-            node: {
-              entityId: true,
-              name: true,
-              defaultImage: {
-                altText: true,
-                url: {
-                  __args: { width: 320 },
-                },
-              },
-              prices: {
-                price: {
-                  value: true,
-                  currencyCode: true,
-                },
-              },
-            },
-          },
-        },
       },
     },
   } satisfies QueryGenqlSelection;

--- a/packages/client/src/queries/getRelatedProducts.ts
+++ b/packages/client/src/queries/getRelatedProducts.ts
@@ -1,0 +1,68 @@
+import { BigCommerceResponse, FetcherInput } from '../fetcher';
+import { generateQueryOp, QueryGenqlSelection, QueryResult } from '../generated';
+import { removeEdgesAndNodes } from '../utils/removeEdgesAndNodes';
+
+import { GetProductOptions } from './getProduct';
+
+async function internalGetProduct<T>(
+  options: GetProductOptions,
+  customFetch: <U>(data: FetcherInput) => Promise<BigCommerceResponse<U>>,
+  config: T = {} as T,
+) {
+  const { productId, optionValueIds } = options;
+
+  const query = {
+    site: {
+      product: {
+        __args: {
+          entityId: productId,
+          optionValueIds,
+        },
+        relatedProducts: {
+          __args: { first: 4 },
+          edges: {
+            node: {
+              entityId: true,
+              name: true,
+              defaultImage: {
+                altText: true,
+                url: {
+                  __args: { width: 320 },
+                },
+              },
+              prices: {
+                price: {
+                  value: true,
+                  currencyCode: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  } satisfies QueryGenqlSelection;
+
+  const queryOp = generateQueryOp(query);
+
+  const response = await customFetch<QueryResult<typeof query>>({
+    ...queryOp,
+    ...config,
+  });
+
+  return response.data.site.product;
+}
+
+export const getRelatedProducts = async <T>(
+  customFetch: <U>(data: FetcherInput) => Promise<BigCommerceResponse<U>>,
+  options: GetProductOptions,
+  config: T = {} as T,
+) => {
+  const product = await internalGetProduct(options, customFetch, config);
+
+  if (!product) {
+    return null;
+  }
+
+  return removeEdgesAndNodes(product.relatedProducts);
+};


### PR DESCRIPTION
## What/Why?
Fetch `relatedProducts` from client and render in PDP. 
Only rendering 4 for now until we create a component that can slide for extra products.

## Screens
![screencapture-localhost-3000-product-93-2023-08-17-13_00_13](https://github.com/bigcommerce/catalyst/assets/196129/2b006a01-a368-4b25-b866-086dee03de18)


## Testing
Locally