### PR TITLE
fix(reactant): CATALYST-00 prevent slideshow autoplay if tab inactive

### DIFF
--- a/packages/reactant/src/components/Slideshow/Slideshow.tsx
+++ b/packages/reactant/src/components/Slideshow/Slideshow.tsx
@@ -41,17 +41,30 @@ const Slideshow = forwardRef<ElementRef<'section'>, SlideshowProps>(
 
     const [activeSlide, setActiveSlide] = useState(0);
 
+    const [visibilityState, setVisibilityState] = useState<
+      DocumentVisibilityState | Omit<string, 'hidden' | 'visible'>
+    >('');
+
     useEffect(() => {
       const autoplay = setInterval(() => {
         if (isPaused) return;
         if (isHoverPaused) return;
         if (!emblaApi) return;
+        if (visibilityState === 'hidden') return;
 
         emblaApi.scrollNext();
       }, interval);
 
       return () => clearInterval(autoplay);
-    }, [emblaApi, isHoverPaused, interval, isPaused]);
+    }, [emblaApi, isHoverPaused, interval, isPaused, visibilityState]);
+
+    useEffect(() => {
+      window.addEventListener('visibilitychange', () => {
+        setVisibilityState(document.visibilityState);
+      });
+
+      return () => window.removeEventListener('visibilitychange', () => null);
+    }, [visibilityState]);
 
     return (
       <SlideshowContext.Provider value={[emblaRef, emblaApi]}>


### PR DESCRIPTION
## What/Why?
Slideshow autoplay is controlled by a `setInterval` in the Slideshow component. Previously, the interval would continue to call `emblaApi.scrollNext();` even if the browser was not focused on the Catalyst storefront tab. 

~~Now the interval checks to see if the tab is active using the `document.visibilityState` API before calling `emblaApi.scrollNext();`~~

**Updated:** Added an event listener to react to visibilitychange events. Now, switching tabs back to the Catalyst storefront causes a re-render (since visibilitystate is tracked in useState), and the autoplay interval is reset each time the tab is navigated "back" to.

**Problem:** Are we ok causing a re-render each time the tab is navigated to/away from?

## Testing
_Note: In both screen recordings below, the Catalyst tab was left inactive for about 2 minutes before recording._

**Before:**

https://github.com/bigcommerce/catalyst/assets/28374851/04f54d1e-64d6-4865-8cf5-712458eff6e4

**After:**
(Switching back to Catalyst tab does not immediately scroll the Slideshow to the next tab, as well as no errors shown in console. Server logs also show no errors, though not captured in screen recording)

https://github.com/bigcommerce/catalyst/assets/28374851/81d8618f-fcea-45d3-a210-edb77c0fb7fb


