### PR TITLE
feat(core): CATALYST-99 Add text field product options

### DIFF
--- a/apps/core/app/(default)/cart/page.tsx
+++ b/apps/core/app/(default)/cart/page.tsx
@@ -113,6 +113,14 @@ export default async function CartPage() {
                               </div>
                             );
 
+                          case 'CartSelectedTextFieldOption':
+                            return (
+                              <div key={selectedOption.entityId}>
+                                <span>{selectedOption.name}:</span>{' '}
+                                <span className="font-semibold">{selectedOption.text}</span>
+                              </div>
+                            );
+
                           case 'CartSelectedDateFieldOption':
                             return (
                               <div key={selectedOption.entityId}>

--- a/apps/core/app/(default)/product/[slug]/_actions/addToCart.ts
+++ b/apps/core/app/(default)/product/[slug]/_actions/addToCart.ts
@@ -23,6 +23,7 @@ export async function handleAddToCart(data: FormData) {
       let multipleChoicesOptionInput;
       let checkboxOptionInput;
       let numberFieldOptionInput;
+      let textFieldOptionInput;
       let multiLineTextFieldOptionInput;
       let dateFieldOptionInput;
 
@@ -68,6 +69,21 @@ export async function handleAddToCart(data: FormData) {
           }
 
           return { ...accum, numberFields: [numberFieldOptionInput] };
+
+        case 'TextFieldOption':
+          textFieldOptionInput = {
+            optionEntityId: option.entityId,
+            text: String(optionValueEntityId),
+          };
+
+          if (accum.textFields) {
+            return {
+              ...accum,
+              textFields: [...accum.textFields, textFieldOptionInput],
+            };
+          }
+
+          return { ...accum, textFields: [textFieldOptionInput] };
 
         case 'MultiLineTextFieldOption':
           multiLineTextFieldOptionInput = {

--- a/apps/core/client/queries/getCart.ts
+++ b/apps/core/client/queries/getCart.ts
@@ -43,6 +43,9 @@ export const GET_CART_QUERY = /* GraphQL */ `
               ... on CartSelectedMultiLineTextFieldOption {
                 text
               }
+              ... on CartSelectedTextFieldOption {
+                text
+              }
               ... on CartSelectedDateFieldOption {
                 date {
                   utc

--- a/apps/core/client/queries/getProduct.ts
+++ b/apps/core/client/queries/getProduct.ts
@@ -114,6 +114,12 @@ export const PRODUCT_OPTIONS_FRAGMENT = /* GraphQL */ `
             limitNumberBy
             lowest
           }
+          ... on TextFieldOption {
+            __typename
+            defaultText: defaultValue
+            maxLength
+            minLength
+          }
           ... on MultiLineTextFieldOption {
             __typename
             defaultText: defaultValue

--- a/apps/core/components/VariantSelector/TextField.tsx
+++ b/apps/core/components/VariantSelector/TextField.tsx
@@ -1,0 +1,32 @@
+import { Input } from '@bigcommerce/reactant/Input';
+import { Label } from '@bigcommerce/reactant/Label';
+
+import { getProduct } from '~/client/queries/getProduct';
+import { ExistingResultType, Unpacked } from '~/client/util';
+
+type TextFieldOption = Extract<
+  Unpacked<ExistingResultType<typeof getProduct>['productOptions']>,
+  { __typename: 'TextFieldOption' }
+>;
+
+export const TextField = ({ option }: { option: TextFieldOption }) => (
+  <>
+    <Label className="my-2 inline-block" htmlFor={`${option.entityId}`}>
+      {option.isRequired ? (
+        <>
+          {option.displayName} <span className="font-normal text-gray-500">(required)</span>
+        </>
+      ) : (
+        option.displayName
+      )}
+    </Label>
+    <Input
+      defaultValue={option.defaultText ?? undefined}
+      id={`${option.entityId}`}
+      maxLength={option.maxLength ?? undefined}
+      minLength={option.minLength ?? undefined}
+      name={`attribute[${option.entityId}]`}
+      required={option.isRequired}
+    />
+  </>
+);

--- a/apps/core/components/VariantSelector/index.tsx
+++ b/apps/core/components/VariantSelector/index.tsx
@@ -10,6 +10,7 @@ import { DateField } from './DateField';
 import { MultiLineTextField } from './MultiLineTextField';
 import { MultipleChoiceField } from './MultipleChoiceField';
 import { NumberField } from './NumberField';
+import { TextField } from './TextField';
 
 type Product = ExistingResultType<typeof getProduct>;
 
@@ -54,6 +55,10 @@ export const VariantSelector = ({ product }: { product: Product }) => {
 
     if (option.__typename === 'MultiLineTextFieldOption') {
       return <MultiLineTextField key={option.entityId} option={option} />;
+    }
+
+    if (option.__typename === 'TextFieldOption') {
+      return <TextField key={option.entityId} option={option} />;
     }
 
     if (option.__typename === 'DateFieldOption') {


### PR DESCRIPTION
Adds support for Text Field product modifier options.

![Screenshot 2023-12-19 at 7 43 14 AM](https://github.com/bigcommerce/catalyst/assets/32500994/aba7947c-260a-4cc7-a6d9-c90108a5748c)
![Screenshot 2023-12-19 at 7 43 26 AM](https://github.com/bigcommerce/catalyst/assets/32500994/59924b4b-1b8e-41d7-8b25-f306048bce0f)
![Screenshot 2023-12-19 at 7 44 35 AM](https://github.com/bigcommerce/catalyst/assets/32500994/644de8e7-045a-48ce-af11-4ffb04c9de39)

## Testing
Tested locally against a product w/ Text Field modifier option, as well as testing min and max lengths work correctly. Product adds to cart and displays correctly in the cart as well.
