### PR TITLE
fix(core): use kv cache when route nodes are null

### DIFF
--- a/apps/core/middlewares/with-custom-urls.ts
+++ b/apps/core/middlewares/with-custom-urls.ts
@@ -46,7 +46,7 @@ const getCustomUrlNode = async (request: NextRequest) => {
   try {
     const route = await getExistingRoute(request);
 
-    if (route) {
+    if (route !== undefined) {
       return route;
     }
 


### PR DESCRIPTION
## What/Why?
Noticed our homepage not using the kv stored response for its route. The route node can be null and its a valid value.