### PR TITLE
fix: remove empty product attribute check

### DIFF
--- a/apps/core/app/(default)/category/[slug]/fetchCategory.ts
+++ b/apps/core/app/(default)/category/[slug]/fetchCategory.ts
@@ -137,7 +137,7 @@ export const PublicToPrivateParams = PublicSearchParamsSchema.catchall(SearchPar
                 minPrice,
               }
             : undefined,
-        productAttributes: productAttributes.length ? productAttributes : undefined,
+        productAttributes,
         rating:
           minRating || maxRating
             ? {


### PR DESCRIPTION
## What/Why?
We initially had this check because we were getting back no products when an empty array was passed. I think it was either resolved one of two ways:
A) Reindexing my store. I did this a couple weeks back and it might've fixed it, but unsure.
B) The recent `@genql` update might have fixed it. I didn't look too much into this but it seems to work now.

## Testing
No query params means that `productAttributes` will be `[]`:
![Screenshot 2023-09-06 at 15 14 21](https://github.com/bigcommerce/catalyst/assets/10539418/1a399dcc-2a14-474f-9a4e-e944881dae4d)
