### PR TITLE
chore: add remote lint and typecheck cache

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -13,6 +13,10 @@ jobs:
     name: Lint and Typecheck
 
     runs-on: ubuntu-latest
+      
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
     steps:
       - name: Checkout code

--- a/turbo.json
+++ b/turbo.json
@@ -25,5 +25,8 @@
       "cache": false,
       "persistent": true
     }
+  },
+  "remoteCache": {
+    "signature": true
   }
 }


### PR DESCRIPTION
## What/Why?
Noticed that our build isn't using our remote cache for building. Seemed like an easy win to speed up PR builds.

## Testing
![Screenshot 2023-10-09 at 11 22 14](https://github.com/bigcommerce/catalyst/assets/10539418/33bb837d-8fca-4dbf-aa2f-6ebf92bae9a6)
