### PR TITLE
fix(reactant): CATALYST-151 fix for PDP fail without product image

### DIFF
--- a/apps/core/app/(default)/product/[slug]/Gallery.tsx
+++ b/apps/core/app/(default)/product/[slug]/Gallery.tsx
@@ -26,16 +26,22 @@ export const Gallery = ({ images }: Props) => {
         <ReactantGallery defaultImageIndex={defaultImageIndex} images={images}>
           <GalleryContent>
             <GalleryImage>
-              {({ selectedImage }) => (
-                <Image
-                  alt={selectedImage.altText}
-                  className="h-full w-full object-contain"
-                  fill
-                  priority={true}
-                  sizes="(min-width: 1024px) 50vw, 100vw"
-                  src={selectedImage.url}
-                />
-              )}
+              {({ selectedImage }) =>
+                selectedImage ? (
+                  <Image
+                    alt={selectedImage.altText}
+                    className="h-full w-full object-contain"
+                    fill
+                    priority={true}
+                    sizes="(min-width: 1024px) 50vw, 100vw"
+                    src={selectedImage.url}
+                  />
+                ) : (
+                  <div className="flex aspect-square items-center justify-center bg-gray-200">
+                    <div className="text-base font-semibold text-gray-500">Coming soon</div>
+                  </div>
+                )
+              }
             </GalleryImage>
             <GalleryControls />
           </GalleryContent>

--- a/apps/docs/stories/Gallery.stories.tsx
+++ b/apps/docs/stories/Gallery.stories.tsx
@@ -57,7 +57,9 @@ export const CustomImageElement: Story = {
     <Gallery defaultImageIndex={0} images={images}>
       <GalleryContent>
         <GalleryImage>
-          {({ selectedImage }) => <img alt={selectedImage.altText} src={selectedImage.url} />}
+          {({ selectedImage }) =>
+            selectedImage && <img alt={selectedImage.altText} src={selectedImage.url} />
+          }
         </GalleryImage>
         <GalleryControls />
       </GalleryContent>

--- a/packages/reactant/src/components/Gallery/Gallery.tsx
+++ b/packages/reactant/src/components/Gallery/Gallery.tsx
@@ -19,7 +19,7 @@ interface Image {
 }
 
 const GalleryContext = createContext<{
-  images: Image[];
+  images: Image[] | [];
   selectedImageIndex: number;
   setSelectedImageIndex: React.Dispatch<React.SetStateAction<number>>;
 }>({
@@ -115,27 +115,30 @@ export const GalleryControls = forwardRef<ElementRef<'div'>, ComponentPropsWithR
 );
 
 interface GalleryImageProps extends Omit<ComponentPropsWithRef<'img'>, 'children'> {
-  children?: (({ selectedImage }: { selectedImage: Image }) => React.ReactNode) | React.ReactNode;
+  children?: (({ selectedImage }: { selectedImage?: Image }) => React.ReactNode) | React.ReactNode;
 }
 
 export const GalleryImage = forwardRef<ElementRef<'img'>, GalleryImageProps>(
   ({ className, children, ...props }, ref) => {
     const { images, selectedImageIndex } = useContext(GalleryContext);
+    const selectedImage = images.length > 0 ? images[selectedImageIndex] : undefined;
 
     if (typeof children === 'function') {
-      return children({ selectedImage: images[selectedImageIndex] });
+      return children({ selectedImage });
     }
 
-    return (
-      <img
-        alt={images[selectedImageIndex].altText}
-        className={cs('h-full w-full object-contain', className)}
-        ref={ref}
-        sizes="100vw"
-        src={images[selectedImageIndex].url}
-        {...props}
-      />
-    );
+    if (selectedImage) {
+      return (
+        <img
+          alt={selectedImage.altText}
+          className={cs('h-full w-full object-contain', className)}
+          ref={ref}
+          sizes="100vw"
+          src={images[selectedImageIndex].url}
+          {...props}
+        />
+      );
+    }
   },
 );
 
@@ -249,7 +252,7 @@ export const GalleryThumbnail = forwardRef<ElementRef<'img'>, GalleryThumbnailPr
 );
 
 interface GalleryProps extends ComponentPropsWithRef<'div'> {
-  images: Image[];
+  images: Image[] | [];
   defaultImageIndex?: number;
 }
 


### PR DESCRIPTION
## What/Why?

This PR fixes error on loading PDP when product image is not available. 
For this purpose Reactant Gallery components were slightly changed and added `<ImagePlaceholder />` and Reactant's `Gallery` can receive prop `substitutionalText` that will be shown alongside Image Placeholder. So now in case of image gallery absence User will see its replacement with some explanation text.

## Testing
(Locally)
Before:

https://github.com/bigcommerce/catalyst/assets/67792608/e51c163b-fec2-47a9-9c88-5bcb28ffa379

After:

https://github.com/bigcommerce/catalyst/assets/67792608/dc5f6a46-e8ba-45fb-9400-84464822cfca


