### PR TITLE
feat(core): CATALYST-30 render product attribute facets

### DIFF
--- a/apps/core/src/app/category/[slug]/Facets.tsx
+++ b/apps/core/src/app/category/[slug]/Facets.tsx
@@ -70,6 +70,38 @@ export const Facets = ({ facets }: Props) => {
           );
         }
 
+        if (facet.__typename === 'ProductAttributeSearchFilter') {
+          return (
+            <AccordionItem key={facet.__typename} value={facet.name}>
+              <AccordionTrigger>
+                <h3>{facet.name}</h3>
+              </AccordionTrigger>
+              <AccordionContent>
+                {facet.attributes.map((attribute) => (
+                  <div className="flex max-w-sm items-center py-2 pl-1" key={attribute.value}>
+                    <Checkbox
+                      defaultChecked={attribute.isSelected}
+                      id={`${facet.filterName}-${attribute.value}`}
+                      name={facet.filterName}
+                      value={attribute.value}
+                    />
+                    <Label
+                      className="cursor-pointer pl-3"
+                      htmlFor={`${facet.filterName}-${attribute.value}`}
+                    >
+                      {attribute.value}
+                      <ProductCount
+                        count={attribute.productCount}
+                        shouldDisplay={facet.displayProductCount}
+                      />
+                    </Label>
+                  </div>
+                ))}
+              </AccordionContent>
+            </AccordionItem>
+          );
+        }
+
         return null;
       })}
     </Accordion>


### PR DESCRIPTION
## What/Why?

Add product attribute facets to the side bar.

## Testing
![screencapture-localhost-3000-category-23-2023-08-18-14_33_42](https://github.com/bigcommerce/catalyst/assets/10539418/9312f2f6-db53-4905-bbff-5d4c39f36bc1)