### PR TITLE
feat(core): add auth to internal api routes

### DIFF
--- a/apps/core/app/api/_internal-auth.ts
+++ b/apps/core/app/api/_internal-auth.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const token = process.env.BIGCOMMERCE_CUSTOMER_IMPERSONATION_TOKEN;
+
+if (!token) {
+  throw new Error('BIGCOMMERCE_CUSTOMER_IMPERSONATION_TOKEN is not defined');
+}
+
+type Handler = (request: NextRequest) => NextResponse | Promise<NextResponse>;
+
+export const withInternalAuth = (handler: Handler) => {
+  return (request: NextRequest) => {
+    const requestHeaders = new Headers(request.headers);
+    const requestToken = requestHeaders.get('x-internal-token');
+
+    if (requestToken !== token) {
+      return Response.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    return handler(request);
+  };
+};

--- a/apps/core/app/api/route/route.ts
+++ b/apps/core/app/api/route/route.ts
@@ -2,7 +2,9 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import client from '~/client';
 
-export const GET = async (request: NextRequest) => {
+import { withInternalAuth } from '../_internal-auth';
+
+const handler = async (request: NextRequest) => {
   const { searchParams } = request.nextUrl;
 
   const path = searchParams.get('path');
@@ -16,5 +18,7 @@ export const GET = async (request: NextRequest) => {
 
   return new NextResponse('Missing path', { status: 400 });
 };
+
+export const GET = withInternalAuth(handler);
 
 export const runtime = 'edge';

--- a/apps/core/app/api/store-settings/route.ts
+++ b/apps/core/app/api/store-settings/route.ts
@@ -2,11 +2,15 @@ import { NextResponse } from 'next/server';
 
 import client from '~/client';
 
-export const GET = async () => {
+import { withInternalAuth } from '../_internal-auth';
+
+const handler = async () => {
   const settings = await client.getStoreSettings({ cache: null, next: { revalidate: 60 * 5 } });
 
   // Middleware is the current consumer of this endpoint. If you need to modify this, ensure middleware is updated.
   return NextResponse.json(settings);
 };
+
+export const GET = withInternalAuth(handler);
 
 export const runtime = 'edge';

--- a/apps/core/middlewares/with-custom-urls.ts
+++ b/apps/core/middlewares/with-custom-urls.ts
@@ -15,6 +15,11 @@ export const withCustomUrls: MiddlewareFactory = (next) => {
   return async (request, event) => {
     const response = await fetch(
       new URL(`/api/route?path=${request.nextUrl.pathname}`, request.url),
+      {
+        headers: {
+          'x-internal-token': process.env.BIGCOMMERCE_CUSTOMER_IMPERSONATION_TOKEN ?? '',
+        },
+      },
     );
 
     if (!response.ok) {

--- a/apps/core/middlewares/with-maintenance-mode.ts
+++ b/apps/core/middlewares/with-maintenance-mode.ts
@@ -5,7 +5,11 @@ import { type MiddlewareFactory } from '../utils/composeMiddlewares';
 
 export const withMaintenanceMode: MiddlewareFactory = (next) => {
   return async (request, event) => {
-    const response = await fetch(new URL(`/api/store-settings`, request.url));
+    const response = await fetch(new URL(`/api/store-settings`, request.url), {
+      headers: {
+        'x-internal-token': process.env.BIGCOMMERCE_CUSTOMER_IMPERSONATION_TOKEN ?? '',
+      },
+    });
 
     if (!response.ok) {
       throw new Error(`BigCommerce API returned ${response.status}`);


### PR DESCRIPTION
## What/Why?
Adds a header as auth for our internal api routes. These routes are meant to be called only from middleware. Reusing `BIGCOMMERCE_CUSTOMER_IMPERSONATION_TOKEN` as the token here.

Checking auth directly in the route handler and not in middleware because then it would be `middleware -> middleware -> handler` which is not ideal.

## Testing
![tYuOlkny](https://github.com/bigcommerce/catalyst/assets/2752665/848c1d64-9859-4851-9980-e4943d555272)