### PR TITLE
chore: remove verbiage around forking repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ Catalyst is configured such that pnpm replaces npm. When you enhance your projec
 
 ## Getting Started
 
-1. [Fork the project repository (GitHub)](https://docs.github.com/en/get-started/quickstart/fork-a-repo), then clone the project to your local environment:
+1. Clone the project to your local environment:
 
 ```shell
-git clone git@github.com:{yourGitHubUsername}/catalyst.git && cd catalyst
+git clone git@github.com:bigcommerce/catalyst.git && cd catalyst
 ```
 
 2. To help stay up to date with the latest changes, add the BigCommerce repo to your project as the upstream repository:


### PR DESCRIPTION
## What/Why?
Removes the verbiage around forking in the README in favor of just cloning directly. This is in recent light of our push to disable and remove existing forks for `internal` + `private` GitHub repositories.

## Testing
N/A