### PR TITLE
fix(core): CATALYST-83 Peg turborepo version to avoid bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "dotenv-cli": "^7.3.0",
-    "turbo": "^1.10.12",
+    "turbo": "1.10.4",
     "typescript": "^5.1.6"
   }
 }


### PR DESCRIPTION
## What/Why?
Set explicit turborepo version to avoid this bug: https://github.com/vercel/turbo/issues/5331

We can bump the version again once it's fixed.

Error I get using latest version:

<img width="1179" alt="image" src="https://github.com/bigcommerce/catalyst/assets/8922457/dea70062-4220-4ce6-93d0-e369e17db300">


## Testing
Tested locally that this version fixed my ability to set up catalyst.