### PR TITLE
chore: use request.url instead of vercel url

### DIFF
--- a/apps/core/middlewares/with-custom-urls.ts
+++ b/apps/core/middlewares/with-custom-urls.ts
@@ -14,10 +14,7 @@ const createRewriteUrl = (path: string, request: NextRequest) => {
 export const withCustomUrls: MiddlewareFactory = (next) => {
   return async (request, event) => {
     const response = await fetch(
-      new URL(
-        `/api/route?path=${request.nextUrl.pathname}`,
-        process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : request.url,
-      ),
+      new URL(`/api/route?path=${request.nextUrl.pathname}`, request.url),
     );
 
     if (!response.ok) {


### PR DESCRIPTION
## What/Why?
Removes the `VERCEL_URL` usage in favor of just `request.url` as it's just the same thing.

## Testing
See preview.