### PR TITLE
chore(core): dont run lint / tsc on vercel

### DIFF
--- a/apps/core/next.config.js
+++ b/apps/core/next.config.js
@@ -10,6 +10,12 @@ const nextConfig = {
       },
     ],
   },
+  typescript: {
+    ignoreBuildErrors: !!process.env.CI,
+  },
+  eslint: {
+    ignoreDuringBuilds: !!process.env.CI,
+  },
 };
 
 module.exports = nextConfig;

--- a/apps/with-makeswift/next.config.js
+++ b/apps/with-makeswift/next.config.js
@@ -10,6 +10,12 @@ const nextConfig = {
       },
     ],
   },
+  typescript: {
+    ignoreBuildErrors: !!process.env.CI,
+  },
+  eslint: {
+    ignoreDuringBuilds: !!process.env.CI,
+  },
 };
 
 module.exports = withMakeswift(nextConfig);


### PR DESCRIPTION
## What/Why?
We run tsc + eslint on our gh action, we don't need to re-run it in vercel. 

For our CLI we may want to re-enable this for merchants.