### PR TITLE
feat(reactant): CATALYST-42 basic slideshow implementation

### DIFF
--- a/apps/core/components/Hero/index.tsx
+++ b/apps/core/components/Hero/index.tsx
@@ -4,47 +4,51 @@ import Image from 'next/image';
 
 export const Hero = () => (
   <Slideshow>
-    <SlideshowContent interval={10_000}>
-      <SlideshowSlide className="duration-700">
-        <div className="absolute -z-10 h-full w-full">
+    <SlideshowContent>
+      <SlideshowSlide>
+        <div className="relative">
           <Image
             alt="an assortment of brandless products against a blank background"
-            className="object-cover"
+            className="absolute -z-10 object-cover"
             fill
             priority
             src="/slideshow-bg-01.jpg"
           />
+          <div className="flex flex-col gap-4 px-12 py-36">
+            <h2 className="text-h1">25% Off Sale</h2>
+            <p className="max-w-xl">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+              incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
+            </p>
+            <Button asChild className="w-fit">
+              <a href="/#">Shop now</a>
+            </Button>
+          </div>
         </div>
-        <div className="flex h-full flex-col justify-center p-12">
-          <h1 className="text-h1">25% Off Sale</h1>
-          <p className="max-w-[548px] pt-4">
+      </SlideshowSlide>
+      <SlideshowSlide>
+        <div className="flex flex-col gap-4 bg-gray-100 px-12 py-36">
+          <h2 className="text-h1">Great Deals</h2>
+          <p className="max-w-xl">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
             incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
           </p>
-          <Button asChild className="mt-10 w-[141px]">
+          <Button asChild className="w-fit">
             <a href="/#">Shop now</a>
           </Button>
         </div>
       </SlideshowSlide>
-      <SlideshowSlide className="flex flex-col justify-center bg-gray-100 p-12 duration-700">
-        <h1 className="text-h1">Great Deals</h1>
-        <p className="max-w-[548px] pt-4">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-          ut labore et dolore magna aliqua. Ut enim ad minim veniam.
-        </p>
-        <Button asChild className="mt-10 w-[141px]">
-          <a href="/#">Shop now</a>
-        </Button>
-      </SlideshowSlide>
-      <SlideshowSlide className="flex flex-col justify-center bg-gray-100 p-12 duration-700">
-        <h1 className="text-h1">Low Prices</h1>
-        <p className="max-w-[548px] pt-4">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-          ut labore et dolore magna aliqua. Ut enim ad minim veniam.
-        </p>
-        <Button asChild className="mt-10 w-[141px]">
-          <a href="/#">Shop now</a>
-        </Button>
+      <SlideshowSlide>
+        <div className="flex flex-col gap-4 bg-gray-100 px-12 py-36">
+          <h2 className="text-h1">Low Prices</h2>
+          <p className="max-w-xl">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
+          </p>
+          <Button asChild className="w-fit">
+            <a href="/#">Shop now</a>
+          </Button>
+        </div>
       </SlideshowSlide>
     </SlideshowContent>
   </Slideshow>

--- a/apps/docs/stories/Slideshow.stories.tsx
+++ b/apps/docs/stories/Slideshow.stories.tsx
@@ -15,20 +15,20 @@ export const OneSlide: Story = {
   render: () => (
     <Slideshow>
       <SlideshowContent>
-        <SlideshowSlide className="duration-700">
-          <div className="relative h-full">
+        <SlideshowSlide>
+          <div className="relative">
             <img
               alt="A plant in a glass vase against a blank background."
               className="absolute -z-10"
               src="/slideshow-bg-01.jpg"
             />
-            <div className="flex h-full flex-col justify-center p-12">
-              <h1 className="text-h1">25% Off Sale</h1>
-              <p className="max-w-[548px] pt-4">
+            <div className="flex flex-col gap-4 px-12 py-24">
+              <h2 className="text-h1">25% Off Sale</h2>
+              <p className="max-w-xl">
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
                 incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
               </p>
-              <Button asChild className="mt-10 w-[141px]">
+              <Button asChild className="w-fit">
                 <a href="/#">Shop now</a>
               </Button>
             </div>
@@ -43,34 +43,36 @@ export const TwoSlides: Story = {
   render: () => (
     <Slideshow>
       <SlideshowContent>
-        <SlideshowSlide className="duration-700">
-          <div className="relative h-full">
+        <SlideshowSlide>
+          <div className="relative">
             <img
               alt="A plant in a glass vase against a blank background."
               className="absolute -z-10"
               src="/slideshow-bg-01.jpg"
             />
-            <div className="flex h-full flex-col justify-center p-12">
-              <h1 className="text-h1">25% Off Sale</h1>
-              <p className="max-w-[548px] pt-4">
+            <div className="flex flex-col gap-4 px-12 py-24">
+              <h2 className="text-h1">25% Off Sale</h2>
+              <p className="max-w-xl">
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
                 incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
               </p>
-              <Button asChild className="mt-10 w-[141px]">
+              <Button asChild className="w-fit">
                 <a href="/#">Shop now</a>
               </Button>
             </div>
           </div>
         </SlideshowSlide>
-        <SlideshowSlide className="flex flex-col justify-center bg-gray-100 p-12 duration-700">
-          <h1 className="text-h1">Great Deals</h1>
-          <p className="max-w-[548px] pt-4">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
-          </p>
-          <Button asChild className="mt-10 w-[141px]">
-            <a href="/#">Shop now</a>
-          </Button>
+        <SlideshowSlide>
+          <div className="flex flex-col gap-4 bg-gray-100 px-12 py-24">
+            <h2 className="text-h1">Great Deals</h2>
+            <p className="max-w-xl">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+              incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
+            </p>
+            <Button asChild className="w-fit">
+              <a href="/#">Shop now</a>
+            </Button>
+          </div>
         </SlideshowSlide>
       </SlideshowContent>
     </Slideshow>
@@ -81,44 +83,48 @@ export const ThreeSlides: Story = {
   render: () => (
     <Slideshow>
       <SlideshowContent>
-        <SlideshowSlide className="duration-700">
-          <div className="relative h-full">
+        <SlideshowSlide>
+          <div className="relative">
             <img
               alt="A plant in a glass vase against a blank background."
               className="absolute -z-10"
               src="/slideshow-bg-01.jpg"
             />
-            <div className="flex h-full flex-col justify-center p-12">
-              <h1 className="text-h1">25% Off Sale</h1>
-              <p className="max-w-[548px] pt-4">
+            <div className="flex flex-col gap-4 px-12 py-24">
+              <h2 className="text-h1">25% Off Sale</h2>
+              <p className="max-w-xl">
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
                 incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
               </p>
-              <Button asChild className="mt-10 w-[141px]">
+              <Button asChild className="w-fit">
                 <a href="/#">Shop now</a>
               </Button>
             </div>
           </div>
         </SlideshowSlide>
-        <SlideshowSlide className="flex flex-col justify-center bg-gray-100 p-12 duration-700">
-          <h1 className="text-h1">Great Deals</h1>
-          <p className="max-w-[548px] pt-4">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
-          </p>
-          <Button asChild className="mt-10 w-[141px]">
-            <a href="/#">Shop now</a>
-          </Button>
+        <SlideshowSlide>
+          <div className="flex flex-col gap-4 bg-gray-100 px-12 py-24">
+            <h2 className="text-h1">Great Deals</h2>
+            <p className="max-w-xl">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+              incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
+            </p>
+            <Button asChild className="w-fit">
+              <a href="/#">Shop now</a>
+            </Button>
+          </div>
         </SlideshowSlide>
-        <SlideshowSlide className="flex flex-col justify-center bg-gray-100 p-12 duration-700">
-          <h1 className="text-h1">Low Prices</h1>
-          <p className="max-w-[548px] pt-4">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
-          </p>
-          <Button asChild className="mt-10 w-[141px]">
-            <a href="/#">Shop now</a>
-          </Button>
+        <SlideshowSlide>
+          <div className="flex flex-col gap-4 bg-gray-100 px-12 py-24">
+            <h2 className="text-h1">Low Prices</h2>
+            <p className="max-w-xl">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+              incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
+            </p>
+            <Button asChild className="w-fit">
+              <a href="/#">Shop now</a>
+            </Button>
+          </div>
         </SlideshowSlide>
       </SlideshowContent>
     </Slideshow>
@@ -132,20 +138,20 @@ export const OneHundredSlides: Story = {
     <Slideshow>
       <SlideshowContent>
         {mocked.map((i) => (
-          <SlideshowSlide className="duration-700" key={i}>
-            <div className="relative h-full">
+          <SlideshowSlide key={i}>
+            <div className="relative">
               <img
                 alt="A plant in a glass vase against a blank background."
                 className="absolute -z-10"
                 src="/slideshow-bg-01.jpg"
               />
-              <div className="flex h-full flex-col justify-center p-12">
-                <h1 className="text-h1">{i + 1}% Off Sale</h1>
-                <p className="max-w-[548px] pt-4">
+              <div className="flex flex-col gap-4 px-12 py-24">
+                <h2 className="text-h1">{i + 1}% Off Sale</h2>
+                <p className="max-w-xl">
                   Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
                   incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
                 </p>
-                <Button asChild className="mt-10 w-[141px]">
+                <Button asChild className="w-fit">
                   <a href="/#">Shop now</a>
                 </Button>
               </div>

--- a/packages/reactant/src/components/Slideshow/Slideshow.tsx
+++ b/packages/reactant/src/components/Slideshow/Slideshow.tsx
@@ -1,245 +1,81 @@
-import { ArrowLeft, ArrowRight, Pause, Play } from 'lucide-react';
+import useEmblaCarousel, { UseEmblaCarouselType } from 'embla-carousel-react';
 import {
-  Children,
   ComponentPropsWithRef,
   createContext,
   ElementRef,
   forwardRef,
-  isValidElement,
-  ReactElement,
+  useCallback,
   useContext,
-  useEffect,
-  useMemo,
-  useReducer,
-  useState,
+  useImperativeHandle,
+  useRef,
 } from 'react';
 
 import { cs } from '../../utils/cs';
-import { Button } from '../Button';
 
-const decrement = (index: number, items: ReactElement[]) =>
-  index - 1 < 0 ? items.length - 1 : index - 1;
+const SlideshowContext = createContext<UseEmblaCarouselType>([() => null, undefined]);
 
-const increment = (index: number, items: ReactElement[]) =>
-  index + 1 > items.length - 1 ? 0 : index + 1;
-
-interface SlideshowSlidePositionState {
-  slidePosition: number;
-}
-
-interface SlideshowState {
-  currentIndex: number;
-  items: ReactElement[];
-}
-
-const SlideshowContentContext = createContext<SlideshowState>({
-  currentIndex: 0,
-  items: [],
-});
-
-const SlideshowSlideContext = createContext<SlideshowSlidePositionState>({ slidePosition: 0 });
-
-export const SlideshowSlide = forwardRef<ElementRef<'li'>, ComponentPropsWithRef<'li'>>(
-  ({ className, children, ...props }, ref) => {
-    const { currentIndex, items } = useContext(SlideshowContentContext);
-    const { slidePosition } = useContext(SlideshowSlideContext);
-
-    const leftIndex = decrement(currentIndex, items);
-    const rightIndex = increment(currentIndex, items);
-
-    const left = slidePosition === leftIndex;
-    const right = slidePosition === rightIndex;
-    const middle = slidePosition === currentIndex;
+export const Slideshow = forwardRef<ElementRef<'section'>, ComponentPropsWithRef<'section'>>(
+  ({ children, className, ...props }, ref) => {
+    const [emblaRef, emblaApi] = useEmblaCarousel({ loop: true });
 
     return (
-      <li
-        className={cs(
-          'absolute h-full w-full transform transition-all',
-          className,
-          left && 'z-10 -translate-x-full',
-          right && 'z-10 translate-x-full',
-          middle && 'z-20 translate-x-0',
-        )}
-        // @ts-expect-error https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60822
-        inert={middle ? null : 'true'}
-        ref={ref}
-        {...props}
-      >
-        {children}
-      </li>
-    );
-  },
-);
-
-interface NextAction {
-  type: 'next';
-}
-
-interface PrevAction {
-  type: 'prev';
-}
-
-type SlideshowNavAction = NextAction | PrevAction;
-
-const slideshowReducer = (state: SlideshowState, action: SlideshowNavAction) => {
-  switch (action.type) {
-    case 'next':
-      return {
-        ...state,
-        currentIndex: increment(state.currentIndex, state.items),
-      };
-
-    case 'prev':
-      return {
-        ...state,
-        currentIndex: decrement(state.currentIndex, state.items),
-      };
-
-    default:
-      return { ...state };
-  }
-};
-
-interface SlideshowContentProps extends ComponentPropsWithRef<'ul'> {
-  interval?: number;
-}
-
-export const SlideshowContent = forwardRef<ElementRef<'ul'>, SlideshowContentProps>(
-  ({ children, className, interval = 10_000, ...props }, ref) => {
-    const [paused, togglePause] = useReducer((isPaused: boolean) => !isPaused, false);
-    const [hoverPaused, setHoverPaused] = useState(false);
-
-    const validChildren = Children.toArray(children).filter(
-      (child): child is ReactElement<ComponentPropsWithRef<'li'>> =>
-        isValidElement<ComponentPropsWithRef<'li'>>(child) &&
-        typeof child !== 'string' &&
-        typeof child !== 'number',
-    );
-
-    /**
-     * We must pad two-slide slideshow with two extra slides
-     * so that we can navigate backwards if currentIndex is 0
-     */
-    const normalizedItems =
-      Children.count(children) === 2 ? [...validChildren, ...validChildren] : validChildren;
-
-    const [state, navigate] = useReducer(slideshowReducer, {
-      currentIndex: 0,
-      items: normalizedItems,
-    });
-
-    useEffect(() => {
-      const autoplay = setInterval(() => {
-        if (!paused && !hoverPaused && Children.count(children) > 1) {
-          navigate({ type: 'next' });
-        }
-      }, interval);
-
-      return () => {
-        clearInterval(autoplay);
-      };
-    }, [children, hoverPaused, interval, paused]);
-
-    const [indicatorTop, indicatorBottom] = useMemo(
-      () => [
-        state.currentIndex + 1 > Children.count(children)
-          ? state.currentIndex + 1 - Children.count(children)
-          : state.currentIndex + 1,
-        Children.count(children),
-      ],
-      [state.currentIndex, children],
-    );
-
-    return (
-      <SlideshowContentContext.Provider value={state}>
-        <ul
-          className={cs(
-            'relative inset-0 h-[640px] overflow-hidden md:h-[508px] lg:h-[600px]',
-            className,
-          )}
-          onBlur={() => setHoverPaused(false)}
-          onFocus={() => setHoverPaused(true)}
-          onMouseEnter={() => setHoverPaused(true)}
-          onMouseLeave={() => setHoverPaused(false)}
+      <SlideshowContext.Provider value={[emblaRef, emblaApi]}>
+        <section
+          aria-label="Interactive slide show"
+          aria-roledescription="carousel"
+          className={cs('relative overflow-hidden', className)}
           ref={ref}
           {...props}
         >
-          {state.items.map((item, index) => (
-            <SlideshowSlideContext.Provider key={index} value={{ slidePosition: index }}>
-              {item}
-            </SlideshowSlideContext.Provider>
-          ))}
-
-          {state.items.length > 1 && (
-            <li>
-              <ul className="absolute bottom-12 start-12 z-30 flex gap-8">
-                <li>
-                  <Button
-                    className="border-0 p-1 text-black hover:bg-transparent hover:text-black"
-                    onClick={() => togglePause()}
-                    variant="secondary"
-                  >
-                    {paused ? (
-                      <Play>
-                        <title>Play</title>
-                      </Play>
-                    ) : (
-                      <Pause>
-                        <title>Pause</title>
-                      </Pause>
-                    )}
-                  </Button>
-                </li>
-
-                <li>
-                  <Button
-                    className="border-0 p-1 text-black hover:bg-transparent hover:text-black"
-                    onClick={() => navigate({ type: 'prev' })}
-                    variant="secondary"
-                  >
-                    <ArrowLeft>
-                      <title>Previous slide</title>
-                    </ArrowLeft>
-                  </Button>
-                </li>
-
-                <li aria-atomic="true" aria-live="polite" className="p-1 font-semibold">
-                  {indicatorTop} of {indicatorBottom}
-                </li>
-
-                <li>
-                  <Button
-                    className="border-0 p-1 text-black hover:bg-transparent hover:text-black"
-                    onClick={() => navigate({ type: 'next' })}
-                    variant="secondary"
-                  >
-                    <ArrowRight>
-                      <title>Next slide</title>
-                    </ArrowRight>
-                  </Button>
-                </li>
-              </ul>
-            </li>
-          )}
-        </ul>
-      </SlideshowContentContext.Provider>
+          {children}
+        </section>
+      </SlideshowContext.Provider>
     );
   },
 );
 
-export const Slideshow = forwardRef<ElementRef<'div'>, ComponentPropsWithRef<'div'>>(
+Slideshow.displayName = 'Slideshow';
+
+type ForwardedRef = ElementRef<'div'> | null;
+
+export const SlideshowContent = forwardRef<ForwardedRef, ComponentPropsWithRef<'ul'>>(
   ({ children, className, ...props }, ref) => {
+    const mutableRef = useRef<ForwardedRef>(null);
+    const [emblaRef] = useContext(SlideshowContext);
+
+    useImperativeHandle<ForwardedRef, ForwardedRef>(ref, () => mutableRef.current, []);
+
+    const refCallback = useCallback(
+      (current: HTMLDivElement) => {
+        emblaRef(current);
+      },
+      [emblaRef],
+    );
+
     return (
-      <div
-        className={cs(
-          'relative inset-0 -mx-6 h-[640px] overflow-hidden sm:-mx-10 md:h-[508px] lg:mx-0 lg:h-[600px]',
-          className,
-        )}
-        ref={ref}
-        {...props}
-      >
-        {children}
+      <div ref={refCallback}>
+        <ul aria-live="off" className={cs('flex', className)} {...props}>
+          {children}
+        </ul>
       </div>
     );
   },
 );
+
+SlideshowContent.displayName = 'SlideshowContent';
+
+export const SlideshowSlide = forwardRef<ElementRef<'li'>, ComponentPropsWithRef<'li'>>(
+  ({ children, className, ...props }, ref) => (
+    <li
+      aria-roledescription="slide"
+      className={cs('min-w-0 shrink-0 grow-0 basis-full', className)}
+      ref={ref}
+      role="group"
+      {...props}
+    >
+      {children}
+    </li>
+  ),
+);
+
+SlideshowSlide.displayName = 'SlideshowSlide';


### PR DESCRIPTION
## What/Why?
> [!IMPORTANT]
> This PR only includes base Embla functionality (following https://www.embla-carousel.com/get-started/react/) and base Accessibility features (following https://www.w3.org/WAI/ARIA/apg/patterns/carousel/). 
>
> Future PR's will include:
> - Navigation Controls (Next/Previous Buttons, Pagination) (PR: #242)
> - Responsiveness (Full Width on Mobile/Tablet, Padding on Desktop+)
> - Autoplay (Play/Pause Buttons, Pause on Mouse Enter/Focus/Interaction)
> - Advanced Accessibility (Dynamic ARIA labels)

This PR replaces the current custom Slideshow implementation with Embla Carousel for simplicity, as well as to standardize behavior + functionality across "carousel-like" components such as `<Carousel />`. This PR allows for the creation of a slideshow with custom content, as well as the ability to navigate through the slideshow via mouse drag/thumb drag.

## Testing
See Storybook/Core Implementation.