### PR TITLE
fix(reactant): CATALYST-42 add misc accessibility improvements

### DIFF
--- a/apps/docs/stories/Slideshow.stories.tsx
+++ b/apps/docs/stories/Slideshow.stories.tsx
@@ -160,9 +160,9 @@ export const CustomControlsAndInterval: Story = {
           <ChevronLeft />
         </SlideshowPreviousIndicator>
         <SlideshowPagination>
-          {({ activeIndex, totalSlides }) => (
+          {({ activeSlide, totalSlides }) => (
             <>
-              {activeIndex}/{totalSlides}
+              {activeSlide}/{totalSlides}
             </>
           )}
         </SlideshowPagination>


### PR DESCRIPTION
## What/Why?
Adds missing accessibility features to Slideshow:
- More accurate variable names
- Prevents tabbing to slides not in view with `inert`
- Adds `slideshow-slides` ID attribute for slideshow control buttons to point to
- Properly sets aria live and atomic regions

## Testing
MacOS VoiceOver Utility (Control + Option + Arrow Keys)