### PR TITLE
fix(core): CATALYST-00 add empty image area

### DIFF
--- a/apps/core/app/(default)/page.tsx
+++ b/apps/core/app/(default)/page.tsx
@@ -19,8 +19,8 @@ const ProductListGrid = ({ children }: { children: ReactNode }) => (
 
 export default async function Home() {
   const [bestSellingProducts, featuredProducts] = await Promise.all([
-    client.getBestSellingProducts(),
-    client.getFeaturedProducts(),
+    client.getBestSellingProducts({ imageWidth: 500, imageHeight: 500 }),
+    client.getFeaturedProducts({ imageWidth: 500, imageHeight: 500 }),
   ]);
 
   return (
@@ -40,7 +40,7 @@ export default async function Home() {
           <ProductListName>Featured Products</ProductListName>
           <ProductListGrid>
             {featuredProducts.map((product) => (
-              <ProductCard key={product.entityId} product={product} />
+              <ProductCard imageSize="tall" key={product.entityId} product={product} />
             ))}
           </ProductListGrid>
         </ProductList>

--- a/apps/core/components/ProductCard/index.tsx
+++ b/apps/core/components/ProductCard/index.tsx
@@ -35,7 +35,11 @@ interface ProductCardProps {
   imagePriority?: boolean;
 }
 
-export const ProductCard = ({ product, imageSize, imagePriority = false }: ProductCardProps) => {
+export const ProductCard = ({
+  product,
+  imageSize = 'square',
+  imagePriority = false,
+}: ProductCardProps) => {
   const currencyFormatter = new Intl.NumberFormat('en-US', {
     style: 'currency',
     currency: product.prices?.price?.currencyCode,
@@ -44,18 +48,25 @@ export const ProductCard = ({ product, imageSize, imagePriority = false }: Produ
   return (
     <ReactantProductCard key={product.entityId}>
       <ProductCardImage>
-        <Image
-          alt={product.defaultImage?.altText ?? product.name ?? ''}
-          className={cs('object-contain object-center', {
+        <div
+          className={cs('relative flex-auto', {
             'aspect-square': imageSize === 'square',
             'aspect-[4/5]': imageSize === 'tall',
             'aspect-[7/5]': imageSize === 'wide',
           })}
-          height={300}
-          priority={imagePriority}
-          src={product.defaultImage?.url ?? ''}
-          width={300}
-        />
+        >
+          {product.defaultImage ? (
+            <Image
+              alt={product.defaultImage.altText ?? product.name ?? ''}
+              className="object-contain"
+              fill
+              priority={imagePriority}
+              src={product.defaultImage.url ?? ''}
+            />
+          ) : (
+            <div className="h-full w-full bg-gray-200" />
+          )}
+        </div>
       </ProductCardImage>
       <ProductCardInfo>
         {product.brand && <ProductCardInfoBrandName>{product.brand.name}</ProductCardInfoBrandName>}


### PR DESCRIPTION
## What/Why?
Added an empty image gray background box for products without images. We didn't account for an image with an empty src which was throwing a bunch of errors in console

@BC-Turner or @davelinke I'm curious if this is a okay addition for now, until we get some designs what an empty image slot looks like? Also, should we add an empty line if the product doesn't have a brand?

**Note:** I also aligned the dimensions of the product images to the same sizes as the designs.

## Testing
<table>
<tr>
	<td>Before
	<td>After
<tr>
	<td><img src="https://github.com/bigcommerce/catalyst/assets/10539418/1a8aa90a-0ad1-466a-99a7-f32bda727504" />
	<td><img src="https://github.com/bigcommerce/catalyst/assets/10539418/5e13767c-8bef-4724-b397-afd826b9fb05" />
</table>
