### PR TITLE
fix(core): quick search bar can be cut off when page is not on the top

### DIFF
--- a/apps/core/components/QuickSearch/index.tsx
+++ b/apps/core/components/QuickSearch/index.tsx
@@ -92,7 +92,7 @@ export const QuickSearch = ({ children, initialTerm = '' }: SearchProps) => {
       <SheetOverlay className="bg-transparent backdrop-blur-none">
         <SheetContent
           className={cs(
-            'absolute left-0 top-0 flex flex min-h-[92px] flex-col flex-col px-6 py-4 data-[state=closed]:duration-0 data-[state=open]:duration-0 md:px-10 md:py-4 lg:px-12',
+            'flex min-h-[92px] flex-col px-6 py-4 data-[state=closed]:duration-0 data-[state=open]:duration-0 md:px-10 md:py-4 lg:px-12',
             searchResults && searchResults.products.length > 0 && 'h-full lg:h-3/4',
           )}
           side="top"


### PR DESCRIPTION
## What/Why?
This pull request contains a fix for the quick search bar being cut off when the user tries to open it without being on the top of the page.
## Testing
**Before**
<img width="1717" alt="search-cut-off-bug" src="https://github.com/bigcommerce/catalyst/assets/66325265/23740086-7d61-4de7-9d0c-d22d751e36b3">
**After**
<img width="1727" alt="search-cut-off-fix" src="https://github.com/bigcommerce/catalyst/assets/66325265/4fdbe131-1509-4db5-84c7-f91891844e6e">
