### PR TITLE
feat(core): CATALYST-56 add category refine-by

### DIFF
--- a/apps/core/app/(default)/(faceted)/_components/faceted-search.tsx
+++ b/apps/core/app/(default)/(faceted)/_components/faceted-search.tsx
@@ -1,9 +1,9 @@
 import { ComponentPropsWithoutRef, PropsWithChildren } from 'react';
 
 import { Props as FacetProps, Facets } from './facets';
-import { RefineBy } from './refine-by';
+import { RefineBy, Props as RefineByProps } from './refine-by';
 
-interface Props extends FacetProps, ComponentPropsWithoutRef<'aside'> {
+interface Props extends FacetProps, RefineByProps, ComponentPropsWithoutRef<'aside'> {
   headingId: string;
 }
 
@@ -22,7 +22,7 @@ export const FacetedSearch = ({
 
       {children}
 
-      <RefineBy facets={facets} />
+      <RefineBy facets={facets} pageType={pageType} />
 
       <Facets facets={facets} pageType={pageType} />
     </aside>

--- a/apps/core/app/(default)/(faceted)/_components/facets.tsx
+++ b/apps/core/app/(default)/(faceted)/_components/facets.tsx
@@ -17,7 +17,7 @@ import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { FormEvent, useRef } from 'react';
 
-import type { Facet } from '../types';
+import type { Facet, PageType } from '../types';
 
 interface ProductCountProps {
   shouldDisplay: boolean;
@@ -42,7 +42,7 @@ const sortRatingsDescending = (a: RatingSearchFilterItem, b: RatingSearchFilterI
 
 export interface Props {
   facets: Facet[];
-  pageType: 'category' | 'brand' | 'search';
+  pageType: PageType;
 }
 
 export const Facets = ({ facets, pageType }: Props) => {

--- a/apps/core/app/(default)/(faceted)/types.ts
+++ b/apps/core/app/(default)/(faceted)/types.ts
@@ -7,3 +7,5 @@ const publicParamKeys = PublicSearchParamsSchema.keyof();
 export type PublicParamKeys = z.infer<typeof publicParamKeys>;
 
 export type Facet = Awaited<ReturnType<typeof fetchFacetedSearch>>['facets']['items'][number];
+
+export type PageType = 'brand' | 'category' | 'search';


### PR DESCRIPTION
## What/Why?
Adds the category refinement tags so that we can utilize it on the brands page. This is done by utilizing the `pageType` prop to show/hide refinements used by the API.

## Testing
![Screenshot 2023-09-15 at 11 50 25](https://github.com/bigcommerce/catalyst/assets/10539418/65026d80-bca6-4137-b63d-9de7812893d7)
