### PR TITLE
feat(core): add QuickSearch component

### DIFF
--- a/apps/core/components/Header/index.tsx
+++ b/apps/core/components/Header/index.tsx
@@ -17,6 +17,7 @@ import { PropsWithChildren, Suspense } from 'react';
 
 import client from '~/client';
 
+import { QuickSearch } from '../QuickSearch';
 import { StoreLogo } from '../StoreLogo';
 
 import { LinkNoCache } from './LinkNoCache';
@@ -166,6 +167,7 @@ export const Header = () => {
           <NavigationMenuToggle className="ms-2 lg:hidden" />
         </div>
         <NavigationMenuCollapsed>
+          <QuickSearch className="px-3" />
           <HeaderNav inCollapsedNav />
         </NavigationMenuCollapsed>
       </NavigationMenu>

--- a/apps/core/components/QuickSearch/index.tsx
+++ b/apps/core/components/QuickSearch/index.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { Button } from '@bigcommerce/reactant/Button';
+import { cs } from '@bigcommerce/reactant/cs';
+import { Field, FieldControl, Form } from '@bigcommerce/reactant/Form';
+import { Input, InputIcon } from '@bigcommerce/reactant/Input';
+import { Search, X } from 'lucide-react';
+import { useRef, useState } from 'react';
+
+interface Props {
+  className?: string;
+  initialTerm?: string;
+}
+
+export const QuickSearch = ({ className, initialTerm = '' }: Props) => {
+  const [term, setTerm] = useState(initialTerm);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleTermChange = (e: React.FormEvent<HTMLInputElement>) => setTerm(e.currentTarget.value);
+  const handleTermClear = () => {
+    setTerm('');
+    inputRef.current?.focus();
+  };
+
+  return (
+    <Form action="/search" className={cs('flex', className)} method="get">
+      <Field className="w-full" name="search">
+        <FieldControl asChild>
+          <Input
+            className="grey-200 peer appearance-none border-2 px-12 py-3 font-semibold"
+            name="term"
+            onChange={handleTermChange}
+            placeholder="Search..."
+            ref={inputRef}
+            value={term}
+          >
+            <InputIcon className="start-3 peer-hover:text-blue-primary peer-focus:text-blue-primary">
+              <Search />
+            </InputIcon>
+            {term.length > 0 ? (
+              <Button
+                aria-label="Clear search"
+                className="absolute end-1.5 top-1/2 w-auto -translate-y-1/2 border-0 bg-transparent p-1.5 text-black hover:bg-transparent focus:text-blue-primary peer-hover:text-blue-primary peer-focus:text-blue-primary"
+                onClick={handleTermClear}
+                type="button"
+              >
+                <X />
+              </Button>
+            ) : null}
+          </Input>
+        </FieldControl>
+      </Field>
+    </Form>
+  );
+};


### PR DESCRIPTION
## What/Why?
This PR adds `QuickSearch` component to the `core` and in `Header`

## Testing
locally

## Proof
https://github.com/bigcommerce/catalyst/assets/66325265/1177516c-07d8-4277-ac4c-8624ba36dcaa


