### PR TITLE
feat(reactant): CATALYST-192 add Calendar component

### DIFF
--- a/apps/docs/stories/Calendar.stories.tsx
+++ b/apps/docs/stories/Calendar.stories.tsx
@@ -1,0 +1,22 @@
+import { Calendar } from '@bigcommerce/reactant/Calendar';
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+
+const meta: Meta<typeof Calendar> = {
+  component: Calendar,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Calendar>;
+
+const StoryRender = () => {
+  const [date, setDate] = useState<Date | undefined>(undefined);
+
+  return <Calendar mode="single" onSelect={setDate} selected={date} />;
+};
+
+export const Single: Story = {
+  render: () => <StoryRender />,
+};

--- a/packages/reactant/package.json
+++ b/packages/reactant/package.json
@@ -47,6 +47,7 @@
     "embla-carousel-react": "8.0.0-rc14",
     "focus-trap-react": "^10.2.3",
     "lucide-react": "^0.292.0",
+    "react-day-picker": "^8.9.1",
     "tailwind-merge": "^2.0.0",
     "tailwindcss-radix": "^2.8.0"
   },

--- a/packages/reactant/src/components/Calendar/Calendar.tsx
+++ b/packages/reactant/src/components/Calendar/Calendar.tsx
@@ -1,0 +1,53 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react';
+import * as React from 'react';
+import { DayPicker } from 'react-day-picker';
+
+import { cs } from '../../utils/cs';
+
+export type CalendarProps = React.ComponentProps<typeof DayPicker>;
+
+export const Calendar = ({
+  className,
+  classNames,
+  showOutsideDays = false,
+  ...props
+}: CalendarProps) => {
+  return (
+    <DayPicker
+      className={cs('w-[304px] p-3 shadow-md', className)}
+      classNames={{
+        month: 'space-y-4',
+        caption: 'flex justify-center pt-1 relative items-center',
+        caption_label: 'text-base',
+        nav: 'space-x-1 flex items-center',
+        nav_button: cs(
+          'h-6 w-6 bg-transparent p-0 text-blue-primary hover:text-blue-secondary focus:text-blue-secondary focus:outline-none focus:ring-4 focus:ring-blue-primary/20',
+        ),
+        nav_button_previous: 'absolute start-1',
+        nav_button_next: 'absolute end-1',
+        head_row: 'flex',
+        head_cell: 'text-gray-400 w-10 text-sm font-normal',
+        row: 'flex w-full',
+        cell: cs(
+          'relative flex h-10 w-10 items-center justify-center p-0 text-center text-sm focus-within:relative focus-within:z-20 focus-within:rounded focus-within:border focus-within:border-blue-primary/20',
+        ),
+        day: cs(
+          'h-8 w-8 p-0 text-base hover:bg-blue-secondary/10 focus:outline-none aria-selected:bg-blue-primary aria-selected:text-white aria-selected:hover:bg-blue-primary aria-selected:hover:text-white',
+        ),
+        day_today: 'bg-blue-secondary/10',
+        day_disabled: 'text-gray-400 aria-selected:bg-gray-100 aria-selected:text-white',
+        ...classNames,
+      }}
+      components={{
+        IconLeft: () => <ChevronLeftIcon className="h-6 w-6" />,
+        IconRight: () => <ChevronRightIcon className="h-6 w-6" />,
+      }}
+      showOutsideDays={showOutsideDays}
+      {...props}
+    />
+  );
+};
+
+Calendar.displayName = 'Calendar';

--- a/packages/reactant/src/components/Calendar/index.ts
+++ b/packages/reactant/src/components/Calendar/index.ts
@@ -1,0 +1,3 @@
+'use client';
+
+export * from './Calendar';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -514,6 +514,9 @@ importers:
       lucide-react:
         specifier: ^0.292.0
         version: 0.292.0(react@18.2.0)
+      react-day-picker:
+        specifier: ^8.9.1
+        version: 8.9.1(date-fns@2.30.0)(react@18.2.0)
       tailwind-merge:
         specifier: ^2.0.0
         version: 2.0.0
@@ -9103,7 +9106,6 @@ packages:
     engines: {node: '>=0.11'}
     dependencies:
       '@babel/runtime': 7.23.2
-    dev: true
 
   /debounce@1.2.1:
     resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
@@ -10273,7 +10275,7 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
     dependencies:
-      '@babel/runtime': 7.23.2
+      '@babel/runtime': 7.22.11
       aria-query: 5.1.3
       array-includes: 3.1.6
       array.prototype.flatmap: 1.3.1
@@ -14656,6 +14658,16 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: true
+
+  /react-day-picker@8.9.1(date-fns@2.30.0)(react@18.2.0):
+    resolution: {integrity: sha512-W0SPApKIsYq+XCtfGeMYDoU0KbsG3wfkYtlw8l+vZp6KoBXGOlhzBUp4tNx1XiwiOZwhfdGOlj7NGSCKGSlg5Q==}
+    peerDependencies:
+      date-fns: ^2.28.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      date-fns: 2.30.0
+      react: 18.2.0
+    dev: false
 
   /react-docgen-typescript@2.2.2(typescript@5.2.2):
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}


### PR DESCRIPTION
Builds off #358 

## What/Why?
Add `Calendar` component to Reactant. Will be used for `DatePicker`.

![Screenshot 2023-11-29 at 3 07 34 PM](https://github.com/bigcommerce/catalyst/assets/196129/4a735b48-0862-4172-852b-8fa6c8d5cf01)

## Testing
Locally