### PR TITLE
feat(core): CATALYST-60 maintenance middleware

### DIFF
--- a/apps/core/middleware.ts
+++ b/apps/core/middleware.ts
@@ -1,0 +1,29 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+import client from './client';
+
+export async function middleware(request: NextRequest) {
+  const settings = await client.getStoreSettings();
+
+  if (settings?.status === 'MAINTENANCE') {
+    // 503 status code not working - https://github.com/vercel/next.js/issues/50155
+    return NextResponse.rewrite(new URL(`/maintenance`, request.url), { status: 503 });
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - api (API routes)
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     */
+    '/((?!api|_next/static|_next/image|favicon.ico).*)',
+    '/',
+  ],
+};

--- a/packages/client/src/queries/getStoreSettings.ts
+++ b/packages/client/src/queries/getStoreSettings.ts
@@ -34,6 +34,7 @@ export const getStoreSettings = async <T>(
           name: true,
           url: true,
         },
+        status: true,
       },
     },
   } satisfies QueryGenqlSelection;


### PR DESCRIPTION
## What/Why?
Rewrite to `/maintenance` when status is maintenance. This is the initial pass to keep PR small, no cache involved.

## Testing
![tJuEJOap](https://github.com/bigcommerce/catalyst/assets/2752665/28ca3590-139a-4f47-9768-8605433329a8)