### PR TITLE
feat(reactant): CATALYST-42 add responsive slideshow styles

### DIFF
--- a/packages/reactant/src/components/Slideshow/Slideshow.tsx
+++ b/packages/reactant/src/components/Slideshow/Slideshow.tsx
@@ -50,7 +50,7 @@ export const Slideshow = forwardRef<ElementRef<'section'>, SlideshowProps>(
           <section
             aria-label="Interactive slide show"
             aria-roledescription="carousel"
-            className={cs('relative overflow-hidden', className)}
+            className={cs('relative -mx-6 overflow-hidden sm:-mx-10 md:-mx-12 lg:mx-0', className)}
             onBlur={() => setIsHoverPaused(false)}
             onFocus={() => setIsHoverPaused(true)}
             onMouseEnter={() => setIsHoverPaused(true)}


### PR DESCRIPTION
## What/Why?
Quick, quick, quick responsive styles. Slideshow now has padding on large screens, and is full width on <= tablet.

## Testing

https://github.com/bigcommerce/catalyst/assets/28374851/8aaa459c-3d04-423e-a0d9-db4b060189dc

