### PR TITLE
Add descriptive User-Agent header

### DIFF
--- a/apps/core/client/index.ts
+++ b/apps/core/client/index.ts
@@ -1,9 +1,12 @@
 import { createClient } from '@bigcommerce/catalyst-client';
 
+import { backendUserAgent } from '../userAgent';
+
 export const client = createClient({
   customerImpersonationToken: process.env.BIGCOMMERCE_CUSTOMER_IMPERSONATION_TOKEN ?? '',
   xAuthToken: process.env.BIGCOMMERCE_ACCESS_TOKEN ?? '',
   storeHash: process.env.BIGCOMMERCE_STORE_HASH ?? '',
   channelId: process.env.BIGCOMMERCE_CHANNEL_ID,
+  backendUserAgentExtensions: backendUserAgent,
   logger: process.env.NODE_ENV !== 'production' || process.env.CLIENT_LOGGER === 'true',
 });

--- a/apps/core/userAgent.ts
+++ b/apps/core/userAgent.ts
@@ -1,0 +1,7 @@
+import packageInfo from '../../package.json';
+
+const { name, version } = packageInfo;
+
+// Add package name and version to the user agent
+// Used as part of API client instantiation
+export const backendUserAgent = `${name}/${version}`;

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -19,7 +19,8 @@
   ],
   "dependencies": {
     "@graphql-typed-document-node/core": "^3.2.0",
-    "graphql": "^16.8.1"
+    "graphql": "^16.8.1",
+    "std-env": "^3.7.0"
   },
   "devDependencies": {
     "@bigcommerce/catalyst-configs": "workspace:^",

--- a/packages/client/src/utils/userAgent.ts
+++ b/packages/client/src/utils/userAgent.ts
@@ -1,0 +1,39 @@
+import { nodeVersion, process, provider, runtime } from 'std-env';
+
+import packageInfo from '../../package.json';
+
+const { name, version } = packageInfo;
+
+/*
+ Attempt to detect hosting platform and environment information to add to user agent
+*/
+const getPlatform = () => {
+  const keysOfInterest = [runtime, provider, nodeVersion, process.env.NODE_ENV].filter(Boolean);
+
+  return keysOfInterest.join('; ');
+};
+
+const detectedPlatform = getPlatform();
+
+/*
+    Construct a User-Agent header value for use in API requests to BigCommerce.
+    Reference https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent
+    for more information on the conventions used here.
+*/
+export const getBackendUserAgent = (platform?: string, extensions?: string): string => {
+  // Version of this client which is directly making the request
+  const userAgentParts = [`${name}/${version}`];
+
+  // Used for host information
+  const platformValue = platform || detectedPlatform;
+
+  userAgentParts.push(`(${platformValue})`);
+
+  // Used for any extensions such as framework or plugin versions,
+  // assumed to already be in a valid user-agent format
+  if (extensions) {
+    userAgentParts.push(extensions);
+  }
+
+  return userAgentParts.join(' ');
+};

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -16,7 +16,8 @@
     "preserveWatchOutput": true,
     "skipLibCheck": true,
     "strict": true,
-    "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json"
+    "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json",
+    "resolveJsonModule": true
   },
   "exclude": ["node_modules"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,6 +241,9 @@ importers:
       graphql:
         specifier: ^16.8.1
         version: 16.8.1
+      std-env:
+        specifier: 3.7.0
+        version: 3.7.0
     devDependencies:
       '@bigcommerce/catalyst-configs':
         specifier: workspace:^
@@ -12837,6 +12840,10 @@ packages:
   /statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
+
+  /std-env@3.7.0:
+    resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
+    dev: false
 
   /stop-iteration-iterator@1.0.0:
     resolution: {integrity: sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==}


### PR DESCRIPTION
## What/Why?
To make it easier to help customers who are using Catalyst, we should decorate the API requests back to the origin with information we can use to help and track usage, version fragmentation, and environment information.

This PR adds an explicit `User-Agent` header for requests back to the BigCommerce platform which reflects the Catalyst client & core name and version, which should nicely update itself as an end user customizes these things. It also adds any environment information that is inexpensively accessible via https://github.com/unjs/std-env

Example output:
`User-Agent: @bigcommerce/catalyst-client/0.1.0 (edge-light; development) @bigcommerce/catalyst/0.1.0`

## Testing
Tested locally and verified that server-side Kibana logs were correctly collecting telemetry.