### PR TITLE
fix: bump turbo concurrency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "packageManager": "pnpm@8.7.4",
   "scripts": {
-    "dev": "dotenv -e .env.local -- turbo run dev",
+    "dev": "dotenv -e .env.local -- turbo run dev --concurrency 11",
     "build": "dotenv -e .env.local -- turbo run build",
     "lint": "turbo lint",
     "typecheck": "turbo typecheck"


### PR DESCRIPTION
## What/Why?
With the introduction of `client-new` we have now 11 concurrent tasks, turbo limits it to 10 by default.

When we remove the original client we will go back to 10, but we should still consider reducing them. Maybe by filtering out some packages/apps by default.

![0HcxBRMW](https://github.com/bigcommerce/catalyst/assets/2752665/0ea460f3-f93d-4909-a722-05132cb30ad0)




## Testing
`pnpm run dev` works as expected.