### PR TITLE
feat(core): add SharingLinks

### DIFF
--- a/apps/core/components/SharingLinks/index.tsx
+++ b/apps/core/components/SharingLinks/index.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { SiFacebook, SiLinkedin, SiPinterest, SiX } from '@icons-pack/react-simple-icons'; 
+
+import { Mail, Printer } from 'lucide-react';
+
+interface SharingLinksProps {
+  blogPostId: string;
+  blogPostImageUrl?: string;
+  blogPostTitle?: string;
+  vanityUrl?: string;
+}
+
+export const SharingLinks = ({
+  blogPostId,
+  /* TODO: use default image */
+  blogPostImageUrl = '',
+  blogPostTitle = '',
+  vanityUrl = '',
+}: SharingLinksProps) => {
+  const encodedTitle = encodeURIComponent(blogPostTitle);
+  const encodedUrl = encodeURIComponent(`${vanityUrl}/blog/${blogPostId}/`);
+
+  return (
+    <div className="mb-10 flex items-center [&>*:not(:last-child)]:mr-2.5">
+      <h3 className="text-h5">Share</h3>
+      <a
+        href={`https://facebook.com/sharer/sharer.php?u=${encodedUrl}`}
+        rel="noopener noreferrer"
+        target="_blank"
+        title="Facebook"
+      >
+        <SiFacebook size={24} />
+      </a>
+      <a
+        href={`mailto:?subject=${encodedTitle}&body=${encodedUrl}`}
+        rel="noopener noreferrer"
+        target="_self"
+        title="Email"
+      >
+        <Mail size={24} />
+      </a>
+      <button
+        onClick={() => {
+          window.print();
+
+          return false;
+        }}
+        title="Print"
+        type="button"
+      >
+        <Printer size={24} />
+      </button>
+      <a
+        href={`https://twitter.com/intent/tweet/?text=${encodedTitle}&url=${encodedUrl}`}
+        rel="noopener noreferrer"
+        target="_blank"
+        title="X"
+      >
+        <SiX size={24} />
+      </a>
+      <a
+        href={`https://www.linkedin.com/shareArticle?mini=true&url=${encodedUrl}&title=${encodedTitle}&summary=${encodedTitle}&source=${encodedUrl}`}
+        rel="noopener noreferrer"
+        target="_blank"
+        title="LinkedIn"
+      >
+        <SiLinkedin size={24} />
+      </a>
+      <a
+        href={`https://pinterest.com/pin/create/button/?url=${encodedUrl}&media=${blogPostImageUrl}&description=${encodedTitle}`}
+        rel="noopener noreferrer"
+        target="_blank"
+        title="Pinterest"
+      >
+        <SiPinterest height={24} width={24} />
+      </a>
+    </div>
+  );
+};

--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@bigcommerce/catalyst-client": "workspace:^",
     "@bigcommerce/reactant": "workspace:^",
+    "@icons-pack/react-simple-icons": "^9.0.0",
     "@vercel/analytics": "^1.0.2",
     "lucide-react": "^0.274.0",
     "next": "^13.4.19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@bigcommerce/reactant':
         specifier: workspace:^
         version: link:../../packages/reactant
+      '@icons-pack/react-simple-icons':
+        specifier: ^9.0.0
+        version: 9.0.0(react@18.2.0)
       '@vercel/analytics':
         specifier: ^1.0.2
         version: 1.0.2
@@ -2406,6 +2409,14 @@ packages:
 
   /@humanwhocodes/object-schema@1.2.1:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
+
+  /@icons-pack/react-simple-icons@9.0.0(react@18.2.0):
+    resolution: {integrity: sha512-2ZLcJKCmz0VESaKbuiJ8ks4Qd8fldTdK63JkO3bLgD0GVXQi994jy7/1Kd+mIrMmrSMGPe23+DGGx5g9aAsc2w==}
+    peerDependencies:
+      react: ^16.13 || ^17 || ^18
+    dependencies:
+      react: 18.2.0
+    dev: false
 
   /@isaacs/cliui@8.0.2:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}


### PR DESCRIPTION
## What/Why?
This PR adds `SharingLinks` component to the `core` that can be used for example in Blog

## Testing
locally

## Proof
<img width="325" alt="sharing-links" src="https://github.com/bigcommerce/catalyst/assets/66325265/2331b175-69ce-4f10-9c30-6b7706b65303">

changed to

<img width="269" alt="sharing-links-2" src="https://github.com/bigcommerce/catalyst/assets/66325265/817e7115-1d34-49ff-8daa-2fd875e3f5e7">
