### PR TITLE
feat(core): CATALYST-90 add star icons for rating on compare page

### DIFF
--- a/apps/core/app/(default)/compare/page.tsx
+++ b/apps/core/app/(default)/compare/page.tsx
@@ -1,10 +1,12 @@
 import { Button } from '@bigcommerce/reactant/Button';
+import { Rating } from '@bigcommerce/reactant/Rating';
 import Image from 'next/image';
 import Link from 'next/link';
 import * as z from 'zod';
 
 import client from '~/client';
 import { SearchForm } from '~/components/SearchForm';
+import { cn } from '~/lib/utils';
 
 import { AddToCartForm } from './AddToCartForm';
 
@@ -193,14 +195,14 @@ export default async function Compare({
             <tr>
               {products.map((product) => (
                 <td
-                  className="border-b px-4 pb-12 pt-20"
+                  className="border-b px-4 pb-8 pt-20"
                   dangerouslySetInnerHTML={{ __html: product.description }}
                   headers="product-description"
                   key={product.entityId}
                 />
               ))}
             </tr>
-            <tr className="absolute mt-8">
+            <tr className="absolute mt-6">
               <th className="sticky left-0 top-0 m-0 pl-4 text-left" id="product-rating">
                 Rating
               </th>
@@ -208,15 +210,29 @@ export default async function Compare({
             <tr>
               {products.map((product) => (
                 <td
-                  className="border-b px-4 pb-12 pt-24"
+                  className="border-b px-4 pb-8 pt-20"
                   headers="product-rating"
                   key={product.entityId}
                 >
-                  {product.reviewSummary.summationOfRatings}
+                  <p
+                    className={cn(
+                      'flex flex-nowrap text-blue-primary',
+                      product.reviewSummary.numberOfReviews === 0 && 'text-gray-400',
+                    )}
+                  >
+                    <Rating
+                      alt={
+                        product.reviewSummary.numberOfReviews === 0
+                          ? `${product.name} has no rating specified`
+                          : `${product.name} rating is ${product.reviewSummary.averageRating} out of 5 stars`
+                      }
+                      value={product.reviewSummary.averageRating}
+                    />
+                  </p>
                 </td>
               ))}
             </tr>
-            <tr className="absolute mt-8">
+            <tr className="absolute mt-6">
               <th className="sticky left-0 top-0 m-0 pl-4 text-left" id="product-availability">
                 Availability
               </th>
@@ -224,7 +240,7 @@ export default async function Compare({
             <tr>
               {products.map((product) => (
                 <td
-                  className="border-b px-4 pb-12 pt-24"
+                  className="border-b px-4 pb-8 pt-20"
                   headers="product-availability"
                   key={product.entityId}
                 >

--- a/packages/client/src/queries/getProducts.ts
+++ b/packages/client/src/queries/getProducts.ts
@@ -54,7 +54,8 @@ export const getProducts = async <T>(
             path: true,
             description: true,
             reviewSummary: {
-              summationOfRatings: true,
+              averageRating: true,
+              numberOfReviews: true,
             },
             prices: {
               basePrice: {

--- a/packages/reactant/src/components/Rating/Rating.tsx
+++ b/packages/reactant/src/components/Rating/Rating.tsx
@@ -21,7 +21,7 @@ const roundHalf = (num: number) => {
 
 type StarIconType = FC<ComponentPropsWithoutRef<'svg'>> | LucideIcon;
 
-interface RatingProps extends ComponentPropsWithRef<'span'> {
+interface RatingProps extends ComponentPropsWithRef<'img'> {
   starEmptyIcon?: StarIconType;
   starFilledIcon?: StarIconType;
   starHalfIcon?: StarIconType;
@@ -30,7 +30,7 @@ interface RatingProps extends ComponentPropsWithRef<'span'> {
   value: number;
 }
 
-export const Rating = forwardRef<ElementRef<'span'>, RatingProps>(
+export const Rating = forwardRef<ElementRef<'img'>, RatingProps>(
   ({ className, starFilledIcon, starHalfIcon, starEmptyIcon, size = 24, value, ...props }, ref) => {
     const stars: ReactElement[] = [];
     const rating = roundHalf(value);


### PR DESCRIPTION
## What/Why?
Add star icons for rating on compare page.

## Testing
<img width="1212" alt="rating" src="https://github.com/bigcommerce/catalyst/assets/66325265/e98ea02b-8c73-4525-a761-14a26872f8a2">
