### PR TITLE
feat(client): CATALYST-56 pass brandIds to getBrands query

### DIFF
--- a/packages/client/src/queries/getBrands.ts
+++ b/packages/client/src/queries/getBrands.ts
@@ -4,11 +4,12 @@ import { removeEdgesAndNodes } from '../utils/removeEdgesAndNodes';
 
 export interface GetBrandsOptions {
   first?: number;
+  brandIds?: number[];
 }
 
 export const getBrands = async <T>(
   customFetch: <U>(data: FetcherInput) => Promise<BigCommerceResponse<U>>,
-  { first = 5 }: GetBrandsOptions = {},
+  { first = 5, brandIds }: GetBrandsOptions = {},
   config: T = {} as T,
 ) => {
   const query = {
@@ -16,6 +17,7 @@ export const getBrands = async <T>(
       brands: {
         __args: {
           first,
+          entityIds: brandIds,
         },
         edges: {
           node: {


### PR DESCRIPTION
## What/Why?
Pass `brandIds` into `getBrands` query. Currently, we don't have a `brand` node in GraphQL (pending [STRF-11220](https://bigcommercecloud.atlassian.net/browse/STRF-11220)), so we have the use the `getBrands` query for now. This also allows consumers to pass multiple brand ids so this is quite interim for our use case.

## Testing
![Screenshot 2023-09-13 at 15 25 30](https://github.com/bigcommerce/catalyst/assets/10539418/04f467b4-fffd-4073-8195-6846a50c8c15)


[STRF-11220]: https://bigcommercecloud.atlassian.net/browse/STRF-11220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ