### PR TITLE
chore(core) CATALYST-209 use new client on deleteCartItem

### DIFF
--- a/apps/core/app/(default)/cart/_actions/removeProduct.ts
+++ b/apps/core/app/(default)/cart/_actions/removeProduct.ts
@@ -3,7 +3,7 @@
 import { revalidateTag } from 'next/cache';
 import { cookies } from 'next/headers';
 
-import client from '~/client';
+import { deleteCartLineItem } from '~/client/mutations/deleteCartLineItem';
 
 export async function removeProduct(formData: FormData) {
   const cartId = cookies().get('cartId')?.value;
@@ -18,7 +18,7 @@ export async function removeProduct(formData: FormData) {
     throw new Error('No lineItemEntityId found');
   }
 
-  const updatedCart = await client.deleteCartLineItem(cartId, lineItemEntityId.toString());
+  const updatedCart = await deleteCartLineItem(cartId, lineItemEntityId.toString());
 
   // If we remove the last item in a cart the cart is deleted
   // so we need to remove the cartId cookie

--- a/apps/core/client/mutations/deleteCartLineItem.ts
+++ b/apps/core/client/mutations/deleteCartLineItem.ts
@@ -1,0 +1,31 @@
+import { newClient } from '..';
+import { graphql } from '../generated';
+
+export const DELETE_CART_LINE_ITEM = /* GraphQL */ `
+  mutation DeleteCartLineItem($input: DeleteCartLineItemInput!) {
+    cart {
+      deleteCartLineItem(input: $input) {
+        cart {
+          entityId
+        }
+      }
+    }
+  }
+`;
+
+export const deleteCartLineItem = async (cartEntityId: string, lineItemEntityId: string) => {
+  const mutation = graphql(DELETE_CART_LINE_ITEM);
+
+  const response = await newClient.fetch({
+    document: mutation,
+    variables: {
+      input: {
+        cartEntityId,
+        lineItemEntityId,
+      },
+    },
+    fetchOptions: { cache: 'no-store' },
+  });
+
+  return response.data.cart.deleteCartLineItem?.cart;
+};


### PR DESCRIPTION
## What/Why?
This PR adds new client for deleteCartLineItem

## Ticket
[CATALYST-209](https://bigcommercecloud.atlassian.net/browse/CATALYST-209)

## Testing
Locally

[CATALYST-209]: https://bigcommercecloud.atlassian.net/browse/CATALYST-209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ