### PR TITLE
chore(core): Add CODE_OF_CONDUCT.md and CONTRIBUTING.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at engineering@bigcommerce.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing to Catalyst
+Thanks for showing interest in contributing!
+
+The following is a set of guidelines for contributing to Catalyst. These are just guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
+
+#### Table of Contents
+
+How Can I Contribute?
+  * [Pull Requests](#pull-requests)
+  * [Issues / Bugs](#issues--bugs)
+  * [Other Ways to Contribute](#other-ways-to-contribute)
+
+Styleguides
+  * [Git Commit Messages](#git-commit-messages)
+
+## Pull Requests
+
+First ensure that your feature isn't already being developed or considered (see open PRs and issues). 
+If it is, please consider contributing to those initiatives.
+
+## Issues / Bugs
+ 
+* Please include a clear, specific title and replicable description.
+
+* Please include your environment, OS, and any exceptions/backtraces that occur. The more
+information that is given, the more likely we can debug and fix the issue.
+
+**If you find a security bug, please do not post as an issue. Send directly to security@bigcommerce.com 
+instead.**
+
+## Other Ways to Contribute
+
+* Consider reporting bugs, contributing to test coverage, or helping spread the word about Catalyst.
+
+## Git Commit Messages
+
+* Use the present tense ("Add feature" not "Added feature")
+* Use the imperative mood ("Move cursor to..." not "Moves cursor to...")
+* Limit the first line to 72 characters or less
+* Reference pull requests and external links liberally
+
+Thank you again for your interest in contributing to Catalyst!


### PR DESCRIPTION
## What/Why?
Adds `CONTRIBUTIONS.md` and `CODE_OF_CONDUCT.md`, per OSS requirements. The contributions guide is a starting point and should be iterated on prior to open sourcing. The changelog does not yet include a release, as we do not yet have one tagged.

## Testing
Documentation change