### PR TITLE
fix(client): update getBlogPost to return post only when post not null

### DIFF
--- a/packages/client/src/queries/getBlogPost.ts
+++ b/packages/client/src/queries/getBlogPost.ts
@@ -54,7 +54,7 @@ export const getBlogPost = async <T>(
 
   const { blog } = response.data.site.content;
 
-  if (!blog) {
+  if (!blog?.post) {
     return undefined;
   }
 


### PR DESCRIPTION
## What/Why?
This PR has fix for minor `typeScript` errors on `Blog Post Page` with accessing to the `BlogPost` entity fields

## Testing
locally