### PR TITLE
fix(chore): Post correct lighthouse scores on pull requests

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -6,9 +6,7 @@ on:
 jobs:
   generate_lighthouse_audit:
     name: Deployment Audit
-
     timeout-minutes: 30
-
     runs-on: ubuntu-latest
 
     steps:
@@ -39,7 +37,7 @@ jobs:
             ${{ github.event.deployment_status.target_url }}
           uploadArtifacts: true
           temporaryPublicStorage: true
-          runs: 3
+          runs: 1
 
       - name: Format lighthouse score
         if: env.AUDIT == 'true'
@@ -65,7 +63,7 @@ jobs:
       - name: Add comment to PR
         if: env.AUDIT == 'true'
         id: comment_to_pr
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v2.8.0
         with:
           recreate: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What/Why?
It's been noticed that there has been a disparity between the lighthouse scores seen in the audit reports and the scores posted as a comment on the active PR. As there isn't a confirmed way to verify the issue and fix here, I'm going to try out by reducing the runs from 3 -> 1 to fetch the scores from only run.

## Testing
On this PR