### PR TITLE
feat(reactant): CATALYST-216 add FileChooser component

### DIFF
--- a/apps/docs/stories/FileChooser.stories.tsx
+++ b/apps/docs/stories/FileChooser.stories.tsx
@@ -1,0 +1,35 @@
+import { FileChooser } from '@bigcommerce/reactant/FileChooser';
+import { Label } from '@bigcommerce/reactant/Label';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof FileChooser> = {
+  component: FileChooser,
+  tags: ['autodocs'],
+  argTypes: {
+    disabled: { control: 'boolean' },
+    accept: { control: 'text', defaultValue: 'image/png,image/jpeg' },
+    variant: { control: 'select', options: ['success', 'error'] },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof FileChooser>;
+
+export const Default: Story = {
+  args: {
+    accept: 'image/png,image/jpeg',
+    disabled: false,
+  },
+  render: (args) => (
+    <>
+      <Label className="my-2 inline-block" htmlFor="file-chooser">
+        File Upload
+      </Label>
+      <p className="pb-2 text-sm text-gray-500" id="file-chooser-description">
+        Upload a file no larger than 500MB in PNG/JPEG format.
+      </p>
+      <FileChooser aria-describedby="file-chooser-description" id="file-chooser" {...args} />
+    </>
+  ),
+};

--- a/packages/reactant/src/components/FileChooser/FileChooser.tsx
+++ b/packages/reactant/src/components/FileChooser/FileChooser.tsx
@@ -1,0 +1,17 @@
+import { ElementRef, forwardRef } from 'react';
+
+import { cs } from '../../utils/cs';
+import { Input, InputProps } from '../Input';
+
+export const FileChooser = forwardRef<ElementRef<'input'>, InputProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <Input
+        className={cs('file:border-none file:bg-transparent file:font-semibold', className)}
+        ref={ref}
+        type="file"
+        {...props}
+      />
+    );
+  },
+);

--- a/packages/reactant/src/components/FileChooser/index.ts
+++ b/packages/reactant/src/components/FileChooser/index.ts
@@ -1,0 +1,1 @@
+export * from './FileChooser';


### PR DESCRIPTION
## What/Why?
Add a wrapper for an`Input` of type `file`.

<img width="670" alt="Screenshot 2023-12-08 at 2 55 32 PM" src="https://github.com/bigcommerce/catalyst/assets/196129/47e534be-be06-4863-8dfd-5d4a1bc10a2f">

<img width="666" alt="Screenshot 2023-12-08 at 2 55 45 PM" src="https://github.com/bigcommerce/catalyst/assets/196129/8f4896ff-2857-4a03-b31d-66b238c098cc">

## Testing
Locally.