### PR TITLE
feat(core): CATALYST-128 add quick search with popup to the header

### DIFF
--- a/apps/core/components/Header/index.tsx
+++ b/apps/core/components/Header/index.tsx
@@ -10,7 +10,7 @@ import {
   NavigationMenuToggle,
   NavigationMenuTrigger,
 } from '@bigcommerce/reactant/NavigationMenu';
-import { ChevronDown, Search, ShoppingCart, User } from 'lucide-react';
+import { ChevronDown, ShoppingCart, User } from 'lucide-react';
 import { cookies } from 'next/headers';
 import Link from 'next/link';
 import { PropsWithChildren, Suspense } from 'react';
@@ -163,11 +163,14 @@ export const Header = () => {
         <div className="flex">
           <NavigationMenuList>
             <NavigationMenuItem>
-              <NavigationMenuLink asChild>
-                <Link aria-label="Search" href="/search">
-                  <Search />
+              <QuickSearch>
+                <Link
+                  className="focus:ring-primary-blue/20 flex focus:outline-none focus:ring-4"
+                  href="/"
+                >
+                  <StoreLogo />
                 </Link>
-              </NavigationMenuLink>
+              </QuickSearch>
             </NavigationMenuItem>
             <NavigationMenuItem className="hidden lg:flex">
               <NavigationMenuLink asChild>
@@ -192,7 +195,6 @@ export const Header = () => {
           <NavigationMenuToggle className="ms-2 lg:hidden" />
         </div>
         <NavigationMenuCollapsed>
-          <QuickSearch className="px-3" />
           <HeaderNav inCollapsedNav />
         </NavigationMenuCollapsed>
       </NavigationMenu>

--- a/apps/core/components/QuickSearch/index.tsx
+++ b/apps/core/components/QuickSearch/index.tsx
@@ -1,19 +1,25 @@
 'use client';
 
 import { Button } from '@bigcommerce/reactant/Button';
-import { cs } from '@bigcommerce/reactant/cs';
 import { Field, FieldControl, Form } from '@bigcommerce/reactant/Form';
 import { Input, InputIcon } from '@bigcommerce/reactant/Input';
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetOverlay,
+  SheetTrigger,
+} from '@bigcommerce/reactant/Sheet';
 import { Search, X } from 'lucide-react';
-import { useRef, useState } from 'react';
+import { PropsWithChildren, useRef, useState } from 'react';
 
-interface Props {
-  className?: string;
+interface SearchProps extends PropsWithChildren {
   initialTerm?: string;
 }
 
-export const QuickSearch = ({ className, initialTerm = '' }: Props) => {
+export const QuickSearch = ({ children, initialTerm = '' }: SearchProps) => {
   const [term, setTerm] = useState(initialTerm);
+  const [open, setOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleTermChange = (e: React.FormEvent<HTMLInputElement>) => setTerm(e.currentTarget.value);
@@ -23,33 +29,63 @@ export const QuickSearch = ({ className, initialTerm = '' }: Props) => {
   };
 
   return (
-    <Form action="/search" className={cs('flex', className)} method="get">
-      <Field className="w-full" name="search">
-        <FieldControl asChild>
-          <Input
-            className="grey-200 peer appearance-none border-2 px-12 py-3 font-semibold"
-            name="term"
-            onChange={handleTermChange}
-            placeholder="Search..."
-            ref={inputRef}
-            value={term}
-          >
-            <InputIcon className="start-3 peer-hover:text-blue-primary peer-focus:text-blue-primary">
-              <Search />
-            </InputIcon>
-            {term.length > 0 ? (
+    <Sheet onOpenChange={setOpen} open={open}>
+      <SheetTrigger asChild>
+        <Button
+          aria-label="Open search popup"
+          className="border-0 bg-transparent p-3 text-black hover:bg-transparent hover:text-blue-primary focus:text-blue-primary"
+        >
+          <Search />
+        </Button>
+      </SheetTrigger>
+      <SheetOverlay className="bg-transparent backdrop-blur-none">
+        <SheetContent className="px-6 pb-8 pt-4 md:px-10 md:pt-4 lg:px-12" side="top">
+          <div className="grid grid-cols-5 items-center">
+            <div className="me-2 hidden lg:block lg:justify-self-start">{children}</div>
+            <Form
+              action="/search"
+              className="col-span-4 flex lg:col-span-3"
+              method="get"
+              role="search"
+            >
+              <Field className="w-full" name="search">
+                <FieldControl asChild>
+                  <Input
+                    className="peer appearance-none border-2 px-12 py-3"
+                    onChange={handleTermChange}
+                    placeholder="Search..."
+                    ref={inputRef}
+                    value={term}
+                  >
+                    <InputIcon className="start-3 peer-hover:text-blue-primary peer-focus:text-blue-primary">
+                      <Search />
+                    </InputIcon>
+                    {term.length > 0 ? (
+                      <Button
+                        aria-label="Clear search"
+                        className="absolute end-1.5 top-1/2 w-auto -translate-y-1/2 border-0 bg-transparent p-1.5 text-black hover:bg-transparent hover:text-blue-primary focus:text-blue-primary peer-hover:text-blue-primary peer-focus:text-blue-primary"
+                        onClick={handleTermClear}
+                        type="button"
+                      >
+                        <X />
+                      </Button>
+                    ) : null}
+                  </Input>
+                </FieldControl>
+              </Field>
+            </Form>
+            <SheetClose asChild>
               <Button
-                aria-label="Clear search"
-                className="absolute end-1.5 top-1/2 w-auto -translate-y-1/2 border-0 bg-transparent p-1.5 text-black hover:bg-transparent focus:text-blue-primary peer-hover:text-blue-primary peer-focus:text-blue-primary"
-                onClick={handleTermClear}
-                type="button"
+                aria-label="Close search popup"
+                className="w-auto justify-self-end border-0 bg-transparent p-2.5 text-black hover:bg-transparent hover:text-blue-primary focus:text-blue-primary peer-hover:text-blue-primary peer-focus:text-blue-primary"
               >
+                <small className="me-2 hidden text-base md:inline-flex">Close</small>
                 <X />
               </Button>
-            ) : null}
-          </Input>
-        </FieldControl>
-      </Field>
-    </Form>
+            </SheetClose>
+          </div>
+        </SheetContent>
+      </SheetOverlay>
+    </Sheet>
   );
 };


### PR DESCRIPTION
## What/Why?
Add quick search to the header on both mobile and desktop with updated designs.

## Testing
https://github.com/bigcommerce/catalyst/assets/66325265/1111e969-0b21-40db-a434-60c94854c8b5

