### PR TITLE
fix(core): CATALYST-218 set min value to 1 in ProductSheet

### DIFF
--- a/apps/core/components/ProductSheet/index.tsx
+++ b/apps/core/components/ProductSheet/index.tsx
@@ -242,7 +242,7 @@ export const ProductSheetForm = ({ children, ...props }: ComponentPropsWithoutRe
         <Label className="my-2 inline-block font-semibold" htmlFor="quantity">
           Quantity
         </Label>
-        <Counter id="quantity" name="quantity" />
+        <Counter id="quantity" min={1} name="quantity" />
       </div>
       {children || <SubmitButton>Add to cart</SubmitButton>}
     </form>


### PR DESCRIPTION
## What/Why?
Fixes issue with having 0 as a default value.

![Screenshot 2023-12-11 at 1 11 15 PM](https://github.com/bigcommerce/catalyst/assets/196129/a94c3972-b3b5-43fb-b707-ad95e6074a10)

## Testing
Locally