### PR TITLE
fix(core): CATALYST-0 use correct size for Rating

### DIFF
--- a/apps/core/components/ProductCard/index.tsx
+++ b/apps/core/components/ProductCard/index.tsx
@@ -104,7 +104,7 @@ export const ProductCard = ({
                 product.reviewSummary.numberOfReviews === 0 && 'text-gray-400',
               )}
             >
-              <Rating size={13} value={product.reviewSummary.averageRating || 0} />
+              <Rating size={16} value={product.reviewSummary.averageRating || 0} />
             </p>
 
             <div className="text-sm text-gray-500" id={summaryId}>


### PR DESCRIPTION
## What/Why?
It was too small.

After fix:
![Screenshot 2023-10-03 at 3 12 59 PM](https://github.com/bigcommerce/catalyst/assets/196129/1505e907-596e-4c67-a081-b1032a7f9626)


## Testing
Local