### PR TITLE
feat(core): CATALYST-242 add shipping countries, states & zones

### DIFF
--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -114,6 +114,66 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     return response.json() as Promise<BigCommerceResponse<TResult>>;
   }
 
+  async fetchAvailableCountries() {
+    const response = await fetch(
+      `https://api.bigcommerce.com/stores/${this.config.storeHash}/v2/countries?limit=250`,
+      {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          'X-Auth-Token': this.config.xAuthToken,
+        },
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`Unable to get available Countries List: ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  async fetchCountryStates(id: number) {
+    const response = await fetch(
+      `https://api.bigcommerce.com/stores/${this.config.storeHash}/v2/countries/${id}/states?limit=60`,
+      {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          'X-Auth-Token': this.config.xAuthToken,
+        },
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`Unable to get available States or Provinces: ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  async fetchShippingZones() {
+    const response = await fetch(
+      `https://api.bigcommerce.com/stores/${this.config.storeHash}/v2/shipping/zones`,
+      {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          'X-Auth-Token': this.config.xAuthToken,
+        },
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`Unable to get Shipping Zones: ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
   private getEndpoint() {
     if (!this.config.channelId || this.config.channelId === '1') {
       return `https://store-${this.config.storeHash}.${graphqlApiDomain}/graphql`;


### PR DESCRIPTION
## What/Why?
This PR adds 3 methods to graphql client based on BigCommerce [Management API](https://developer.bigcommerce.com/docs/rest-management/shipping-v2/shipping-zones):
- get all available Countries per Store;
- get a list of States belonging to a Country;
-  get a list of all Shipping Zones

## Testing
locally

[CATALYST-242]: https://bigcommercecloud.atlassian.net/browse/CATALYST-242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ