### PR TITLE
feat(core): CATALYST-79 replace url when selecting variants

### DIFF
--- a/apps/core/components/VariantSelector/index.tsx
+++ b/apps/core/components/VariantSelector/index.tsx
@@ -26,7 +26,7 @@ export const VariantSelector = ({ product }: { product: NonNullable<Product> }) 
 
     optionSearchParams.set(String(optionId), String(valueId));
 
-    router.push(`${pathname}?${optionSearchParams.toString()}`, { scroll: false });
+    router.replace(`${pathname}?${optionSearchParams.toString()}`, { scroll: false });
   };
 
   return product.productOptions?.map((option) => {


### PR DESCRIPTION
## What/Why?
Replace instead of push to allow back navigation to previous page instead of cycling between variant options.

## Testing
Locally