### PR TITLE
chore(docs): CATALYST-0 use markdown alert syntax for warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,8 @@
 # Catalyst
 
----
-
-:warning: Notice
-
-- Catalyst is in development and should not be used in production environments
-- The experimental `with-makeswift` version of Catalyst is not quite ready for feedback. During Catalyst’s developer preview you should be focused on the core Catalyst storefront
-
----
+> [!WARNING]
+> - Catalyst is in development and should not be used in production environments
+> - The experimental `with-makeswift` version of Catalyst is not quite ready for feedback. During Catalyst’s developer preview you should be focused on the core Catalyst storefront
 
 A fully customizable headless storefront, Catalyst offers a set of opinionated defaults, while being composable to fit the needs of the developer, merchant, and shopper.
 
@@ -43,11 +38,8 @@ Update `.env.local` with the appropriate values:
 * `BIGCOMMERCE_CDN_HOSTNAME` can remain unchanged from its default value.
 * `MAKESWIFT_API_KEY` is only used by the experimental `with-makeswift` version of Catalyst, and can be left blank when working with the core product.
 
----
-
-:warning: Notice
-
-The experimental `with-makeswift` version of Catalyst is not ready and users should focus on the core product only. While we are not looking for feedback yet with the experimental `with-makeswift` version of Catalyst, the following onboarding instructions are if users want to experiment with the current state of the experimental `with-makeswift` version of Catalyst. During Developer Preview you should be looking at Core.
+> [!WARNING]
+> The experimental `with-makeswift` version of Catalyst is not ready and users should focus on the core product only. While we are not looking for feedback yet with the experimental `with-makeswift` version of Catalyst, the following onboarding instructions are if users want to experiment with the current state of the experimental `with-makeswift` version of Catalyst. During Developer Preview you should be looking at Core.
 
 ---
 

--- a/apps/with-makeswift/README.md
+++ b/apps/with-makeswift/README.md
@@ -1,12 +1,7 @@
 # Catalyst
 
----
-
-:warning: Notice
-
-The experimental `with-makeswift` version of Catalyst is not quite ready for feedback. During Catalyst’s developer preview you should be focused on the core Catalyst storefront.
-
----
+> [!WARNING]
+> The experimental `with-makeswift` version of Catalyst is not quite ready for feedback. During Catalyst’s developer preview you should be focused on the core Catalyst storefront.
 
 A fully customizable headless storefront, Catalyst offers a set of opinionated defaults, while being composable to fit the needs of the developer, merchant, and shopper. Catalyst is built with [Next.js](https://nextjs.org/) and [Makeswift](https://www.makeswift.com/) using our React.js storefront component library called Reactant.
 
@@ -32,13 +27,8 @@ Update `.env.local` with the appropriate values:
 * `BIGCOMMERCE_CDN_HOSTNAME` can remain unchanged from its default value.
 * `MAKESWIFT_API_KEY` is only used by the experimental `with-makeswift` version of Catalyst, and can be left blank when working with the core product.
 
----
-
-:warning: Notice
-
-The experimental `with-makeswift` version of Catalyst is not ready and users should focus on the core product only. While we are not looking for feedback yet with the experimental `with-makeswift` version of Catalyst, the following onboarding instructions are if users want to experiment with the current state of the experimental `with-makeswift` version of Catalyst. During Developer Preview you should be looking at Core.
-
----
+> [!WARNING]
+> The experimental `with-makeswift` version of Catalyst is not ready and users should focus on the core product only. While we are not looking for feedback yet with the experimental `with-makeswift` version of Catalyst, the following onboarding instructions are if users want to experiment with the current state of the experimental `with-makeswift` version of Catalyst. During Developer Preview you should be looking at Core.
 
 Follow the instructions at https://github.com/makeswift/makeswift/tree/main/examples/bigcommerce#visually-build-with-bigcommerce-components to build and deploy a MakeSwift integration with your BigCommerce Storefront. (Or follow along with the video at https://www.makeswift.com/components/nextjs/bigcommerce)
 

--- a/packages/create-catalyst/README.md
+++ b/packages/create-catalyst/README.md
@@ -1,12 +1,7 @@
 # packages/create-catalyst
 
----
-
-:warning: Notice
-
-The create-catalyst package is in development and not published to the NPM registry
-
----
+> [!WARNING]
+> The create-catalyst package is in development and not published to the NPM registry
 
 Scaffolding for Catalyst storefront projects.
 


### PR DESCRIPTION
## What/Why?
GitHub [supports an official markdown extension for alerts](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts):

> Alerts are an extension of Markdown used to emphasize critical information. On GitHub, they are displayed with distinctive colors and icons to indicate the importance of the content.

## Testing
**Before**
<img width="887" alt="Screenshot 2023-09-06 at 10 43 41 AM" src="https://github.com/bigcommerce/catalyst/assets/28374851/94694d78-1e9f-4631-b7c8-16862d50e153">

**After**
<img width="912" alt="Screenshot 2023-09-06 at 10 46 42 AM" src="https://github.com/bigcommerce/catalyst/assets/28374851/6f8a7ad4-e7e7-4064-91aa-c179f2880c2e">

