### PR TITLE
fix(core): middleware running for _vercel urls

### DIFF
--- a/apps/core/middleware.ts
+++ b/apps/core/middleware.ts
@@ -12,9 +12,10 @@ export const config = {
      * - api (API routes)
      * - _next/static (static files)
      * - _next/image (image optimization files)
+     * - _vercel (vercel internals, eg: web vitals)
      * - favicon.ico (favicon file)
      */
-    '/((?!api|_next/static|_next/image|favicon.ico).*)',
+    '/((?!api|_next/static|_next/image|_vercel|favicon.ico).*)',
     '/',
   ],
 };


### PR DESCRIPTION
## What/Why?
Added some logs to our `KV` and noticed we were running middleware on `_vercel` urls.