### PR TITLE
fix(reactant): make carousel emblaref composable for makeswift

### DIFF
--- a/packages/reactant/src/components/Carousel/Carousel.tsx
+++ b/packages/reactant/src/components/Carousel/Carousel.tsx
@@ -8,6 +8,8 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useImperativeHandle,
+  useRef,
   useState,
 } from 'react';
 
@@ -36,17 +38,28 @@ export const Carousel = forwardRef<ElementRef<'section'>, ComponentPropsWithRef<
 
 Carousel.displayName = 'Carousel';
 
-export const CarouselContent = forwardRef<ElementRef<'div'>, ComponentPropsWithRef<'ul'>>(
+type ForwardedRef = ElementRef<'div'> | null;
+
+export const CarouselContent = forwardRef<ForwardedRef, ComponentPropsWithRef<'ul'>>(
   ({ children, className, ...props }, ref) => {
+    const mutableRef = useRef<ForwardedRef>(null);
     const [emblaRef] = useContext(CarouselContext);
 
+    useImperativeHandle<ForwardedRef, ForwardedRef>(ref, () => mutableRef.current, []);
+
+    const refCallback = useCallback(
+      (current: ForwardedRef) => {
+        emblaRef(current);
+        mutableRef.current = current;
+      },
+      [emblaRef],
+    );
+
     return (
-      <div ref={ref}>
-        <div ref={emblaRef}>
-          <ul aria-live="polite" className={cs('mb-16 mt-8 flex lg:mt-10', className)} {...props}>
-            {children}
-          </ul>
-        </div>
+      <div ref={refCallback}>
+        <ul aria-live="polite" className={cs('mb-16 mt-8 flex lg:mt-10', className)} {...props}>
+          {children}
+        </ul>
       </div>
     );
   },

--- a/packages/reactant/src/components/Slideshow/Slideshow.tsx
+++ b/packages/reactant/src/components/Slideshow/Slideshow.tsx
@@ -48,6 +48,7 @@ export const SlideshowContent = forwardRef<ForwardedRef, ComponentPropsWithRef<'
     const refCallback = useCallback(
       (current: HTMLDivElement) => {
         emblaRef(current);
+        mutableRef.current = current;
       },
       [emblaRef],
     );


### PR DESCRIPTION
## What/Why?

### The Problem: 

In order to properly register components with Makeswift, as well as give `apps/core` developers access to all native JSX properties + attributes, we use `forwardRef` in order to expose the `ref` property. 

However, we run into a problem with libraries such as `embla-carousel-react` [that use `ref`'s to attach functionality to some of the components we're creating](https://www.embla-carousel.com/get-started/react/#the-component-structure). 

The problem is that now we have two libraries that require access to the `ref` attribute of the single DOM element returned by CarouselContent. If we set the `ref` attribute of the `<div>` returned by CarouselContent equal to `emblaRef`, we cannot also set it to the ref passed via `forwardRef`. This breaks Makeswift. 

### The Fix:

This PR allows both the `emblaRef` as well as the forwarded `ref` to access a single DOM element via `useImperativeHandle`:

1. First, we allow CarouselContent to accept a `ref` prop by wrapping it with `forwardRef`.
2. Then we pass the forwarded ref given to CarouselContent (if any) into `useImperativeHook` [in order to customize the handle that's exposed as a ref](https://react.dev/reference/react/useImperativeHandle). Finally, we need to ensure this handle is connected to the `<div>` element returned by the component:
3. So, we replace the value of the `ref` property in the `<div>` element with `refCallback`.
4. `refCallback` then receives the value of the `current` ref property as an argument, uses it as a parameter in Embla's `emblaRef` method (`emblaRef` [is just a setState method](https://github.com/davidjerleke/embla-carousel/blob/c02be9b84df117dbc0d735ff484e0dff2c399abd/packages/embla-carousel-react/src/components/useEmblaCarousel.ts#L62)), as well as use the `current` argument to set the `current` property of the forwarded ref so that Makeswift (and other `apps/core` developers) can use it for their own purposes.

## Testing

**`<CarouselContent />` Passes Type Checks When Given a Ref:**
![Screenshot 2023-09-26 at 4 56 19 PM](https://github.com/bigcommerce/catalyst/assets/28374851/0251272f-1ada-493e-b69f-a0f02868198f)

**(also passes in `apps/core`):**
![Screenshot 2023-09-26 at 5 03 44 PM](https://github.com/bigcommerce/catalyst/assets/28374851/31b3132c-7c05-45b1-8986-163f52e02b86)

**Carousel still works in Storybook:** https://catalyst-storybook-git-fork-matthew-241fc8-bigcommerce-platform.vercel.app/?path=%2Fdocs%2Fcarousel--docs

**Forwarded `ref`'s have access to the `current` property, which is set to the `<div>` returned by CarouselContent:**
https://github.com/bigcommerce/catalyst/assets/28374851/902fa4e8-d146-49e8-bf68-d39a6da29a72


