### PR TITLE
feat(core): CATALYST-158 add loading state and skeleton for PLP

### DIFF
--- a/apps/core/app/(default)/(faceted)/category/[slug]/loading.tsx
+++ b/apps/core/app/(default)/(faceted)/category/[slug]/loading.tsx
@@ -1,0 +1,136 @@
+import { Skeleton } from '@bigcommerce/reactant/Skeleton';
+
+export default function Loading() {
+  return (
+    <div>
+      <div className="mb-8 lg:flex lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex flex-col items-center gap-3 whitespace-nowrap md:flex-row">
+          <div className="flex w-full flex-col gap-3 md:flex-row md:justify-between lg:hidden">
+            <Skeleton className="h-12 w-full md:w-56" />
+            <Skeleton className="h-12  w-full md:w-56" />
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-4 gap-8">
+        <div className="mb-8 hidden lg:block">
+          <div className="mb-8 hidden flex-col gap-8 lg:flex">
+            <div className="flex flex-wrap justify-between gap-y-3">
+              <Skeleton className="h-10 w-2/5" />
+              <Skeleton className="h-10 w-2/5" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+
+            <div className="flex flex-wrap gap-4">
+              <Skeleton className="h-8 w-2/4" />
+              <Skeleton className="h-8 w-1/4" />
+              <Skeleton className="h-8 w-2/3" />
+              <Skeleton className="h-8 w-1/3" />
+            </div>
+
+            <div className="flex flex-col gap-3">
+              <Skeleton className="mb-2 h-4 w-2/4" />
+
+              <div className="inline-flex items-center gap-4">
+                <Skeleton className="h-6 w-6" />
+                <Skeleton className="h-4 w-2/3" />
+              </div>
+              <div className="inline-flex items-center gap-4">
+                <Skeleton className="h-6 w-6" />
+                <Skeleton className="h-4 w-2/3" />
+              </div>
+              <div className="inline-flex items-center gap-4">
+                <Skeleton className="h-6 w-6" />
+                <Skeleton className="h-4 w-2/3" />
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-3">
+              <Skeleton className="mb-2 h-4 w-2/4" />
+
+              <div className="inline-flex items-center gap-4">
+                <Skeleton className="h-6 w-6" />
+                <Skeleton className="h-4 w-2/3" />
+              </div>
+              <div className="inline-flex items-center gap-4">
+                <Skeleton className="h-6 w-6" />
+                <Skeleton className="h-4 w-2/3" />
+              </div>
+              <div className="inline-flex items-center gap-4">
+                <Skeleton className="h-6 w-6" />
+                <Skeleton className="h-4 w-2/3" />
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-3">
+              <Skeleton className="mb-2 h-4 w-2/4" />
+
+              <div className="inline-flex items-center gap-4">
+                <Skeleton className="h-6 w-6" />
+                <Skeleton className="h-4 w-2/3" />
+              </div>
+              <div className="inline-flex items-center gap-4">
+                <Skeleton className="h-6 w-6" />
+                <Skeleton className="h-4 w-2/3" />
+              </div>
+              <div className="inline-flex items-center gap-4">
+                <Skeleton className="h-6 w-6" />
+                <Skeleton className="h-4 w-2/3" />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <section aria-labelledby="product-heading" className="col-span-4 lg:col-span-3">
+          <div className="grid grid-cols-2 gap-6 sm:grid-cols-3 sm:gap-8">
+            <div className="flex flex-col gap-3 sm:gap-4">
+              <Skeleton className="h-24 w-full sm:h-52 md:h-52" />
+              <Skeleton className="h-7 w-full sm:h-7 md:h-7" />
+              <Skeleton className="h-7 w-full sm:h-7 md:h-7" />
+            </div>
+            <div className="flex flex-col gap-3 sm:gap-4">
+              <Skeleton className="h-24 w-full sm:h-52 md:h-52" />
+              <Skeleton className="h-7 w-full sm:h-7 md:h-7" />
+              <Skeleton className="h-7 w-full sm:h-7 md:h-7" />
+            </div>
+            <div className="flex flex-col gap-3 sm:gap-4">
+              <Skeleton className="h-24 w-full sm:h-52 md:h-52" />
+              <Skeleton className="h-7 w-full sm:h-7 md:h-7" />
+              <Skeleton className="h-7 w-full sm:h-7 md:h-7" />
+            </div>
+            <div className="flex flex-col gap-3 sm:gap-4">
+              <Skeleton className="h-24 w-full sm:h-52 md:h-52" />
+              <Skeleton className="h-7 w-full sm:h-7 md:h-7" />
+              <Skeleton className="h-7 w-full sm:h-7 md:h-7" />
+            </div>
+            <div className="flex flex-col gap-3 sm:gap-4">
+              <Skeleton className="h-24 w-full sm:h-52 md:h-52" />
+              <Skeleton className="h-7 w-full sm:h-7 md:h-7" />
+              <Skeleton className="h-7 w-full sm:h-7 md:h-7" />
+            </div>
+            <div className="flex flex-col gap-3 sm:gap-4">
+              <Skeleton className="h-24 w-full sm:h-52 md:h-52" />
+              <Skeleton className="h-7 w-full sm:h-7 md:h-7" />
+              <Skeleton className="h-7 w-full sm:h-7 md:h-7" />
+            </div>
+            <div className="flex flex-col gap-3 sm:gap-4">
+              <Skeleton className="h-24 w-full sm:h-52 md:h-52" />
+              <Skeleton className="h-7 w-full sm:h-7 md:h-7" />
+              <Skeleton className="h-7 w-full sm:h-7 md:h-7" />
+            </div>
+            <div className="flex flex-col gap-3 sm:gap-4">
+              <Skeleton className="h-24 w-full sm:h-52 md:h-52" />
+              <Skeleton className="h-7 w-full sm:h-7 md:h-7" />
+              <Skeleton className="h-7 w-full sm:h-7 md:h-7" />
+            </div>
+            <div className="hidden flex-col gap-3 sm:flex sm:gap-4">
+              <Skeleton className="h-24 w-full sm:h-52 md:h-52" />
+              <Skeleton className="h-7 w-full sm:h-7 md:h-7" />
+              <Skeleton className="h-7 w-full sm:h-7 md:h-7" />
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/core/app/(default)/(faceted)/category/[slug]/page.tsx
+++ b/apps/core/app/(default)/(faceted)/category/[slug]/page.tsx
@@ -21,7 +21,6 @@ interface Props {
 
 export default async function Category({ params, searchParams }: Props) {
   const categoryId = Number(params.slug);
-
   const search = await fetchFacetedSearch({ ...searchParams, category: [params.slug] });
 
   // We will only need a partial of this query to fetch the category name and breadcrumbs.

--- a/apps/core/app/(default)/product/[slug]/layout.tsx
+++ b/apps/core/app/(default)/product/[slug]/layout.tsx
@@ -1,7 +1,0 @@
-import { PropsWithChildren, Suspense } from 'react';
-
-import Loading from './loading';
-
-export default function ProductPageLayout({ children }: PropsWithChildren) {
-  return <Suspense fallback={<Loading />}>{children}</Suspense>;
-}


### PR DESCRIPTION
## What/Why?
This PR adds skeleton UI for PLP while it's loading.

## Ticket
[CATALYST-158](https://bigcommercecloud.atlassian.net/browse/CATALYST-158)

## Testing
locally

https://github.com/bigcommerce/catalyst/assets/67792608/887bc84b-b11a-48ba-97ff-633cbf226b36



[CATALYST-158]: https://bigcommercecloud.atlassian.net/browse/CATALYST-158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ