### PR TITLE
feat(core): add dev kv adapter

### DIFF
--- a/apps/core/.eslintrc.cjs
+++ b/apps/core/.eslintrc.cjs
@@ -12,6 +12,7 @@ const config = {
   rules: {
     '@typescript-eslint/naming-convention': 'off',
     '@next/next/no-html-link-for-pages': 'off',
+    'import/dynamic-import-chunkname': 'off',
     'no-underscore-dangle': ['error', { allow: ['__typename'] }],
   },
 };

--- a/apps/core/lib/kv/adapters/dev.ts
+++ b/apps/core/lib/kv/adapters/dev.ts
@@ -1,0 +1,29 @@
+/* eslint-disable @typescript-eslint/require-await */
+import { KvAdapter } from '../types';
+
+export class DevKvAdapter implements KvAdapter {
+  private kv = new Map<string, unknown>();
+
+  constructor() {
+    // eslint-disable-next-line no-console
+    console.log(`
+[BigCommerce] --------------------------------
+[BigCommerce] KV WARNING: Using DevKvAdapter.
+[BigCommerce] This KV adapter does not persist data or support key expiration.
+[BigCommerce] --------------------------------
+`);
+  }
+
+  async get<Data>(key: string) {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const value = this.kv.get(key) as Data;
+
+    return value;
+  }
+
+  async set<Data>(key: string, value: Data) {
+    this.kv.set(key, value);
+
+    return value;
+  }
+}

--- a/apps/core/lib/kv/adapters/vercel.ts
+++ b/apps/core/lib/kv/adapters/vercel.ts
@@ -2,7 +2,7 @@ import { kv } from '@vercel/kv';
 
 import { KvAdapter, SetCommandOptions } from '../types';
 
-class VercelKvAdapter implements KvAdapter {
+export class VercelKvAdapter implements KvAdapter {
   constructor(private adapter = kv) {}
 
   async get<Data>(key: string) {
@@ -23,5 +23,3 @@ class VercelKvAdapter implements KvAdapter {
     return response;
   }
 }
-
-export const vercelKvAdapter = new VercelKvAdapter();


### PR DESCRIPTION
## What/Why?
Adds a `DevKvAdapter`, this is a simple `Map` adapter to make development a bit easier without setting up Vercel's KV. This adepter is pretty simple and does not support any option such as key expiration, we can add some options later if we see the need.

Also added some logging in development to our `KV` implementation makes it easier to see what keys we are reading/writing, already found a couple of bugs using this.

Made sure to dynamically import the adapter and created a local build to make sure the middleware doesn't end up with all adapters in its bundle.

## Testing
![eOZHfCes](https://github.com/bigcommerce/catalyst/assets/2752665/ee7def81-d0ef-48d5-b8b4-d2d13b9a5a38)
