### PR TITLE
New Issue templates for Catalyst

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,17 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Have questions?
+    url: https://catalyst.dev/docs
+    about: Explore the Catalyst Docs.
+  - name: Need help with Catalyst?
+    url: https://github.com/bigcommerce/catalyst/discussions/new?category=q-a
+    about: If you can't get something to work the way you expect, join us in Discussions to browse existing topics or to share a new post.
+  - name: Feature Request
+    url: https://github.com/bigcommerce/catalyst/discussions/new?category=ideas
+    about: Join us in Discussions to share your idea on improving Catalyst. Thanks for your contribution!
+  - name: Official BigCommerce Support
+    url: https://support.bigcommerce.com/contact
+    about: To report a platform bug, outage or greater platform issue, contact our Technical Support team. If you're a partner, please do so via your Partner Portal.
+  - name: 💙 Join the BigCommerceDevs Community
+    url: https://developer.bigcommerce.com/community
+    about: Connect with other devs building on BigCommerce!


### PR DESCRIPTION
## What/Why?

*What --* Issue templates to guide contributors to the best resource for their need. The options include: Discussions for Ideas (feature requests) and Issues, Catalyst Documentation, our Developer Community, as well as Support for platform outages or bugs. 

*Why --* This will be helpful to connect with and to gather contributions from our community. 


## Testing
  Callout on the documentation reference, this is not yet set up but the URL in my pr is planned to be supported soon.