### PR TITLE
fix(core): CATALYST-56 temp fix to link to brand pages

### DIFF
--- a/apps/core/components/Footer/FooterMenus/BrandFooterMenu.tsx
+++ b/apps/core/components/Footer/FooterMenus/BrandFooterMenu.tsx
@@ -5,9 +5,15 @@ import { BaseFooterMenu } from './BaseFooterMenu';
 export const BrandFooterMenu = async () => {
   const brands = await client.getBrands();
 
-  if (brands.length === 0) {
+  // Temp workaround until we have the middleware that converts paths to real urls
+  const items = brands.map((item) => ({
+    ...item,
+    path: `/brand/${item.entityId}`,
+  }));
+
+  if (!items.length) {
     return null;
   }
 
-  return <BaseFooterMenu items={brands} title="Brands" />;
+  return <BaseFooterMenu items={items} title="Brands" />;
 };


### PR DESCRIPTION
## What/Why?
Since we don't have middleware path rewrites yet, we need to change these urls in the footer to use the `entityId` instead of the `path`. This is a temp work-a-round until the middleware stuff is done (same logic as the category footer menu).

## Testing
![Screenshot 2023-09-14 at 16 50 51](https://github.com/bigcommerce/catalyst/assets/10539418/eb257d4b-78bc-4033-90d9-2d27e75e198e)
