### PR TITLE
CATALYST-0000 Add html product descriptions

### DIFF
--- a/apps/core/app/(default)/compare/page.tsx
+++ b/apps/core/app/(default)/compare/page.tsx
@@ -194,11 +194,10 @@ export default async function Compare({
               {products.map((product) => (
                 <td
                   className="border-b px-4 pb-12 pt-20"
+                  dangerouslySetInnerHTML={{ __html: product.description }}
                   headers="product-description"
                   key={product.entityId}
-                >
-                  {product.plainTextDescription}
-                </td>
+                />
               ))}
             </tr>
             <tr className="absolute mt-8">

--- a/apps/core/app/(default)/product/[slug]/page.tsx
+++ b/apps/core/app/(default)/product/[slug]/page.tsx
@@ -117,10 +117,10 @@ const ProductDetails = ({ product }: { product: NonNullable<Product> }) => {
 const ProductDescriptionAndReviews = ({ product }: { product: NonNullable<Product> }) => {
   return (
     <div className="lg:col-span-2">
-      {Boolean(product.plainTextDescription) && (
+      {Boolean(product.description) && (
         <>
           <h2 className="mb-4 text-h5">Description</h2>
-          <p>{product.plainTextDescription}</p>
+          <div dangerouslySetInnerHTML={{ __html: product.description }} />
         </>
       )}
 

--- a/packages/client/src/queries/getProduct.ts
+++ b/packages/client/src/queries/getProduct.ts
@@ -123,6 +123,7 @@ async function internalGetProduct<T>(
         sku: true,
         warranty: true,
         name: true,
+        description: true,
         plainTextDescription: {
           __args: { characterLimit: 2_000 },
         },

--- a/packages/client/src/queries/getProducts.ts
+++ b/packages/client/src/queries/getProducts.ts
@@ -52,7 +52,7 @@ export const getProducts = async <T>(
             },
             name: true,
             path: true,
-            plainTextDescription: true,
+            description: true,
             reviewSummary: {
               summationOfRatings: true,
             },


### PR DESCRIPTION
## What/Why?
Change the PDP and compare page to use html product descriptions rather than plain text. I think we'll need this, but notably this PR is not using a sanitizer. I attempted to use https://github.com/kkomelin/isomorphic-dompurify, but ran into issues with it supporting the edge runtime. I suspect this is gonna be a challenging problem and am mostly opening this as a place to discuss.

## Testing
Tested in dev environment against trail575.com, which has html product descriptions (such as the awesome haikus I wrote)