### PR TITLE
fix(core): CATALYST-0 set Compare label to font-normal

### DIFF
--- a/apps/core/components/ProductCard/Compare.tsx
+++ b/apps/core/components/ProductCard/Compare.tsx
@@ -30,7 +30,9 @@ export const Compare = ({ productId }: { productId: number }) => {
         id={checkboxId}
         onCheckedChange={handleOnCheckedChange}
       />
-      <Label htmlFor={checkboxId}>Compare</Label>
+      <Label className="font-normal" htmlFor={checkboxId}>
+        Compare
+      </Label>
     </div>
   );
 };

--- a/apps/core/components/VariantSelector/index.tsx
+++ b/apps/core/components/VariantSelector/index.tsx
@@ -36,7 +36,7 @@ export const VariantSelector = ({ product }: { product: NonNullable<Product> }) 
         case 'Swatch':
           return (
             <Fragment key={option.entityId}>
-              <Label className="my-2 inline-block font-semibold" id={`label-${option.entityId}`}>
+              <Label className="my-2 inline-block" id={`label-${option.entityId}`}>
                 {option.displayName}
               </Label>
               <Swatch
@@ -72,7 +72,7 @@ export const VariantSelector = ({ product }: { product: NonNullable<Product> }) 
         case 'RectangleBoxes':
           return (
             <Fragment key={option.entityId}>
-              <Label className="my-2 inline-block font-semibold" id={`label-${option.entityId}`}>
+              <Label className="my-2 inline-block" id={`label-${option.entityId}`}>
                 {option.displayName}
               </Label>
               <RectangleList
@@ -127,7 +127,7 @@ export const VariantSelector = ({ product }: { product: NonNullable<Product> }) 
               required={option.isRequired}
               value={option.checkedOptionValueEntityId}
             />
-            <Label className="mx-3" htmlFor={`${option.entityId}`}>
+            <Label className="mx-3 font-normal" htmlFor={`${option.entityId}`}>
               {option.label}
             </Label>
           </div>


### PR DESCRIPTION
## What/Why?
PR #327 changed the default font weight of labels (which make sense). In this case, we want the weight to remain normal sized.

![Screenshot 2023-11-10 at 11 40 45 AM](https://github.com/bigcommerce/catalyst/assets/196129/626c5574-4b23-492e-9440-b0c95efb4d29)


## Testing
Locally