### PR TITLE
fix(reactant): CATALYST-00 invert compare drawer chevron rotation

### DIFF
--- a/apps/core/components/CompareDrawer/index.tsx
+++ b/apps/core/components/CompareDrawer/index.tsx
@@ -92,7 +92,7 @@ export const CompareDrawer = () => {
         <AccordionItem className="flex flex-col" value="compare">
           <div className="flex">
             <CompareLink products={products} />
-            <AccordionTrigger className="align-center flex aspect-square h-12 grow-0 justify-center border border-blue-primary text-blue-primary md:hidden" />
+            <AccordionTrigger className="align-center flex aspect-square h-12 grow-0 justify-center border border-blue-primary text-blue-primary md:hidden [&[data-state=closed]>svg]:rotate-180 [&[data-state=open]>svg]:rotate-0" />
           </div>
           <AccordionContent className="mt-4">
             <ul className="flex max-h-44 flex-col overflow-auto">


### PR DESCRIPTION
## What/Why?
Noticed during the bi-weekly demo that the ChevronDown indicator in the mobile compare drawer was oriented such that it implied an "open" action when the drawer was already open, and a "close" action when the drawer was already closed. This is a simple PR to invert the behavior. Please see before/after recordings below.

## Testing
#### Before

https://github.com/bigcommerce/catalyst/assets/28374851/7dc0d648-5c42-40fc-b9f9-cc7cb50d43f3

#### After

https://github.com/bigcommerce/catalyst/assets/28374851/ec34e03e-0ed3-4b14-a6ff-cb481675bccb

