### PR TITLE
refactor(core): CATALYST-56 allow SubCategories to be optional

### DIFF
--- a/apps/core/app/(default)/(faceted)/_components/faceted-search.tsx
+++ b/apps/core/app/(default)/(faceted)/_components/faceted-search.tsx
@@ -1,25 +1,28 @@
-import { ComponentPropsWithoutRef } from 'react';
+import { ComponentPropsWithoutRef, PropsWithChildren } from 'react';
 
 import type { Facet } from '../types';
 
 import { Facets } from './facets';
 import { RefineBy } from './refine-by';
-import { SubCategories } from './sub-categories';
 
 interface Props extends ComponentPropsWithoutRef<'aside'> {
-  categoryId: number;
   facets: Facet[];
   headingId: string;
 }
 
-export const FacetedSearch = ({ categoryId, facets, headingId, ...props }: Props) => {
+export const FacetedSearch = ({
+  facets,
+  headingId,
+  children,
+  ...props
+}: PropsWithChildren<Props>) => {
   return (
     <aside aria-labelledby={headingId} {...props}>
       <h2 className="sr-only" id={headingId}>
         Filters
       </h2>
 
-      <SubCategories categoryId={categoryId} />
+      {children}
 
       <RefineBy facets={facets} />
 

--- a/apps/core/app/(default)/(faceted)/_components/sub-categories.tsx
+++ b/apps/core/app/(default)/(faceted)/_components/sub-categories.tsx
@@ -14,7 +14,7 @@ export async function SubCategories({ categoryId }: Props) {
   }
 
   return (
-    <div>
+    <div className="mb-8">
       <h3 className="mb-3 text-h5">Categories</h3>
 
       <ul className="flex flex-col gap-4 text-base">

--- a/apps/core/app/(default)/(faceted)/category/[slug]/page.tsx
+++ b/apps/core/app/(default)/(faceted)/category/[slug]/page.tsx
@@ -9,6 +9,7 @@ import { Breadcrumbs } from '../../_components/breadcrumbs';
 import { FacetedSearch } from '../../_components/faceted-search';
 import { MobileSideNav } from '../../_components/mobile-side-nav';
 import { SortBy } from '../../_components/sort-by';
+import { SubCategories } from '../../_components/sub-categories';
 import { fetchFacetedSearch } from '../../fetchFacetedSearch';
 
 interface Props {
@@ -46,11 +47,9 @@ export default async function Category({ params, searchParams }: Props) {
 
         <div className="flex flex-col items-center gap-3 whitespace-nowrap md:flex-row">
           <MobileSideNav>
-            <FacetedSearch
-              categoryId={categoryId}
-              facets={search.facets.items}
-              headingId="mobile-filter-heading"
-            />
+            <FacetedSearch facets={search.facets.items} headingId="mobile-filter-heading">
+              <SubCategories categoryId={categoryId} />
+            </FacetedSearch>
           </MobileSideNav>
           <div className="flex w-full flex-col items-start gap-4 md:flex-row md:items-center md:justify-end md:gap-6">
             <SortBy />
@@ -64,11 +63,12 @@ export default async function Category({ params, searchParams }: Props) {
 
       <div className="grid grid-cols-4 gap-8">
         <FacetedSearch
-          categoryId={categoryId}
           className="mb-8 hidden lg:block"
           facets={search.facets.items}
           headingId="desktop-filter-heading"
-        />
+        >
+          <SubCategories categoryId={categoryId} />
+        </FacetedSearch>
 
         <section aria-labelledby="product-heading" className="col-span-4 lg:col-span-3">
           <h2 className="sr-only" id="product-heading">


### PR DESCRIPTION
## What/Why?
Using the `children` prop in `FacetedSearch`, we are enabling the `SubCategories` component to be optional. This will also enable merchants/devs to inject whatever they want above the facets which is a bit of a plus. This is to enable other faceted pages to be able to pass in `SubCategories` or other components if they choose to.

## Testing
![Screenshot 2023-09-14 at 16 02 59](https://github.com/bigcommerce/catalyst/assets/10539418/ff04c3fc-10c6-441e-8043-bc69028992f7)
