### PR TITLE
chore: disable fragment masking and update graphql config

### DIFF
--- a/apps/core/codegen.ts
+++ b/apps/core/codegen.ts
@@ -53,6 +53,9 @@ const config: CodegenConfig = {
   generates: {
     './client/generated/': {
       preset: 'client',
+      presetConfig: {
+        fragmentMasking: false,
+      },
       config: {
         documentMode: 'string',
         scalars: {

--- a/graphql.config.json
+++ b/graphql.config.json
@@ -1,3 +1,6 @@
 {
-  "schema": "apps/core/schema.graphql"
+  "schema": "apps/core/schema.graphql",
+  "documents": [
+    "apps/core/client/queries/**/*.ts"   
+  ]
 }


### PR DESCRIPTION
## What/Why?
When we use fragments by default they are masked, for now we aren't using masking so this PR disables it. Also adds the path to our core documents so that gql extensions can find fragments.