### PR TITLE
chore(core): CATALYST-210 use new client for Login

### DIFF
--- a/apps/core/app/(default)/login/_actions/submitLoginForm.ts
+++ b/apps/core/app/(default)/login/_actions/submitLoginForm.ts
@@ -2,11 +2,11 @@
 
 import { z } from 'zod';
 
-import client from '~/client';
+import { login } from '~/client/mutations/login';
 
 const LoginSchema = z.object({
   email: z.string().email(),
-  password: z.string().nonempty(),
+  password: z.string().min(1),
 });
 
 export const submitLoginForm = async (formData: FormData) => {
@@ -16,7 +16,7 @@ export const submitLoginForm = async (formData: FormData) => {
       password: formData.get('password'),
     });
 
-    const customer = await client.login(email, password);
+    const customer = await login(email, password);
 
     return { status: 'success', data: customer };
   } catch (e: unknown) {

--- a/apps/core/client/mutations/login.ts
+++ b/apps/core/client/mutations/login.ts
@@ -1,0 +1,23 @@
+import { newClient } from '..';
+import { graphql } from '../generated';
+
+export const LOGIN_MUTATION = /* GraphQL */ `
+  mutation Login($email: String!, $password: String!) {
+    login(email: $email, password: $password) {
+      customer {
+        entityId
+      }
+    }
+  }
+`;
+
+export const login = async (email: string, password: string) => {
+  const mutation = graphql(LOGIN_MUTATION);
+
+  const response = await newClient.fetch({
+    document: mutation,
+    variables: { email, password },
+  });
+
+  return response.data.login.customer;
+};

--- a/apps/core/codegen.ts
+++ b/apps/core/codegen.ts
@@ -49,7 +49,7 @@ const config: CodegenConfig = {
       },
     },
   ],
-  documents: ['client/queries/**/*.ts', 'client/fragments/**/*.ts'],
+  documents: ['client/queries/**/*.ts', 'client/mutations/**/*.ts', 'client/fragments/**/*.ts'],
   generates: {
     './client/generated/': {
       preset: 'client',

--- a/graphql.config.json
+++ b/graphql.config.json
@@ -2,6 +2,7 @@
   "schema": "apps/core/schema.graphql",
   "documents": [
     "apps/core/client/queries/**/*.ts",
+    "apps/core/client/mutations/**/*.ts",
     "apps/core/client/fragments/**/*.ts"
   ]
 }


### PR DESCRIPTION
## What/Why?
This PR upgrades mutation Login with switching to new graphql client.

## Ticket
[CATALYST-210](https://bigcommercecloud.atlassian.net/browse/CATALYST-210)

## Testing
locally

[CATALYST-210]: https://bigcommercecloud.atlassian.net/browse/CATALYST-210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ