### PR TITLE
fix(client): CATALYST-35 reshape getProducts response

### DIFF
--- a/apps/core/app/(default)/compare/page.tsx
+++ b/apps/core/app/(default)/compare/page.tsx
@@ -29,15 +29,13 @@ export default async function Compare({
   const parsed = CompareParamsSchema.parse(searchParams);
   const productIds = parsed.ids?.filter((id) => !Number.isNaN(id));
 
-  const response = await client.getProducts({
+  const products = await client.getProducts({
     productIds: productIds ?? [],
     first: productIds?.length ? MAX_COMPARE_LIMIT : 0,
     images: { width: 300 },
   });
 
-  const products = response.data.site.products.edges;
-
-  if (!products || !products.length) {
+  if (!products.length) {
     return <h1 className="text-h2">Well, there's nothing to compare!</h1>;
   }
 

--- a/packages/client/src/queries/getProducts.ts
+++ b/packages/client/src/queries/getProducts.ts
@@ -1,5 +1,6 @@
 import { BigCommerceResponse, FetcherInput } from '../fetcher';
 import { generateQueryOp, QueryGenqlSelection, QueryResult } from '../generated';
+import { removeEdgesAndNodes } from '../utils/removeEdgesAndNodes';
 
 export interface GetProductsArguments {
   productIds: number[];
@@ -77,8 +78,15 @@ export const getProducts = async <T>(
 
   const queryOp = generateQueryOp(query);
 
-  return customFetch<QueryResult<typeof query>>({
+  const response = await customFetch<QueryResult<typeof query>>({
     ...queryOp,
     ...config,
   });
+
+  const products = removeEdgesAndNodes(response.data.site.products);
+
+  return products.map((product) => ({
+    ...product,
+    images: removeEdgesAndNodes(product.images),
+  }));
 };


### PR DESCRIPTION
## What/Why?
Reshape `getProducts` response to remove edges and nodes from both the parent `products` response as well as the nested `images` response.

_Note: This PR is dependent on https://github.com/bigcommerce/catalyst/pull/154 to ensure the build does not break._

## Testing
Run `pnpm build` and ensure `core` builds without errors.