### PR TITLE
feat(core): CATALYST-35 distinct handling for not found and empty states

### DIFF
--- a/apps/core/app/(default)/compare/[...productIds]/page.tsx
+++ b/apps/core/app/(default)/compare/[...productIds]/page.tsx
@@ -1,5 +1,0 @@
-export default function Compare({ params }: { params: { productIds: string[] } }) {
-  const productIds = params.productIds;
-
-  return <h1 className="text-h2">Comparing {productIds.length} products</h1>;
-}

--- a/apps/core/app/(default)/compare/page.tsx
+++ b/apps/core/app/(default)/compare/page.tsx
@@ -1,0 +1,53 @@
+import * as z from 'zod';
+
+import client from '~/client';
+
+const MAX_COMPARE_LIMIT = 10;
+
+const CompareParamsSchema = z.object({
+  ids: z
+    .union([z.string(), z.array(z.string()), z.undefined()])
+    .transform((value) => {
+      if (Array.isArray(value)) {
+        return value;
+      }
+
+      if (typeof value === 'string') {
+        return [...value.split(',')];
+      }
+
+      return undefined;
+    })
+    .transform((value) => value?.map((id) => parseInt(id, 10))),
+});
+
+export default async function Compare({
+  searchParams,
+}: {
+  searchParams: { [key: string]: string | string[] | undefined };
+}) {
+  const parsed = CompareParamsSchema.parse(searchParams);
+  const productIds = parsed.ids?.filter((id) => !Number.isNaN(id));
+
+  const response = await client.getProducts({
+    productIds: productIds ?? [],
+    first: productIds?.length ? MAX_COMPARE_LIMIT : 0,
+    images: { width: 300 },
+  });
+
+  const products = response.data.site.products.edges;
+
+  if (!products || !products.length) {
+    return <h1 className="text-h2">Well, there's nothing to compare!</h1>;
+  }
+
+  return (
+    <>
+      <h1 className="text-h2">Comparing {products.length} products</h1>
+      <p className="my-4 italic text-gray-400">
+        Only {MAX_COMPARE_LIMIT} products can be compared at a time. Below are the first{' '}
+        {MAX_COMPARE_LIMIT}.
+      </p>
+    </>
+  );
+}

--- a/packages/client/src/queries/getProducts.ts
+++ b/packages/client/src/queries/getProducts.ts
@@ -3,6 +3,7 @@ import { generateQueryOp, QueryGenqlSelection, QueryResult } from '../generated'
 
 export interface GetProductsArguments {
   productIds: number[];
+  first: number;
   images: { width: number; height?: number };
 }
 
@@ -11,13 +12,14 @@ export const getProducts = async <T>(
   args: GetProductsArguments,
   config: T = {} as T,
 ) => {
-  const { productIds, images } = args;
+  const { productIds, images, first } = args;
 
   const query = {
     site: {
       products: {
         __args: {
           entityIds: productIds,
+          first,
         },
         edges: {
           node: {


### PR DESCRIPTION
## What/Why?
We now have an "empty" state for the Product Comparison page. 

* If a request is sent to `/compare`, user should land on empty Product Comparison page
* If a request is sent to `/compare?ids=1,2,3`, user should land on populated Product Comparison page

## Testing

1. `GET /compare` returns Empty State
2. `GET /compare?gtm_source=email` returns Empty State
3. `GET /compare?invalid` returns Empty State
4. `GET /compare?ids` returns Empty State
5. `GET /compare?ids=[...invalidIds]` returns Empty State
6. `GET /compare?ids=[...validIds][,...invalidIds]` returns compare for valid
7. `GET /compare?ids=[...validIds][,...invalidIds]&gtm_source=email` returns compare for valid