### PR TITLE
feat(core): CATALYST-56 add category facet

### DIFF
--- a/apps/core/app/(default)/(faceted)/_components/facets.tsx
+++ b/apps/core/app/(default)/(faceted)/_components/facets.tsx
@@ -123,6 +123,45 @@ export const Facets = ({ facets, pageType }: Props) => {
             );
           }
 
+          if (facet.__typename === 'CategorySearchFilter' && pageType !== 'category') {
+            return (
+              <AccordionItem key={facet.__typename} value={facet.name}>
+                <AccordionTrigger>
+                  <h3>{facet.name}</h3>
+                </AccordionTrigger>
+                <AccordionContent>
+                  {facet.categories.map((category) => {
+                    const normalizedCategoryName = category.name.replace(/\s/g, '-').toLowerCase();
+                    const id = `${normalizedCategoryName}-${category.entityId}`;
+                    const labelId = `${normalizedCategoryName}-${category.entityId}-label`;
+
+                    const key = `${category.entityId}-${category.isSelected.toString()}`;
+
+                    return (
+                      <div className="flex max-w-sm items-center py-2 ps-1" key={key}>
+                        <Checkbox
+                          aria-labelledby={labelId}
+                          defaultChecked={category.isSelected}
+                          id={id}
+                          name="category"
+                          onCheckedChange={submitForm}
+                          value={category.entityId}
+                        />
+                        <Label className="cursor-pointer ps-3" htmlFor={id} id={labelId}>
+                          {category.name}
+                          <ProductCount
+                            count={category.productCount}
+                            shouldDisplay={facet.displayProductCount}
+                          />
+                        </Label>
+                      </div>
+                    );
+                  })}
+                </AccordionContent>
+              </AccordionItem>
+            );
+          }
+
           if (facet.__typename === 'ProductAttributeSearchFilter') {
             return (
               <AccordionItem key={`${facet.__typename}-${facet.filterName}`} value={facet.name}>

--- a/apps/core/app/(default)/(faceted)/category/[slug]/page.tsx
+++ b/apps/core/app/(default)/(faceted)/category/[slug]/page.tsx
@@ -22,7 +22,7 @@ interface Props {
 export default async function Category({ params, searchParams }: Props) {
   const categoryId = Number(params.slug);
 
-  const search = await fetchFacetedSearch({ category: [params.slug], ...searchParams });
+  const search = await fetchFacetedSearch({ ...searchParams, category: [params.slug] });
 
   // We will only need a partial of this query to fetch the category name and breadcrumbs.
   // The rest of the arguments are useless at this point.


### PR DESCRIPTION
## What/Why?
>[!WARNING]
> Builds on top of #223 

Adds the category facet to be shown on brand pages.

## Testing

#### Commented out pageType filter
![Screenshot 2023-09-14 at 16 35 14](https://github.com/bigcommerce/catalyst/assets/10539418/c9aafb20-3fe1-4e1f-a4af-1014ab5a8bbc)


#### Normal category page:

![Screenshot 2023-09-14 at 16 32 51](https://github.com/bigcommerce/catalyst/assets/10539418/59c0feeb-ac7b-4edf-aeba-88b522221443)
