### PR TITLE
chore(core): prefix attribute facets

### DIFF
--- a/apps/core/app/(default)/(faceted)/_components/facets.tsx
+++ b/apps/core/app/(default)/(faceted)/_components/facets.tsx
@@ -187,7 +187,7 @@ export const Facets = ({ facets, pageType }: Props) => {
                           aria-labelledby={labelId}
                           defaultChecked={attribute.isSelected}
                           id={id}
-                          name={facet.filterName}
+                          name={`attr_${facet.filterName}`}
                           onCheckedChange={submitForm}
                           value={attribute.value}
                         />

--- a/apps/core/app/(default)/(faceted)/_components/refine-by.tsx
+++ b/apps/core/app/(default)/(faceted)/_components/refine-by.tsx
@@ -60,7 +60,7 @@ const mapFacetsToRefinements = ({ facets, pageType }: Props) =>
             .filter(({ isSelected }) => isSelected)
             .map<FacetProps<string>>(({ value }) => {
               return {
-                key: facet.filterName,
+                key: `attr_${facet.filterName}`,
                 display_name: value,
                 value,
               };


### PR DESCRIPTION
## What/Why?
Appends the `attr_` prefix for product attributes in order to enable additional query params to be used within the page. Without this, any additional params are treated like product attribute filters, which prevents us from being able to pass in things like `utm_campaign` or quick view filtering.

## Testing

https://github.com/bigcommerce/catalyst/assets/10539418/39162010-d259-4758-bbbc-f1c1e404a554


