### PR TITLE
feat(core): catalyst-87 add product schema to pdp

### DIFF
--- a/apps/core/app/(default)/product/[slug]/ProductSchema.tsx
+++ b/apps/core/app/(default)/product/[slug]/ProductSchema.tsx
@@ -1,0 +1,93 @@
+import { Product as ProductSchemaType, WithContext } from 'schema-dts';
+
+import client from '~/client';
+
+export const ProductSchema = ({
+  product,
+}: {
+  product: Awaited<ReturnType<typeof client.getProduct>>;
+}) => {
+  if (product === null) return null;
+
+  /* TODO: use common default image when product has no images */
+  const image = product.defaultImage ? { image: product.defaultImage.url } : null;
+
+  const sku = product.sku ? { sku: product.sku } : null;
+  const gtin = product.gtin ? { gtin: product.gtin } : null;
+  const mpn = product.mpn ? { mpn: product.mpn } : null;
+
+  const brand = product.brand
+    ? {
+        '@type': 'Brand' as const,
+        url: product.brand.path,
+        name: product.brand.name,
+      }
+    : null;
+
+  const aggregateRating =
+    product.reviewSummary.numberOfReviews > 0
+      ? {
+          '@type': 'AggregateRating' as const,
+          ratingValue: product.reviewSummary.averageRating,
+          reviewCount: product.reviewSummary.numberOfReviews,
+        }
+      : null;
+
+  const priceSpecification = product.prices
+    ? {
+        '@type': 'PriceSpecification' as const,
+        price: product.prices.price.value,
+        priceCurrency: product.prices.price.currencyCode,
+        ...(product.prices.priceRange.min.value !== product.prices.priceRange.max.value
+          ? {
+              minPrice: product.prices.priceRange.min.value,
+              maxPrice: product.prices.priceRange.max.value,
+            }
+          : null),
+      }
+    : null;
+
+  enum ItemCondition {
+    NEW = 'https://schema.org/NewCondition',
+    USED = 'https://schema.org/UsedCondition',
+    REFURBISHED = 'https://schema.org/RefurbishedCondition',
+  }
+
+  const itemCondition = ItemCondition[product.condition ?? 'NEW'];
+
+  enum Availability {
+    Preorder = 'PreOrder',
+    Unavailable = 'OutOfStock',
+    Available = 'InStock',
+  }
+
+  const availability = Availability[product.availabilityV2.status];
+
+  const productSchema: WithContext<ProductSchemaType> = {
+    '@context': 'https://schema.org',
+    '@type': 'Product',
+    name: product.name,
+    url: product.path,
+    description: product.plainTextDescription,
+    ...(brand && { brand }),
+    ...(aggregateRating && { aggregateRating }),
+    ...image,
+    ...sku,
+    ...gtin,
+    ...mpn,
+    offers: {
+      '@type': 'Offer',
+      ...(priceSpecification && { priceSpecification }),
+      itemCondition,
+      availability,
+      url: product.path,
+    },
+  };
+
+  return (
+    <script
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(productSchema) }}
+      type="application/ld+json"
+    />
+  );
+};

--- a/apps/core/app/(default)/product/[slug]/page.tsx
+++ b/apps/core/app/(default)/product/[slug]/page.tsx
@@ -12,6 +12,7 @@ import { AddToCart } from './AddToCart';
 import { BreadCrumbs } from './Breadcrumbs';
 import { Gallery } from './Gallery';
 import { ProductForm } from './ProductForm';
+import { ProductSchema } from './ProductSchema';
 import { RelatedProducts } from './RelatedProducts';
 import { Reviews } from './Reviews';
 import { ReviewSummary } from './ReviewSummary';
@@ -113,6 +114,7 @@ const ProductDetails = ({
           )}
         </div>
       </div>
+      <ProductSchema product={product} />
     </div>
   );
 };

--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -20,6 +20,7 @@
     "next": "^13.5.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "schema-dts": "^1.1.2",
     "server-only": "^0.0.1",
     "sharp": "^0.32.5",
     "tailwind-merge": "^1.14.0",

--- a/packages/client/src/queries/getProduct.ts
+++ b/packages/client/src/queries/getProduct.ts
@@ -152,12 +152,25 @@ async function internalGetProduct<T>(
             value: true,
             currencyCode: true,
           },
+          priceRange: {
+            min: {
+              value: true,
+              currencyCode: true,
+            },
+            max: {
+              value: true,
+              currencyCode: true,
+            },
+          },
         },
         brand: {
           name: true,
+          path: true,
         },
         upc: true,
         path: true,
+        mpn: true,
+        gtin: true,
         minPurchaseQuantity: true,
         maxPurchaseQuantity: true,
         condition: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
+      schema-dts:
+        specifier: ^1.1.2
+        version: 1.1.2(typescript@5.2.2)
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
@@ -11544,6 +11547,14 @@ packages:
     resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
     dependencies:
       loose-envify: 1.4.0
+
+  /schema-dts@1.1.2(typescript@5.2.2):
+    resolution: {integrity: sha512-MpNwH0dZJHinVxk9bT8XUdjKTxMYrA5bLtrrGmFA6PTLwlOKnhi67XoRd6/ty+Djt6ZC0slR57qFhZDNMI6DhQ==}
+    peerDependencies:
+      typescript: '>=4.1.0'
+    dependencies:
+      typescript: 5.2.2
+    dev: false
 
   /schema-utils@3.3.0:
     resolution: {integrity: sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==}


### PR DESCRIPTION
## What/Why?
This pr adds schema for pdp and minor updates for `getProduct` query to fetch needed fields

## Testing
With [schema.org](https://schema.org/) and [google rich results](https://search.google.com/test/rich-results)

**Product with one price**
<img width="837" alt="product-with-one-price" src="https://github.com/bigcommerce/catalyst/assets/66325265/e47581ff-b307-49b8-ba86-d056fc4ff375">

**Product with price range**
<img width="837" alt="product-with-price-range" src="https://github.com/bigcommerce/catalyst/assets/66325265/ab242de8-1f55-4bdb-862a-bfbc243b383e">
