### PR TITLE
feat(client): CATALYST-60 add getRoute

### DIFF
--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -24,6 +24,7 @@ import { getProductReviews } from './queries/getProductReviews';
 import { getProducts } from './queries/getProducts';
 import { getProductSearchResults } from './queries/getProductSearchResults';
 import { getRelatedProducts } from './queries/getRelatedProducts';
+import { getRoute } from './queries/getRoute';
 import { getStoreSettings } from './queries/getStoreSettings';
 
 type OmitFirstInTuple<T extends unknown[]> = T extends [unknown, ...infer U] ? U : [];
@@ -87,6 +88,10 @@ class Client<CustomRequestInit extends FetcherRequestInit = FetcherRequestInit> 
 
   getCart(...args: PublicParams<typeof getCart<CustomRequestInit>>) {
     return getCart(this.fetch, ...args);
+  }
+
+  getRoute(...args: PublicParams<typeof getRoute<CustomRequestInit>>) {
+    return getRoute(this.fetch, ...args);
   }
 
   createCart(...args: PublicParams<typeof createCart<CustomRequestInit>>) {

--- a/packages/client/src/queries/getRoute.ts
+++ b/packages/client/src/queries/getRoute.ts
@@ -1,0 +1,39 @@
+import { BigCommerceResponse, FetcherInput } from '../fetcher';
+import { generateQueryOp, QueryGenqlSelection, QueryResult } from '../generated';
+
+export interface GetRouteOptions {
+  path: string;
+}
+
+export const getRoute = async <T>(
+  customFetch: <U>(data: FetcherInput) => Promise<BigCommerceResponse<U>>,
+  { path }: GetRouteOptions,
+  config: T = {} as T,
+) => {
+  const query = {
+    site: {
+      route: {
+        __args: {
+          path,
+        },
+        node: {
+          __typename: true,
+          on_Product: { entityId: true },
+          on_Category: { entityId: true },
+          on_Brand: { entityId: true },
+        },
+      },
+    },
+  } satisfies QueryGenqlSelection;
+
+  const queryOp = generateQueryOp(query);
+
+  const response = await customFetch<QueryResult<typeof query>>({
+    ...queryOp,
+    ...config,
+  });
+
+  const { site } = response.data;
+
+  return site.route.node;
+};


### PR DESCRIPTION
## What/Why?
Adds a `getRoute` method to the client. Prep work for translating urls.