### PR TITLE
chore(core): CATALYST-211 add new client to update cart item

### DIFF
--- a/apps/core/app/(default)/cart/_actions/updateProductQuantity.ts
+++ b/apps/core/app/(default)/cart/_actions/updateProductQuantity.ts
@@ -4,7 +4,7 @@ import { CartLineItemInput, UpdateCartLineItemInput } from '@bigcommerce/catalys
 import { revalidatePath } from 'next/cache';
 import { cookies } from 'next/headers';
 
-import client from '~/client';
+import { updateCartLineItem } from '~/client/mutations/updateCartLineItem';
 
 interface UpdateProductQuantityParams extends CartLineItemInput {
   lineItemEntityId: UpdateCartLineItemInput['lineItemEntityId'];
@@ -31,7 +31,7 @@ export async function updateProductQuantity({
     variantEntityId && { variantEntityId },
   );
 
-  const updatedCart = await client.updateCartLineItem(cartId, lineItemEntityId, {
+  const updatedCart = await updateCartLineItem(cartId, lineItemEntityId, {
     lineItem: cartLineItemData,
   });
 

--- a/apps/core/client/mutations/createCart.ts
+++ b/apps/core/client/mutations/createCart.ts
@@ -3,7 +3,7 @@ import { graphql } from '../generated';
 import { CreateCartInput } from '../generated/graphql';
 
 export const CREATE_CART_MUTATION = /* GraphQL */ `
-  mutation createCartSimple($createCartInput: CreateCartInput!) {
+  mutation CreateCart($createCartInput: CreateCartInput!) {
     cart {
       createCart(input: $createCartInput) {
         cart {

--- a/apps/core/client/mutations/updateCartLineItem.ts
+++ b/apps/core/client/mutations/updateCartLineItem.ts
@@ -1,0 +1,37 @@
+import { newClient } from '..';
+import { graphql } from '../generated';
+import { UpdateCartLineItemDataInput } from '../generated/graphql';
+
+export const UPDATE_CART_LINE_ITEM_MUTATION = /* GraphQL */ `
+  mutation UpdateCartLineItem($input: UpdateCartLineItemInput!) {
+    cart {
+      updateCartLineItem(input: $input) {
+        cart {
+          entityId
+        }
+      }
+    }
+  }
+`;
+
+export const updateCartLineItem = async (
+  cartEntityId: string,
+  lineItemEntityId: string,
+  data: UpdateCartLineItemDataInput,
+) => {
+  const mutation = graphql(UPDATE_CART_LINE_ITEM_MUTATION);
+
+  const response = await newClient.fetch({
+    document: mutation,
+    variables: {
+      input: {
+        cartEntityId,
+        lineItemEntityId,
+        data,
+      },
+    },
+    fetchOptions: { cache: 'no-store' },
+  });
+
+  return response.data.cart.updateCartLineItem?.cart;
+};


### PR DESCRIPTION
## What/Why?
This PR adds new client for `updateCartLineItem`

## Ticket
[CATALYST-211](https://bigcommercecloud.atlassian.net/browse/CATALYST-211)

## Testing
locally

[CATALYST-211]: https://bigcommercecloud.atlassian.net/browse/CATALYST-211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ