### PR TITLE
feat(core): CATALYST-179 simplify products in home page

### DIFF
--- a/apps/core/app/(default)/page.tsx
+++ b/apps/core/app/(default)/page.tsx
@@ -1,21 +1,6 @@
-import { cs } from '@bigcommerce/reactant/cs';
-import { ReactNode } from 'react';
-
 import client from '~/client';
 import { Hero } from '~/components/Hero';
-import { ProductCard } from '~/components/ProductCard';
-
-const ProductList = ({ children }: { children: ReactNode }) => (
-  <section className={cs('mb-10')}>{children}</section>
-);
-
-const ProductListName = ({ children }: { children: ReactNode }) => (
-  <h2 className={cs('mb-10 text-center text-h3 sm:text-left')}>{children}</h2>
-);
-
-const ProductListGrid = ({ children }: { children: ReactNode }) => (
-  <div className={cs('grid grid-cols-2 gap-x-6 gap-y-8 md:grid-cols-4')}>{children}</div>
-);
+import { ProductCardCarousel } from '~/components/ProductCardCarousel';
 
 export default async function Home() {
   const [bestSellingProducts, featuredProducts] = await Promise.all([
@@ -27,23 +12,18 @@ export default async function Home() {
     <>
       <Hero />
       <div className="my-10">
-        <ProductList>
-          <ProductListName>Best Selling Products</ProductListName>
-          <ProductListGrid>
-            {bestSellingProducts.map((product) => (
-              <ProductCard imageSize="tall" key={product.entityId} product={product} />
-            ))}
-          </ProductListGrid>
-        </ProductList>
-
-        <ProductList>
-          <ProductListName>Featured Products</ProductListName>
-          <ProductListGrid>
-            {featuredProducts.map((product) => (
-              <ProductCard imageSize="tall" key={product.entityId} product={product} />
-            ))}
-          </ProductListGrid>
-        </ProductList>
+        <ProductCardCarousel
+          products={bestSellingProducts}
+          showCart={false}
+          showCompare={false}
+          title="Best Selling Products"
+        />
+        <ProductCardCarousel
+          products={featuredProducts}
+          showCart={false}
+          showCompare={false}
+          title="Featured Products"
+        />
       </div>
     </>
   );

--- a/apps/core/components/ProductCard/index.tsx
+++ b/apps/core/components/ProductCard/index.tsx
@@ -67,12 +67,17 @@ interface ProductCardProps {
   product: Partial<Product>;
   imageSize?: 'tall' | 'wide' | 'square';
   imagePriority?: boolean;
+  showCart?: boolean;
+  showCompare?: boolean;
 }
 
+// eslint-disable-next-line complexity
 export const ProductCard = ({
   product,
   imageSize = 'square',
   imagePriority = false,
+  showCart = true,
+  showCompare = true,
 }: ProductCardProps) => {
   const currencyFormatter = new Intl.NumberFormat('en-US', {
     style: 'currency',
@@ -111,7 +116,7 @@ export const ProductCard = ({
           )}
         </div>
       </ProductCardImage>
-      <ProductCardInfo className="justify-end">
+      <ProductCardInfo className={cs(showCart && 'justify-end')}>
         {product.brand && <ProductCardInfoBrandName>{product.brand.name}</ProductCardInfoBrandName>}
         <ProductCardInfoProductName>
           {product.path ? (
@@ -192,10 +197,10 @@ export const ProductCard = ({
               )}
             </div>
           )}
-          <Compare productId={product.entityId} />
+          {showCompare && <Compare productId={product.entityId} />}
         </div>
       </ProductCardInfo>
-      <Cart product={product} />
+      {showCart && <Cart product={product} />}
     </ReactantProductCard>
   );
 };

--- a/apps/core/components/ProductCardCarousel/index.tsx
+++ b/apps/core/components/ProductCardCarousel/index.tsx
@@ -14,9 +14,13 @@ import { Pagination } from './Pagination';
 export const ProductCardCarousel = ({
   title,
   products,
+  showCart = true,
+  showCompare = true,
 }: {
   title: string;
   products: Array<Partial<Product>>;
+  showCart?: boolean;
+  showCompare?: boolean;
 }) => {
   const id = useId();
 
@@ -58,7 +62,13 @@ export const ProductCardCarousel = ({
             key={index}
           >
             {group.map((product) => (
-              <ProductCard imageSize="tall" key={product.entityId} product={product} />
+              <ProductCard
+                imageSize="tall"
+                key={product.entityId}
+                product={product}
+                showCart={showCart}
+                showCompare={showCompare}
+              />
             ))}
           </CarouselSlide>
         ))}

--- a/packages/client/src/queries/getBestSellingProducts.ts
+++ b/packages/client/src/queries/getBestSellingProducts.ts
@@ -64,11 +64,6 @@ export const getBestSellingProducts = async <T>(
                 },
               },
             },
-            reviewSummary: {
-              summationOfRatings: true,
-              numberOfReviews: true,
-              averageRating: true,
-            },
             productOptions: {
               __args: { first: 3 },
               edges: {

--- a/packages/client/src/queries/getFeaturedProducts.ts
+++ b/packages/client/src/queries/getFeaturedProducts.ts
@@ -64,11 +64,6 @@ export const getFeaturedProducts = async <T>(
                 },
               },
             },
-            reviewSummary: {
-              summationOfRatings: true,
-              numberOfReviews: true,
-              averageRating: true,
-            },
             productOptions: {
               __args: { first: 3 },
               edges: {


### PR DESCRIPTION
## What/Why?
Simplify product card and use carousels for products in home page.

## How
Added a `showCart/showCompare` prop in Product Card/Carousel that will hide reviews/cart buttons/compare/favorites (when available).

![screencapture-localhost-3000-2023-11-07-12_07_45](https://github.com/bigcommerce/catalyst/assets/196129/02daa6c8-23cb-437a-986f-30d6403cc950)

## Testing
Locally.