### PR TITLE
chore(docs): prevent storybook from opening on dev command

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "storybook dev -p 6006",
+    "dev": "storybook dev -p 6006 --no-open",
     "build": "storybook build"
   },
   "dependencies": {


### PR DESCRIPTION
## What/Why?
I'm tired of storybook hijacking my browser tabs when starting the dev command. This prevents it from opening by default.

## Testing
https://storybook.js.org/docs/react/api/cli-options