### PR TITLE
chore(core): CATALYST-30 cleanup category page layout

### DIFF
--- a/apps/core/app/(default)/category/[slug]/page.tsx
+++ b/apps/core/app/(default)/category/[slug]/page.tsx
@@ -45,7 +45,7 @@ export default async function Category({ params, searchParams }: Props) {
     <div>
       <Breadcrumbs breadcrumbs={category.breadcrumbs.items} category={category.name} />
 
-      <div className="lg:mb-8 lg:flex lg:flex-row lg:items-center lg:justify-between">
+      <div className="md:mb-8 lg:flex lg:flex-row lg:items-center lg:justify-between">
         <h1 className="mb-4 text-h2 lg:mb-0">{category.name}</h1>
 
         <div className="flex flex-col items-center gap-3 whitespace-nowrap md:flex-row">
@@ -62,8 +62,8 @@ export default async function Category({ params, searchParams }: Props) {
         </div>
       </div>
 
-      <div className="sm:grid sm:grid-cols-3 lg:gap-x-8 xl:grid-cols-4">
-        <aside aria-labelledby="filters-heading" className="flex flex-col gap-6">
+      <div className="grid grid-cols-4 gap-8">
+        <aside aria-labelledby="filters-heading" className="hidden lg:block">
           <h2 className="sr-only" id="filters-heading">
             Filters
           </h2>
@@ -75,17 +75,14 @@ export default async function Category({ params, searchParams }: Props) {
           <Facets facets={search.facets} />
         </aside>
 
-        <section
-          aria-labelledby="product-heading"
-          className="mt-6 sm:col-span-2 lg:mt-0 xl:col-span-3"
-        >
+        <section aria-labelledby="product-heading" className="col-span-4 lg:col-span-3">
           <h2 className="sr-only" id="product-heading">
             Products
           </h2>
 
-          <div className="grid grid-cols-1 gap-y-4 sm:grid-cols-2 sm:gap-x-6 sm:gap-y-10 lg:gap-x-8 xl:grid-cols-3">
+          <div className="grid grid-cols-2 gap-6 sm:grid-cols-3 sm:gap-8">
             {products.map((product) => (
-              <ProductCard key={product.entityId} product={product} />
+              <ProductCard imageSize="wide" key={product.entityId} product={product} />
             ))}
           </div>
 

--- a/apps/core/app/(default)/page.tsx
+++ b/apps/core/app/(default)/page.tsx
@@ -31,7 +31,7 @@ export default async function Home() {
           <ProductListName>Best Selling Products</ProductListName>
           <ProductListGrid>
             {bestSellingProducts.map((product) => (
-              <ProductCard key={product.entityId} product={product} />
+              <ProductCard imageSize="tall" key={product.entityId} product={product} />
             ))}
           </ProductListGrid>
         </ProductList>

--- a/apps/core/components/ProductCard/index.tsx
+++ b/apps/core/components/ProductCard/index.tsx
@@ -1,3 +1,4 @@
+import { cs } from '@bigcommerce/reactant/cs';
 import {
   ProductCardImage,
   ProductCardInfo,
@@ -22,34 +23,51 @@ interface Product {
   prices?: {
     price?: {
       value?: number;
+      currencyCode?: string;
     };
   };
 }
 
 interface ProductCardProps {
   product: Product;
+  imageSize?: 'tall' | 'wide' | 'square';
 }
 
-export const ProductCard = ({ product }: ProductCardProps) => (
-  <ReactantProductCard key={product.entityId}>
-    <ProductCardImage>
-      <Image
-        alt={product.defaultImage?.altText ?? product.name}
-        className="h-full w-full object-contain object-center sm:h-full sm:w-full"
-        height={300}
-        src={product.defaultImage?.url ?? ''}
-        width={300}
-      />
-    </ProductCardImage>
-    <ProductCardInfo>
-      {product.brand && <ProductCardInfoBrandName>{product.brand.name}</ProductCardInfoBrandName>}
-      <ProductCardInfoProductName>
-        <Link href={`/product/${product.entityId}`}>
-          <span aria-hidden="true" className="absolute inset-0" />
-          {product.name}
-        </Link>
-      </ProductCardInfoProductName>
-      <ProductCardInfoPrice>${product.prices?.price?.value}</ProductCardInfoPrice>
-    </ProductCardInfo>
-  </ReactantProductCard>
-);
+export const ProductCard = ({ product, imageSize }: ProductCardProps) => {
+  const currencyFormatter = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: product.prices?.price?.currencyCode,
+  });
+
+  return (
+    <ReactantProductCard key={product.entityId}>
+      <ProductCardImage>
+        <Image
+          alt={product.defaultImage?.altText ?? product.name}
+          className={cs('object-contain object-center', {
+            'aspect-square': imageSize === 'square',
+            'aspect-[4/5]': imageSize === 'tall',
+            'aspect-[7/5]': imageSize === 'wide',
+          })}
+          height={300}
+          src={product.defaultImage?.url ?? ''}
+          width={300}
+        />
+      </ProductCardImage>
+      <ProductCardInfo>
+        {product.brand && <ProductCardInfoBrandName>{product.brand.name}</ProductCardInfoBrandName>}
+        <ProductCardInfoProductName>
+          <Link href={`/product/${product.entityId}`}>
+            <span aria-hidden="true" className="absolute inset-0" />
+            {product.name}
+          </Link>
+        </ProductCardInfoProductName>
+        {product.prices?.price?.value !== undefined && (
+          <ProductCardInfoPrice>
+            {currencyFormatter.format(product.prices.price.value)}
+          </ProductCardInfoPrice>
+        )}
+      </ProductCardInfo>
+    </ReactantProductCard>
+  );
+};

--- a/packages/client/src/queries/getProductSearchResults.ts
+++ b/packages/client/src/queries/getProductSearchResults.ts
@@ -55,6 +55,7 @@ export const getProductSearchResults = async <T>(
                 prices: {
                   price: {
                     value: true,
+                    currencyCode: true,
                   },
                 },
                 defaultImage: {

--- a/packages/reactant/src/components/ProductCard/ProductCard.tsx
+++ b/packages/reactant/src/components/ProductCard/ProductCard.tsx
@@ -5,14 +5,7 @@ import { cs } from '../../utils/cs';
 export const ProductCard = forwardRef<ElementRef<'div'>, ComponentPropsWithRef<'div'>>(
   ({ children, className, ...props }, ref) => {
     return (
-      <div
-        className={cs(
-          'group relative mx-auto flex max-w-[144px] flex-col md:max-w-[154px] lg:max-w-[292px]',
-          className,
-        )}
-        ref={ref}
-        {...props}
-      >
+      <div className={cs('group relative flex flex-col', className)} ref={ref} {...props}>
         {children}
       </div>
     );
@@ -22,11 +15,7 @@ export const ProductCard = forwardRef<ElementRef<'div'>, ComponentPropsWithRef<'
 export const ProductCardImage = forwardRef<ElementRef<'div'>, ComponentPropsWithRef<'div'>>(
   ({ children, className, ...props }, ref) => {
     return (
-      <div
-        className={cs('h-[180px] pb-3 group-hover:opacity-75 lg:h-[365px]', className)}
-        ref={ref}
-        {...props}
-      >
+      <div className={cs('mx-auto pb-3 group-hover:opacity-75', className)} ref={ref} {...props}>
         {children}
       </div>
     );
@@ -38,7 +27,7 @@ export const ProductCardBadge = forwardRef<ElementRef<'span'>, ComponentPropsWit
     return (
       <span
         className={cs(
-          'absolute left-0 top-4 bg-black py-1 px-4 text-white group-hover:opacity-75',
+          'absolute left-0 top-4 bg-black px-4 py-1 text-white group-hover:opacity-75',
           className,
         )}
         ref={ref}


### PR DESCRIPTION
## What/Why?
Cleaned up the category page and product tiles along with:
- Added currency formatting for product tiles
- Added `imageSize` prop to control aspect ratios on ProductCards
- Hid the `aside` on mobile

## Testing

https://github.com/bigcommerce/catalyst/assets/10539418/aed20384-0928-4778-9fb1-595c0db64d8e

