### PR TITLE
fix(core): CATALYST-101 social icons alignment

### DIFF
--- a/apps/core/components/Footer/SocialIcons.tsx
+++ b/apps/core/components/Footer/SocialIcons.tsx
@@ -31,7 +31,7 @@ export const SocialIcons = async () => {
 
   return (
     <FooterNav aria-label="Social media links" className="block">
-      <FooterNavGroupList>
+      <FooterNavGroupList className="flex-row gap-6">
         {socialMediaLinks.map((link) => {
           const Icon = ICON_MAP[link.name];
 

--- a/packages/reactant/src/components/Footer/Footer.tsx
+++ b/packages/reactant/src/components/Footer/Footer.tsx
@@ -15,7 +15,7 @@ export const FooterSection = forwardRef<ElementRef<'section'>, ComponentPropsWit
   ({ children, className, ...props }, ref) => (
     <section
       className={cs(
-        'flex flex-col gap-4 border-t border-gray-200 py-8 px-6 sm:flex-row sm:px-10 lg:px-12 2xl:container 2xl:mx-auto 2xl:px-0',
+        'flex flex-col gap-4 border-t border-gray-200 px-6 py-8 2xl:container sm:flex-row sm:px-10 lg:px-12 2xl:mx-auto 2xl:px-0',
         className,
       )}
       {...props}
@@ -41,7 +41,7 @@ export const FooterNav = forwardRef<ElementRef<'nav'>, ComponentPropsWithRef<'na
 
 export const FooterNavGroupList = forwardRef<ElementRef<'ul'>, ComponentPropsWithRef<'ul'>>(
   ({ children, className, ...props }, ref) => (
-    <ul className={cs('space-y-4', className)} ref={ref} {...props}>
+    <ul className={cs('flex flex-col gap-4', className)} ref={ref} {...props}>
       {children}
     </ul>
   ),


### PR DESCRIPTION
## What/Why?
Before:
![Screenshot 2023-09-18 at 4 41 07 PM](https://github.com/bigcommerce/catalyst/assets/196129/c69b2b6e-ffed-4386-9f31-e3f8e1f5b3da)

After:
![Screenshot 2023-09-18 at 4 45 48 PM](https://github.com/bigcommerce/catalyst/assets/196129/1d9edeb3-a3f2-4f4e-8733-999ccf09e780)
