### PR TITLE
feat(core): add custom url middleware

### DIFF
--- a/apps/core/app/api/route/route.ts
+++ b/apps/core/app/api/route/route.ts
@@ -10,10 +10,11 @@ export const GET = async (request: NextRequest) => {
   if (path) {
     const node = await client.getRoute({ path }, { cache: null, next: { revalidate: 60 * 30 } });
 
+    // Middleware is the current consumer of this endpoint. If you need to modify this, ensure middleware is updated.
     return NextResponse.json(node);
   }
 
-  return new Response('Missing path', { status: 400 });
+  return new NextResponse('Missing path', { status: 400 });
 };
 
 export const runtime = 'edge';

--- a/apps/core/components/Footer/FooterMenus/BrandFooterMenu.tsx
+++ b/apps/core/components/Footer/FooterMenus/BrandFooterMenu.tsx
@@ -5,15 +5,9 @@ import { BaseFooterMenu } from './BaseFooterMenu';
 export const BrandFooterMenu = async () => {
   const brands = await client.getBrands();
 
-  // Temp workaround until we have the middleware that converts paths to real urls
-  const items = brands.map((item) => ({
-    ...item,
-    path: `/brand/${item.entityId}`,
-  }));
-
-  if (!items.length) {
+  if (!brands.length) {
     return null;
   }
 
-  return <BaseFooterMenu items={items} title="Brands" />;
+  return <BaseFooterMenu items={brands} title="Brands" />;
 };

--- a/apps/core/middleware.ts
+++ b/apps/core/middleware.ts
@@ -1,22 +1,8 @@
-import { NextResponse } from 'next/server';
+import { withCustomUrls } from './middlewares/with-custom-urls';
+import { withMaintenanceMode } from './middlewares/with-maitenance-mode';
+import { composeMiddlewares } from './utils/composeMiddlewares';
 
-import client from './client';
-import { composeMiddlewares, type MiddlewareFactory } from './utils/composeMiddlewares';
-
-const withMaintenanceMode: MiddlewareFactory = (next) => {
-  return async (request, event) => {
-    const settings = await client.getStoreSettings();
-
-    if (settings?.status === 'MAINTENANCE') {
-      // 503 status code not working - https://github.com/vercel/next.js/issues/50155
-      return NextResponse.rewrite(new URL(`/maintenance`, request.url), { status: 503 });
-    }
-
-    return next(request, event);
-  };
-};
-
-export const middleware = composeMiddlewares(withMaintenanceMode);
+export const middleware = composeMiddlewares(withMaintenanceMode, withCustomUrls);
 
 export const config = {
   matcher: [

--- a/apps/core/middlewares/with-custom-urls.ts
+++ b/apps/core/middlewares/with-custom-urls.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+
+import client from '../client';
+import { type MiddlewareFactory } from '../utils/composeMiddlewares';
+
+export const withCustomUrls: MiddlewareFactory = (next) => {
+  return async (request, event) => {
+    const response = await fetch(
+      new URL(
+        `/api/route?path=${request.nextUrl.pathname}`,
+        process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : request.url,
+      ),
+    );
+
+    if (!response.ok) {
+      throw new Error(`BigCommerce API returned ${response.status}`);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const node = (await response.json()) as Awaited<ReturnType<typeof client.getRoute>>;
+
+    switch (node?.__typename) {
+      case 'Brand': {
+        const url = new URL(`/brand/${node.entityId}`, request.url);
+
+        url.search = request.nextUrl.search;
+
+        return NextResponse.rewrite(url);
+      }
+
+      default:
+        return next(request, event);
+    }
+  };
+};

--- a/apps/core/middlewares/with-maitenance-mode.ts
+++ b/apps/core/middlewares/with-maitenance-mode.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+
+import client from '../client';
+import { type MiddlewareFactory } from '../utils/composeMiddlewares';
+
+export const withMaintenanceMode: MiddlewareFactory = (next) => {
+  return async (request, event) => {
+    const settings = await client.getStoreSettings();
+
+    if (settings?.status === 'MAINTENANCE') {
+      // 503 status code not working - https://github.com/vercel/next.js/issues/50155
+      return NextResponse.rewrite(new URL(`/maintenance`, request.url), { status: 503 });
+    }
+
+    return next(request, event);
+  };
+};


### PR DESCRIPTION
## What/Why?
Adds the custom url middleware and initially adds `brands` as the first user of custom URLs.

## Testing
See the preview link but here is some navigating around with brand facets.

https://github.com/bigcommerce/catalyst/assets/10539418/6472cf94-2446-41b0-9b47-f415c0fbf53f

