### PR TITLE
refactor(core): CATALYST-30 move param mapping internally

### DIFF
--- a/apps/core/app/(default)/category/[slug]/page.tsx
+++ b/apps/core/app/(default)/category/[slug]/page.tsx
@@ -8,7 +8,7 @@ import { ProductCard } from '~/components/ProductCard';
 
 import { Breadcrumbs } from './Breadcrumbs';
 import { Facets } from './Facets';
-import { fetchCategory, PublicToPrivateParams } from './fetchCategory';
+import { fetchCategory } from './fetchCategory';
 import { RefineBy } from './RefineBy';
 import { SortBy } from './SortBy';
 import { SubCategories } from './SubCategories';
@@ -23,9 +23,7 @@ interface Props {
 export default async function Category({ params, searchParams }: Props) {
   const categoryId = Number(params.slug);
 
-  const privateParams = PublicToPrivateParams.parse({ categoryId, ...searchParams });
-
-  const search = await fetchCategory(privateParams);
+  const search = await fetchCategory({ categoryId, ...searchParams });
 
   // We will only need a partial of this query to fetch the category name and breadcrumbs.
   // The rest of the arguments are useless at this point.
@@ -56,7 +54,7 @@ export default async function Category({ params, searchParams }: Props) {
             <SortBy />
             <div className="order-3 py-4 text-base font-semibold md:order-2 md:py-0">
               {/* TODO: Plural vs. singular items */}
-              {search.products.collectionInfo?.totalItems} items
+              {productsCollection.collectionInfo?.totalItems} items
             </div>
           </div>
         </div>


### PR DESCRIPTION
## What/Why?
Moves the `PublicToPrivateParams` parsing inside the `fetchCategory` call. The layout generally doesn't need to know about private vs. public params, which relocating the parsing cleans up a bit of the page-level component.

⚠️ [Hide whitespace](https://github.com/bigcommerce/catalyst/pull/184/files?w=1) for easier review.
