### PR TITLE
feat(core): CATALYST-95 add DateField option

### DIFF
--- a/apps/core/app/(default)/cart/page.tsx
+++ b/apps/core/app/(default)/cart/page.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@bigcommerce/reactant/Button';
+import { format } from 'date-fns';
 import { Trash2 as Trash } from 'lucide-react';
 import { cookies } from 'next/headers';
 import Image from 'next/image';
@@ -114,6 +115,16 @@ export default async function CartPage() {
                               <div key={selectedOption.entityId}>
                                 <span>{selectedOption.name}:</span>{' '}
                                 <span className="font-semibold">{selectedOption.text}</span>
+                              </div>
+                            );
+
+                          case 'CartSelectedDateFieldOption':
+                            return (
+                              <div key={selectedOption.entityId}>
+                                <span>{selectedOption.name}:</span>{' '}
+                                <span className="font-semibold">
+                                  {format(new Date(selectedOption.date.utc), 'MM/dd/yyyy')}
+                                </span>
                               </div>
                             );
                         }

--- a/apps/core/app/(default)/product/[slug]/_actions/addToCart.ts
+++ b/apps/core/app/(default)/product/[slug]/_actions/addToCart.ts
@@ -23,6 +23,7 @@ export async function handleAddToCart(data: FormData) {
       let checkboxOptionInput;
       let numberFieldOptionInput;
       let multiLineTextFieldOptionInput;
+      let dateFieldOptionInput;
 
       switch (option.__typename) {
         case 'MultipleChoiceOption':
@@ -81,6 +82,21 @@ export async function handleAddToCart(data: FormData) {
           }
 
           return { ...accum, multiLineTextFields: [multiLineTextFieldOptionInput] };
+
+        case 'DateFieldOption':
+          dateFieldOptionInput = {
+            optionEntityId: option.entityId,
+            date: new Date(String(optionValueEntityId)).toISOString(),
+          };
+
+          if (accum.dateFields) {
+            return {
+              ...accum,
+              dateFields: [...accum.dateFields, dateFieldOptionInput],
+            };
+          }
+
+          return { ...accum, dateFields: [dateFieldOptionInput] };
       }
 
       return accum;

--- a/apps/core/client/queries/getProduct.ts
+++ b/apps/core/client/queries/getProduct.ts
@@ -113,6 +113,13 @@ export const PRODUCT_OPTIONS_FRAGMENT = /* GraphQL */ `
             minLength
             maxLines
           }
+          ... on DateFieldOption {
+            __typename
+            defaultDate: defaultValue
+            earliest
+            latest
+            limitDateBy
+          }
         }
       }
     }

--- a/apps/core/components/VariantSelector/DateField.tsx
+++ b/apps/core/components/VariantSelector/DateField.tsx
@@ -1,0 +1,54 @@
+import { DatePicker } from '@bigcommerce/reactant/DatePicker';
+import { Label } from '@bigcommerce/reactant/Label';
+
+import { getProduct } from '~/client/queries/getProduct';
+import { ExistingResultType, Unpacked } from '~/client/util';
+
+type DateFieldOption = Extract<
+  Unpacked<ExistingResultType<typeof getProduct>['productOptions']>,
+  { __typename: 'DateFieldOption' }
+>;
+
+const getDisabledDays = (option: DateFieldOption) => {
+  switch (option.limitDateBy) {
+    case 'EARLIEST_DATE':
+      return option.earliest ? [{ before: new Date(option.earliest) }] : [];
+
+    case 'LATEST_DATE':
+      return option.latest ? [{ after: new Date(option.latest) }] : [];
+
+    case 'RANGE':
+      return option.earliest && option.latest
+        ? [{ before: new Date(option.earliest), after: new Date(option.latest) }]
+        : [];
+
+    case 'NO_LIMIT':
+    default:
+      return [];
+  }
+};
+
+export const DateField = ({ option }: { option: DateFieldOption }) => {
+  const disabledDays = getDisabledDays(option);
+
+  return (
+    <>
+      <Label className="my-2 inline-block" htmlFor={`${option.entityId}`}>
+        {option.isRequired ? (
+          <>
+            {option.displayName} <span className="font-normal text-gray-500">(required)</span>
+          </>
+        ) : (
+          option.displayName
+        )}
+      </Label>
+      <DatePicker
+        defaultValue={option.defaultDate ?? undefined}
+        disabledDays={disabledDays}
+        id={`${option.entityId}`}
+        name={`attribute[${option.entityId}]`}
+        required={option.isRequired}
+      />
+    </>
+  );
+};

--- a/apps/core/components/VariantSelector/MultiLineTextField.tsx
+++ b/apps/core/components/VariantSelector/MultiLineTextField.tsx
@@ -22,6 +22,7 @@ export const MultiLineTextField = ({ option }: { option: MultiLineTextFieldOptio
     </Label>
     <TextArea
       defaultValue={option.defaultText ?? undefined}
+      id={`${option.entityId}`}
       maxLength={option.maxLength ?? undefined}
       minLength={option.minLength ?? undefined}
       name={`attribute[${option.entityId}]`}

--- a/apps/core/components/VariantSelector/index.tsx
+++ b/apps/core/components/VariantSelector/index.tsx
@@ -6,6 +6,7 @@ import { getProduct } from '~/client/queries/getProduct';
 import { ExistingResultType } from '~/client/util';
 
 import { CheckboxField } from './CheckboxField';
+import { DateField } from './DateField';
 import { MultiLineTextField } from './MultiLineTextField';
 import { MultipleChoiceField } from './MultipleChoiceField';
 import { NumberField } from './NumberField';
@@ -53,6 +54,10 @@ export const VariantSelector = ({ product }: { product: Product }) => {
 
     if (option.__typename === 'MultiLineTextFieldOption') {
       return <MultiLineTextField key={option.entityId} option={option} />;
+    }
+
+    if (option.__typename === 'DateFieldOption') {
+      return <DateField key={option.entityId} option={option} />;
     }
 
     return null;

--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -22,6 +22,7 @@
     "@icons-pack/react-simple-icons": "^9.1.0",
     "@vercel/analytics": "^1.1.1",
     "clsx": "^2.0.0",
+    "date-fns": "^2.30.0",
     "lodash.debounce": "^4.0.8",
     "lucide-react": "^0.292.0",
     "next": "^14.0.1",

--- a/packages/client/src/queries/getCart.ts
+++ b/packages/client/src/queries/getCart.ts
@@ -53,6 +53,11 @@ export async function getCart<T>(
               on_CartSelectedMultiLineTextFieldOption: {
                 text: true,
               },
+              on_CartSelectedDateFieldOption: {
+                date: {
+                  utc: true,
+                },
+              },
             },
           },
         },

--- a/packages/reactant/src/components/DatePicker/DatePicker.tsx
+++ b/packages/reactant/src/components/DatePicker/DatePicker.tsx
@@ -9,14 +9,29 @@ import { Calendar } from '../Calendar';
 import { Input, InputIcon, InputProps } from '../Input';
 import { Popover, PopoverContent, PopoverTrigger } from '../Popover';
 
-type DatePickerProps = InputProps & {
+type DatePickerProps = Omit<InputProps, 'defaultValue'> & {
+  defaultValue?: string | Date;
   selected?: DayPickerSingleProps['selected'];
   onSelect?: DayPickerSingleProps['onSelect'];
+  disabledDays?: DayPickerSingleProps['disabled'];
 };
 
 export const DatePicker = React.forwardRef<React.ElementRef<'div'>, DatePickerProps>(
-  ({ selected, onSelect, placeholder = 'MM/DD/YYYY', ...props }, ref) => {
-    const [date, setDate] = React.useState<Date>();
+  (
+    {
+      defaultValue,
+      disabledDays,
+      selected,
+      onSelect,
+      placeholder = 'MM/DD/YYYY',
+      required,
+      ...props
+    },
+    ref,
+  ) => {
+    const [date, setDate] = React.useState<Date | undefined>(
+      defaultValue ? new Date(defaultValue) : undefined,
+    );
 
     const formattedSelected = selected ? format(selected, 'MM/dd/yyyy') : undefined;
     const formattedDate = date ? format(date, 'MM/dd/yyyy') : undefined;
@@ -27,8 +42,10 @@ export const DatePicker = React.forwardRef<React.ElementRef<'div'>, DatePickerPr
           <PopoverTrigger asChild>
             <Input
               placeholder={placeholder}
+              readOnly={true}
+              required={required}
               type="text"
-              value={formattedSelected ?? formattedDate}
+              value={formattedSelected ?? formattedDate ?? ''}
               {...props}
             >
               <InputIcon>
@@ -38,9 +55,11 @@ export const DatePicker = React.forwardRef<React.ElementRef<'div'>, DatePickerPr
           </PopoverTrigger>
           <PopoverContent align="start" className="w-auto p-0">
             <Calendar
+              disabled={disabledDays}
               initialFocus
               mode="single"
               onSelect={onSelect || setDate}
+              required={required}
               selected={selected ?? date}
             />
           </PopoverContent>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       clsx:
         specifier: ^2.0.0
         version: 2.0.0
+      date-fns:
+        specifier: ^2.30.0
+        version: 2.30.0
       lodash.debounce:
         specifier: ^4.0.8
         version: 4.0.8
@@ -4876,7 +4879,7 @@ packages:
   /@radix-ui/number@1.0.1:
     resolution: {integrity: sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==}
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.2
 
   /@radix-ui/primitive@1.0.1:
     resolution: {integrity: sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==}
@@ -4973,7 +4976,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.2
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.37)(react@18.2.0)
       '@radix-ui/react-context': 1.0.1(@types/react@18.2.37)(react@18.2.0)
@@ -5001,7 +5004,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.2
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.37)(react@18.2.0)
       '@radix-ui/react-context': 1.0.1(@types/react@18.2.37)(react@18.2.0)
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.14)(@types/react@18.2.37)(react-dom@18.2.0)(react@18.2.0)
@@ -5080,7 +5083,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.2
       '@types/react': 18.2.37
       react: 18.2.0
 
@@ -5122,7 +5125,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.2
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.37)(react@18.2.0)
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.14)(@types/react@18.2.37)(react-dom@18.2.0)(react@18.2.0)
@@ -5143,7 +5146,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.2
       '@types/react': 18.2.37
       react: 18.2.0
 
@@ -5183,7 +5186,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.2
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.37)(react@18.2.0)
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.14)(@types/react@18.2.37)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.37)(react@18.2.0)
@@ -5366,7 +5369,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.2
       '@floating-ui/react-dom': 2.0.1(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-arrow': 1.0.3(@types/react-dom@18.2.14)(@types/react@18.2.37)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.37)(react@18.2.0)
@@ -5510,7 +5513,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.2
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-collection': 1.0.3(@types/react-dom@18.2.14)(@types/react@18.2.37)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.37)(react@18.2.0)
@@ -5637,7 +5640,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.2
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.37)(react@18.2.0)
       '@types/react': 18.2.37
       react: 18.2.0
@@ -5728,7 +5731,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.2
       '@types/react': 18.2.37
       react: 18.2.0
 
@@ -5769,7 +5772,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.2
       '@types/react': 18.2.37
       react: 18.2.0
 
@@ -5782,7 +5785,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.2
       '@types/react': 18.2.37
       react: 18.2.0
 
@@ -5809,7 +5812,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.2
       '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.37)(react@18.2.0)
       '@types/react': 18.2.37
       react: 18.2.0
@@ -5827,7 +5830,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.2
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.14)(@types/react@18.2.37)(react-dom@18.2.0)(react@18.2.0)
       '@types/react': 18.2.37
       '@types/react-dom': 18.2.14
@@ -10290,7 +10293,7 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.23.2
       aria-query: 5.1.3
       array-includes: 3.1.6
       array.prototype.flatmap: 1.3.1


### PR DESCRIPTION
## What/Why?
Add `DateField` option to PDP:
- Fetch product option with field values
- Use DatePicker component to render input with Calendar. 
  - Allow `disabledDays` to set `earliest/latest/range` values, plus `defaultValue`.
- Update `addToCart` to accept new option.
- Update `getCart` to fetch date fields.
- Show date in Cart.

Plus misc. changes to DatePicker to to allow defaultValues + required property.

![Screenshot 2023-12-07 at 11 50 47 AM](https://github.com/bigcommerce/catalyst/assets/196129/beb2f7f3-bc27-4cc8-923f-866154d1df05)

![Screenshot 2023-12-07 at 11 50 59 AM](https://github.com/bigcommerce/catalyst/assets/196129/b09bba6a-a2a9-4c8a-8382-8b2bcc4e896e)


## Testing
Locally