### PR TITLE
refactor(core): CATALYST-56 loosen fetchFacetedSearch arguments

### DIFF
--- a/apps/core/app/(default)/(faceted)/category/[slug]/page.tsx
+++ b/apps/core/app/(default)/(faceted)/category/[slug]/page.tsx
@@ -21,7 +21,7 @@ interface Props {
 export default async function Category({ params, searchParams }: Props) {
   const categoryId = Number(params.slug);
 
-  const search = await fetchFacetedSearch({ categoryId, ...searchParams });
+  const search = await fetchFacetedSearch({ category: [params.slug], ...searchParams });
 
   // We will only need a partial of this query to fetch the category name and breadcrumbs.
   // The rest of the arguments are useless at this point.

--- a/apps/core/app/(default)/(faceted)/fetchFacetedSearch.ts
+++ b/apps/core/app/(default)/(faceted)/fetchFacetedSearch.ts
@@ -75,7 +75,7 @@ export const PublicSearchParamsSchema = z.object({
   after: z.string().optional(),
   before: z.string().optional(),
   brand: SearchParamToArray.transform((value) => value?.map(Number)),
-  categoryId: z.number(),
+  category: SearchParamToArray.transform((value) => value?.map(Number)),
   isFeatured: z.coerce.boolean().optional(),
   limit: z.coerce.number().optional(),
   minPrice: z.coerce.number().optional(),
@@ -99,7 +99,7 @@ export const PublicToPrivateParams = PublicSearchParamsSchema.catchall(SearchPar
 
     const {
       brand,
-      categoryId,
+      category,
       isFeatured,
       minPrice,
       maxPrice,
@@ -126,7 +126,7 @@ export const PublicToPrivateParams = PublicSearchParamsSchema.catchall(SearchPar
       sort,
       filters: {
         brandEntityIds: brand,
-        categoryEntityId: categoryId,
+        categoryEntityIds: category,
         hideOutOfStock: stock?.includes('in_stock'),
         isFreeShipping: shipping?.includes('free_shipping'),
         isFeatured,
@@ -152,7 +152,7 @@ export const PublicToPrivateParams = PublicSearchParamsSchema.catchall(SearchPar
 
 export const fetchFacetedSearch = cache(
   // We need to make sure the reference passed into this function is the same if we want it to be memoized.
-  async (params: z.infer<typeof PublicSearchParamsSchema>) => {
+  async (params: z.input<typeof PublicSearchParamsSchema>) => {
     const { after, before, limit = 9, sort, filters } = PublicToPrivateParams.parse(params);
 
     return client.getProductSearchResults(


### PR DESCRIPTION
## What/Why?
Loosen what is required as input for the `fetchFacetedSearch` function. This is to enabled this function to be called on multiple pages without having to require params such as `categoryId`.

## Testing
![Screenshot 2023-09-14 at 15 16 22](https://github.com/bigcommerce/catalyst/assets/10539418/c2dfdb1c-8e58-4942-95e1-135a7d639d1e)
