### PR TITLE
feat(reactant): CATALYST-42 refactor slideshow component api

### DIFF
--- a/apps/core/components/Hero/index.tsx
+++ b/apps/core/components/Hero/index.tsx
@@ -1,21 +1,33 @@
 import { Button } from '@bigcommerce/reactant/Button';
-import { Slideshow, SlideshowItem } from '@bigcommerce/reactant/Slideshow';
+import { Slideshow, SlideshowContent, SlideshowSlide } from '@bigcommerce/reactant/Slideshow';
 import Image from 'next/image';
 
 export const Hero = () => (
-  <Slideshow interval={10_000}>
-    <SlideshowItem className="duration-700">
-      <div className="absolute -z-10 h-full w-full">
-        <Image
-          alt="an assortment of brandless products against a blank background"
-          className="object-cover"
-          fill
-          priority
-          src="/slideshow-bg-01.jpg"
-        />
-      </div>
-      <div className="flex h-full flex-col justify-center p-12">
-        <h1 className="text-h1">25% Off Sale</h1>
+  <Slideshow>
+    <SlideshowContent interval={10_000}>
+      <SlideshowSlide className="duration-700">
+        <div className="absolute -z-10 h-full w-full">
+          <Image
+            alt="an assortment of brandless products against a blank background"
+            className="object-cover"
+            fill
+            priority
+            src="/slideshow-bg-01.jpg"
+          />
+        </div>
+        <div className="flex h-full flex-col justify-center p-12">
+          <h1 className="text-h1">25% Off Sale</h1>
+          <p className="max-w-[548px] pt-4">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
+          </p>
+          <Button asChild className="mt-10 w-[141px]">
+            <a href="/#">Shop now</a>
+          </Button>
+        </div>
+      </SlideshowSlide>
+      <SlideshowSlide className="flex flex-col justify-center bg-gray-100 p-12 duration-700">
+        <h1 className="text-h1">Great Deals</h1>
         <p className="max-w-[548px] pt-4">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
           ut labore et dolore magna aliqua. Ut enim ad minim veniam.
@@ -23,27 +35,17 @@ export const Hero = () => (
         <Button asChild className="mt-10 w-[141px]">
           <a href="/#">Shop now</a>
         </Button>
-      </div>
-    </SlideshowItem>
-    <SlideshowItem className="flex flex-col justify-center bg-gray-100 p-12 duration-700">
-      <h1 className="text-h1">Great Deals</h1>
-      <p className="max-w-[548px] pt-4">
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-        labore et dolore magna aliqua. Ut enim ad minim veniam.
-      </p>
-      <Button asChild className="mt-10 w-[141px]">
-        <a href="/#">Shop now</a>
-      </Button>
-    </SlideshowItem>
-    <SlideshowItem className="flex flex-col justify-center bg-gray-100 p-12 duration-700">
-      <h1 className="text-h1">Low Prices</h1>
-      <p className="max-w-[548px] pt-4">
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-        labore et dolore magna aliqua. Ut enim ad minim veniam.
-      </p>
-      <Button asChild className="mt-10 w-[141px]">
-        <a href="/#">Shop now</a>
-      </Button>
-    </SlideshowItem>
+      </SlideshowSlide>
+      <SlideshowSlide className="flex flex-col justify-center bg-gray-100 p-12 duration-700">
+        <h1 className="text-h1">Low Prices</h1>
+        <p className="max-w-[548px] pt-4">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
+          ut labore et dolore magna aliqua. Ut enim ad minim veniam.
+        </p>
+        <Button asChild className="mt-10 w-[141px]">
+          <a href="/#">Shop now</a>
+        </Button>
+      </SlideshowSlide>
+    </SlideshowContent>
   </Slideshow>
 );

--- a/apps/docs/stories/Slideshow.stories.tsx
+++ b/apps/docs/stories/Slideshow.stories.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@bigcommerce/reactant/Button';
-import { Slideshow, SlideshowItem } from '@bigcommerce/reactant/Slideshow';
+import { Slideshow, SlideshowContent, SlideshowSlide } from '@bigcommerce/reactant/Slideshow';
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof Slideshow> = {
@@ -14,118 +14,8 @@ type Story = StoryObj<typeof Slideshow>;
 export const OneSlide: Story = {
   render: () => (
     <Slideshow>
-      <SlideshowItem className="duration-700">
-        <div className="relative h-full">
-          <img
-            alt="A plant in a glass vase against a blank background."
-            className="absolute -z-10"
-            src="/slideshow-bg-01.jpg"
-          />
-          <div className="flex h-full flex-col justify-center p-12">
-            <h1 className="text-h1">25% Off Sale</h1>
-            <p className="max-w-[548px] pt-4">
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-              incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
-            </p>
-            <Button asChild className="mt-10 w-[141px]">
-              <a href="/#">Shop now</a>
-            </Button>
-          </div>
-        </div>
-      </SlideshowItem>
-    </Slideshow>
-  ),
-};
-
-export const TwoSlides: Story = {
-  render: () => (
-    <Slideshow>
-      <SlideshowItem className="duration-700">
-        <div className="relative h-full">
-          <img
-            alt="A plant in a glass vase against a blank background."
-            className="absolute -z-10"
-            src="/slideshow-bg-01.jpg"
-          />
-          <div className="flex h-full flex-col justify-center p-12">
-            <h1 className="text-h1">25% Off Sale</h1>
-            <p className="max-w-[548px] pt-4">
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-              incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
-            </p>
-            <Button asChild className="mt-10 w-[141px]">
-              <a href="/#">Shop now</a>
-            </Button>
-          </div>
-        </div>
-      </SlideshowItem>
-      <SlideshowItem className="flex flex-col justify-center bg-gray-100 p-12 duration-700">
-        <h1 className="text-h1">Great Deals</h1>
-        <p className="max-w-[548px] pt-4">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-          ut labore et dolore magna aliqua. Ut enim ad minim veniam.
-        </p>
-        <Button asChild className="mt-10 w-[141px]">
-          <a href="/#">Shop now</a>
-        </Button>
-      </SlideshowItem>
-    </Slideshow>
-  ),
-};
-
-export const ThreeSlides: Story = {
-  render: () => (
-    <Slideshow>
-      <SlideshowItem className="duration-700">
-        <div className="relative h-full">
-          <img
-            alt="A plant in a glass vase against a blank background."
-            className="absolute -z-10"
-            src="/slideshow-bg-01.jpg"
-          />
-          <div className="flex h-full flex-col justify-center p-12">
-            <h1 className="text-h1">25% Off Sale</h1>
-            <p className="max-w-[548px] pt-4">
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-              incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
-            </p>
-            <Button asChild className="mt-10 w-[141px]">
-              <a href="/#">Shop now</a>
-            </Button>
-          </div>
-        </div>
-      </SlideshowItem>
-      <SlideshowItem className="flex flex-col justify-center bg-gray-100 p-12 duration-700">
-        <h1 className="text-h1">Great Deals</h1>
-        <p className="max-w-[548px] pt-4">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-          ut labore et dolore magna aliqua. Ut enim ad minim veniam.
-        </p>
-        <Button asChild className="mt-10 w-[141px]">
-          <a href="/#">Shop now</a>
-        </Button>
-      </SlideshowItem>
-      <SlideshowItem className="flex flex-col justify-center bg-gray-100 p-12 duration-700">
-        <h1 className="text-h1">Low Prices</h1>
-        <p className="max-w-[548px] pt-4">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-          ut labore et dolore magna aliqua. Ut enim ad minim veniam.
-        </p>
-        <Button asChild className="mt-10 w-[141px]">
-          <a href="/#">Shop now</a>
-        </Button>
-      </SlideshowItem>
-    </Slideshow>
-  ),
-};
-
-const mocked = new Array(100).fill(undefined).map((_, index) => index);
-
-export const OneHundredSlides: Story = {
-  render: () => (
-    <Slideshow>
-      {mocked.map((i) => (
-        <SlideshowItem className="duration-700" key={i}>
+      <SlideshowContent>
+        <SlideshowSlide className="duration-700">
           <div className="relative h-full">
             <img
               alt="A plant in a glass vase against a blank background."
@@ -133,7 +23,7 @@ export const OneHundredSlides: Story = {
               src="/slideshow-bg-01.jpg"
             />
             <div className="flex h-full flex-col justify-center p-12">
-              <h1 className="text-h1">{i + 1}% Off Sale</h1>
+              <h1 className="text-h1">25% Off Sale</h1>
               <p className="max-w-[548px] pt-4">
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
                 incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
@@ -143,8 +33,126 @@ export const OneHundredSlides: Story = {
               </Button>
             </div>
           </div>
-        </SlideshowItem>
-      ))}
+        </SlideshowSlide>
+      </SlideshowContent>
+    </Slideshow>
+  ),
+};
+
+export const TwoSlides: Story = {
+  render: () => (
+    <Slideshow>
+      <SlideshowContent>
+        <SlideshowSlide className="duration-700">
+          <div className="relative h-full">
+            <img
+              alt="A plant in a glass vase against a blank background."
+              className="absolute -z-10"
+              src="/slideshow-bg-01.jpg"
+            />
+            <div className="flex h-full flex-col justify-center p-12">
+              <h1 className="text-h1">25% Off Sale</h1>
+              <p className="max-w-[548px] pt-4">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+                incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
+              </p>
+              <Button asChild className="mt-10 w-[141px]">
+                <a href="/#">Shop now</a>
+              </Button>
+            </div>
+          </div>
+        </SlideshowSlide>
+        <SlideshowSlide className="flex flex-col justify-center bg-gray-100 p-12 duration-700">
+          <h1 className="text-h1">Great Deals</h1>
+          <p className="max-w-[548px] pt-4">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
+          </p>
+          <Button asChild className="mt-10 w-[141px]">
+            <a href="/#">Shop now</a>
+          </Button>
+        </SlideshowSlide>
+      </SlideshowContent>
+    </Slideshow>
+  ),
+};
+
+export const ThreeSlides: Story = {
+  render: () => (
+    <Slideshow>
+      <SlideshowContent>
+        <SlideshowSlide className="duration-700">
+          <div className="relative h-full">
+            <img
+              alt="A plant in a glass vase against a blank background."
+              className="absolute -z-10"
+              src="/slideshow-bg-01.jpg"
+            />
+            <div className="flex h-full flex-col justify-center p-12">
+              <h1 className="text-h1">25% Off Sale</h1>
+              <p className="max-w-[548px] pt-4">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+                incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
+              </p>
+              <Button asChild className="mt-10 w-[141px]">
+                <a href="/#">Shop now</a>
+              </Button>
+            </div>
+          </div>
+        </SlideshowSlide>
+        <SlideshowSlide className="flex flex-col justify-center bg-gray-100 p-12 duration-700">
+          <h1 className="text-h1">Great Deals</h1>
+          <p className="max-w-[548px] pt-4">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
+          </p>
+          <Button asChild className="mt-10 w-[141px]">
+            <a href="/#">Shop now</a>
+          </Button>
+        </SlideshowSlide>
+        <SlideshowSlide className="flex flex-col justify-center bg-gray-100 p-12 duration-700">
+          <h1 className="text-h1">Low Prices</h1>
+          <p className="max-w-[548px] pt-4">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
+          </p>
+          <Button asChild className="mt-10 w-[141px]">
+            <a href="/#">Shop now</a>
+          </Button>
+        </SlideshowSlide>
+      </SlideshowContent>
+    </Slideshow>
+  ),
+};
+
+const mocked = new Array(100).fill(undefined).map((_, index) => index);
+
+export const OneHundredSlides: Story = {
+  render: () => (
+    <Slideshow>
+      <SlideshowContent>
+        {mocked.map((i) => (
+          <SlideshowSlide className="duration-700" key={i}>
+            <div className="relative h-full">
+              <img
+                alt="A plant in a glass vase against a blank background."
+                className="absolute -z-10"
+                src="/slideshow-bg-01.jpg"
+              />
+              <div className="flex h-full flex-col justify-center p-12">
+                <h1 className="text-h1">{i + 1}% Off Sale</h1>
+                <p className="max-w-[548px] pt-4">
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+                  incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
+                </p>
+                <Button asChild className="mt-10 w-[141px]">
+                  <a href="/#">Shop now</a>
+                </Button>
+              </div>
+            </div>
+          </SlideshowSlide>
+        ))}
+      </SlideshowContent>
     </Slideshow>
   ),
 };


### PR DESCRIPTION
## What/Why?
Refactors the Slideshow component API to be three "levels" instead of two. This is in preparation for the "three level" Embla API that will eventually take over Slideshow functionality. 

**Before:**
```
<Slideshow> → <SlideshowItem>
```

**After:**
```
<Slideshow> → <SlideshowContent> → <SlideshowSlide>
```

## Testing
Recommend testing via Storybook deployment in Vercel.