### PR TITLE
feat(core): CATALYST-137 show default image for variants

### DIFF
--- a/apps/core/app/(default)/product/[slug]/page.tsx
+++ b/apps/core/app/(default)/product/[slug]/page.tsx
@@ -244,11 +244,30 @@ export default async function Product({ params, searchParams }: ProductPageProps
     return notFound();
   }
 
+  // make a copy of product.images
+  const images = product.images;
+
+  // pick the top-level default image out of the `Image` response
+  const topLevelDefaultImg = product.images.find((image) => image.isDefault);
+
+  // if product.defaultImage exists, and product.defaultImage.url is not equal to the url of the isDefault image in the Image response, mark the existing isDefault image to "isDefault = false" and append the correct default image to images
+  if (product.defaultImage && topLevelDefaultImg?.url !== product.defaultImage.url) {
+    images.forEach((image) => {
+      image.isDefault = false;
+    });
+
+    images.push({
+      url: product.defaultImage.url,
+      altText: product.defaultImage.altText,
+      isDefault: true,
+    });
+  }
+
   return (
     <>
       <BreadCrumbs productId={productId} />
       <div className="mb-12 mt-4 lg:grid lg:grid-cols-2 lg:gap-8">
-        <Gallery images={product.images} />
+        <Gallery images={images} />
         <ProductDetails product={product} />
         <ProductDescriptionAndReviews product={product} />
       </div>

--- a/packages/reactant/src/components/Gallery/Gallery.tsx
+++ b/packages/reactant/src/components/Gallery/Gallery.tsx
@@ -274,6 +274,10 @@ const Gallery = forwardRef<ElementRef<'div'>, GalleryProps>(
   ({ className, children, images, defaultImageIndex = 0, ...props }, ref) => {
     const [selectedImageIndex, setSelectedImageIndex] = useState(defaultImageIndex);
 
+    useEffect(() => {
+      setSelectedImageIndex(defaultImageIndex);
+    }, [defaultImageIndex]);
+
     return (
       <GalleryContext.Provider value={{ images, selectedImageIndex, setSelectedImageIndex }}>
         <div aria-live="polite" className={cs(className)} ref={ref} {...props}>


### PR DESCRIPTION
## What/Why?
Show default image for variant when its options applied

## Testing

https://github.com/bigcommerce/catalyst/assets/66325265/00407567-1cdb-47e2-bd27-14a1a90c28c9

