### PR TITLE
fix(core): CATALYST-20 update legacy image component props

### DIFF
--- a/apps/core/components/Hero/index.tsx
+++ b/apps/core/components/Hero/index.tsx
@@ -8,8 +8,8 @@ export const Hero = () => (
       <div className="absolute -z-10 h-full w-full">
         <Image
           alt="an assortment of brandless products against a blank background"
-          layout="fill"
-          objectFit="cover"
+          className="object-cover"
+          fill
           src="/carousel-bg-01.jpg"
         />
       </div>


### PR DESCRIPTION
## What/Why?
The `layout` and `objectFit` props on the `next/image` `<Image />` component are now marked as legacy props in NextJS 13. This is a quick fix to get rid of the warnings shown in the console.

## Testing
Run `pnpm dev` and check server logs:

**Before:**
![Screenshot 2023-08-23 at 4 30 20 PM](https://github.com/bigcommerce/catalyst/assets/28374851/bf94f18f-489f-4ea2-9c0a-0ca8b4bbff78)

**After:**
![Screenshot 2023-08-23 at 4 30 47 PM](https://github.com/bigcommerce/catalyst/assets/28374851/ff99cc63-ea42-4346-a4ec-56ad254cd964)
