### PR TITLE
feat(core): add store-settings api route

### DIFF
--- a/apps/core/app/api/store-settings/route.ts
+++ b/apps/core/app/api/store-settings/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+
+import client from '~/client';
+
+export const GET = async () => {
+  const settings = await client.getStoreSettings({ cache: null, next: { revalidate: 60 * 5 } });
+
+  // Middleware is the current consumer of this endpoint. If you need to modify this, ensure middleware is updated.
+  return NextResponse.json(settings);
+};
+
+export const runtime = 'edge';


### PR DESCRIPTION
## What/Why?
Adds a store-settings route, will be used in middleware. We are adding this to get some kind of cache for it, 5 min.

## Tests / Screenshots
![vRIM8hkg](https://github.com/bigcommerce/catalyst/assets/2752665/b2fb8aab-bdc2-41f0-a80a-8879a834007b)
