### PR TITLE
chore(core): CATALYST-208 use new client on cart creation

### DIFF
--- a/apps/core/app/(default)/compare/_actions/addToCart.ts
+++ b/apps/core/app/(default)/compare/_actions/addToCart.ts
@@ -3,8 +3,8 @@
 import { revalidateTag } from 'next/cache';
 import { cookies } from 'next/headers';
 
-import client from '~/client';
 import { addCartLineItem } from '~/client/mutations/addCartLineItem';
+import { createCart } from '~/client/mutations/createCart';
 
 export const addToCart = async (data: FormData) => {
   const productEntityId = Number(data.get('product_id'));
@@ -26,7 +26,7 @@ export const addToCart = async (data: FormData) => {
     return;
   }
 
-  const cart = await client.createCart([{ productEntityId, quantity: 1 }]);
+  const cart = await createCart([{ productEntityId, quantity: 1 }]);
 
   if (cart) {
     cookies().set({

--- a/apps/core/app/(default)/product/[slug]/_actions/addToCart.ts
+++ b/apps/core/app/(default)/product/[slug]/_actions/addToCart.ts
@@ -4,8 +4,8 @@ import { CartSelectedOptionsInput } from '@bigcommerce/catalyst-client';
 import { revalidateTag } from 'next/cache';
 import { cookies } from 'next/headers';
 
-import client from '~/client';
 import { addCartLineItem } from '~/client/mutations/addCartLineItem';
+import { createCart } from '~/client/mutations/createCart';
 import { getProduct } from '~/client/queries/getProduct';
 
 export async function handleAddToCart(data: FormData) {
@@ -137,7 +137,7 @@ export async function handleAddToCart(data: FormData) {
     }
 
     // Create cart
-    const cart = await client.createCart([
+    const cart = await createCart([
       {
         productEntityId,
         selectedOptions,

--- a/apps/core/client/mutations/createCart.ts
+++ b/apps/core/client/mutations/createCart.ts
@@ -1,0 +1,31 @@
+import { newClient } from '..';
+import { graphql } from '../generated';
+import { CreateCartInput } from '../generated/graphql';
+
+export const CREATE_CART_MUTATION = /* GraphQL */ `
+  mutation createCartSimple($createCartInput: CreateCartInput!) {
+    cart {
+      createCart(input: $createCartInput) {
+        cart {
+          entityId
+        }
+      }
+    }
+  }
+`;
+
+export const createCart = async (cartItems: CreateCartInput['lineItems']) => {
+  const mutation = graphql(CREATE_CART_MUTATION);
+
+  const response = await newClient.fetch({
+    document: mutation,
+    variables: {
+      createCartInput: {
+        lineItems: cartItems,
+      },
+    },
+    fetchOptions: { cache: 'no-store' },
+  });
+
+  return response.data.cart.createCart?.cart;
+};


### PR DESCRIPTION
## What/Why?
This PR upgrades createCart mutation with new Client approach.

## Ticket
[Catalyst-208](https://bigcommercecloud.atlassian.net/browse/CATALYST-208)

## Testing
locally