### PR TITLE
fix(core): catalyst-131 update contact form accessibility

### DIFF
--- a/apps/core/components/Forms/ContactUs.tsx
+++ b/apps/core/components/Forms/ContactUs.tsx
@@ -70,17 +70,20 @@ export const ContactUs = ({ fields }: { fields: string[] }) => {
 
               return (
                 <Field className={cs('relative space-y-2 pb-7')} key={label} name={label}>
-                  <FieldLabel>{label}</FieldLabel>
+                  <FieldLabel htmlFor={label}>{label}</FieldLabel>
                   <FieldControl asChild>
-                    <Input />
+                    <Input id={label} />
                   </FieldControl>
                 </Field>
               );
             })}
           <Field className={cs('relative space-y-2 pb-7')} key="email" name="email">
-            <FieldLabel isRequired>Email</FieldLabel>
+            <FieldLabel htmlFor="email" isRequired>
+              Email
+            </FieldLabel>
             <FieldControl asChild>
               <Input
+                id="email"
                 onChange={handleInputValidation}
                 onInvalid={handleInputValidation}
                 required
@@ -106,9 +109,12 @@ export const ContactUs = ({ fields }: { fields: string[] }) => {
             key="comments"
             name="comments"
           >
-            <FieldLabel isRequired>Comments/questions</FieldLabel>
+            <FieldLabel htmlFor="comments" isRequired>
+              Comments/questions
+            </FieldLabel>
             <FieldControl asChild>
               <TextArea
+                id="comments"
                 onChange={handleTextFieldValidation}
                 onInvalid={handleTextFieldValidation}
                 required

--- a/packages/reactant/src/components/Form/Form.tsx
+++ b/packages/reactant/src/components/Form/Form.tsx
@@ -59,9 +59,13 @@ interface FieldLabelProps extends ComponentPropsWithRef<typeof Label> {
 
 export const FieldLabel = forwardRef<ElementRef<typeof Label>, FieldLabelProps>(
   ({ className, children, isRequired, ...props }, ref) => (
-    <Label className={cs('inline-flex w-full justify-between', className)} ref={ref} {...props}>
+    <Label
+      className={cs('inline-flex w-full items-center justify-between', className)}
+      ref={ref}
+      {...props}
+    >
       <span>{children}</span>
-      {isRequired && <span className="text-sm font-normal text-gray-200">Required</span>}
+      {isRequired && <span className="text-sm font-normal text-gray-500">Required</span>}
     </Label>
   ),
 );


### PR DESCRIPTION
## What/Why?
This PR fixes accessibility coverage for contact form and also update colour on required label.

## Testing
Locally

Before:
![Screenshot 2023-10-04 at 11 40 23](https://github.com/bigcommerce/catalyst/assets/67792608/06b4b599-a6ed-4170-bcf9-1fb7cbc7eedb)

After:
![Screenshot 2023-10-04 at 11 10 12](https://github.com/bigcommerce/catalyst/assets/67792608/dcf1944c-f49f-4768-bec2-4e11ffef0b5f)


