### PR TITLE
fix: replace styles with logical properties

### DIFF
--- a/apps/core/app/(default)/category/[slug]/_components/facets.tsx
+++ b/apps/core/app/(default)/category/[slug]/_components/facets.tsx
@@ -30,7 +30,7 @@ const ProductCount = ({ shouldDisplay, count }: ProductCountProps) => {
   }
 
   return (
-    <span className="pl-3 text-gray-500">
+    <span className="ps-3 text-gray-500">
       {count} <span className="sr-only">products</span>
     </span>
   );
@@ -93,7 +93,7 @@ export const Facets = ({ facets }: Props) => {
                   {facet.brands.map((brand) => {
                     return (
                       <div
-                        className="flex max-w-sm items-center py-2 pl-1"
+                        className="flex max-w-sm items-center py-2 ps-1"
                         key={`${brand.entityId}-${brand.isSelected.toString()}`}
                       >
                         <Checkbox
@@ -104,7 +104,7 @@ export const Facets = ({ facets }: Props) => {
                           value={brand.entityId}
                         />
                         <Label
-                          className="cursor-pointer pl-3"
+                          className="cursor-pointer ps-3"
                           htmlFor={`${brand.name}-${brand.entityId}`}
                         >
                           {brand.name}
@@ -130,7 +130,7 @@ export const Facets = ({ facets }: Props) => {
                 <AccordionContent>
                   {facet.attributes.map((attribute) => (
                     <div
-                      className="flex max-w-sm items-center py-2 pl-1"
+                      className="flex max-w-sm items-center py-2 ps-1"
                       key={`${facet.filterName}-${
                         attribute.value
                       }-${attribute.isSelected.toString()}`}
@@ -143,7 +143,7 @@ export const Facets = ({ facets }: Props) => {
                         value={attribute.value}
                       />
                       <Label
-                        className="cursor-pointer pl-3"
+                        className="cursor-pointer ps-3"
                         htmlFor={`${facet.filterName}-${attribute.value}`}
                       >
                         {attribute.value}
@@ -187,7 +187,7 @@ export const Facets = ({ facets }: Props) => {
                           >
                             <Rating value={parseInt(rating.value, 10)} />
                           </div>
-                          <span className="pl-2">
+                          <span className="ps-2">
                             {/* TODO: singular vs. plural */}
                             <span className="sr-only">{rating.value} stars</span> & up
                           </span>
@@ -237,7 +237,7 @@ export const Facets = ({ facets }: Props) => {
                 </AccordionTrigger>
                 <AccordionContent>
                   {facet.freeShipping && (
-                    <div className="flex max-w-sm items-center py-2 pl-1">
+                    <div className="flex max-w-sm items-center py-2 ps-1">
                       <Checkbox
                         defaultChecked={facet.freeShipping.isSelected}
                         id="shipping-free_shipping"
@@ -245,7 +245,7 @@ export const Facets = ({ facets }: Props) => {
                         onCheckedChange={submitForm}
                         value="free_shipping"
                       />
-                      <Label className="cursor-pointer pl-3" htmlFor="shipping-free_shipping">
+                      <Label className="cursor-pointer ps-3" htmlFor="shipping-free_shipping">
                         Free shipping
                         <ProductCount
                           count={facet.freeShipping.productCount}
@@ -255,14 +255,14 @@ export const Facets = ({ facets }: Props) => {
                     </div>
                   )}
                   {facet.isFeatured && (
-                    <div className="flex max-w-sm items-center py-2 pl-1">
+                    <div className="flex max-w-sm items-center py-2 ps-1">
                       <Checkbox
                         defaultChecked={facet.isFeatured.isSelected}
                         id="isFeatured"
                         name="isFeatured"
                         onCheckedChange={submitForm}
                       />
-                      <Label className="cursor-pointer pl-3" htmlFor="isFeatured">
+                      <Label className="cursor-pointer ps-3" htmlFor="isFeatured">
                         Is featured
                         <ProductCount
                           count={facet.isFeatured.productCount}
@@ -272,7 +272,7 @@ export const Facets = ({ facets }: Props) => {
                     </div>
                   )}
                   {facet.isInStock && (
-                    <div className="flex max-w-sm items-center py-2 pl-1">
+                    <div className="flex max-w-sm items-center py-2 ps-1">
                       <Checkbox
                         defaultChecked={facet.isInStock.isSelected}
                         id="stock-in_stock"
@@ -280,7 +280,7 @@ export const Facets = ({ facets }: Props) => {
                         onCheckedChange={submitForm}
                         value="in_stock"
                       />
-                      <Label className="cursor-pointer pl-3" htmlFor="stock-in_stock">
+                      <Label className="cursor-pointer ps-3" htmlFor="stock-in_stock">
                         In stock
                         <ProductCount
                           count={facet.isInStock.productCount}

--- a/apps/core/app/(default)/category/[slug]/_components/mobile-side-nav.tsx
+++ b/apps/core/app/(default)/category/[slug]/_components/mobile-side-nav.tsx
@@ -24,7 +24,7 @@ export const MobileSideNav = ({ children }: PropsWithChildren) => {
     <Sheet onOpenChange={setOpen} open={open}>
       <SheetTrigger asChild>
         <Button className="items-center md:w-auto lg:hidden" variant="secondary">
-          <Filter className="mr-3" /> <span>Show Filters</span>
+          <Filter className="me-3" /> <span>Show Filters</span>
         </Button>
       </SheetTrigger>
       <SheetOverlay className="bg-transparent, backdrop-blur-none lg:hidden">

--- a/apps/core/app/(default)/product/[slug]/Breadcrumbs.tsx
+++ b/apps/core/app/(default)/product/[slug]/Breadcrumbs.tsx
@@ -23,7 +23,7 @@ export const BreadCrumbs = async ({ productId }: Props) => {
 
           return (
             <li
-              className={cs('p-1 pl-0 hover:text-blue-primary', {
+              className={cs('p-1 ps-0 hover:text-blue-primary', {
                 'font-semibold': !isLast,
                 'font-extrabold': isLast,
               })}

--- a/apps/core/app/(default)/product/[slug]/Reviews.tsx
+++ b/apps/core/app/(default)/product/[slug]/Reviews.tsx
@@ -21,7 +21,7 @@ export const Reviews = async ({ productId, reviewSectionId }: Props) => {
       <h3 className="mb-4 mt-8 text-h5">
         Reviews
         {reviews.length > 0 && (
-          <span className="ms-2 pl-1 text-gray-500">
+          <span className="ms-2 ps-1 text-gray-500">
             <span className="sr-only">Count:</span>
             {reviews.length}
           </span>

--- a/apps/core/components/Header/index.tsx
+++ b/apps/core/components/Header/index.tsx
@@ -92,7 +92,7 @@ const HeaderNav = async ({
               <NavigationMenuContent
                 className={cs(
                   !inCollapsedNav && 'mx-auto flex w-[700px] flex-row gap-20',
-                  inCollapsedNav && 'pl-6',
+                  inCollapsedNav && 'ps-6',
                 )}
               >
                 {category.children.map((childCategory1) => (

--- a/apps/core/components/SearchForm/index.tsx
+++ b/apps/core/components/SearchForm/index.tsx
@@ -17,7 +17,7 @@ export const SearchForm = ({ initialTerm = '' }: Props) => {
     <div className="flex flex-col gap-8">
       <h3 className="text-h3">Search our store</h3>
       <Form action="/search" className="flex" method="get">
-        <Field className="mr-4 w-full" name="search">
+        <Field className="me-4 w-full" name="search">
           <FieldControl asChild>
             <Input
               className="grey-200 border-2 px-8 py-3 font-semibold"

--- a/apps/docs/stories/Accordion.stories.tsx
+++ b/apps/docs/stories/Accordion.stories.tsx
@@ -60,7 +60,7 @@ export const WithComponentExample: Story = {
         <AccordionTrigger>
           <div className="flex flex-row items-center gap-2">
             <Info />
-            <span className="ml-2">Information</span>
+            <span className="ms-2">Information</span>
           </div>
         </AccordionTrigger>
         <AccordionContent className="p-4">

--- a/apps/docs/stories/Checkbox.stories.tsx
+++ b/apps/docs/stories/Checkbox.stories.tsx
@@ -46,7 +46,7 @@ export const CheckboxWithLabel: Story = {
   render: ({ children }) => (
     <div className="flex max-w-sm items-center">
       <Checkbox id="CheckboxWithLabel" />
-      <Label className="cursor-pointer pl-4" htmlFor="CheckboxWithLabel">
+      <Label className="cursor-pointer ps-4" htmlFor="CheckboxWithLabel">
         {children}
       </Label>
     </div>

--- a/apps/docs/stories/NavigationMenu.stories.tsx
+++ b/apps/docs/stories/NavigationMenu.stories.tsx
@@ -266,7 +266,7 @@ export const BasicExample: Story = {
                       />
                     </NavigationMenuLink>
                   </NavigationMenuTrigger>
-                  <NavigationMenuContent className="pl-6">
+                  <NavigationMenuContent className="ps-6">
                     {category.children.map((childCategory, index) => (
                       <ul className="pb-6" key={index}>
                         <NavigationMenuItem>
@@ -378,7 +378,7 @@ export const NavigationAlignmentLeft: Story = {
                       />
                     </NavigationMenuLink>
                   </NavigationMenuTrigger>
-                  <NavigationMenuContent className="pl-6">
+                  <NavigationMenuContent className="ps-6">
                     {category.children.map((childCategory, index) => (
                       <ul className="pb-6" key={index}>
                         <NavigationMenuItem>
@@ -490,7 +490,7 @@ export const NavigationAlignmentRight: Story = {
                       />
                     </NavigationMenuLink>
                   </NavigationMenuTrigger>
-                  <NavigationMenuContent className="pl-6">
+                  <NavigationMenuContent className="ps-6">
                     {category.children.map((childCategory, index) => (
                       <ul className="pb-6" key={index}>
                         <NavigationMenuItem>
@@ -604,7 +604,7 @@ export const LogoCentered: Story = {
                       />
                     </NavigationMenuLink>
                   </NavigationMenuTrigger>
-                  <NavigationMenuContent className="pl-6">
+                  <NavigationMenuContent className="ps-6">
                     {category.children.map((childCategory, index) => (
                       <ul className="pb-6" key={index}>
                         <NavigationMenuItem>
@@ -719,7 +719,7 @@ export const BottomNavigationLeft: Story = {
                         />
                       </NavigationMenuLink>
                     </NavigationMenuTrigger>
-                    <NavigationMenuContent className="pl-6">
+                    <NavigationMenuContent className="ps-6">
                       {category.children.map((childCategory, index) => (
                         <ul className="pb-6" key={index}>
                           <NavigationMenuItem>
@@ -834,7 +834,7 @@ export const BottomNavigationCenter: Story = {
                       />
                     </NavigationMenuLink>
                   </NavigationMenuTrigger>
-                  <NavigationMenuContent className="pl-6">
+                  <NavigationMenuContent className="ps-6">
                     {category.children.map((childCategory, index) => (
                       <ul className="pb-6" key={index}>
                         <NavigationMenuItem>
@@ -948,7 +948,7 @@ export const BottomNavigationRight: Story = {
                       />
                     </NavigationMenuLink>
                   </NavigationMenuTrigger>
-                  <NavigationMenuContent className="pl-6">
+                  <NavigationMenuContent className="ps-6">
                     {category.children.map((childCategory, index) => (
                       <ul className="pb-6" key={index}>
                         <NavigationMenuItem>
@@ -1069,7 +1069,7 @@ export const NavigationWithBadge: Story = {
                       />
                     </NavigationMenuLink>
                   </NavigationMenuTrigger>
-                  <NavigationMenuContent className="pl-6">
+                  <NavigationMenuContent className="ps-6">
                     {category.children.map((childCategory, index) => (
                       <ul className="pb-6" key={index}>
                         <NavigationMenuItem>
@@ -1182,7 +1182,7 @@ export const CustomNavigationMenuToggle: Story = {
                       />
                     </NavigationMenuLink>
                   </NavigationMenuTrigger>
-                  <NavigationMenuContent className="pl-6">
+                  <NavigationMenuContent className="ps-6">
                     {category.children.map((childCategory, index) => (
                       <ul className="pb-6" key={index}>
                         <NavigationMenuItem>

--- a/apps/docs/stories/RadioGroup.stories.tsx
+++ b/apps/docs/stories/RadioGroup.stories.tsx
@@ -59,7 +59,7 @@ export const BaseRadioGroup: Story = {
         {MOCKED_SIZE_OPTIONS.map((option) => (
           <div className="mb-2 flex" key={option.id}>
             <RadioItem {...option} />
-            <Label className="cursor-pointer pl-4" htmlFor={option.id}>
+            <Label className="cursor-pointer ps-4" htmlFor={option.id}>
               {option.value}
             </Label>
           </div>
@@ -83,7 +83,7 @@ export const RadioGroupWithIcon: Story = {
                 />
               </RadioIndicator>
             </RadioItem>
-            <Label className="cursor-pointer pl-4" htmlFor={option.id}>
+            <Label className="cursor-pointer ps-4" htmlFor={option.id}>
               {option.value}
             </Label>
           </div>

--- a/apps/with-makeswift/lib/components/Carousel/Carousel.tsx
+++ b/apps/with-makeswift/lib/components/Carousel/Carousel.tsx
@@ -145,8 +145,8 @@ export function Carousel({ className, slides, loop = true, autoplay = 0 }: Props
             ))}
           </div>
 
-          <div className="absolute bottom-6 left-6 z-10 flex items-center md:bottom-12 md:left-20 lg:bottom-16 lg:left-24 [&>button]:p-4 [&>button]:outline-none [&_svg]:drop-shadow-md">
-            <button aria-label="Pause carousel" className="mr-4">
+          <div className="absolute bottom-6 start-6 z-10 flex items-center md:bottom-12 md:start-20 lg:bottom-16 lg:start-24 [&>button]:p-4 [&>button]:outline-none [&_svg]:drop-shadow-md">
+            <button aria-label="Pause carousel" className="me-4">
               <Pause />
             </button>
 

--- a/apps/with-makeswift/lib/components/Navigation/Navigation.tsx
+++ b/apps/with-makeswift/lib/components/Navigation/Navigation.tsx
@@ -149,7 +149,7 @@ export function Navigation({
                           {mainNavLink.text}
                           <ChevronDown
                             absoluteStrokeWidth={true}
-                            className="linear ml-1 transition-transform duration-300 group-data-[state=open]:-rotate-180"
+                            className="linear ms-1 transition-transform duration-300 group-data-[state=open]:-rotate-180"
                             size={16}
                             strokeWidth={2}
                           />
@@ -254,10 +254,10 @@ export function Navigation({
                   {mainNavLink.subnavGroups.length > 0 ? (
                     <>
                       <Accordion.Trigger asChild>
-                        <span className="group flex w-full items-center justify-between py-3 pr-4 leading-normal outline-none">
+                        <span className="group flex w-full items-center justify-between py-3 pe-4 leading-normal outline-none">
                           {mainNavLink.text}
                           <svg
-                            className="linear duration-250 ml-2 h-2 w-3 stroke-current transition-transform group-data-[state=open]:-rotate-180"
+                            className="linear duration-250 ms-2 h-2 w-3 stroke-current transition-transform group-data-[state=open]:-rotate-180"
                             fill="none"
                             viewBox="0 0 12 8"
                           >
@@ -273,7 +273,7 @@ export function Navigation({
                       <Accordion.AccordionContent asChild>
                         <>
                           {mainNavLink.subnavGroups.map((subnavGroup, i) => (
-                            <ul className="space-y-3 pb-4 pl-6 pt-2" key={i}>
+                            <ul className="space-y-3 pb-4 ps-6 pt-2" key={i}>
                               {subnavGroup.heading.length > 0 ? (
                                 <li className="pt-2">{subnavGroup.heading}</li>
                               ) : null}
@@ -306,7 +306,7 @@ export function Navigation({
               ))}
             </Accordion.Root>
 
-            <ul className="pt-4 leading-normal [&_a]:flex [&_a]:items-center [&_a]:py-3 [&_a]:pr-3 [&_span]:flex-1">
+            <ul className="pt-4 leading-normal [&_a]:flex [&_a]:items-center [&_a]:py-3 [&_a]:pe-3 [&_span]:flex-1">
               <li>
                 <Link href="#">
                   <span>Compare</span>

--- a/apps/with-makeswift/lib/components/ProductCard/ProductCard.tsx
+++ b/apps/with-makeswift/lib/components/ProductCard/ProductCard.tsx
@@ -45,7 +45,7 @@ export function ProductCard({
           <div className="h-full w-full bg-gray-100" />
         )}
         {hasBadge && (
-          <div className="absolute left-0 top-4 bg-black px-4 py-1 text-base font-semibold text-white">
+          <div className="absolute start-0 top-4 bg-black px-4 py-1 text-base font-semibold text-white">
             {badgeText}
           </div>
         )}
@@ -55,7 +55,7 @@ export function ProductCard({
       <p className="text-base">
         ${price}
         {Boolean(originalPrice) && (
-          <span className="ml-3 line-through opacity-50">${originalPrice}</span>
+          <span className="ms-3 line-through opacity-50">${originalPrice}</span>
         )}
       </p>
     </a>

--- a/packages/reactant/src/components/Badge/Badge.tsx
+++ b/packages/reactant/src/components/Badge/Badge.tsx
@@ -7,7 +7,7 @@ export const Badge = forwardRef<ElementRef<'span'>, ComponentPropsWithRef<'span'
     return (
       <span
         className={cs(
-          'absolute right-0 top-0 min-w-[24px] rounded-[28px] border-2 border-white bg-blue-primary px-1 py-px text-center text-sm font-bold leading-normal text-white',
+          'absolute end-0 top-0 min-w-[24px] rounded-[28px] border-2 border-white bg-blue-primary px-1 py-px text-center text-sm font-bold leading-normal text-white',
           className,
         )}
         ref={ref}

--- a/packages/reactant/src/components/Carousel/Carousel.tsx
+++ b/packages/reactant/src/components/Carousel/Carousel.tsx
@@ -173,7 +173,7 @@ export const Carousel = forwardRef<ElementRef<'ul'>, CarouselProps>(
           ))}
 
           {state.items.length > 1 && (
-            <ul className="absolute bottom-12 left-12 z-30 flex gap-8">
+            <ul className="absolute bottom-12 start-12 z-30 flex gap-8">
               <li>
                 <Button
                   className="border-0 p-1 text-black hover:bg-transparent hover:text-black"

--- a/packages/reactant/src/components/Counter/Counter.tsx
+++ b/packages/reactant/src/components/Counter/Counter.tsx
@@ -15,7 +15,7 @@ export const Counter = forwardRef<ElementRef<'div'>, ComponentPropsWithRef<'inpu
           aria-hidden="true"
           aria-label="Decrease count"
           className={cs(
-            'peer/down absolute top-0 left-0 flex h-full w-12 items-center justify-center focus:outline-none disabled:text-gray-200',
+            'peer/down absolute start-0 top-0 flex h-full w-12 items-center justify-center focus:outline-none disabled:text-gray-200',
           )}
           disabled={value <= 1 || disabled}
           onClick={() => {
@@ -31,7 +31,7 @@ export const Counter = forwardRef<ElementRef<'div'>, ComponentPropsWithRef<'inpu
           aria-hidden="true"
           aria-label="Increase count"
           className={cs(
-            'peer/up absolute top-0 right-0 flex h-full w-12 items-center justify-center focus:outline-none disabled:text-gray-200',
+            'peer/up absolute end-0 top-0 flex h-full w-12 items-center justify-center focus:outline-none disabled:text-gray-200',
           )}
           disabled={disabled}
           onClick={() => {
@@ -45,7 +45,7 @@ export const Counter = forwardRef<ElementRef<'div'>, ComponentPropsWithRef<'inpu
         </button>
         <input
           className={cs(
-            'focus:ring-primary-blue/20 peer/input w-full border-2 border-gray-200 py-2.5 px-12 text-center text-base placeholder:text-gray-500 hover:border-blue-primary focus:border-blue-primary focus:outline-none focus:ring-4 disabled:bg-gray-100 disabled:hover:border-gray-200 peer-hover/up:border-blue-primary peer-hover/down:border-blue-primary peer-hover/down:disabled:border-gray-200 peer-hover/up:disabled:border-gray-200 [&::-webkit-inner-spin-button]:appearance-none',
+            'focus:ring-primary-blue/20 peer/input w-full border-2 border-gray-200 px-12 py-2.5 text-center text-base placeholder:text-gray-500 hover:border-blue-primary focus:border-blue-primary focus:outline-none focus:ring-4 disabled:bg-gray-100 disabled:hover:border-gray-200 peer-hover/down:border-blue-primary peer-hover/up:border-blue-primary peer-hover/down:disabled:border-gray-200 peer-hover/up:disabled:border-gray-200 [&::-webkit-inner-spin-button]:appearance-none',
             className,
           )}
           disabled={disabled}

--- a/packages/reactant/src/components/Input/Input.tsx
+++ b/packages/reactant/src/components/Input/Input.tsx
@@ -10,9 +10,9 @@ const inputVariants = cva(
     variants: {
       variant: {
         success:
-          'pr-12 border-green-100 focus:border-green-100 focus:ring-green-100/20 disabled:border-gray-200 hover:border-green-200',
+          'pe-12 border-green-100 focus:border-green-100 focus:ring-green-100/20 disabled:border-gray-200 hover:border-green-200',
         error:
-          'pr-12 border-red-100 focus:border-red-100 focus:ring-red-100/20 disabled:border-gray-200 hover:border-red-200',
+          'pe-12 border-red-100 focus:border-red-100 focus:ring-red-100/20 disabled:border-gray-200 hover:border-red-200',
       },
     },
   },
@@ -34,7 +34,7 @@ export const InputIcon = forwardRef<ElementRef<'span'>, ComponentPropsWithRef<'s
       <span
         aria-hidden="true"
         className={cs(
-          'pointer-events-none absolute right-4 top-0 flex h-full items-center peer-disabled:text-gray-200',
+          'pointer-events-none absolute end-4 top-0 flex h-full items-center peer-disabled:text-gray-200',
           variant === 'success' && 'text-green-100',
           variant === 'error' && 'text-red-100',
           className,

--- a/packages/reactant/src/components/Message/Message.tsx
+++ b/packages/reactant/src/components/Message/Message.tsx
@@ -4,7 +4,7 @@ import { ComponentPropsWithRef, ElementRef, forwardRef } from 'react';
 
 import { cs } from '../../utils/cs';
 
-const messageVariants = cva('flex w-full justify-start gap-x-2.5 py-3 pl-3 text-base', {
+const messageVariants = cva('flex w-full justify-start gap-x-2.5 py-3 ps-3 text-base', {
   variants: {
     variant: {
       success: 'bg-green-300/20 [&>svg]:text-green-300',

--- a/packages/reactant/src/components/NavigationMenu/NavigationMenu.tsx
+++ b/packages/reactant/src/components/NavigationMenu/NavigationMenu.tsx
@@ -38,7 +38,7 @@ export const NavigationMenu = forwardRef<
           <div className="relative">
             <div
               className={cs(
-                'group flex min-h-[92px] items-center justify-between bg-white px-6 sm:px-10 lg:px-12 2xl:container 2xl:mx-auto 2xl:px-0',
+                'group flex min-h-[92px] items-center justify-between bg-white px-6 2xl:container sm:px-10 lg:px-12 2xl:mx-auto 2xl:px-0',
                 className,
               )}
               {...props}
@@ -47,7 +47,9 @@ export const NavigationMenu = forwardRef<
             </div>
             {!isExpanded && (
               <NavigationMenuPrimitive.Viewport
-                className={cs('absolute top-full left-0 z-50 w-full bg-white pt-6 pb-12 shadow-xl')}
+                className={cs(
+                  'absolute start-0 top-full z-50 w-full bg-white pb-12 pt-6 shadow-xl',
+                )}
               />
             )}
           </div>
@@ -176,7 +178,7 @@ export const NavigationMenuCollapsed = forwardRef<ElementRef<'div'>, ComponentPr
     return (
       <div
         className={cs(
-          'in-collapsed-nav group absolute top-full left-0 z-50 w-full bg-white px-3 pb-6 sm:px-7 lg:px-9 2xl:container 2xl:mx-auto 2xl:px-0',
+          'in-collapsed-nav group absolute start-0 top-full z-50 w-full bg-white px-3 pb-6 2xl:container sm:px-7 lg:px-9 2xl:mx-auto 2xl:px-0',
           className,
           !isExpanded && 'hidden',
         )}

--- a/packages/reactant/src/components/ProductCard/ProductCard.tsx
+++ b/packages/reactant/src/components/ProductCard/ProductCard.tsx
@@ -27,7 +27,7 @@ export const ProductCardBadge = forwardRef<ElementRef<'span'>, ComponentPropsWit
     return (
       <span
         className={cs(
-          'absolute left-0 top-4 bg-black px-4 py-1 text-white group-hover:opacity-75',
+          'absolute start-0 top-4 bg-black px-4 py-1 text-white group-hover:opacity-75',
           className,
         )}
         ref={ref}

--- a/packages/reactant/src/components/Sheet/Sheet.tsx
+++ b/packages/reactant/src/components/Sheet/Sheet.tsx
@@ -55,9 +55,9 @@ const sheetVariants = cva(
         top: 'inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top',
         bottom:
           'inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
-        left: 'inset-y-0 left-0 h-full w-full sm:w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm',
+        left: 'inset-y-0 start-0 h-full w-full sm:w-3/4 border-e data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm',
         right:
-          'inset-y-0 right-0 h-full w-full sm:w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm',
+          'inset-y-0 end-0 h-full w-full sm:w-3/4 border-s data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm',
       },
     },
     defaultVariants: {

--- a/packages/reactant/src/components/Swatch/Swatch.tsx
+++ b/packages/reactant/src/components/Swatch/Swatch.tsx
@@ -53,7 +53,7 @@ export const SwatchItem = forwardRef<
       >
         <span
           className={cs(
-            'absolute -left-px -top-[2px] w-[51px] origin-top-left rotate-45 border-t-2 border-red-100 group-disabled:opacity-30',
+            'absolute -start-px -top-[2px] w-[51px] origin-top-left rotate-45 border-t-2 border-red-100 group-disabled:opacity-30',
           )}
         />
       </span>

--- a/packages/reactant/src/components/Tag/Tag.tsx
+++ b/packages/reactant/src/components/Tag/Tag.tsx
@@ -25,7 +25,7 @@ export type TagContentProps = ComponentPropsWithRef<'span'>;
 const TagContent = forwardRef<ElementRef<'span'>, TagContentProps>(
   ({ className, ...props }, ref) => {
     return (
-      <span className={cs('pl-4 pr-2 font-semibold only:px-4', className)} ref={ref} {...props} />
+      <span className={cs('pe-2 ps-4 font-semibold only:px-4', className)} ref={ref} {...props} />
     );
   },
 );

--- a/packages/reactant/src/components/TextArea/TextArea.tsx
+++ b/packages/reactant/src/components/TextArea/TextArea.tsx
@@ -9,9 +9,9 @@ const textAreaVariants = cva(
     variants: {
       variant: {
         success:
-          'pr-12 border-green-100 focus:border-green-100 focus:ring-green-100/20 disabled:border-gray-200 hover:border-green-200',
+          'pe-12 border-green-100 focus:border-green-100 focus:ring-green-100/20 disabled:border-gray-200 hover:border-green-200',
         error:
-          'ring-red-100/20 focus:ring-red-100/20 !border-red-100 pr-12 hover:border-red-100 focus:border-red-100  disabled:border-gray-200',
+          'ring-red-100/20 focus:ring-red-100/20 !border-red-100 pe-12 hover:border-red-100 focus:border-red-100  disabled:border-gray-200',
       },
     },
   },


### PR DESCRIPTION
## What/Why?
Swap all the right/left styles with logical property equivalents. 

## Testing
![Screenshot 2023-08-30 at 15 56 26](https://github.com/bigcommerce/catalyst/assets/10539418/33dccb89-4250-4763-b902-a164a64886f0)
