### PR TITLE
feat(core): add api route to cache custom url paths

### DIFF
--- a/apps/core/app/api/route/route.ts
+++ b/apps/core/app/api/route/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import client from '~/client';
+
+export const GET = async (request: NextRequest) => {
+  const { searchParams } = request.nextUrl;
+
+  const path = searchParams.get('path');
+
+  if (path) {
+    const node = await client.getRoute({ path }, { cache: null, next: { revalidate: 60 * 30 } });
+
+    return NextResponse.json(node);
+  }
+
+  return new Response('Missing path', { status: 400 });
+};
+
+export const runtime = 'edge';


### PR DESCRIPTION
## What/Why?
This is a first step at creating an API route that our middleware will use to cache custom url requests. Per conversations with Vercel, middleware does not support caching for a multitude of reason, so we had to get a little creative on how to cache these requests. Below is a diagram of how this will work:

```mermaid
sequenceDiagram
    participant Client
    participant Middleware
    participant API Route
    participant BigCommerce API

    Client->>Middleware: Request to /custom-product-route
    activate Middleware
    Middleware->>API Route:  Fetches /api/route?path=/custom-product-route
    API Route->>BigCommerce API: Query site.route(path: /custom-product-route)
    BigCommerce API->>API Route: Returns node and caches request on API route
    API Route->>Middleware: Returns node
    Middleware-->>Client: Rewrites custom path to internal path
    deactivate Middleware
    Note over Client,BigCommerce API: Time passes...
    Client->>Middleware: Request to /custom-product-route
    activate Middleware
    Middleware->>API Route:  Fetches /api/route?path=/custom-product-route
    API Route->>Middleware: Returns cached node
    Middleware-->>Client: Rewrites custom path to internal path
    deactivate Middleware
```

This portion of the work covers the `API Route` segment of this flow. The default caching time is 5 minutes but would love some input if that is too short. Maybe we can play around with it.

## Testing
![Screenshot 2023-10-04 at 11 13 30](https://github.com/bigcommerce/catalyst/assets/10539418/781a8ab5-44c7-47ae-a158-2f283debcd45)

Notice that the first request took longer than the rest:

https://github.com/bigcommerce/catalyst/assets/10539418/483a48a1-86d9-44d4-a6eb-4758fbf8ae8b

