### PR TITLE
feat(reactant): CATALYST-86 add Carousel component

### DIFF
--- a/apps/docs/stories/Carousel.stories.tsx
+++ b/apps/docs/stories/Carousel.stories.tsx
@@ -1,0 +1,229 @@
+import {
+  Carousel,
+  CarouselContent,
+  CarouselNextIndicator,
+  CarouselPagination,
+  CarouselPaginationTab,
+  CarouselPreviousIndicator,
+  CarouselSlide,
+} from '@bigcommerce/reactant/Carousel';
+import {
+  ProductCard,
+  ProductCardBadge,
+  ProductCardImage,
+  ProductCardInfo,
+  ProductCardInfoBrandName,
+  ProductCardInfoPrice,
+  ProductCardInfoProductName,
+} from '@bigcommerce/reactant/ProductCard';
+import { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof Carousel> = {
+  component: Carousel,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Carousel>;
+
+export const MultipleSlides: Story = {
+  render: () => (
+    <Carousel aria-labelledby="title">
+      <div className="flex items-center justify-between">
+        <h2 className="text-h3" id="title">
+          Related Products
+        </h2>
+        <span className="no-wrap flex">
+          <CarouselPreviousIndicator />
+          <CarouselNextIndicator />
+        </span>
+      </div>
+
+      <CarouselContent>
+        <CarouselSlide aria-label="1 of 2" id="slide-1" index={0}>
+          <ProductCard>
+            <ProductCardImage>
+              <div className="h-[180px] w-full bg-gray-200" />
+            </ProductCardImage>
+            <ProductCardBadge>On sale</ProductCardBadge>
+            <ProductCardInfo>
+              <ProductCardInfoBrandName>Nike</ProductCardInfoBrandName>
+              <ProductCardInfoProductName>
+                <a href="/">Air Jordans</a>
+              </ProductCardInfoProductName>
+              <ProductCardInfoPrice>$200</ProductCardInfoPrice>
+            </ProductCardInfo>
+          </ProductCard>
+          <ProductCard>
+            <ProductCardImage>
+              <div className="h-[180px] w-full bg-gray-200" />
+            </ProductCardImage>
+            <ProductCardBadge>On sale</ProductCardBadge>
+            <ProductCardInfo>
+              <ProductCardInfoBrandName>Nike</ProductCardInfoBrandName>
+              <ProductCardInfoProductName>
+                <a href="/">Air Jordans</a>
+              </ProductCardInfoProductName>
+              <ProductCardInfoPrice>$200</ProductCardInfoPrice>
+            </ProductCardInfo>
+          </ProductCard>
+          <ProductCard>
+            <ProductCardImage>
+              <div className="h-[180px] w-full bg-gray-200" />
+            </ProductCardImage>
+            <ProductCardBadge>On sale</ProductCardBadge>
+            <ProductCardInfo>
+              <ProductCardInfoBrandName>Nike</ProductCardInfoBrandName>
+              <ProductCardInfoProductName>
+                <a href="/">Air Jordans</a>
+              </ProductCardInfoProductName>
+              <ProductCardInfoPrice>$200</ProductCardInfoPrice>
+            </ProductCardInfo>
+          </ProductCard>
+          <ProductCard>
+            <ProductCardImage>
+              <div className="h-[180px] w-full bg-gray-200" />
+            </ProductCardImage>
+            <ProductCardBadge>On sale</ProductCardBadge>
+            <ProductCardInfo>
+              <ProductCardInfoBrandName>Nike</ProductCardInfoBrandName>
+              <ProductCardInfoProductName>
+                <a href="/">Air Jordans</a>
+              </ProductCardInfoProductName>
+              <ProductCardInfoPrice>$200</ProductCardInfoPrice>
+            </ProductCardInfo>
+          </ProductCard>
+        </CarouselSlide>
+        <CarouselSlide aria-label="2 of 2" id="slide-2" index={1}>
+          <ProductCard>
+            <ProductCardImage>
+              <div className="h-[180px] w-full bg-gray-200" />
+            </ProductCardImage>
+            <ProductCardBadge>On sale</ProductCardBadge>
+            <ProductCardInfo>
+              <ProductCardInfoBrandName>Nike</ProductCardInfoBrandName>
+              <ProductCardInfoProductName>
+                <a href="/">Air Jordans</a>
+              </ProductCardInfoProductName>
+              <ProductCardInfoPrice>$200</ProductCardInfoPrice>
+            </ProductCardInfo>
+          </ProductCard>
+          <ProductCard>
+            <ProductCardImage>
+              <div className="h-[180px] w-full bg-gray-200" />
+            </ProductCardImage>
+            <ProductCardBadge>On sale</ProductCardBadge>
+            <ProductCardInfo>
+              <ProductCardInfoBrandName>Nike</ProductCardInfoBrandName>
+              <ProductCardInfoProductName>
+                <a href="/">Air Jordans</a>
+              </ProductCardInfoProductName>
+              <ProductCardInfoPrice>$200</ProductCardInfoPrice>
+            </ProductCardInfo>
+          </ProductCard>
+          <ProductCard>
+            <ProductCardImage>
+              <div className="h-[180px] w-full bg-gray-200" />
+            </ProductCardImage>
+            <ProductCardBadge>On sale</ProductCardBadge>
+            <ProductCardInfo>
+              <ProductCardInfoBrandName>Nike</ProductCardInfoBrandName>
+              <ProductCardInfoProductName>
+                <a href="/">Air Jordans</a>
+              </ProductCardInfoProductName>
+              <ProductCardInfoPrice>$200</ProductCardInfoPrice>
+            </ProductCardInfo>
+          </ProductCard>
+        </CarouselSlide>
+      </CarouselContent>
+      <CarouselPagination>
+        {({ selectedIndex, scrollTo }) => (
+          <>
+            <CarouselPaginationTab
+              aria-controls="slide-1"
+              aria-label="Slide 1"
+              isSelected={selectedIndex === 0}
+              onClick={() => scrollTo(0)}
+            />
+            <CarouselPaginationTab
+              aria-controls="slide-2"
+              aria-label="Slide 2"
+              isSelected={selectedIndex === 1}
+              onClick={() => scrollTo(1)}
+            />
+          </>
+        )}
+      </CarouselPagination>
+    </Carousel>
+  ),
+};
+
+export const SingleSlide: Story = {
+  render: () => (
+    <Carousel aria-labelledby="title">
+      <div className="flex items-center justify-between">
+        <h2 className="text-h3" id="title">
+          Related Products
+        </h2>
+        <span className="no-wrap flex">
+          <CarouselPreviousIndicator />
+          <CarouselNextIndicator />
+        </span>
+      </div>
+
+      <CarouselContent>
+        <CarouselSlide aria-label="1 of 1" index={0}>
+          <ProductCard>
+            <ProductCardImage>
+              <div className="h-[180px] w-full bg-gray-200" />
+            </ProductCardImage>
+            <ProductCardBadge>On sale</ProductCardBadge>
+            <ProductCardInfo>
+              <ProductCardInfoBrandName>Nike</ProductCardInfoBrandName>
+              <ProductCardInfoProductName>
+                <a href="/">Air Jordans</a>
+              </ProductCardInfoProductName>
+              <ProductCardInfoPrice>$200</ProductCardInfoPrice>
+            </ProductCardInfo>
+          </ProductCard>
+          <ProductCard>
+            <ProductCardImage>
+              <div className="h-[180px] w-full bg-gray-200" />
+            </ProductCardImage>
+            <ProductCardBadge>On sale</ProductCardBadge>
+            <ProductCardInfo>
+              <ProductCardInfoBrandName>Nike</ProductCardInfoBrandName>
+              <ProductCardInfoProductName>
+                <a href="/">Air Jordans</a>
+              </ProductCardInfoProductName>
+              <ProductCardInfoPrice>$200</ProductCardInfoPrice>
+            </ProductCardInfo>
+          </ProductCard>
+          <ProductCard>
+            <ProductCardImage>
+              <div className="h-[180px] w-full bg-gray-200" />
+            </ProductCardImage>
+            <ProductCardBadge>On sale</ProductCardBadge>
+            <ProductCardInfo>
+              <ProductCardInfoBrandName>Nike</ProductCardInfoBrandName>
+              <ProductCardInfoProductName>
+                <a href="/">Air Jordans</a>
+              </ProductCardInfoProductName>
+              <ProductCardInfoPrice>$200</ProductCardInfoPrice>
+            </ProductCardInfo>
+          </ProductCard>
+        </CarouselSlide>
+      </CarouselContent>
+      <CarouselPagination>
+        {({ selectedIndex, scrollTo }) => (
+          <CarouselPaginationTab
+            aria-label="Slide 1"
+            isSelected={selectedIndex === 0}
+            onClick={() => scrollTo(0)}
+          />
+        )}
+      </CarouselPagination>
+    </Carousel>
+  ),
+};

--- a/apps/docs/stories/ProductCard.stories.tsx
+++ b/apps/docs/stories/ProductCard.stories.tsx
@@ -22,7 +22,7 @@ export const BasicExample: Story = {
   render: () => (
     <ProductCard>
       <ProductCardImage>
-        <div className="h-full w-full bg-gray-200" />
+        <div className="h-[180px] w-full bg-gray-200" />
       </ProductCardImage>
       <ProductCardBadge>On sale</ProductCardBadge>
       <ProductCardInfo>

--- a/packages/reactant/package.json
+++ b/packages/reactant/package.json
@@ -42,6 +42,7 @@
     "@radix-ui/react-slot": "^1.0.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
+    "embla-carousel-react": "8.0.0-rc12",
     "focus-trap-react": "^10.2.1",
     "lucide-react": "^0.274.0",
     "tailwind-merge": "^1.14.0",

--- a/packages/reactant/src/components/Carousel/Carousel.tsx
+++ b/packages/reactant/src/components/Carousel/Carousel.tsx
@@ -1,0 +1,260 @@
+import useEmblaCarousel, { UseEmblaCarouselType } from 'embla-carousel-react';
+import { ArrowLeft, ArrowRight } from 'lucide-react';
+import {
+  ComponentPropsWithRef,
+  createContext,
+  ElementRef,
+  forwardRef,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+
+import { cs } from '../../utils/cs';
+
+const CarouselContext = createContext<UseEmblaCarouselType>([() => null, undefined]);
+
+export const Carousel = forwardRef<ElementRef<'section'>, ComponentPropsWithRef<'section'>>(
+  ({ children, className, ...props }, ref) => {
+    const [emblaRef, emblaApi] = useEmblaCarousel({ loop: true });
+
+    return (
+      <CarouselContext.Provider value={[emblaRef, emblaApi]}>
+        <section
+          aria-roledescription="carousel"
+          className={cs('relative -m-2 overflow-hidden p-2', className)}
+          ref={ref}
+          {...props}
+        >
+          {children}
+        </section>
+      </CarouselContext.Provider>
+    );
+  },
+);
+
+Carousel.displayName = 'Carousel';
+
+export const CarouselContent = forwardRef<ElementRef<'div'>, ComponentPropsWithRef<'ul'>>(
+  ({ children, className, ...props }, ref) => {
+    const [emblaRef] = useContext(CarouselContext);
+
+    return (
+      <div ref={ref}>
+        <div ref={emblaRef}>
+          <ul aria-live="polite" className={cs('mb-16 mt-8 flex lg:mt-10', className)} {...props}>
+            {children}
+          </ul>
+        </div>
+      </div>
+    );
+  },
+);
+
+CarouselContent.displayName = 'CarouselContent';
+
+interface CarouselSlideProps extends ComponentPropsWithRef<'li'> {
+  index: number;
+}
+
+export const CarouselSlide = forwardRef<ElementRef<'li'>, CarouselSlideProps>(
+  ({ children, className, index, ...props }, ref) => {
+    const [, emblaApi] = useContext(CarouselContext);
+    const [slidesInView, setSlidesInView] = useState<number[]>([0]);
+
+    useEffect(() => {
+      if (!emblaApi) return;
+
+      emblaApi.on('slidesInView', () => {
+        setSlidesInView(emblaApi.slidesInView());
+      });
+    }, [emblaApi]);
+
+    return (
+      <li
+        aria-roledescription="slide"
+        className={cs(
+          'mx-6 grid min-w-0 flex-shrink-0 flex-grow-0 basis-full grid-cols-2 gap-6 md:grid-cols-4 lg:gap-8',
+          !slidesInView.includes(index) && 'invisible',
+          className,
+        )}
+        ref={ref}
+        role="tabpanel"
+        {...props}
+      >
+        {children}
+      </li>
+    );
+  },
+);
+
+CarouselSlide.displayName = 'CarouselSlide';
+
+export const CarouselPreviousIndicator = forwardRef<
+  ElementRef<'button'>,
+  ComponentPropsWithRef<'button'>
+>(({ children, className, onClick, ...props }, ref) => {
+  const [, emblaApi] = useContext(CarouselContext);
+  const [isHidden, setIsHidden] = useState(false);
+
+  const scrollPrev = useCallback(() => {
+    if (emblaApi) emblaApi.scrollPrev();
+  }, [emblaApi]);
+
+  useEffect(() => {
+    if (emblaApi) setIsHidden(emblaApi.scrollSnapList().length <= 1);
+  }, [emblaApi]);
+
+  return (
+    <button
+      aria-label="Previous products"
+      className={cs(
+        'focus:ring-primary-blue/20 inline-flex h-12 w-12 items-center justify-center focus:outline-none focus:ring-4',
+        isHidden && 'hidden',
+        className,
+      )}
+      onClick={(e) => {
+        scrollPrev();
+
+        if (onClick) {
+          onClick(e);
+        }
+      }}
+      ref={ref}
+      {...props}
+    >
+      {children || <ArrowLeft />}
+    </button>
+  );
+});
+
+CarouselPreviousIndicator.displayName = 'CarouselPreviousIndicator';
+
+export const CarouselNextIndicator = forwardRef<
+  ElementRef<'button'>,
+  ComponentPropsWithRef<'button'>
+>(({ children, className, onClick, ...props }, ref) => {
+  const [, emblaApi] = useContext(CarouselContext);
+  const [isHidden, setIsHidden] = useState(false);
+
+  const scrollNext = useCallback(() => {
+    if (emblaApi) emblaApi.scrollNext();
+  }, [emblaApi]);
+
+  useEffect(() => {
+    if (emblaApi) setIsHidden(emblaApi.scrollSnapList().length <= 1);
+  }, [emblaApi]);
+
+  return (
+    <button
+      aria-label="Next products"
+      className={cs(
+        'focus:ring-primary-blue/20 inline-flex h-12 w-12 items-center justify-center focus:outline-none focus:ring-4',
+        isHidden && 'hidden',
+        className,
+      )}
+      onClick={(e) => {
+        scrollNext();
+
+        if (onClick) {
+          onClick(e);
+        }
+      }}
+      ref={ref}
+      {...props}
+    >
+      {children || <ArrowRight />}
+    </button>
+  );
+});
+
+CarouselNextIndicator.displayName = 'CarouselNextIndicator';
+
+interface CarouselPaginationProps extends Omit<ComponentPropsWithRef<'div'>, 'children'> {
+  children?:
+    | (({
+        selectedIndex,
+        scrollTo,
+      }: {
+        selectedIndex: number;
+        scrollTo: (index: number) => void | undefined;
+      }) => React.ReactNode)
+    | React.ReactNode;
+}
+
+export const CarouselPagination = forwardRef<ElementRef<'div'>, CarouselPaginationProps>(
+  ({ children, className, onClick, ...props }, ref) => {
+    const [, emblaApi] = useContext(CarouselContext);
+    const [selectedIndex, setSelectedIndex] = useState(0);
+
+    const [scrollSnaps, setScrollSnaps] = useState<number[]>([]);
+
+    const onInit = useCallback(() => {
+      if (emblaApi) setScrollSnaps(emblaApi.scrollSnapList());
+    }, [emblaApi]);
+
+    const scrollTo = useCallback(
+      (index: number) => emblaApi && emblaApi.scrollTo(index),
+      [emblaApi],
+    );
+
+    const onSelect = useCallback(() => {
+      if (emblaApi) setSelectedIndex(emblaApi.selectedScrollSnap());
+    }, [emblaApi]);
+
+    useEffect(() => {
+      if (!emblaApi) return;
+
+      onInit();
+      emblaApi.on('reInit', onInit);
+      emblaApi.on('select', onSelect);
+    }, [emblaApi, onInit, onSelect]);
+
+    if (scrollSnaps.length <= 1) {
+      return null;
+    }
+
+    if (typeof children === 'function') {
+      return (
+        <div
+          aria-label="Slides"
+          className={cs('no-wrap absolute bottom-1 flex w-full items-center justify-center gap-2')}
+          ref={ref}
+          role="tablist"
+          {...props}
+        >
+          {children({ selectedIndex, scrollTo })}
+        </div>
+      );
+    }
+
+    return null;
+  },
+);
+
+CarouselPagination.displayName = 'CarouselPagination';
+
+interface CarouselPaginationTabProps extends ComponentPropsWithRef<'button'> {
+  isSelected: boolean;
+}
+
+export const CarouselPaginationTab = forwardRef<ElementRef<'button'>, CarouselPaginationTabProps>(
+  ({ children, className, isSelected, ...props }, ref) => {
+    return (
+      <button
+        aria-selected={isSelected}
+        className={cs(
+          "focus:ring-primary-blue/20 h-7 w-7 p-0.5 after:block after:h-0.5 after:w-full after:bg-gray-400 after:content-[''] focus:outline-none focus:ring-4",
+          isSelected && 'after:bg-black',
+          className,
+        )}
+        ref={ref}
+        role="tab"
+        {...props}
+      />
+    );
+  },
+);
+
+CarouselPaginationTab.displayName = 'CarouselPaginationTab';

--- a/packages/reactant/src/components/Carousel/index.ts
+++ b/packages/reactant/src/components/Carousel/index.ts
@@ -1,0 +1,3 @@
+'use client';
+
+export * from './Carousel';

--- a/packages/reactant/src/components/ProductCard/ProductCard.tsx
+++ b/packages/reactant/src/components/ProductCard/ProductCard.tsx
@@ -15,7 +15,11 @@ export const ProductCard = forwardRef<ElementRef<'div'>, ComponentPropsWithRef<'
 export const ProductCardImage = forwardRef<ElementRef<'div'>, ComponentPropsWithRef<'div'>>(
   ({ children, className, ...props }, ref) => {
     return (
-      <div className={cs('mx-auto pb-3 group-hover:opacity-75', className)} ref={ref} {...props}>
+      <div
+        className={cs('flex justify-center pb-3 group-hover:opacity-75', className)}
+        ref={ref}
+        {...props}
+      >
         {children}
       </div>
     );

--- a/packages/reactant/tsconfig.json
+++ b/packages/reactant/tsconfig.json
@@ -2,10 +2,14 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Default",
   "compilerOptions": {
+    "target": "esnext",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "jsx": "react-jsx",
-    "lib": ["dom", "ES2015"],
     "module": "ESNext",
-    "target": "es6",
     "composite": false,
     "declaration": true,
     "declarationMap": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -316,7 +316,7 @@ importers:
         version: 3.0.3
       tsup:
         specifier: ^6.7.0
-        version: 6.7.0(typescript@5.2.2)
+        version: 6.7.0(postcss@8.4.29)(typescript@5.2.2)
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
@@ -411,6 +411,9 @@ importers:
       clsx:
         specifier: ^2.0.0
         version: 2.0.0
+      embla-carousel-react:
+        specifier: 8.0.0-rc12
+        version: 8.0.0-rc12(react@18.2.0)
       focus-trap-react:
         specifier: ^10.2.1
         version: 10.2.1(prop-types@15.8.1)(react-dom@18.2.0)(react@18.2.0)
@@ -1704,7 +1707,7 @@ packages:
       eslint-config-prettier: 8.10.0(eslint@8.48.0)
       eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.59.8)(eslint-plugin-import@2.27.5)(eslint@8.48.0)
       eslint-plugin-gettext: 1.2.0
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.8)(eslint-import-resolver-typescript@3.5.5)(eslint@8.48.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.8)(eslint@8.48.0)
       eslint-plugin-jest: 26.9.0(@typescript-eslint/eslint-plugin@5.59.8)(eslint@8.48.0)(typescript@5.2.2)
       eslint-plugin-jest-formatting: 3.1.0(eslint@8.48.0)
       eslint-plugin-jsdoc: 39.9.1(eslint@8.48.0)
@@ -6467,6 +6470,28 @@ packages:
   /electron-to-chromium@1.4.495:
     resolution: {integrity: sha512-mwknuemBZnoOCths4GtpU/SDuVMp3uQHKa2UNJT9/aVD6WVRjGpXOxRGX7lm6ILIenTdGXPSTCTDaWos5tEU8Q==}
 
+  /embla-carousel-react@8.0.0-rc12(react@18.2.0):
+    resolution: {integrity: sha512-Tyd9TNH9i8bb/0S9/WZsmEvfZm8jlFU9sgaWNNgLzbPsUtz/L6UTYuRGOBDOt2oh6VPhaL1G8vRuOAuH81G5Cg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.1 || ^18.0.0
+    dependencies:
+      embla-carousel: 8.0.0-rc12
+      embla-carousel-reactive-utils: 8.0.0-rc12(embla-carousel@8.0.0-rc12)
+      react: 18.2.0
+    dev: false
+
+  /embla-carousel-reactive-utils@8.0.0-rc12(embla-carousel@8.0.0-rc12):
+    resolution: {integrity: sha512-sHYqMYW2qk9UXNMLoBmo4PRe+8qOW8CJDDqfkMB0WlSfrzgi9fCc36nArQz6k9olHsVfEc3haw00KiqRBvVwEg==}
+    peerDependencies:
+      embla-carousel: 8.0.0-rc12
+    dependencies:
+      embla-carousel: 8.0.0-rc12
+    dev: false
+
+  /embla-carousel@8.0.0-rc12:
+    resolution: {integrity: sha512-/Xkf5zp9gs9Y45lSAT1Witn+r+o+EtoIIZg4V2lYTCaaqdDTxyO0Ddn+z00ya38JGNZrGH9U8wLGK5Hi76CRxw==}
+    dev: false
+
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -6791,7 +6816,6 @@ packages:
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
       - supports-color
-    dev: true
 
   /eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.59.8)(eslint-plugin-import@2.27.5)(eslint@8.48.0):
     resolution: {integrity: sha512-TdJqPHs2lW5J9Zpe17DZNQuDnox4xo2o+0tE7Pggain9Rbc19ik8kFtXdxZ250FVx2kF4vlt2RSf4qlUpG7bhw==}
@@ -6803,8 +6827,8 @@ packages:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.48.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.59.8)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.48.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.8)(eslint-import-resolver-typescript@3.5.5)(eslint@8.48.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.59.8)(eslint-import-resolver-typescript@3.5.5)(eslint@8.48.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.8)(eslint@8.48.0)
       get-tsconfig: 4.6.0
       globby: 13.2.2
       is-core-module: 2.13.0
@@ -6841,6 +6865,34 @@ packages:
       debug: 3.2.7
       eslint: 8.48.0
       eslint-import-resolver-node: 0.3.7
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.59.8)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.48.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  /eslint-module-utils@2.8.0(@typescript-eslint/parser@5.59.8)(eslint-import-resolver-typescript@3.5.5)(eslint@8.48.0):
+    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 5.59.8(eslint@8.48.0)(typescript@5.2.2)
+      debug: 3.2.7
+      eslint: 8.48.0
       eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.59.8)(eslint-plugin-import@2.27.5)(eslint@8.48.0)
     transitivePeerDependencies:
       - supports-color
@@ -6852,6 +6904,38 @@ packages:
       gettext-parser: 4.2.0
 
   /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.59.8)(eslint-import-resolver-typescript@3.5.5)(eslint@8.48.0):
+    resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 5.59.8(eslint@8.48.0)(typescript@5.2.2)
+      array-includes: 3.1.6
+      array.prototype.flat: 1.3.1
+      array.prototype.flatmap: 1.3.1
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 8.48.0
+      eslint-import-resolver-node: 0.3.7
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.59.8)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.48.0)
+      has: 1.0.3
+      is-core-module: 2.13.0
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.values: 1.1.6
+      resolve: 1.22.4
+      semver: 6.3.1
+      tsconfig-paths: 3.14.2
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.59.8)(eslint@8.48.0):
     resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -9449,22 +9533,6 @@ packages:
       postcss: 8.4.29
     dev: true
 
-  /postcss-load-config@3.1.4:
-    resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
-    engines: {node: '>= 10'}
-    peerDependencies:
-      postcss: '>=8.0.9'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      postcss:
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      lilconfig: 2.1.0
-      yaml: 1.10.2
-    dev: true
-
   /postcss-load-config@3.1.4(postcss@8.4.29):
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
     engines: {node: '>= 10'}
@@ -11132,42 +11200,6 @@ packages:
       joycon: 3.1.1
       postcss: 8.4.29
       postcss-load-config: 3.1.4(postcss@8.4.29)
-      resolve-from: 5.0.0
-      rollup: 3.28.1
-      source-map: 0.8.0-beta.0
-      sucrase: 3.34.0
-      tree-kill: 1.2.2
-      typescript: 5.2.2
-    transitivePeerDependencies:
-      - supports-color
-      - ts-node
-    dev: true
-
-  /tsup@6.7.0(typescript@5.2.2):
-    resolution: {integrity: sha512-L3o8hGkaHnu5TdJns+mCqFsDBo83bJ44rlK7e6VdanIvpea4ArPcU3swWGsLVbXak1PqQx/V+SSmFPujBK+zEQ==}
-    engines: {node: '>=14.18'}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': ^1
-      postcss: ^8.4.12
-      typescript: '>=4.1.0'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      postcss:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      bundle-require: 4.0.1(esbuild@0.17.19)
-      cac: 6.7.14
-      chokidar: 3.5.3
-      debug: 4.3.4
-      esbuild: 0.17.19
-      execa: 5.1.1
-      globby: 11.1.0
-      joycon: 3.1.1
-      postcss-load-config: 3.1.4
       resolve-from: 5.0.0
       rollup: 3.28.1
       source-map: 0.8.0-beta.0


### PR DESCRIPTION
## What/Why?
Add `Carousel` to reactant. Use component for Related Products in PDP.

## How
Use [embla-carousel-react](https://www.embla-carousel.com/) to manage carousel state/animations.

## API
```jsx
<Carousel aria-labelledby="title" className="mb-14">
  <div className="flex items-center justify-between">
    <h2 className="text-h3" id="title">
      {title}
    </h2>
    <span className="no-wrap flex">
      <CarouselPreviousIndicator />
      <CarouselNextIndicator />
    </span>
  </div>
  <CarouselContent>
    {groupedProducts.map((group, index) => (
      <CarouselSlide
        aria-label={`${index + 1} of ${groupedProducts.length}`}
        id={`${id}-slide-${index + 1}`}
        index={index}
        key={index}
      >
        {group.map((product) => (
          <ProductCard imageSize="tall" key={product.entityId} product={product} />
        ))}
      </CarouselSlide>
    ))}
  </CarouselContent>
  <CarouselPagination>
    {({ selectedIndex, scrollTo }) =>
      groupedProducts.map((_, index) => (
        <CarouselPaginationTab
          aria-controls={`${id}-slide-${index + 1}`}
          aria-label={`Slide ${index + 1}`}
          isSelected={selectedIndex === index}
          key={index}
          onClick={() => scrollTo(index)}
        />
      ))
    }
  </CarouselPagination>
</Carousel>
```

## Demo
https://github.com/bigcommerce/catalyst/assets/196129/78be3eb0-edf3-4ccf-9995-57ec83fdfd67

## Testing
Locally.