### PR TITLE
feat(core): CATALYST-159 show retail, base, sale price comparison in PCs

### DIFF
--- a/apps/core/components/ProductCard/index.tsx
+++ b/apps/core/components/ProductCard/index.tsx
@@ -31,6 +31,18 @@ export interface Product {
       value?: number;
       currencyCode?: string;
     };
+    basePrice?: {
+      value?: number;
+      currencyCode?: string;
+    } | null;
+    retailPrice?: {
+      value?: number;
+      currencyCode?: string;
+    } | null;
+    salePrice?: {
+      value?: number;
+      currencyCode?: string;
+    } | null;
   } | null;
   reviewSummary?: {
     numberOfReviews: number;
@@ -126,12 +138,36 @@ export const ProductCard = ({
             </div>
           </div>
         )}
-        <div className="flex flex-wrap items-center justify-between pt-2">
-          {product.prices?.price?.value !== undefined && (
-            <ProductCardInfoPrice className="w-[144px] shrink-0 pt-0">
-              {currencyFormatter.format(product.prices.price.value)}
-            </ProductCardInfoPrice>
-          )}
+        <div className="flex flex-wrap items-end justify-between pt-2">
+          <div>
+            {product.prices?.retailPrice?.value !== undefined && (
+              <ProductCardInfoPrice className="w-[144px] shrink-0 pt-0">
+                MSRP:{' '}
+                <span className="line-through">
+                  {currencyFormatter.format(product.prices.retailPrice.value)}
+                </span>
+              </ProductCardInfoPrice>
+            )}
+            {product.prices?.basePrice?.value !== undefined && (
+              <ProductCardInfoPrice className="w-[144px] shrink-0 pt-0">
+                {product.prices.salePrice?.value ? (
+                  <>
+                    Was:{' '}
+                    <span className="line-through">
+                      {currencyFormatter.format(product.prices.basePrice.value)}
+                    </span>
+                  </>
+                ) : (
+                  currencyFormatter.format(product.prices.basePrice.value)
+                )}
+              </ProductCardInfoPrice>
+            )}
+            {product.prices?.salePrice?.value !== undefined && (
+              <ProductCardInfoPrice className="w-[144px] shrink-0 pt-0">
+                Now: {currencyFormatter.format(product.prices.salePrice.value)}
+              </ProductCardInfoPrice>
+            )}
+          </div>
           <Compare productId={product.entityId} />
         </div>
       </ProductCardInfo>

--- a/packages/client/src/queries/getBestSellingProducts.ts
+++ b/packages/client/src/queries/getBestSellingProducts.ts
@@ -24,8 +24,21 @@ export const getBestSellingProducts = async <T>(
             name: true,
             entityId: true,
             prices: {
+              basePrice: {
+                currencyCode: true,
+                value: true,
+              },
               price: {
-                __scalar: true,
+                currencyCode: true,
+                value: true,
+              },
+              retailPrice: {
+                currencyCode: true,
+                value: true,
+              },
+              salePrice: {
+                currencyCode: true,
+                value: true,
               },
             },
             brand: {

--- a/packages/client/src/queries/getFeaturedProducts.ts
+++ b/packages/client/src/queries/getFeaturedProducts.ts
@@ -25,8 +25,21 @@ export const getFeaturedProducts = async <T>(
             entityId: true,
             path: true,
             prices: {
+              basePrice: {
+                currencyCode: true,
+                value: true,
+              },
               price: {
-                __scalar: true,
+                currencyCode: true,
+                value: true,
+              },
+              retailPrice: {
+                currencyCode: true,
+                value: true,
+              },
+              salePrice: {
+                currencyCode: true,
+                value: true,
               },
             },
             brand: {

--- a/packages/client/src/queries/getProduct.ts
+++ b/packages/client/src/queries/getProduct.ts
@@ -149,9 +149,21 @@ async function internalGetProduct<T>(
           },
         },
         prices: {
-          price: {
-            value: true,
+          basePrice: {
             currencyCode: true,
+            value: true,
+          },
+          price: {
+            currencyCode: true,
+            value: true,
+          },
+          retailPrice: {
+            currencyCode: true,
+            value: true,
+          },
+          salePrice: {
+            currencyCode: true,
+            value: true,
           },
           priceRange: {
             min: {

--- a/packages/client/src/queries/getProductSearchResults.ts
+++ b/packages/client/src/queries/getProductSearchResults.ts
@@ -53,9 +53,21 @@ export const getProductSearchResults = async <T>(
                   name: true,
                 },
                 prices: {
-                  price: {
-                    value: true,
+                  basePrice: {
                     currencyCode: true,
+                    value: true,
+                  },
+                  price: {
+                    currencyCode: true,
+                    value: true,
+                  },
+                  retailPrice: {
+                    currencyCode: true,
+                    value: true,
+                  },
+                  salePrice: {
+                    currencyCode: true,
+                    value: true,
                   },
                 },
                 defaultImage: {


### PR DESCRIPTION
## What/Why?
Show the price comparisons in Product Cards.

- If retail price is available, it will show MSRP
- If sale price is available, it will show was/now prices.

Pending:
- Handling mapPrice
- Handling these prices in PDP.
- Prices ranges.

An example with retail price and sale price:

![Screenshot 2023-10-25 at 2 43 44 PM](https://github.com/bigcommerce/catalyst/assets/196129/c2760901-5486-43af-9e3c-a67e27f3c2cb)

## Testing
Locally