### PR TITLE
feat(reactant): CATALYST-156 add Skeleton component

### DIFF
--- a/apps/docs/stories/Skeleton.stories.tsx
+++ b/apps/docs/stories/Skeleton.stories.tsx
@@ -1,0 +1,33 @@
+import { Skeleton } from '@bigcommerce/reactant/Skeleton';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof Skeleton> = {
+  component: Skeleton,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Skeleton>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="m-20 flex flex-col gap-10">
+      <div className="inline-flex flex-col gap-6">
+        <Skeleton className="h-16 w-full" />
+        <Skeleton className="h-16 w-full" />
+      </div>
+      <div className="inline-flex flex-col gap-3">
+        <Skeleton className="h-8 w-full" />
+        <Skeleton className="h-8 w-full" />
+        <Skeleton className="h-8 w-full" />
+        <Skeleton className="h-8 w-full" />
+        <Skeleton className="h-8 w-1/2" />
+      </div>
+      <div className="inline-flex flex-col gap-4 md:flex-row">
+        <Skeleton className="h-10 w-full md:w-1/3" />
+        <Skeleton className="h-10 w-full md:w-1/3" />
+      </div>
+    </div>
+  ),
+};

--- a/packages/reactant/src/components/Skeleton/Skeleton.tsx
+++ b/packages/reactant/src/components/Skeleton/Skeleton.tsx
@@ -1,0 +1,11 @@
+import { ComponentPropsWithRef, ElementRef, forwardRef } from 'react';
+
+import { cs } from '../../utils/cs';
+
+type SkeletonProps = ComponentPropsWithRef<'div'>;
+
+export const Skeleton = forwardRef<ElementRef<'div'>, SkeletonProps>(
+  ({ className, ...props }, ref) => {
+    return <div className={cs('animate-pulse bg-gray-200', className)} ref={ref} {...props} />;
+  },
+);

--- a/packages/reactant/src/components/Skeleton/index.ts
+++ b/packages/reactant/src/components/Skeleton/index.ts
@@ -1,0 +1,1 @@
+export * from './Skeleton';


### PR DESCRIPTION
## What/Why?
This PR adds Skeleton component to Reactant with its Story. The component can be used to create a UI placeholder on loading state.

## Ticket
[CATALYST-156](https://bigcommercecloud.atlassian.net/browse/CATALYST-156)

## Testing
locally
<img width="1493" alt="Screenshot 2023-11-20 at 10 54 06" src="https://github.com/bigcommerce/catalyst/assets/67792608/94f0a2b8-7980-4fb2-a624-db8dbdbcce99">



[CATALYST-156]: https://bigcommercecloud.atlassian.net/browse/CATALYST-156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ