### PR TITLE
feat(reactant): CATALYST-42 implement slideshow nav controls

### DIFF
--- a/apps/core/components/Hero/index.tsx
+++ b/apps/core/components/Hero/index.tsx
@@ -1,5 +1,13 @@
 import { Button } from '@bigcommerce/reactant/Button';
-import { Slideshow, SlideshowContent, SlideshowSlide } from '@bigcommerce/reactant/Slideshow';
+import {
+  Slideshow,
+  SlideshowContent,
+  SlideshowControls,
+  SlideshowNextIndicator,
+  SlideshowPagination,
+  SlideshowPreviousIndicator,
+  SlideshowSlide,
+} from '@bigcommerce/reactant/Slideshow';
 import Image from 'next/image';
 
 export const Hero = () => (
@@ -14,7 +22,7 @@ export const Hero = () => (
             priority
             src="/slideshow-bg-01.jpg"
           />
-          <div className="flex flex-col gap-4 px-12 py-36">
+          <div className="flex flex-col gap-4 px-12 pb-48 pt-36">
             <h2 className="text-h1">25% Off Sale</h2>
             <p className="max-w-xl">
               Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
@@ -27,7 +35,7 @@ export const Hero = () => (
         </div>
       </SlideshowSlide>
       <SlideshowSlide>
-        <div className="flex flex-col gap-4 bg-gray-100 px-12 py-36">
+        <div className="flex flex-col gap-4 bg-gray-100 px-12 pb-48 pt-36">
           <h2 className="text-h1">Great Deals</h2>
           <p className="max-w-xl">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
@@ -39,7 +47,7 @@ export const Hero = () => (
         </div>
       </SlideshowSlide>
       <SlideshowSlide>
-        <div className="flex flex-col gap-4 bg-gray-100 px-12 py-36">
+        <div className="flex flex-col gap-4 bg-gray-100 px-12 pb-48 pt-36">
           <h2 className="text-h1">Low Prices</h2>
           <p className="max-w-xl">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
@@ -51,5 +59,10 @@ export const Hero = () => (
         </div>
       </SlideshowSlide>
     </SlideshowContent>
+    <SlideshowControls>
+      <SlideshowPreviousIndicator />
+      <SlideshowPagination />
+      <SlideshowNextIndicator />
+    </SlideshowControls>
   </Slideshow>
 );

--- a/apps/docs/stories/Slideshow.stories.tsx
+++ b/apps/docs/stories/Slideshow.stories.tsx
@@ -1,6 +1,15 @@
 import { Button } from '@bigcommerce/reactant/Button';
-import { Slideshow, SlideshowContent, SlideshowSlide } from '@bigcommerce/reactant/Slideshow';
+import {
+  Slideshow,
+  SlideshowContent,
+  SlideshowControls,
+  SlideshowNextIndicator,
+  SlideshowPagination,
+  SlideshowPreviousIndicator,
+  SlideshowSlide,
+} from '@bigcommerce/reactant/Slideshow';
 import type { Meta, StoryObj } from '@storybook/react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 
 const meta: Meta<typeof Slideshow> = {
   component: Slideshow,
@@ -22,7 +31,7 @@ export const OneSlide: Story = {
               className="absolute -z-10"
               src="/slideshow-bg-01.jpg"
             />
-            <div className="flex flex-col gap-4 px-12 py-24">
+            <div className="flex flex-col gap-4 px-12 pb-48 pt-36">
               <h2 className="text-h1">25% Off Sale</h2>
               <p className="max-w-xl">
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
@@ -50,7 +59,7 @@ export const TwoSlides: Story = {
               className="absolute -z-10"
               src="/slideshow-bg-01.jpg"
             />
-            <div className="flex flex-col gap-4 px-12 py-24">
+            <div className="flex flex-col gap-4 px-12 pb-48 pt-36">
               <h2 className="text-h1">25% Off Sale</h2>
               <p className="max-w-xl">
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
@@ -63,7 +72,7 @@ export const TwoSlides: Story = {
           </div>
         </SlideshowSlide>
         <SlideshowSlide>
-          <div className="flex flex-col gap-4 bg-gray-100 px-12 py-24">
+          <div className="flex flex-col gap-4 bg-gray-100 px-12 pb-48 pt-36">
             <h2 className="text-h1">Great Deals</h2>
             <p className="max-w-xl">
               Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
@@ -75,6 +84,11 @@ export const TwoSlides: Story = {
           </div>
         </SlideshowSlide>
       </SlideshowContent>
+      <SlideshowControls>
+        <SlideshowPreviousIndicator />
+        <SlideshowPagination />
+        <SlideshowNextIndicator />
+      </SlideshowControls>
     </Slideshow>
   ),
 };
@@ -90,7 +104,7 @@ export const ThreeSlides: Story = {
               className="absolute -z-10"
               src="/slideshow-bg-01.jpg"
             />
-            <div className="flex flex-col gap-4 px-12 py-24">
+            <div className="flex flex-col gap-4 px-12 pb-48 pt-36">
               <h2 className="text-h1">25% Off Sale</h2>
               <p className="max-w-xl">
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
@@ -103,7 +117,7 @@ export const ThreeSlides: Story = {
           </div>
         </SlideshowSlide>
         <SlideshowSlide>
-          <div className="flex flex-col gap-4 bg-gray-100 px-12 py-24">
+          <div className="flex flex-col gap-4 bg-gray-100 px-12 pb-48 pt-36">
             <h2 className="text-h1">Great Deals</h2>
             <p className="max-w-xl">
               Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
@@ -115,7 +129,7 @@ export const ThreeSlides: Story = {
           </div>
         </SlideshowSlide>
         <SlideshowSlide>
-          <div className="flex flex-col gap-4 bg-gray-100 px-12 py-24">
+          <div className="flex flex-col gap-4 bg-gray-100 px-12 pb-48 pt-36">
             <h2 className="text-h1">Low Prices</h2>
             <p className="max-w-xl">
               Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
@@ -127,6 +141,11 @@ export const ThreeSlides: Story = {
           </div>
         </SlideshowSlide>
       </SlideshowContent>
+      <SlideshowControls>
+        <SlideshowPreviousIndicator />
+        <SlideshowPagination />
+        <SlideshowNextIndicator />
+      </SlideshowControls>
     </Slideshow>
   ),
 };
@@ -145,7 +164,7 @@ export const OneHundredSlides: Story = {
                 className="absolute -z-10"
                 src="/slideshow-bg-01.jpg"
               />
-              <div className="flex flex-col gap-4 px-12 py-24">
+              <div className="flex flex-col gap-4 px-12 pb-48 pt-36">
                 <h2 className="text-h1">{i + 1}% Off Sale</h2>
                 <p className="max-w-xl">
                   Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
@@ -159,6 +178,66 @@ export const OneHundredSlides: Story = {
           </SlideshowSlide>
         ))}
       </SlideshowContent>
+      <SlideshowControls>
+        <SlideshowPreviousIndicator />
+        <SlideshowPagination />
+        <SlideshowNextIndicator />
+      </SlideshowControls>
+    </Slideshow>
+  ),
+};
+
+export const CustomControls: Story = {
+  render: () => (
+    <Slideshow>
+      <SlideshowContent>
+        <SlideshowSlide>
+          <div className="relative">
+            <img
+              alt="A plant in a glass vase against a blank background."
+              className="absolute -z-10"
+              src="/slideshow-bg-01.jpg"
+            />
+            <div className="flex flex-col gap-4 px-12 pb-48 pt-36">
+              <h2 className="text-h1">25% Off Sale</h2>
+              <p className="max-w-xl">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+                incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
+              </p>
+              <Button asChild className="w-fit">
+                <a href="/#">Shop now</a>
+              </Button>
+            </div>
+          </div>
+        </SlideshowSlide>
+        <SlideshowSlide>
+          <div className="flex flex-col gap-4 bg-gray-100 px-12 pb-48 pt-36">
+            <h2 className="text-h1">Great Deals</h2>
+            <p className="max-w-xl">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+              incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
+            </p>
+            <Button asChild className="w-fit">
+              <a href="/#">Shop now</a>
+            </Button>
+          </div>
+        </SlideshowSlide>
+      </SlideshowContent>
+      <SlideshowControls>
+        <SlideshowPreviousIndicator>
+          <ChevronLeft />
+        </SlideshowPreviousIndicator>
+        <SlideshowPagination>
+          {({ activeIndex, totalSlides }) => (
+            <>
+              {activeIndex}/{totalSlides}
+            </>
+          )}
+        </SlideshowPagination>
+        <SlideshowNextIndicator>
+          <ChevronRight />
+        </SlideshowNextIndicator>
+      </SlideshowControls>
     </Slideshow>
   ),
 };

--- a/packages/reactant/src/components/Slideshow/Slideshow.tsx
+++ b/packages/reactant/src/components/Slideshow/Slideshow.tsx
@@ -1,13 +1,17 @@
 import useEmblaCarousel, { UseEmblaCarouselType } from 'embla-carousel-react';
+import { ArrowLeft, ArrowRight } from 'lucide-react';
 import {
   ComponentPropsWithRef,
   createContext,
   ElementRef,
   forwardRef,
+  MouseEvent,
   useCallback,
   useContext,
+  useEffect,
   useImperativeHandle,
   useRef,
+  useState,
 } from 'react';
 
 import { cs } from '../../utils/cs';
@@ -80,3 +84,141 @@ export const SlideshowSlide = forwardRef<ElementRef<'li'>, ComponentPropsWithRef
 );
 
 SlideshowSlide.displayName = 'SlideshowSlide';
+
+export const SlideshowControls = forwardRef<ElementRef<'div'>, ComponentPropsWithRef<'div'>>(
+  ({ children, className, ...props }, ref) => {
+    const [, emblaApi] = useContext(SlideshowContext);
+
+    if (!emblaApi || emblaApi.scrollSnapList().length <= 1) {
+      return null;
+    }
+
+    return (
+      <div
+        className={cs('absolute bottom-12 left-12 flex items-center gap-4', className)}
+        ref={ref}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+
+SlideshowControls.displayName = 'SlideshowControls';
+
+export const SlideshowNextIndicator = forwardRef<
+  ElementRef<'button'>,
+  ComponentPropsWithRef<'button'>
+>(({ children, className, onClick, ...props }, ref) => {
+  const [, emblaApi] = useContext(SlideshowContext);
+
+  const scrollNext = (e: MouseEvent<HTMLButtonElement, globalThis.MouseEvent>) => {
+    if (emblaApi) emblaApi.scrollNext();
+    if (onClick) onClick(e);
+  };
+
+  return (
+    <button
+      aria-label="Next slide"
+      className={cs(
+        'focus:ring-primary-blue/20 inline-flex h-12 w-12 items-center justify-center focus:outline-none focus:ring-4',
+        className,
+      )}
+      onClick={scrollNext}
+      ref={ref}
+      {...props}
+    >
+      {children || <ArrowRight />}
+    </button>
+  );
+});
+
+SlideshowNextIndicator.displayName = 'SlideshowNextIndicator';
+
+export const SlideshowPreviousIndicator = forwardRef<
+  ElementRef<'button'>,
+  ComponentPropsWithRef<'button'>
+>(({ children, className, onClick, ...props }, ref) => {
+  const [, emblaApi] = useContext(SlideshowContext);
+
+  const scrollPrev = (e: MouseEvent<HTMLButtonElement, globalThis.MouseEvent>) => {
+    if (emblaApi) emblaApi.scrollPrev();
+    if (onClick) onClick(e);
+  };
+
+  return (
+    <button
+      aria-label="Previous slide"
+      className={cs(
+        'focus:ring-primary-blue/20 inline-flex h-12 w-12 items-center justify-center focus:outline-none focus:ring-4',
+        className,
+      )}
+      onClick={scrollPrev}
+      ref={ref}
+      {...props}
+    >
+      {children || <ArrowLeft />}
+    </button>
+  );
+});
+
+SlideshowPreviousIndicator.displayName = 'SlideshowPreviousIndicator';
+
+interface SlideshowPaginationProps extends Omit<ComponentPropsWithRef<'div'>, 'children'> {
+  children?:
+    | (({
+        activeIndex,
+        totalSlides,
+      }: {
+        activeIndex: number;
+        totalSlides: number;
+      }) => React.ReactNode)
+    | React.ReactNode;
+}
+
+export const SlideshowPagination = forwardRef<ElementRef<'span'>, SlideshowPaginationProps>(
+  ({ children, className, ...props }, ref) => {
+    const [, emblaApi] = useContext(SlideshowContext);
+
+    const [activeIndex, setActiveIndex] = useState(0);
+    const [totalSlides, setTotalSlides] = useState(0);
+
+    useEffect(() => {
+      if (!emblaApi) return;
+
+      // We must reinitialize Embla on client-side navigation
+      // E.g., navigating from Homepage to PDP to Homepage
+      emblaApi.reInit();
+
+      const initialize = () => {
+        setTotalSlides(emblaApi.scrollSnapList().length);
+        setActiveIndex(emblaApi.selectedScrollSnap() + 1);
+      };
+
+      const onSelect = () => {
+        setActiveIndex(emblaApi.selectedScrollSnap() + 1);
+      };
+
+      emblaApi.on('slidesInView', initialize);
+      emblaApi.on('reInit', initialize);
+      emblaApi.on('select', onSelect);
+    }, [emblaApi]);
+
+    if (typeof children === 'function') {
+      return (
+        <span className={cs('font-semibold', className)} ref={ref} {...props}>
+          {children({ activeIndex, totalSlides })}
+        </span>
+      );
+    }
+
+    return (
+      <span className={cs('font-semibold', className)} ref={ref} {...props}>
+        {activeIndex} of {totalSlides}
+      </span>
+    );
+  },
+);
+
+SlideshowPagination.displayName = 'SlideshowPagination';


### PR DESCRIPTION
## What/Why?
> [!WARNING]
> This PR builds on top of #241 to include navigation controls and pagination UI. 
>
> Future PR's will include:
> - Responsiveness (Full Width on Mobile/Tablet, Padding on Desktop+)
> - Autoplay (Play/Pause Buttons, Pause on Mouse Enter/Focus/Interaction)
> - Advanced Accessibility (Dynamic ARIA labels)

Adds slideshow navigation controls (next and previous indicators) as well as a UI element to display pagination for the slideshow.

## Testing
See implementation in Core.