### PR TITLE
feat(core): CATALYST-82 Add meta tag to identify Catalyst storefronts

### DIFF
--- a/apps/core/app/layout.tsx
+++ b/apps/core/app/layout.tsx
@@ -12,6 +12,9 @@ const inter = Inter({
 export const metadata = {
   title: 'Catalyst Store',
   description: 'Example store built with Catalyst',
+  other: {
+    platform: 'bigcommerce.catalyst',
+  },
 };
 
 export default function RootLayout({ children }: PropsWithChildren) {


### PR DESCRIPTION
## What/Why?
Add meta tag which affirmatively identifies Catalyst storefronts to make it easy for tools like Builtwith, Wappalyzer, and Chrome Dev Tools to identify a catalyst storefront.

This copies the representation we have in stencil.

Example output:
```
<meta name='platform' content='bigcommerce.catalyst' />
```

## Testing
Local:
<img width="1261" alt="image" src="https://github.com/bigcommerce/catalyst/assets/8922457/1fe5bb9c-6fa8-48be-9ca3-13300b18fbc6">

