### PR TITLE
feat: CATALYST-31 add contact us form

### DIFF
--- a/apps/core/components/Forms/ContactUs.tsx
+++ b/apps/core/components/Forms/ContactUs.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { Button } from '@bigcommerce/reactant/Button';
+import { cs } from '@bigcommerce/reactant/cs';
+import {
+  Field,
+  FieldControl,
+  FieldLabel,
+  FieldMessage,
+  Form,
+  FormSubmit,
+} from '@bigcommerce/reactant/Form';
+import { Input } from '@bigcommerce/reactant/Input';
+import { Message } from '@bigcommerce/reactant/Message';
+import { TextArea } from '@bigcommerce/reactant/TextArea';
+import { Loader2 as Spinner } from 'lucide-react';
+import { ChangeEvent, useState } from 'react';
+import { experimental_useFormStatus as useFormStatus } from 'react-dom';
+
+import { submitContactForm } from './_actions/submitContactForm';
+
+interface FieldMapping {
+  [key: string]: string;
+}
+
+const fieldNameMapping: FieldMapping = {
+  fullname: 'Full name',
+  companyname: 'Company name',
+  phone: 'Phone',
+  orderno: 'Order number',
+  rma: 'RMA number',
+};
+
+export const ContactUs = ({ fields }: { fields: string[] }) => {
+  const { pending } = useFormStatus();
+  const [isMessageVisible, showMessage] = useState(false);
+  const [isTextFieldValid, setTextFieldValidation] = useState(true);
+  const [isInputValid, setInputValidation] = useState(true);
+  const onSubmit = async (formData: FormData) => {
+    const { status } = await submitContactForm(formData);
+
+    if (status === 'success') {
+      showMessage(true);
+    }
+  };
+  const handleTextFieldValidation = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    setTextFieldValidation(!e.target.validity.valueMissing);
+  };
+  const handleInputValidation = (e: ChangeEvent<HTMLInputElement>) => {
+    const validityState = e.target.validity;
+    const validationStatus = validityState.valueMissing || validityState.typeMismatch;
+
+    return setInputValidation(!validationStatus);
+  };
+
+  return (
+    <>
+      {isMessageVisible && (
+        <Message className="mx-auto lg:w-[830px]" variant="success">
+          <p>
+            Thanks for reaching out. We'll get back to you soon. <strong>Keep shopping</strong>
+          </p>
+        </Message>
+      )}
+      <Form
+        action={onSubmit}
+        className="mx-auto mb-[42px] mt-8 grid grid-cols-1 gap-y-6 lg:w-[830px] lg:grid-cols-2 lg:gap-x-6 lg:gap-y-2"
+      >
+        <>
+          {fields.map((field) => {
+            return (
+              <Field
+                className={cs('relative space-y-2 pb-7')}
+                key={fieldNameMapping[field]}
+                name={fieldNameMapping[field]!}
+              >
+                <FieldLabel>{fieldNameMapping[field]}</FieldLabel>
+                <FieldControl asChild>
+                  <Input />
+                </FieldControl>
+              </Field>
+            );
+          })}
+          <Field className={cs('relative space-y-2 pb-7')} key="email" name="email">
+            <FieldLabel isRequired>Email</FieldLabel>
+            <FieldControl asChild>
+              <Input
+                onChange={handleInputValidation}
+                onInvalid={handleInputValidation}
+                required
+                type="email"
+                variant={!isInputValid ? 'error' : undefined}
+              />
+            </FieldControl>
+            <FieldMessage
+              className="absolute inset-x-0 bottom-0 inline-flex w-full text-sm text-red-200"
+              match="valueMissing"
+            >
+              Enter a valid email such as name@domain.com
+            </FieldMessage>
+            <FieldMessage
+              className="absolute inset-x-0 bottom-0 inline-flex w-full text-sm text-red-200"
+              match="typeMismatch"
+            >
+              Enter a valid email such as name@domain.com
+            </FieldMessage>
+          </Field>
+          <Field
+            className={cs('relative col-span-full max-w-full space-y-2 pb-5')}
+            key="comments"
+            name="comments"
+          >
+            <FieldLabel isRequired>Comments/questions</FieldLabel>
+            <FieldControl asChild>
+              <TextArea
+                onChange={handleTextFieldValidation}
+                onInvalid={handleTextFieldValidation}
+                required
+                variant={!isTextFieldValid ? 'error' : undefined}
+              />
+            </FieldControl>
+            <FieldMessage
+              className="absolute inset-x-0 bottom-0 inline-flex w-full text-sm text-red-200"
+              match="valueMissing"
+            >
+              Please provide a valid Comments
+            </FieldMessage>
+          </Field>
+        </>
+        <FormSubmit asChild>
+          <Button
+            className="mt-8 w-fit items-center px-8 py-2"
+            disabled={pending}
+            variant="primary"
+          >
+            {pending ? (
+              <>
+                <Spinner aria-hidden="true" className="animate-spin" />
+                <span className="sr-only">Submitting...</span>
+              </>
+            ) : (
+              <span>Submit form</span>
+            )}
+          </Button>
+        </FormSubmit>
+      </Form>
+    </>
+  );
+};

--- a/apps/core/components/Forms/_actions/submitContactForm.ts
+++ b/apps/core/components/Forms/_actions/submitContactForm.ts
@@ -1,0 +1,38 @@
+/* eslint-disable  @typescript-eslint/require-await */
+
+'use server';
+
+import { z } from 'zod';
+
+const ContactUsSchema = z.object({
+  companyName: z.string().optional(),
+  fullName: z.string().optional(),
+  phone: z.string().optional(),
+  orderNumber: z.string().optional(),
+  rmaNumber: z.string().optional(),
+  email: z.string().email(),
+  comments: z.string().trim().nonempty(),
+});
+
+export const submitContactForm = async (
+  formData: FormData,
+): Promise<{ status: 'success' | 'failed' }> => {
+  try {
+    const parsedData = ContactUsSchema.parse({
+      email: formData.get('email'),
+      comments: formData.get('comments'),
+      companyName: formData.get('Company name'),
+      fullName: formData.get('Full name'),
+      phone: formData.get('Phone'),
+      orderNumber: formData.get('Order number'),
+      rmaNumber: formData.get('RMA number'),
+    });
+
+    console.log('contact us data', parsedData);
+    // TODO: add graphql mutation on submit;
+
+    return { status: 'success' };
+  } catch (e) {
+    return { status: 'failed' };
+  }
+};

--- a/apps/core/components/Forms/index.ts
+++ b/apps/core/components/Forms/index.ts
@@ -1,0 +1,1 @@
+export * from './ContactUs';

--- a/apps/docs/stories/Form.stories.tsx
+++ b/apps/docs/stories/Form.stories.tsx
@@ -119,7 +119,7 @@ export const ValidityStateWrapper: Story = {
       <Field className="relative space-y-2 pb-6" name="email">
         <FieldLabel isRequired>Email Mismatch</FieldLabel>
         <FieldValidation>
-          {(validity: BuiltInValidityState) => {
+          {(validity: BuiltInValidityState | undefined): JSX.Element => {
             const handleControlValidation = () => {
               let validationState: boolean;
 

--- a/packages/reactant/src/components/Form/Form.tsx
+++ b/packages/reactant/src/components/Form/Form.tsx
@@ -6,7 +6,6 @@ import { Label } from '../Label';
 
 export type ValidationPattern =
   | 'badInput'
-  | 'customError'
   | 'patternMismatch'
   | 'rangeOverflow'
   | 'rangeUnderflow'
@@ -41,14 +40,18 @@ export const Field = forwardRef<
   </FormPrimitive.Field>
 ));
 
-export const FieldMessage = forwardRef<
-  ElementRef<typeof FormPrimitive.Message>,
-  ComponentPropsWithRef<typeof FormPrimitive.Message>
->(({ className, children, ...props }, ref) => (
-  <FormPrimitive.Message className={cs(className)} ref={ref} {...props}>
-    {children}
-  </FormPrimitive.Message>
-));
+interface FieldMessageProps
+  extends Omit<ComponentPropsWithRef<typeof FormPrimitive.Message>, 'match'> {
+  match?: ValidationPattern;
+}
+
+export const FieldMessage = forwardRef<ElementRef<typeof FormPrimitive.Message>, FieldMessageProps>(
+  ({ className, children, ...props }, ref) => (
+    <FormPrimitive.Message className={cs(className)} ref={ref} {...props}>
+      {children}
+    </FormPrimitive.Message>
+  ),
+);
 
 interface FieldLabelProps extends ComponentPropsWithRef<typeof Label> {
   isRequired?: boolean;


### PR DESCRIPTION
## What/Why?
This PR adds a form generator that can be reused for adding different forms like Contact us, Log In/Out, Create Account and few others.

## Testing

https://github.com/bigcommerce/catalyst/assets/67792608/30c5d66e-815f-45f7-8f06-95fb4f1982c0


