### PR TITLE
fix(core): convert FacetedSearch back to server component

### DIFF
--- a/apps/core/app/(default)/category/[slug]/_components/faceted-search.tsx
+++ b/apps/core/app/(default)/category/[slug]/_components/faceted-search.tsx
@@ -1,6 +1,4 @@
-'use client';
-
-import { useId } from 'react';
+import { ComponentPropsWithoutRef } from 'react';
 
 import type { Facet } from '../types';
 
@@ -8,17 +6,16 @@ import { Facets } from './facets';
 import { RefineBy } from './refine-by';
 import { SubCategories } from './sub-categories';
 
-interface Props {
+interface Props extends ComponentPropsWithoutRef<'aside'> {
   categoryId: number;
   facets: Facet[];
+  headingId: string;
 }
 
-export const FacetedSearch = ({ categoryId, facets }: Props) => {
-  const id = useId();
-
+export const FacetedSearch = ({ categoryId, facets, headingId, ...props }: Props) => {
   return (
-    <aside aria-labelledby={id} className="hidden lg:block">
-      <h2 className="sr-only" id={id}>
+    <aside aria-labelledby={headingId} {...props}>
+      <h2 className="sr-only" id={headingId}>
         Filters
       </h2>
 

--- a/apps/core/app/(default)/category/[slug]/page.tsx
+++ b/apps/core/app/(default)/category/[slug]/page.tsx
@@ -59,7 +59,12 @@ export default async function Category({ params, searchParams }: Props) {
       </div>
 
       <div className="grid grid-cols-4 gap-8">
-        <FacetedSearch categoryId={categoryId} facets={search.facets.items} />
+        <FacetedSearch
+          categoryId={categoryId}
+          className="hidden lg:block"
+          facets={search.facets.items}
+          headingId="desktop-filter-heading"
+        />
 
         <section aria-labelledby="product-heading" className="col-span-4 lg:col-span-3">
           <h2 className="sr-only" id="product-heading">


### PR DESCRIPTION
## What/Why?
In #185 I converted `FacetedSearch` to a client component which was causing the children to fetch data from the client. This converts it back and preps it for being used in multiple places.

## Testing
![Screenshot 2023-08-29 at 12 29 51](https://github.com/bigcommerce/catalyst/assets/10539418/e66f0b50-5ce2-42ab-afee-bdfdbdac5075)
