### PR TITLE
feat(core): use new vercel speed insights

### DIFF
--- a/apps/core/app/layout.tsx
+++ b/apps/core/app/layout.tsx
@@ -1,4 +1,5 @@
 import { Analytics } from '@vercel/analytics/react';
+import { SpeedInsights } from '@vercel/speed-insights/next';
 import { Inter } from 'next/font/google';
 import { PropsWithChildren } from 'react';
 
@@ -25,6 +26,7 @@ export default function RootLayout({ children }: PropsWithChildren) {
       <body className="flex h-screen flex-col">
         <Providers>{children}</Providers>
         <Analytics />
+        <SpeedInsights />
       </body>
     </html>
   );

--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -21,6 +21,7 @@
     "@graphql-typed-document-node/core": "^3.2.0",
     "@icons-pack/react-simple-icons": "^9.1.0",
     "@vercel/analytics": "^1.1.1",
+    "@vercel/speed-insights": "^1.0.1",
     "clsx": "^2.0.0",
     "lodash.debounce": "^4.0.8",
     "lucide-react": "^0.292.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@vercel/analytics':
         specifier: ^1.1.1
         version: 1.1.1
+      '@vercel/speed-insights':
+        specifier: ^1.0.1
+        version: 1.0.1
       clsx:
         specifier: ^2.0.0
         version: 2.0.0
@@ -7636,6 +7639,11 @@ packages:
     resolution: {integrity: sha512-+NqgNmSabg3IFfxYhrWCfB/H+RCUOCR5ExRudNG2+pcRehq628DJB5e1u1xqwpLtn4pAYii4D98w7kofORAGQA==}
     dependencies:
       server-only: 0.0.1
+    dev: false
+
+  /@vercel/speed-insights@1.0.1:
+    resolution: {integrity: sha512-cm8KTTsDgS1AbWsgIEZuMoyPUjclzeqJihyLp0tnA21B/x9iTE8hu2S5zM+/DBzihuHxWL1dx9pCWk22ctMFWQ==}
+    requiresBuild: true
     dev: false
 
   /@vitejs/plugin-react@3.1.0(vite@4.5.1):


### PR DESCRIPTION
## What/Why?
Adds the new `@vercel/speed-insights` lib to get the new insights panel. **Now includes TTFB!**

![Screenshot 2023-12-11 at 15 29 35](https://github.com/bigcommerce/catalyst/assets/10539418/2f3ee4f3-b4f1-467d-b293-a013f91cdf8c)


## Testing
Script loads:

![Screenshot 2023-12-11 at 15 28 48](https://github.com/bigcommerce/catalyst/assets/10539418/af3559ee-5e1f-4540-b5db-986062075786)
