### PR TITLE
feat(core): CATALYST-35 display products for comparison in table

### DIFF
--- a/apps/core/app/(default)/compare/page.tsx
+++ b/apps/core/app/(default)/compare/page.tsx
@@ -1,3 +1,6 @@
+import { Button } from '@bigcommerce/reactant/Button';
+import Image from 'next/image';
+import Link from 'next/link';
 import * as z from 'zod';
 
 import client from '~/client';
@@ -21,6 +24,42 @@ const CompareParamsSchema = z.object({
     .transform((value) => value?.map((id) => parseInt(id, 10))),
 });
 
+type Prices = Awaited<ReturnType<typeof client.getProducts>>[number]['prices'];
+
+const Prices = ({ prices }: { prices: Prices }) => {
+  if (!prices) {
+    return <p>N/A</p>;
+  }
+
+  const { format } = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: prices.price.currencyCode,
+  });
+
+  const { retailPrice, price, basePrice } = prices;
+
+  if (retailPrice) {
+    if (basePrice && basePrice.value !== price.value) {
+      return (
+        <>
+          <p className="text-gray-500 line-through">{format(Number(retailPrice.value))}</p>
+          <p className="text-gray-500 line-through">{format(Number(basePrice.value))}</p>
+          <p>{format(Number(price.value))}</p>
+        </>
+      );
+    }
+
+    return (
+      <>
+        <p className="text-gray-500 line-through">{format(Number(retailPrice.value))}</p>
+        <p>{format(Number(price.value))}</p>
+      </>
+    );
+  }
+
+  return <p>{format(Number(price.value))}</p>;
+};
+
 export default async function Compare({
   searchParams,
 }: {
@@ -41,11 +80,140 @@ export default async function Compare({
 
   return (
     <>
-      <h1 className="text-h2">Comparing {products.length} products</h1>
-      <p className="my-4 italic text-gray-400">
-        Only {MAX_COMPARE_LIMIT} products can be compared at a time. Below are the first{' '}
-        {MAX_COMPARE_LIMIT}.
-      </p>
+      <h1 className="pb-8 text-h2">Comparing {products.length} products</h1>
+
+      <div className="-mx-6 overflow-auto overscroll-x-contain px-6 sm:-mx-10 sm:px-10 lg:-mx-12 lg:px-12">
+        <table className="mx-auto w-full max-w-full table-fixed text-base md:w-fit">
+          <caption className="sr-only">Product Comparison</caption>
+
+          <colgroup>
+            <col className="w-80" span={products.length} />
+          </colgroup>
+
+          <thead>
+            <tr>
+              {products.map((product) => (
+                <th className="sr-only" key={product.entityId} scope="col">
+                  {product.name}
+                </th>
+              ))}
+            </tr>
+            <tr>
+              {products.map((product) => {
+                const defaultImg = product.images.find((image) => image.isDefault);
+
+                if (defaultImg) {
+                  const defaultImgUrl = defaultImg.url;
+                  const defaultImgAlt = defaultImg.altText;
+
+                  return (
+                    <td className="px-4" key={product.entityId}>
+                      <Link aria-label={product.name} href={`/product/${product.entityId}`}>
+                        <Image alt={defaultImgAlt} height={300} src={defaultImgUrl} width={300} />
+                      </Link>
+                    </td>
+                  );
+                }
+
+                return (
+                  <td className="px-4" key={product.entityId}>
+                    <Link aria-label={product.name} href={`/product/${product.entityId}`}>
+                      <div className="flex aspect-square items-center justify-center bg-gray-200 text-gray-500">
+                        <p className="text-lg">No Image</p>
+                      </div>
+                    </Link>
+                  </td>
+                );
+              })}
+            </tr>
+            <tr>
+              {products.map((product) => (
+                <td className="px-4 pt-4 text-gray-500" key={product.entityId}>
+                  {product.brand?.name}
+                </td>
+              ))}
+            </tr>
+            <tr>
+              {products.map((product) => (
+                <td className="px-4 align-top text-h5" key={product.entityId}>
+                  <Link href={`/product/${product.entityId}`}>{product.name}</Link>
+                </td>
+              ))}
+            </tr>
+            <tr>
+              {products.map((product) => (
+                <td className="px-4 py-4 align-bottom" key={product.entityId}>
+                  <Prices prices={product.prices} />
+                </td>
+              ))}
+            </tr>
+            <tr>
+              {products.map((product) => (
+                <td className="border-b px-4 pb-12" key={product.entityId}>
+                  <Button aria-label={product.name}>Add to Cart</Button>
+                </td>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            <tr className="absolute mt-6">
+              <th className="sticky left-0 top-0 m-0 pl-4 text-left" id="product-description">
+                Description
+              </th>
+            </tr>
+            <tr>
+              {products.map((product) => (
+                <td
+                  className="border-b px-4 pb-12 pt-20"
+                  headers="product-description"
+                  key={product.entityId}
+                >
+                  {product.plainTextDescription}
+                </td>
+              ))}
+            </tr>
+            <tr className="absolute mt-8">
+              <th className="sticky left-0 top-0 m-0 pl-4 text-left" id="product-rating">
+                Rating
+              </th>
+            </tr>
+            <tr>
+              {products.map((product) => (
+                <td
+                  className="border-b px-4 pb-12 pt-24"
+                  headers="product-rating"
+                  key={product.entityId}
+                >
+                  {product.reviewSummary.summationOfRatings}
+                </td>
+              ))}
+            </tr>
+            <tr className="absolute mt-8">
+              <th className="sticky left-0 top-0 m-0 pl-4 text-left" id="product-availability">
+                Availability
+              </th>
+            </tr>
+            <tr>
+              {products.map((product) => (
+                <td
+                  className="border-b px-4 pb-12 pt-24"
+                  headers="product-availability"
+                  key={product.entityId}
+                >
+                  {product.inventory.aggregated?.availableToSell || 'N/A'}
+                </td>
+              ))}
+            </tr>
+            <tr>
+              {products.map((product) => (
+                <td className="px-4 pb-24 pt-12" key={product.entityId}>
+                  <Button aria-label={product.name}>Add to Cart</Button>
+                </td>
+              ))}
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </>
   );
 }


### PR DESCRIPTION
## What/Why?
Display products for comparison in table

## Testing

- **[Compare 10 Products](https://catalyst-git-fork-matthewvolk-catal-10de76-bigcommerce-platform.vercel.app/compare?ids=77%2C80%2C81%2C86%2C88%2C93%2C94%2C97%2C98%2C103%2C104%2C107%2C111)**
- **[Compare 3 Products](https://catalyst-git-fork-matthewvolk-catal-10de76-bigcommerce-platform.vercel.app/compare?ids=77%2C80%2C81)**

<img width="932" alt="Screenshot 2023-09-12 at 4 25 19 PM" src="https://github.com/bigcommerce/catalyst/assets/28374851/c436642c-a280-4e81-809a-21673bb2adde">

