### PR TITLE
chore(core): use new client for bestSeeling and featured

### DIFF
--- a/apps/core/app/(default)/page.tsx
+++ b/apps/core/app/(default)/page.tsx
@@ -1,16 +1,18 @@
-import client from '~/client';
+import { getBestSellingProducts } from '~/client/queries/getBestSellingProducts';
+import { getFeaturedProducts } from '~/client/queries/getFeaturedProducts';
 import { Hero } from '~/components/Hero';
 import { ProductCardCarousel } from '~/components/ProductCardCarousel';
 
 export default async function Home() {
   const [bestSellingProducts, featuredProducts] = await Promise.all([
-    client.getBestSellingProducts({ imageWidth: 500, imageHeight: 500 }),
-    client.getFeaturedProducts({ imageWidth: 500, imageHeight: 500 }),
+    getBestSellingProducts({ imageWidth: 500, imageHeight: 500 }),
+    getFeaturedProducts({ imageWidth: 500, imageHeight: 500 }),
   ]);
 
   return (
     <>
       <Hero />
+
       <div className="my-10">
         <ProductCardCarousel
           products={bestSellingProducts}
@@ -18,6 +20,7 @@ export default async function Home() {
           showCompare={false}
           title="Best Selling Products"
         />
+
         <ProductCardCarousel
           products={featuredProducts}
           showCart={false}
@@ -30,3 +33,4 @@ export default async function Home() {
 }
 
 export const runtime = 'edge';
+export const fetchCache = 'force-cache';

--- a/apps/core/client/fragments/productDetails.ts
+++ b/apps/core/client/fragments/productDetails.ts
@@ -1,0 +1,42 @@
+export const PRODUCT_DETAILS_FRAGMENT = /* GraphQL */ `
+  fragment ProductDetails on Product {
+    entityId
+    name
+    path
+    prices {
+      basePrice {
+        value
+        currencyCode
+      }
+      price {
+        value
+        currencyCode
+      }
+      retailPrice {
+        value
+        currencyCode
+      }
+      salePrice {
+        value
+        currencyCode
+      }
+      priceRange {
+        min {
+          value
+          currencyCode
+        }
+        max {
+          value
+          currencyCode
+        }
+      }
+    }
+    brand {
+      name
+    }
+    defaultImage {
+      url(width: $imageWidth, height: $imageHeight)
+      altText
+    }
+  }
+`;

--- a/apps/core/client/queries/getBestSellingProducts.ts
+++ b/apps/core/client/queries/getBestSellingProducts.ts
@@ -1,0 +1,41 @@
+import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client-new';
+
+import { newClient } from '..';
+import { graphql } from '../generated';
+
+export const GET_BEST_SELLING_PRODUCTS_QUERY = /* GraphQL */ `
+  query getBestSellingProducts($first: Int, $imageHeight: Int!, $imageWidth: Int!) {
+    site {
+      bestSellingProducts(first: $first) {
+        edges {
+          node {
+            ...ProductDetails
+          }
+        }
+      }
+    }
+  }
+`;
+
+interface Options {
+  first?: number;
+  imageWidth?: number;
+  imageHeight?: number;
+}
+
+export const getBestSellingProducts = async ({
+  first = 10,
+  imageHeight = 300,
+  imageWidth = 300,
+}: Options = {}) => {
+  const query = graphql(GET_BEST_SELLING_PRODUCTS_QUERY);
+
+  const response = await newClient.fetch({
+    document: query,
+    variables: { first, imageWidth, imageHeight },
+  });
+
+  const { site } = response.data;
+
+  return removeEdgesAndNodes(site.bestSellingProducts);
+};

--- a/apps/core/client/queries/getFeaturedProducts.ts
+++ b/apps/core/client/queries/getFeaturedProducts.ts
@@ -1,0 +1,41 @@
+import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client-new';
+
+import { newClient } from '..';
+import { graphql } from '../generated';
+
+export const GET_FEATURED_PRODUCTS_QUERY = /* GraphQL */ `
+  query getFeaturedProducts($first: Int, $imageHeight: Int!, $imageWidth: Int!) {
+    site {
+      featuredProducts(first: $first) {
+        edges {
+          node {
+            ...ProductDetails
+          }
+        }
+      }
+    }
+  }
+`;
+
+interface Options {
+  first?: number;
+  imageWidth?: number;
+  imageHeight?: number;
+}
+
+export const getFeaturedProducts = async ({
+  first = 10,
+  imageHeight = 300,
+  imageWidth = 300,
+}: Options = {}) => {
+  const query = graphql(GET_FEATURED_PRODUCTS_QUERY);
+
+  const response = await newClient.fetch({
+    document: query,
+    variables: { first, imageWidth, imageHeight },
+  });
+
+  const { site } = response.data;
+
+  return removeEdgesAndNodes(site.featuredProducts);
+};

--- a/apps/core/codegen.ts
+++ b/apps/core/codegen.ts
@@ -49,7 +49,7 @@ const config: CodegenConfig = {
       },
     },
   ],
-  documents: ['client/queries/**/*.ts'],
+  documents: ['client/queries/**/*.ts', 'client/fragments/**/*.ts'],
   generates: {
     './client/generated/': {
       preset: 'client',

--- a/graphql.config.json
+++ b/graphql.config.json
@@ -1,6 +1,7 @@
 {
   "schema": "apps/core/schema.graphql",
   "documents": [
-    "apps/core/client/queries/**/*.ts"   
+    "apps/core/client/queries/**/*.ts",
+    "apps/core/client/fragments/**/*.ts"
   ]
 }


### PR DESCRIPTION
## What/Why?
Migrates the BSP + FP queries to the new client.

>[!NOTE]
>`with-makeswift` still uses the old client with these two queries so couldn't remove them quite yet.

## Testing
See the preview URL