### PR TITLE
refactor(core): CATALYST-56 enable conditional facets based on page type

### DIFF
--- a/apps/core/app/(default)/(faceted)/_components/faceted-search.tsx
+++ b/apps/core/app/(default)/(faceted)/_components/faceted-search.tsx
@@ -1,18 +1,16 @@
 import { ComponentPropsWithoutRef, PropsWithChildren } from 'react';
 
-import type { Facet } from '../types';
-
-import { Facets } from './facets';
+import { Props as FacetProps, Facets } from './facets';
 import { RefineBy } from './refine-by';
 
-interface Props extends ComponentPropsWithoutRef<'aside'> {
-  facets: Facet[];
+interface Props extends FacetProps, ComponentPropsWithoutRef<'aside'> {
   headingId: string;
 }
 
 export const FacetedSearch = ({
   facets,
   headingId,
+  pageType,
   children,
   ...props
 }: PropsWithChildren<Props>) => {
@@ -26,7 +24,7 @@ export const FacetedSearch = ({
 
       <RefineBy facets={facets} />
 
-      <Facets facets={facets} />
+      <Facets facets={facets} pageType={pageType} />
     </aside>
   );
 };

--- a/apps/core/app/(default)/(faceted)/_components/facets.tsx
+++ b/apps/core/app/(default)/(faceted)/_components/facets.tsx
@@ -40,11 +40,12 @@ const sortRatingsDescending = (a: RatingSearchFilterItem, b: RatingSearchFilterI
   return parseInt(b.value, 10) - parseInt(a.value, 10);
 };
 
-interface Props {
+export interface Props {
   facets: Facet[];
+  pageType: 'category' | 'brand' | 'search';
 }
 
-export const Facets = ({ facets }: Props) => {
+export const Facets = ({ facets, pageType }: Props) => {
   const ref = useRef<HTMLFormElement>(null);
   const router = useRouter();
   const pathname = usePathname();
@@ -83,7 +84,7 @@ export const Facets = ({ facets }: Props) => {
     <Accordion defaultValue={defaultOpenFacets} type="multiple">
       <form onSubmit={handleSubmit} ref={ref}>
         {facets.map((facet) => {
-          if (facet.__typename === 'BrandSearchFilter') {
+          if (facet.__typename === 'BrandSearchFilter' && pageType !== 'brand') {
             return (
               <AccordionItem key={facet.__typename} value={facet.name}>
                 <AccordionTrigger>

--- a/apps/core/app/(default)/(faceted)/category/[slug]/page.tsx
+++ b/apps/core/app/(default)/(faceted)/category/[slug]/page.tsx
@@ -47,7 +47,11 @@ export default async function Category({ params, searchParams }: Props) {
 
         <div className="flex flex-col items-center gap-3 whitespace-nowrap md:flex-row">
           <MobileSideNav>
-            <FacetedSearch facets={search.facets.items} headingId="mobile-filter-heading">
+            <FacetedSearch
+              facets={search.facets.items}
+              headingId="mobile-filter-heading"
+              pageType="category"
+            >
               <SubCategories categoryId={categoryId} />
             </FacetedSearch>
           </MobileSideNav>
@@ -66,6 +70,7 @@ export default async function Category({ params, searchParams }: Props) {
           className="mb-8 hidden lg:block"
           facets={search.facets.items}
           headingId="desktop-filter-heading"
+          pageType="category"
         >
           <SubCategories categoryId={categoryId} />
         </FacetedSearch>


### PR DESCRIPTION
## What/Why?
This enables `Facets` to be able to conditionally render facets based on the page type. For example, on a category page, we don't want to be able to filter by category because we are technically filtering by a specific category. While on the brands page we don't want to be able to filter by brands because, again, we are on a filtered by brand page.

## Testing
![Screenshot 2023-09-14 at 16 15 44](https://github.com/bigcommerce/catalyst/assets/10539418/2b5c5416-98e4-4d12-8712-b48dd78114f4)
