### PR TITLE
chore(core): CATALYST-258 remove old client usage

### DIFF
--- a/apps/core/app/(default)/cart/CartItemCounter.tsx
+++ b/apps/core/app/(default)/cart/CartItemCounter.tsx
@@ -1,12 +1,13 @@
 'use client';
 
+import { Counter } from '@bigcommerce/reactant/Counter';
+import { useState } from 'react';
+
 import {
   CartLineItemInput,
   CartPhysicalItem,
   UpdateCartLineItemInput,
-} from '@bigcommerce/catalyst-client';
-import { Counter } from '@bigcommerce/reactant/Counter';
-import { useState } from 'react';
+} from '~/client/generated/graphql';
 
 import { updateProductQuantity } from './_actions/updateProductQuantity';
 

--- a/apps/core/app/(default)/cart/_actions/updateProductQuantity.ts
+++ b/apps/core/app/(default)/cart/_actions/updateProductQuantity.ts
@@ -1,9 +1,9 @@
 'use server';
 
-import { CartLineItemInput, UpdateCartLineItemInput } from '@bigcommerce/catalyst-client';
 import { revalidatePath } from 'next/cache';
 import { cookies } from 'next/headers';
 
+import { CartLineItemInput, UpdateCartLineItemInput } from '~/client/generated/graphql';
 import { updateCartLineItem } from '~/client/mutations/updateCartLineItem';
 
 interface UpdateProductQuantityParams extends CartLineItemInput {

--- a/apps/core/app/(default)/product/[slug]/_actions/addToCart.ts
+++ b/apps/core/app/(default)/product/[slug]/_actions/addToCart.ts
@@ -1,9 +1,9 @@
 'use server';
 
-import { CartSelectedOptionsInput } from '@bigcommerce/catalyst-client';
 import { revalidateTag } from 'next/cache';
 import { cookies } from 'next/headers';
 
+import { CartSelectedOptionsInput } from '~/client/generated/graphql';
 import { addCartLineItem } from '~/client/mutations/addCartLineItem';
 import { createCart } from '~/client/mutations/createCart';
 import { getCart } from '~/client/queries/getCart';

--- a/apps/core/app/(default)/product/[slug]/_components/RelatedProducts.tsx
+++ b/apps/core/app/(default)/product/[slug]/_components/RelatedProducts.tsx
@@ -1,5 +1,4 @@
-import { OptionValueId } from '@bigcommerce/catalyst-client';
-
+import { OptionValueId } from '~/client/generated/graphql';
 import { getRelatedProducts } from '~/client/queries/getRelatedProducts';
 import { ProductCardCarousel } from '~/components/ProductCardCarousel';
 

--- a/apps/core/client/index.ts
+++ b/apps/core/client/index.ts
@@ -1,12 +1,4 @@
-import { createClient } from '@bigcommerce/catalyst-client';
 import { createClient as createNewClient } from '@bigcommerce/catalyst-client-new';
-
-const client = createClient({
-  key: process.env.BIGCOMMERCE_CUSTOMER_IMPERSONATION_TOKEN ?? '',
-  storeHash: process.env.BIGCOMMERCE_STORE_HASH ?? '',
-  xAuthToken: process.env.BIGCOMMERCE_ACCESS_TOKEN ?? '',
-  channelId: process.env.BIGCOMMERCE_CHANNEL_ID,
-});
 
 export const newClient = createNewClient({
   customerImpersonationToken: process.env.BIGCOMMERCE_CUSTOMER_IMPERSONATION_TOKEN ?? '',
@@ -15,5 +7,3 @@ export const newClient = createNewClient({
   channelId: process.env.BIGCOMMERCE_CHANNEL_ID,
   logger: process.env.NODE_ENV !== 'production' || process.env.CLIENT_LOGGER === 'true',
 });
-
-export default client;

--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -15,7 +15,6 @@
     "test": "jest"
   },
   "dependencies": {
-    "@bigcommerce/catalyst-client": "workspace:^",
     "@bigcommerce/catalyst-client-new": "workspace:^",
     "@bigcommerce/reactant": "workspace:^",
     "@graphql-typed-document-node/core": "^3.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
 
   apps/core:
     dependencies:
-      '@bigcommerce/catalyst-client':
-        specifier: workspace:^
-        version: link:../../packages/client
       '@bigcommerce/catalyst-client-new':
         specifier: workspace:^
         version: link:../../packages/client-new


### PR DESCRIPTION
## What/Why?
First PR to remove the old client. This removes the last usages from core.

Follow up PRs:
- Delete the old client 
- Rename new client