### PR TITLE
chore(core): catalyst-240 use new client on checkout url

### DIFF
--- a/apps/core/app/(default)/cart/page.tsx
+++ b/apps/core/app/(default)/cart/page.tsx
@@ -4,7 +4,7 @@ import { cookies } from 'next/headers';
 import Image from 'next/image';
 import { Suspense } from 'react';
 
-import client from '~/client';
+import { getCheckoutUrl } from '~/client/management/getCheckoutUrl';
 import { getCart } from '~/client/queries/getCart';
 
 import { removeProduct } from './_actions/removeProduct';
@@ -23,7 +23,7 @@ const EmptyCart = () => (
 );
 
 const CheckoutButton = async ({ cartId }: { cartId: string }) => {
-  const checkoutUrl = await client.getCheckoutUrl(cartId);
+  const checkoutUrl = await getCheckoutUrl(cartId);
 
   return (
     <Button asChild className="mt-6">

--- a/apps/core/client/management/getCheckoutUrl.ts
+++ b/apps/core/client/management/getCheckoutUrl.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+import { newClient } from '..';
+
+const RedirectUrlsSchema = z.object({
+  data: z.object({
+    checkout_url: z.string().min(1),
+    embedded_checkout_url: z.string(),
+    cart_url: z.string(),
+  }),
+});
+
+// Url used to redirect the user to the checkout page
+export const getCheckoutUrl = async (cartId: string) => {
+  const response = await newClient.fetchCartRedirectUrls(cartId);
+  const parsedResponse = RedirectUrlsSchema.safeParse(response);
+
+  if (parsedResponse.success) {
+    return parsedResponse.data.data.checkout_url;
+  }
+
+  throw new Error('Unable to get checkout URL: Invalid response');
+};

--- a/packages/client-new/src/client.ts
+++ b/packages/client-new/src/client.ts
@@ -77,6 +77,30 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     return response.json() as Promise<BigCommerceResponse<TResult>>;
   }
 
+  async fetchCartRedirectUrls<TResult>(cartId: string) {
+    const response = await fetch(
+      `https://api.bigcommerce.com/stores/${this.config.storeHash}/v3/carts/${cartId}/redirect_urls`,
+      {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          'X-Auth-Token': this.config.xAuthToken,
+        },
+        cache: 'no-store',
+        body: JSON.stringify({
+          cart_id: cartId,
+        }),
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`Unable to get checkout URL: ${response.statusText}`);
+    }
+
+    return response.json() as Promise<BigCommerceResponse<TResult>>;
+  }
+
   private getEndpoint() {
     if (!this.config.channelId || this.config.channelId === '1') {
       return `https://store-${this.config.storeHash}.mybigcommerce.com/graphql`;


### PR DESCRIPTION
## What/Why?
This PR upgrades `CheckoutUrl` with new Client approach.

## Ticket
[Catalyst-240](https://bigcommercecloud.atlassian.net/browse/CATALYST-240)

## Testing
locally