### PR TITLE
feat(core): CATALYST-98 add NumberFieldOption to PDP

### DIFF
--- a/apps/core/app/(default)/cart/page.tsx
+++ b/apps/core/app/(default)/cart/page.tsx
@@ -100,6 +100,14 @@ export default async function CartPage() {
                                 <span className="font-semibold">{selectedOption.value}</span>
                               </div>
                             );
+
+                          case 'CartSelectedNumberFieldOption':
+                            return (
+                              <div key={selectedOption.entityId}>
+                                <span>{selectedOption.name}:</span>{' '}
+                                <span className="font-semibold">{selectedOption.number}</span>
+                              </div>
+                            );
                         }
 
                         return null;

--- a/apps/core/app/(default)/product/[slug]/_actions/addToCart.ts
+++ b/apps/core/app/(default)/product/[slug]/_actions/addToCart.ts
@@ -17,21 +17,28 @@ export async function handleAddToCart(data: FormData) {
   const selectedOptions =
     product?.productOptions?.reduce<CartSelectedOptionsInput>((accum, option) => {
       const optionValueEntityId = Number(data.get(`attribute[${option.entityId}]`));
-      let optionInput = {
-        optionEntityId: option.entityId,
-        optionValueEntityId,
-      };
+      let multipleChoicesOptionInput;
+      let checkboxOptionInput;
+      let numberFieldOptionInput;
 
       switch (option.__typename) {
         case 'MultipleChoiceOption':
+          multipleChoicesOptionInput = {
+            optionEntityId: option.entityId,
+            optionValueEntityId,
+          };
+
           if (accum.multipleChoices) {
-            return { ...accum, multipleChoices: [...accum.multipleChoices, optionInput] };
+            return {
+              ...accum,
+              multipleChoices: [...accum.multipleChoices, multipleChoicesOptionInput],
+            };
           }
 
-          return { ...accum, multipleChoices: [optionInput] };
+          return { ...accum, multipleChoices: [multipleChoicesOptionInput] };
 
         case 'CheckboxOption':
-          optionInput = {
+          checkboxOptionInput = {
             optionEntityId: option.entityId,
             optionValueEntityId:
               optionValueEntityId !== 0
@@ -40,10 +47,22 @@ export async function handleAddToCart(data: FormData) {
           };
 
           if (accum.checkboxes) {
-            return { ...accum, checkboxes: [...accum.checkboxes, optionInput] };
+            return { ...accum, checkboxes: [...accum.checkboxes, checkboxOptionInput] };
           }
 
-          return { ...accum, checkboxes: [optionInput] };
+          return { ...accum, checkboxes: [checkboxOptionInput] };
+
+        case 'NumberFieldOption':
+          numberFieldOptionInput = {
+            optionEntityId: option.entityId,
+            number: optionValueEntityId,
+          };
+
+          if (accum.numberFields) {
+            return { ...accum, numberFields: [...accum.numberFields, numberFieldOptionInput] };
+          }
+
+          return { ...accum, numberFields: [numberFieldOptionInput] };
       }
 
       return accum;

--- a/apps/core/app/(default)/product/[slug]/page.tsx
+++ b/apps/core/app/(default)/product/[slug]/page.tsx
@@ -91,7 +91,7 @@ const ProductDetails = ({ product }: { product: NonNullable<Product> }) => {
           <Label className="my-2 inline-block font-semibold" htmlFor="quantity">
             Quantity
           </Label>
-          <Counter id="quantity" name="quantity" />
+          <Counter id="quantity" min={1} name="quantity" required />
         </div>
 
         <div className="mt-10 flex flex-col gap-4 sm:flex-row">

--- a/apps/core/components/VariantSelector/index.tsx
+++ b/apps/core/components/VariantSelector/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Checkbox } from '@bigcommerce/reactant/Checkbox';
+import { Counter } from '@bigcommerce/reactant/Counter';
 import { Label } from '@bigcommerce/reactant/Label';
 import { RectangleList, RectangleListItem } from '@bigcommerce/reactant/RectangleList';
 import { Swatch, SwatchItem } from '@bigcommerce/reactant/Swatch';
@@ -132,6 +133,27 @@ export const VariantSelector = ({ product }: { product: NonNullable<Product> }) 
             </Label>
           </div>
         </fieldset>
+      );
+    }
+
+    if (option.__typename === 'NumberFieldOption') {
+      return (
+        <Fragment key={option.entityId}>
+          <Label className="my-2 inline-block" htmlFor={`${option.entityId}`}>
+            {option.displayName}
+          </Label>
+          <div className="sm:w-[120px]">
+            <Counter
+              defaultValue={Number(option.defaultValue) || 0}
+              id={`${option.entityId}`}
+              isInteger={option.isIntegerOnly}
+              max={Number(option.highest)}
+              min={Number(option.lowest)}
+              name={`attribute[${option.entityId}]`}
+              required={option.isRequired}
+            />
+          </div>
+        </Fragment>
       );
     }
 

--- a/packages/client/src/queries/getCart.ts
+++ b/packages/client/src/queries/getCart.ts
@@ -47,6 +47,9 @@ export async function getCart<T>(
               on_CartSelectedCheckboxOption: {
                 value: true,
               },
+              on_CartSelectedNumberFieldOption: {
+                number: true,
+              },
             },
           },
         },

--- a/packages/client/src/queries/getProduct.ts
+++ b/packages/client/src/queries/getProduct.ts
@@ -89,7 +89,7 @@ async function internalGetProduct<T>(
           },
         },
         productOptions: {
-          __args: { first: 3 },
+          __args: { first: 10 },
           edges: {
             node: {
               entityId: true,
@@ -121,6 +121,13 @@ async function internalGetProduct<T>(
                 label: true,
                 checkedOptionValueEntityId: true,
                 uncheckedOptionValueEntityId: true,
+              },
+              on_NumberFieldOption: {
+                defaultValue: true,
+                highest: true,
+                isIntegerOnly: true,
+                limitNumberBy: true,
+                lowest: true,
               },
             },
           },


### PR DESCRIPTION
Builds off #336 

## What/Why?
Show `NumberFieldOption` in PDP.

![Screenshot 2023-11-10 at 3 04 42 PM](https://github.com/bigcommerce/catalyst/assets/196129/c31b96df-172c-4f0b-9c22-48e2179922c9)

![Screenshot 2023-11-10 at 3 04 49 PM](https://github.com/bigcommerce/catalyst/assets/196129/2ddf0f72-99fa-4408-bafd-9e942deed579)

## Testing
Locally.