### PR TITLE
feat(reactant): CATALYST-42 add slideshow autoplay and controls

### DIFF
--- a/apps/core/components/Hero/index.tsx
+++ b/apps/core/components/Hero/index.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@bigcommerce/reactant/Button';
 import {
   Slideshow,
+  SlideshowAutoplayControl,
   SlideshowContent,
   SlideshowControls,
   SlideshowNextIndicator,
@@ -60,6 +61,7 @@ export const Hero = () => (
       </SlideshowSlide>
     </SlideshowContent>
     <SlideshowControls>
+      <SlideshowAutoplayControl />
       <SlideshowPreviousIndicator />
       <SlideshowPagination />
       <SlideshowNextIndicator />

--- a/apps/docs/stories/Slideshow.stories.tsx
+++ b/apps/docs/stories/Slideshow.stories.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@bigcommerce/reactant/Button';
 import {
   Slideshow,
+  SlideshowAutoplayControl,
   SlideshowContent,
   SlideshowControls,
   SlideshowNextIndicator,
@@ -85,6 +86,7 @@ export const TwoSlides: Story = {
         </SlideshowSlide>
       </SlideshowContent>
       <SlideshowControls>
+        <SlideshowAutoplayControl />
         <SlideshowPreviousIndicator />
         <SlideshowPagination />
         <SlideshowNextIndicator />
@@ -142,6 +144,7 @@ export const ThreeSlides: Story = {
         </SlideshowSlide>
       </SlideshowContent>
       <SlideshowControls>
+        <SlideshowAutoplayControl />
         <SlideshowPreviousIndicator />
         <SlideshowPagination />
         <SlideshowNextIndicator />
@@ -179,6 +182,7 @@ export const OneHundredSlides: Story = {
         ))}
       </SlideshowContent>
       <SlideshowControls>
+        <SlideshowAutoplayControl />
         <SlideshowPreviousIndicator />
         <SlideshowPagination />
         <SlideshowNextIndicator />
@@ -187,9 +191,9 @@ export const OneHundredSlides: Story = {
   ),
 };
 
-export const CustomControls: Story = {
+export const CustomControlsAndInterval: Story = {
   render: () => (
-    <Slideshow>
+    <Slideshow interval={5_000}>
       <SlideshowContent>
         <SlideshowSlide>
           <div className="relative">
@@ -224,6 +228,9 @@ export const CustomControls: Story = {
         </SlideshowSlide>
       </SlideshowContent>
       <SlideshowControls>
+        <SlideshowAutoplayControl className="font-semibold">
+          {({ isPaused }) => (isPaused ? 'Play' : 'Pause')}
+        </SlideshowAutoplayControl>
         <SlideshowPreviousIndicator>
           <ChevronLeft />
         </SlideshowPreviousIndicator>


### PR DESCRIPTION
## What/Why?
> [!NOTE]
> Next PR will include final requirements to finish the Slideshow: Responsive styles, advanced accessibility, logical CSS fixes, LTR/RTL text direction, and organization of the Storybook components.

Adds an `AutoplayContext` that handles slideshow autoplay functionality and controls. Our slideshow requirements were difficult to meet if we were to use the [Autplay plugin provided by Embla](https://www.embla-carousel.com/plugins/autoplay/) only because their plugin doesn't expose an API to return whether or not Autoplay is enabled; it only returns methods to pause and start autoplay. We need a boolean for "isPaused" in order to conditionally render a play/pause button. Turned out to be less code if we rolled our own autoplay. 

## Testing

- **Storybook:** https://catalyst-storybook-git-fork-matthew-888269-bigcommerce-platform.vercel.app/?path=%2Fstory%2Fslideshow--one-hundred-slides
- **Core:** https://catalyst-git-fork-matthewvolk-catal-e16801-bigcommerce-platform.vercel.app/
- **Custom Controls + Interval:** https://catalyst-storybook-git-fork-matthew-888269-bigcommerce-platform.vercel.app/?path=%2Fstory%2Fslideshow--custom-controls-and-interval