### PR TITLE
feat(core): CATALYST-247 use customerId in Product queries

### DIFF
--- a/apps/core/client/queries/getBestSellingProducts.ts
+++ b/apps/core/client/queries/getBestSellingProducts.ts
@@ -1,6 +1,8 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client-new';
 import { cache } from 'react';
 
+import { getSessionCustomerId } from '~/auth';
+
 import { newClient } from '..';
 import { graphql } from '../generated';
 
@@ -27,10 +29,15 @@ interface Options {
 export const getBestSellingProducts = cache(
   async ({ first = 12, imageHeight = 300, imageWidth = 300 }: Options = {}) => {
     const query = graphql(GET_BEST_SELLING_PRODUCTS_QUERY);
+    const customerId = await getSessionCustomerId();
 
     const response = await newClient.fetch({
       document: query,
       variables: { first, imageWidth, imageHeight },
+      customerId,
+      fetchOptions: {
+        cache: customerId ? 'no-store' : 'force-cache',
+      },
     });
 
     const { site } = response.data;

--- a/apps/core/client/queries/getFeaturedProducts.ts
+++ b/apps/core/client/queries/getFeaturedProducts.ts
@@ -1,6 +1,8 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client-new';
 import { cache } from 'react';
 
+import { getSessionCustomerId } from '~/auth';
+
 import { newClient } from '..';
 import { graphql } from '../generated';
 
@@ -27,10 +29,15 @@ interface Options {
 export const getFeaturedProducts = cache(
   async ({ first = 12, imageHeight = 300, imageWidth = 300 }: Options = {}) => {
     const query = graphql(GET_FEATURED_PRODUCTS_QUERY);
+    const customerId = await getSessionCustomerId();
 
     const response = await newClient.fetch({
       document: query,
       variables: { first, imageWidth, imageHeight },
+      customerId,
+      fetchOptions: {
+        cache: customerId ? 'no-store' : 'force-cache',
+      },
     });
 
     const { site } = response.data;

--- a/apps/core/client/queries/getProduct.ts
+++ b/apps/core/client/queries/getProduct.ts
@@ -1,6 +1,8 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client-new';
 import { cache } from 'react';
 
+import { getSessionCustomerId } from '~/auth';
+
 import { newClient } from '..';
 import { graphql } from '../generated';
 import { ExistingResultType } from '../util';
@@ -219,10 +221,15 @@ export const GET_PRODUCT_QUERY = /* GraphQL */ `
 
 const getInternalProduct = async (productId: number, optionValueIds?: OptionValueId[]) => {
   const query = graphql(GET_PRODUCT_QUERY);
+  const customerId = await getSessionCustomerId();
 
   const response = await newClient.fetch({
     document: query,
     variables: { productId, optionValueIds },
+    customerId,
+    fetchOptions: {
+      cache: customerId ? 'no-store' : 'force-cache',
+    },
   });
 
   const product = response.data.site.product;

--- a/apps/core/client/queries/getProductSearchResults.ts
+++ b/apps/core/client/queries/getProductSearchResults.ts
@@ -1,6 +1,8 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client-new';
 import { cache } from 'react';
 
+import { getSessionCustomerId } from '~/auth';
+
 import { newClient } from '..';
 import { graphql } from '../generated';
 import { SearchProductsFiltersInput, SearchProductsSortInput } from '../generated/graphql';
@@ -166,11 +168,13 @@ export const getProductSearchResults = cache(
     imageWidth = 300,
   }: ProductSearch) => {
     const query = graphql(GET_PRODUCT_SEARCH_RESULTS_QUERY);
+    const customerId = await getSessionCustomerId();
 
     const response = await newClient.fetch({
       document: query,
       variables: { first: limit, after, filters, sort, imageHeight, imageWidth },
-      fetchOptions: { next: { revalidate: 300 } },
+      customerId,
+      fetchOptions: { cache: customerId ? 'no-store' : 'force-cache', next: { revalidate: 300 } },
     });
 
     const { site } = response.data;

--- a/apps/core/client/queries/getProducts.ts
+++ b/apps/core/client/queries/getProducts.ts
@@ -1,6 +1,8 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client-new';
 import { cache } from 'react';
 
+import { getSessionCustomerId } from '~/auth';
+
 import { newClient } from '..';
 import { graphql } from '../generated';
 
@@ -28,10 +30,15 @@ const GET_PRODUCTS_QUERY = /* GraphQL */ `
 export const getProducts = cache(
   async ({ productIds, first, imageWidth = 300, imageHeight = 300 }: GetProductsArguments) => {
     const query = graphql(GET_PRODUCTS_QUERY);
+    const customerId = await getSessionCustomerId();
 
     const response = await newClient.fetch({
       document: query,
       variables: { entityIds: productIds, first, imageWidth, imageHeight },
+      customerId,
+      fetchOptions: {
+        cache: customerId ? 'no-store' : 'force-cache',
+      },
     });
 
     const products = removeEdgesAndNodes(response.data.site.products);

--- a/apps/core/client/queries/getQuickSearchResults.ts
+++ b/apps/core/client/queries/getQuickSearchResults.ts
@@ -1,6 +1,8 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client-new';
 import { cache } from 'react';
 
+import { getSessionCustomerId } from '~/auth';
+
 import { newClient } from '..';
 import { graphql } from '../generated';
 
@@ -35,10 +37,15 @@ const GET_QUICK_SEARCH_RESULTS_QUERY = /* GraphQL */ `
 export const getQuickSearchResults = cache(
   async ({ searchTerm, imageHeight = 300, imageWidth = 300 }: QuickSearch) => {
     const query = graphql(GET_QUICK_SEARCH_RESULTS_QUERY);
+    const customerId = await getSessionCustomerId();
 
     const response = await newClient.fetch({
       document: query,
       variables: { filters: { searchTerm }, imageHeight, imageWidth },
+      customerId,
+      fetchOptions: {
+        cache: customerId ? 'no-store' : 'force-cache',
+      },
     });
 
     const { products } = response.data.site.search.searchProducts;

--- a/apps/core/client/queries/getRelatedProducts.ts
+++ b/apps/core/client/queries/getRelatedProducts.ts
@@ -1,6 +1,8 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client-new';
 import { cache } from 'react';
 
+import { getSessionCustomerId } from '~/auth';
+
 import { newClient } from '..';
 import { graphql } from '../generated';
 
@@ -39,10 +41,14 @@ export const getRelatedProducts = cache(
     const { productId, optionValueIds, first = 12, imageWidth = 300, imageHeight = 300 } = options;
 
     const query = graphql(GET_RELATED_PRODUCTS);
+    const customerId = await getSessionCustomerId();
 
     const response = await newClient.fetch({
       document: query,
       variables: { entityId: productId, optionValueIds, first, imageWidth, imageHeight },
+      fetchOptions: {
+        cache: customerId ? 'no-store' : 'force-cache',
+      },
     });
 
     const { product } = response.data.site;


### PR DESCRIPTION
Builds off #418 

## What/Why?
Pass `customerId` to all product queries.

Our initial caching strategy will be to make all queries with `customerId`  as `no-store` cache to prevent over saturation of Data Cache. If no `customerId` is passed, it should default to `force-cache` as it is [the default in NextJS](https://nextjs.org/docs/app/api-reference/functions/fetch).

## Testing
Locally