### PR TITLE
refactor(core): CATALYST-170 add cn helper in core

### DIFF
--- a/apps/core/app/(default)/(faceted)/_components/facets.tsx
+++ b/apps/core/app/(default)/(faceted)/_components/facets.tsx
@@ -9,13 +9,14 @@ import {
 } from '@bigcommerce/reactant/Accordion';
 import { Button } from '@bigcommerce/reactant/Button';
 import { Checkbox } from '@bigcommerce/reactant/Checkbox';
-import { cs } from '@bigcommerce/reactant/cs';
 import { Input } from '@bigcommerce/reactant/Input';
 import { Label } from '@bigcommerce/reactant/Label';
 import { Rating } from '@bigcommerce/reactant/Rating';
 import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { FormEvent, useRef } from 'react';
+
+import { cn } from '~/lib/utils';
 
 import type { Facet, PageType } from '../types';
 
@@ -230,7 +231,7 @@ export const Facets = ({ facets, pageType }: Props) => {
                           key={key}
                         >
                           <div
-                            className={cs('flex flex-row flex-nowrap', {
+                            className={cn('flex flex-row flex-nowrap', {
                               'text-blue-primary': rating.isSelected,
                             })}
                           >

--- a/apps/core/app/(default)/(webpages)/_components/PageContent.tsx
+++ b/apps/core/app/(default)/(webpages)/_components/PageContent.tsx
@@ -1,4 +1,4 @@
-import { cs } from '@bigcommerce/reactant/cs';
+import { cn } from '~/lib/utils';
 
 interface Props {
   className?: string;
@@ -8,7 +8,7 @@ interface Props {
 
 export const PageContent = ({ className, content, title }: Props) => {
   return (
-    <div className={cs('mx-auto mb-10 flex flex-col justify-center gap-8 lg:w-2/3', className)}>
+    <div className={cn('mx-auto mb-10 flex flex-col justify-center gap-8 lg:w-2/3', className)}>
       <h1 className="text-h3 lg:text-h2">{title}</h1>
       <div dangerouslySetInnerHTML={{ __html: content }} />
     </div>

--- a/apps/core/app/(default)/login/LoginForm.tsx
+++ b/apps/core/app/(default)/login/LoginForm.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { Button } from '@bigcommerce/reactant/Button';
-import { cs } from '@bigcommerce/reactant/cs';
 import {
   Field,
   FieldControl,
@@ -16,6 +15,8 @@ import { Loader2 as Spinner } from 'lucide-react';
 import Link from 'next/link';
 import { ChangeEvent, useState } from 'react';
 import { useFormStatus } from 'react-dom';
+
+import { cn } from '~/lib/utils';
 
 import { submitLoginForm } from './_actions/submitLoginForm';
 
@@ -63,7 +64,7 @@ export const LoginForm = () => {
         </Message>
       )}
       <Form action={onSubmit} className="mb-14 flex flex-col gap-3 md:p-8 lg:p-0">
-        <Field className={cs('relative space-y-2 pb-7')} name="email">
+        <Field className={cn('relative space-y-2 pb-7')} name="email">
           <FieldLabel htmlFor="email">Email</FieldLabel>
           <FieldControl asChild>
             <Input
@@ -83,7 +84,7 @@ export const LoginForm = () => {
             Enter your email.
           </FieldMessage>
         </Field>
-        <Field className={cs('relative space-y-2 pb-7')} name="password">
+        <Field className={cn('relative space-y-2 pb-7')} name="password">
           <FieldLabel htmlFor="password">Password</FieldLabel>
           <FieldControl asChild>
             <Input

--- a/apps/core/app/(default)/product/[slug]/Breadcrumbs.tsx
+++ b/apps/core/app/(default)/product/[slug]/Breadcrumbs.tsx
@@ -1,7 +1,7 @@
-import { cs } from '@bigcommerce/reactant/cs';
 import Link from 'next/link';
 
 import client from '~/client';
+import { cn } from '~/lib/utils';
 
 interface Props {
   productId: number;
@@ -23,7 +23,7 @@ export const BreadCrumbs = async ({ productId }: Props) => {
 
           return (
             <li
-              className={cs('p-1 ps-0 hover:text-blue-primary', {
+              className={cn('p-1 ps-0 hover:text-blue-primary', {
                 'font-semibold': !isLast,
                 'font-extrabold': isLast,
               })}

--- a/apps/core/app/not-found.tsx
+++ b/apps/core/app/not-found.tsx
@@ -1,4 +1,3 @@
-import { cs } from '@bigcommerce/reactant/cs';
 import { Message } from '@bigcommerce/reactant/Message';
 
 import { SearchForm } from 'components/SearchForm';
@@ -6,6 +5,7 @@ import client from '~/client';
 import { Footer } from '~/components/Footer/Footer';
 import { Header } from '~/components/Header';
 import { ProductCard } from '~/components/ProductCard';
+import { cn } from '~/lib/utils';
 
 export default async function NotFound() {
   const featuredProducts = await client.getFeaturedProducts();
@@ -21,9 +21,9 @@ export default async function NotFound() {
           </p>
         </Message>
         <SearchForm />
-        <section className={cs('w-full')}>
-          <h3 className={cs('mb-10 text-center text-h3 sm:text-left')}>Featured Products</h3>
-          <div className={cs('grid grid-cols-2 gap-x-8 gap-y-8 md:grid-cols-4')}>
+        <section className={cn('w-full')}>
+          <h3 className={cn('mb-10 text-center text-h3 sm:text-left')}>Featured Products</h3>
+          <div className={cn('grid grid-cols-2 gap-x-8 gap-y-8 md:grid-cols-4')}>
             {featuredProducts.map((product) => (
               <ProductCard key={product.entityId} product={product} />
             ))}

--- a/apps/core/components/Forbidden/index.tsx
+++ b/apps/core/components/Forbidden/index.tsx
@@ -1,17 +1,17 @@
-import { cs } from '@bigcommerce/reactant/cs';
 import { Message } from '@bigcommerce/reactant/Message';
 
 import { SearchForm } from 'components/SearchForm';
 import client from '~/client';
 import { ProductCard } from '~/components/ProductCard';
+import { cn } from '~/lib/utils';
 
 const FeaturedProducts = async () => {
   const featuredProducts = await client.getFeaturedProducts();
 
   return (
-    <section className={cs('w-full')}>
-      <h3 className={cs('mb-10 text-center text-h3 sm:text-left')}>Featured Products</h3>
-      <div className={cs('grid grid-cols-2 gap-x-8 gap-y-8 md:grid-cols-4')}>
+    <section className={cn('w-full')}>
+      <h3 className={cn('mb-10 text-center text-h3 sm:text-left')}>Featured Products</h3>
+      <div className={cn('grid grid-cols-2 gap-x-8 gap-y-8 md:grid-cols-4')}>
         {featuredProducts.map((product) => (
           <ProductCard key={product.entityId} product={product} />
         ))}

--- a/apps/core/components/Forms/ContactUs.tsx
+++ b/apps/core/components/Forms/ContactUs.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@bigcommerce/reactant/Button';
-import { cs } from '@bigcommerce/reactant/cs';
 import {
   Field,
   FieldControl,
@@ -14,6 +13,8 @@ import { TextArea } from '@bigcommerce/reactant/TextArea';
 import { Loader2 as Spinner } from 'lucide-react';
 import { ChangeEvent, useState } from 'react';
 import { useFormStatus } from 'react-dom';
+
+import { cn } from '~/lib/utils';
 
 import { submitContactForm } from './_actions/submitContactForm';
 
@@ -69,7 +70,7 @@ export const ContactUs = ({ fields }: { fields: string[] }) => {
               const label = fieldNameMapping[field];
 
               return (
-                <Field className={cs('relative space-y-2 pb-7')} key={label} name={label}>
+                <Field className={cn('relative space-y-2 pb-7')} key={label} name={label}>
                   <FieldLabel htmlFor={label}>{label}</FieldLabel>
                   <FieldControl asChild>
                     <Input id={label} />
@@ -77,7 +78,7 @@ export const ContactUs = ({ fields }: { fields: string[] }) => {
                 </Field>
               );
             })}
-          <Field className={cs('relative space-y-2 pb-7')} key="email" name="email">
+          <Field className={cn('relative space-y-2 pb-7')} key="email" name="email">
             <FieldLabel htmlFor="email" isRequired>
               Email
             </FieldLabel>
@@ -105,7 +106,7 @@ export const ContactUs = ({ fields }: { fields: string[] }) => {
             </FieldMessage>
           </Field>
           <Field
-            className={cs('relative col-span-full max-w-full space-y-2 pb-5')}
+            className={cn('relative col-span-full max-w-full space-y-2 pb-5')}
             key="comments"
             name="comments"
           >

--- a/apps/core/components/Header/index.tsx
+++ b/apps/core/components/Header/index.tsx
@@ -1,5 +1,4 @@
 import { Badge } from '@bigcommerce/reactant/Badge';
-import { cs } from '@bigcommerce/reactant/cs';
 import {
   NavigationMenu,
   NavigationMenuCollapsed,
@@ -16,6 +15,7 @@ import Link from 'next/link';
 import { PropsWithChildren, Suspense } from 'react';
 
 import client from '~/client';
+import { cn } from '~/lib/utils';
 
 import { QuickSearch } from '../QuickSearch';
 import { StoreLogo } from '../StoreLogo';
@@ -74,14 +74,14 @@ const HeaderNav = async ({
   return (
     <>
       <NavigationMenuList
-        className={cs(
+        className={cn(
           !inCollapsedNav && 'lg:gap-4',
           inCollapsedNav && 'flex-col items-start pb-6',
           className,
         )}
       >
         {categoryTree.map((category) => (
-          <NavigationMenuItem className={cs(inCollapsedNav && 'w-full')} key={category.path}>
+          <NavigationMenuItem className={cn(inCollapsedNav && 'w-full')} key={category.path}>
             {category.children.length > 0 ? (
               <>
                 <NavigationMenuTrigger className="gap-0 p-0">
@@ -91,10 +91,10 @@ const HeaderNav = async ({
                         {category.name}
                       </Link>
                     </NavigationMenuLink>
-                    <span className={cs(inCollapsedNav && 'p-3')}>
+                    <span className={cn(inCollapsedNav && 'p-3')}>
                       <ChevronDown
                         aria-hidden="true"
-                        className={cs(
+                        className={cn(
                           'cursor-pointer transition duration-200 group-data-[state=open]/button:-rotate-180',
                         )}
                       />
@@ -102,13 +102,13 @@ const HeaderNav = async ({
                   </>
                 </NavigationMenuTrigger>
                 <NavigationMenuContent
-                  className={cs(
+                  className={cn(
                     !inCollapsedNav && 'mx-auto flex w-[700px] flex-row gap-20',
                     inCollapsedNav && 'ps-3',
                   )}
                 >
                   {category.children.map((childCategory1) => (
-                    <ul className={cs(inCollapsedNav && 'pb-4')} key={childCategory1.entityId}>
+                    <ul className={cn(inCollapsedNav && 'pb-4')} key={childCategory1.entityId}>
                       <NavigationMenuItem>
                         <NavigationMenuLink href={childCategory1.path}>
                           {childCategory1.name}
@@ -134,13 +134,13 @@ const HeaderNav = async ({
         ))}
       </NavigationMenuList>
       <NavigationMenuList
-        className={cs(
+        className={cn(
           'border-t border-gray-200 pt-6 lg:hidden',
           !inCollapsedNav && 'hidden',
           inCollapsedNav && 'flex-col items-start',
         )}
       >
-        <NavigationMenuItem className={cs(inCollapsedNav && 'w-full')}>
+        <NavigationMenuItem className={cn(inCollapsedNav && 'w-full')}>
           <NavigationMenuLink href="/login">
             Your Account <User />
           </NavigationMenuLink>

--- a/apps/core/components/ProductCard/AddToCart.tsx
+++ b/apps/core/components/ProductCard/AddToCart.tsx
@@ -1,15 +1,16 @@
 'use client';
 
 import { Button } from '@bigcommerce/reactant/Button';
-import { cs } from '@bigcommerce/reactant/cs';
 import { Loader2 as Spinner } from 'lucide-react';
 import { useFormStatus } from 'react-dom';
+
+import { cn } from '~/lib/utils';
 
 export const AddToCart = () => {
   const { pending } = useFormStatus();
 
   return (
-    <Button className={cs('mt-2')} disabled={pending} type="submit">
+    <Button className={cn('mt-2')} disabled={pending} type="submit">
       {pending ? (
         <>
           <Spinner aria-hidden="true" className="animate-spin" />

--- a/apps/core/components/ProductCard/index.tsx
+++ b/apps/core/components/ProductCard/index.tsx
@@ -1,4 +1,3 @@
-import { cs } from '@bigcommerce/reactant/cs';
 import {
   ProductCardImage,
   ProductCardInfo,
@@ -10,6 +9,8 @@ import { Rating } from '@bigcommerce/reactant/Rating';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useId } from 'react';
+
+import { cn } from '~/lib/utils';
 
 import { Cart } from './Cart';
 import { Compare } from './Compare';
@@ -88,7 +89,7 @@ export const ProductCard = ({
     <ReactantProductCard key={product.entityId}>
       <ProductCardImage>
         <div
-          className={cs('relative flex-auto', {
+          className={cn('relative flex-auto', {
             'aspect-square': imageSize === 'square',
             'aspect-[4/5]': imageSize === 'tall',
             'aspect-[7/5]': imageSize === 'wide',
@@ -107,7 +108,7 @@ export const ProductCard = ({
           )}
         </div>
       </ProductCardImage>
-      <ProductCardInfo className={cs(showCart && 'justify-end')}>
+      <ProductCardInfo className={cn(showCart && 'justify-end')}>
         {product.brand && <ProductCardInfoBrandName>{product.brand.name}</ProductCardInfoBrandName>}
         <ProductCardInfoProductName>
           {product.path ? (
@@ -126,7 +127,7 @@ export const ProductCard = ({
           <div className="flex items-center gap-3">
             <p
               aria-describedby={summaryId}
-              className={cs(
+              className={cn(
                 'flex flex-nowrap text-blue-primary',
                 product.reviewSummary.numberOfReviews === 0 && 'text-gray-400',
               )}

--- a/apps/core/components/ProductSheet/index.tsx
+++ b/apps/core/components/ProductSheet/index.tsx
@@ -2,7 +2,6 @@
 
 import { Button } from '@bigcommerce/reactant/Button';
 import { Counter } from '@bigcommerce/reactant/Counter';
-import { cs } from '@bigcommerce/reactant/cs';
 import { Label } from '@bigcommerce/reactant/Label';
 import { Rating } from '@bigcommerce/reactant/Rating';
 import {
@@ -30,6 +29,7 @@ import { useFormStatus } from 'react-dom';
 
 import client from '~/client';
 import { VariantSelector } from '~/components/VariantSelector';
+import { cn } from '~/lib/utils';
 
 const ProductContext = createContext<{ product: Awaited<ReturnType<typeof client.getProduct>> }>({
   product: null,
@@ -112,7 +112,7 @@ export const ProductSheetContent = ({
     return (
       <>
         <div className="flex">
-          <div className={cs('square relative h-[144px] w-[144px] shrink-0 grow-0')}>
+          <div className={cn('square relative h-[144px] w-[144px] shrink-0 grow-0')}>
             {product.defaultImage ? (
               <Image
                 alt={product.defaultImage.altText}
@@ -135,7 +135,7 @@ export const ProductSheetContent = ({
             <div className="mb-2 flex items-center gap-3">
               <p
                 aria-describedby={summaryId}
-                className={cs(
+                className={cn(
                   'flex flex-nowrap text-blue-primary',
                   product.reviewSummary.numberOfReviews === 0 && 'text-gray-400',
                 )}
@@ -215,7 +215,7 @@ const SubmitButton = ({ children }: PropsWithChildren) => {
   const { pending } = useFormStatus();
 
   return (
-    <Button className={cs('mt-6')} disabled={pending} type="submit">
+    <Button className={cn('mt-6')} disabled={pending} type="submit">
       {pending ? (
         <>
           <Spinner aria-hidden="true" className="animate-spin" />

--- a/apps/core/lib/utils.ts
+++ b/apps/core/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -16,6 +16,7 @@
     "@bigcommerce/reactant": "workspace:^",
     "@icons-pack/react-simple-icons": "^9.1.0",
     "@vercel/analytics": "^1.1.1",
+    "clsx": "^2.0.0",
     "lucide-react": "^0.292.0",
     "next": "^14.0.1",
     "react": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@vercel/analytics':
         specifier: ^1.1.1
         version: 1.1.1
+      clsx:
+        specifier: ^2.0.0
+        version: 2.0.0
       lucide-react:
         specifier: ^0.292.0
         version: 0.292.0(react@18.2.0)
@@ -7668,7 +7671,6 @@ packages:
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
       - supports-color
-    dev: true
 
   /eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.10.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.0)(eslint@8.53.0):
     resolution: {integrity: sha512-xgdptdoi5W3niYeuQxKmzVDTATvLYqhpwmykwsh7f6HIOStGWEIL9iqZgQDF9u9OEzrRwR8no5q2VT+bjAujTg==}


### PR DESCRIPTION
## What/Why?

This PR adds changes into `core` by creating a `cn` helper and use it in core instead of identical `cs` helper from reactant package. Also refactoring has done in core components. 

## Ticket
[CATALYST-170](https://bigcommercecloud.atlassian.net/browse/CATALYST-170)

## Testing
locally

[CATALYST-170]: https://bigcommercecloud.atlassian.net/browse/CATALYST-170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ