### PR TITLE
feat(client): CATALYST-35 add getProducts query

### DIFF
--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -15,6 +15,7 @@ import { getCategoryTree } from './queries/getCategoryTree';
 import { getFeaturedProducts } from './queries/getFeaturedProducts';
 import { getProduct } from './queries/getProduct';
 import { getProductReviews } from './queries/getProductReviews';
+import { getProducts } from './queries/getProducts';
 import { getProductSearchResults } from './queries/getProductSearchResults';
 import { getStoreSettings } from './queries/getStoreSettings';
 
@@ -53,6 +54,10 @@ class Client<CustomRequestInit extends RequestInit = RequestInit> {
 
   getProduct(...args: PublicParams<typeof getProduct<CustomRequestInit>>) {
     return getProduct(this.fetch, ...args);
+  }
+
+  getProducts(...args: PublicParams<typeof getProducts<CustomRequestInit>>) {
+    return getProducts(this.fetch, ...args);
   }
 
   getProductReviews(...args: PublicParams<typeof getProductReviews<CustomRequestInit>>) {

--- a/packages/client/src/queries/getProducts.ts
+++ b/packages/client/src/queries/getProducts.ts
@@ -1,0 +1,82 @@
+import { BigCommerceResponse, FetcherInput } from '../fetcher';
+import { generateQueryOp, QueryGenqlSelection, QueryResult } from '../generated';
+
+export interface GetProductsArguments {
+  productIds: number[];
+  images: { width: number; height?: number };
+}
+
+export const getProducts = async <T>(
+  customFetch: <U>(data: FetcherInput) => Promise<BigCommerceResponse<U>>,
+  args: GetProductsArguments,
+  config: T = {} as T,
+) => {
+  const { productIds, images } = args;
+
+  const query = {
+    site: {
+      products: {
+        __args: {
+          entityIds: productIds,
+        },
+        edges: {
+          node: {
+            brand: {
+              name: true,
+            },
+            entityId: true,
+            images: {
+              edges: {
+                node: {
+                  url: {
+                    __args: {
+                      width: images.width,
+                      height: images.height,
+                    },
+                  },
+                  altText: true,
+                  isDefault: true,
+                },
+              },
+            },
+            inventory: {
+              aggregated: {
+                availableToSell: true,
+              },
+            },
+            name: true,
+            plainTextDescription: true,
+            reviewSummary: {
+              summationOfRatings: true,
+            },
+            prices: {
+              basePrice: {
+                currencyCode: true,
+                value: true,
+              },
+              price: {
+                currencyCode: true,
+                value: true,
+              },
+              retailPrice: {
+                currencyCode: true,
+                value: true,
+              },
+              salePrice: {
+                currencyCode: true,
+                value: true,
+              },
+            },
+          },
+        },
+      },
+    },
+  } satisfies QueryGenqlSelection;
+
+  const queryOp = generateQueryOp(query);
+
+  return customFetch<QueryResult<typeof query>>({
+    ...queryOp,
+    ...config,
+  });
+};


### PR DESCRIPTION
## What/Why?
Adds a client method to retrieve a `ProductConnection` from GraphQL storefront API. 

## Testing
Manually passed an array of product ID's:
- Passing an empty array returns all products, paginated (expected)
- Passing an array of 1 item, where the 1 item is an invalid ID returns an empty array (expected)
- Passing an array of many items, where `x` items are invalid ID's, returns `many - x` product nodes (expected)
- Passing an array of `<= 10` items, where all items are valid ID's, returns an array of product nodes of the same length (expcted)
- Passing an array of `>10` items, where all items are valid ID's, returns an array of 10 product nodes (expected, default limit is 10)