### PR TITLE
feat(core): CATALYST-97 add MultiLineTextFieldOption to PDP

### DIFF
--- a/apps/core/app/(default)/cart/page.tsx
+++ b/apps/core/app/(default)/cart/page.tsx
@@ -108,6 +108,14 @@ export default async function CartPage() {
                                 <span className="font-semibold">{selectedOption.number}</span>
                               </div>
                             );
+
+                          case 'CartSelectedMultiLineTextFieldOption':
+                            return (
+                              <div key={selectedOption.entityId}>
+                                <span>{selectedOption.name}:</span>{' '}
+                                <span className="font-semibold">{selectedOption.text}</span>
+                              </div>
+                            );
                         }
 
                         return null;

--- a/apps/core/app/(default)/product/[slug]/_actions/addToCart.ts
+++ b/apps/core/app/(default)/product/[slug]/_actions/addToCart.ts
@@ -16,16 +16,18 @@ export async function handleAddToCart(data: FormData) {
 
   const selectedOptions =
     product?.productOptions?.reduce<CartSelectedOptionsInput>((accum, option) => {
-      const optionValueEntityId = Number(data.get(`attribute[${option.entityId}]`));
+      const optionValueEntityId = data.get(`attribute[${option.entityId}]`);
+
       let multipleChoicesOptionInput;
       let checkboxOptionInput;
       let numberFieldOptionInput;
+      let multiLineTextFieldOptionInput;
 
       switch (option.__typename) {
         case 'MultipleChoiceOption':
           multipleChoicesOptionInput = {
             optionEntityId: option.entityId,
-            optionValueEntityId,
+            optionValueEntityId: Number(optionValueEntityId),
           };
 
           if (accum.multipleChoices) {
@@ -41,7 +43,7 @@ export async function handleAddToCart(data: FormData) {
           checkboxOptionInput = {
             optionEntityId: option.entityId,
             optionValueEntityId:
-              optionValueEntityId !== 0
+              Number(optionValueEntityId) !== 0
                 ? option.checkedOptionValueEntityId
                 : option.uncheckedOptionValueEntityId,
           };
@@ -55,7 +57,7 @@ export async function handleAddToCart(data: FormData) {
         case 'NumberFieldOption':
           numberFieldOptionInput = {
             optionEntityId: option.entityId,
-            number: optionValueEntityId,
+            number: Number(optionValueEntityId),
           };
 
           if (accum.numberFields) {
@@ -63,6 +65,21 @@ export async function handleAddToCart(data: FormData) {
           }
 
           return { ...accum, numberFields: [numberFieldOptionInput] };
+
+        case 'MultiLineTextFieldOption':
+          multiLineTextFieldOptionInput = {
+            optionEntityId: option.entityId,
+            text: String(optionValueEntityId),
+          };
+
+          if (accum.multiLineTextFields) {
+            return {
+              ...accum,
+              multiLineTextFields: [...accum.multiLineTextFields, multiLineTextFieldOptionInput],
+            };
+          }
+
+          return { ...accum, multiLineTextFields: [multiLineTextFieldOptionInput] };
       }
 
       return accum;

--- a/apps/core/components/VariantSelector/MultiLineTextField.tsx
+++ b/apps/core/components/VariantSelector/MultiLineTextField.tsx
@@ -1,0 +1,25 @@
+import { MultiLineTextFieldOption } from '@bigcommerce/catalyst-client';
+import { Label } from '@bigcommerce/reactant/Label';
+import { TextArea } from '@bigcommerce/reactant/TextArea';
+
+export const MultiLineTextField = ({ option }: { option: MultiLineTextFieldOption }) => (
+  <>
+    <Label className="my-2 inline-block" htmlFor={`${option.entityId}`}>
+      {option.isRequired ? (
+        <>
+          {option.displayName} <span className="font-normal text-gray-500">(required)</span>
+        </>
+      ) : (
+        option.displayName
+      )}
+    </Label>
+    <TextArea
+      defaultValue={option.defaultValue ?? undefined}
+      maxLength={option.maxLength ?? undefined}
+      minLength={option.minLength ?? undefined}
+      name={`attribute[${option.entityId}]`}
+      required={option.isRequired}
+      rows={1}
+    />
+  </>
+);

--- a/apps/core/components/VariantSelector/index.tsx
+++ b/apps/core/components/VariantSelector/index.tsx
@@ -5,6 +5,7 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import client from '~/client';
 
 import { CheckboxField } from './CheckboxField';
+import { MultiLineTextField } from './MultiLineTextField';
 import { MultipleChoiceField } from './MultipleChoiceField';
 import { NumberField } from './NumberField';
 
@@ -47,6 +48,10 @@ export const VariantSelector = ({ product }: { product: NonNullable<Product> }) 
 
     if (option.__typename === 'NumberFieldOption') {
       return <NumberField key={option.entityId} option={option} />;
+    }
+
+    if (option.__typename === 'MultiLineTextFieldOption') {
+      return <MultiLineTextField key={option.entityId} option={option} />;
     }
 
     return null;

--- a/packages/client/src/queries/getCart.ts
+++ b/packages/client/src/queries/getCart.ts
@@ -50,6 +50,9 @@ export async function getCart<T>(
               on_CartSelectedNumberFieldOption: {
                 number: true,
               },
+              on_CartSelectedMultiLineTextFieldOption: {
+                text: true,
+              },
             },
           },
         },

--- a/packages/client/src/queries/getProduct.ts
+++ b/packages/client/src/queries/getProduct.ts
@@ -129,6 +129,12 @@ async function internalGetProduct<T>(
                 limitNumberBy: true,
                 lowest: true,
               },
+              on_MultiLineTextFieldOption: {
+                // defaultValue: true, TODO: need aliases to make this work
+                maxLength: true,
+                minLength: true,
+                // maxLines: true, TODO: use when we add custom validation
+              },
             },
           },
         },


### PR DESCRIPTION
Builds off #345 (check last commit)

## What/Why?
Show `MultiLineTextFieldOption` in PDP.

Pending: Validation with number of lines. Will handle validation on a different PR.

Issues: I get an error when trying to fetch `defaultValue` for this option since the type crashes with NumberField. For now we don't support aliases so leaving out for now.

<img width="1468" alt="Screenshot 2023-11-17 at 3 29 36 PM" src="https://github.com/bigcommerce/catalyst/assets/196129/0090100d-a230-46be-94b7-db3a62e10647">

<img width="1448" alt="Screenshot 2023-11-17 at 3 29 57 PM" src="https://github.com/bigcommerce/catalyst/assets/196129/d8b70a05-47a8-49ee-8518-2b7b5cc8350e">

## Testing
Locally