### PR TITLE
feat(core): add client methods related to shipping

### DIFF
--- a/apps/core/client/management/get-countries.ts
+++ b/apps/core/client/management/get-countries.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+import { client } from '..';
+
+const CountriesListSchema = z.array(
+  z.object({
+    id: z.number().min(1),
+    country: z.string().min(1),
+    country_iso2: z.string(),
+    country_iso3: z.string(),
+    states: z.object({
+      url: z.string(),
+      resource: z.string(),
+    }),
+  }),
+);
+
+// List of available countries
+export const getCountries = async () => {
+  const response = await client.fetchAvailableCountries();
+  const parsedResponse = CountriesListSchema.safeParse(response);
+
+  if (parsedResponse.success) {
+    return parsedResponse.data;
+  }
+
+  throw new Error('Unable to get data on Countries: Invalid response');
+};

--- a/apps/core/client/management/get-country-states.ts
+++ b/apps/core/client/management/get-country-states.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+import { client } from '..';
+
+const CountryStatesSchema = z.array(
+  z.object({
+    id: z.number().min(1),
+    state: z.string().min(1),
+    state_abbreviation: z.string(),
+    country_id: z.number(),
+  }),
+);
+
+// List of States or Provinces for Country
+export const getCountryStates = async (countryId: number) => {
+  const response = await client.fetchCountryStates(countryId);
+  const parsedResponse = CountryStatesSchema.safeParse(response);
+
+  if (parsedResponse.success) {
+    return parsedResponse.data;
+  }
+
+  throw new Error('Unable to get data on Provinces/States: Invalid response');
+};

--- a/apps/core/client/management/get-shipping-zones.ts
+++ b/apps/core/client/management/get-shipping-zones.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+import { client } from '..';
+
+const ShippingZonesSchema = z.array(
+  z.object({
+    id: z.number(),
+    name: z.string(),
+    type: z.string(),
+    locations: z.array(
+      z.object({ id: z.number(), country_iso2: z.string(), zip: z.string().optional() }),
+    ),
+    free_shipping: z.object({
+      enabled: z.boolean(),
+      minimum_sub_total: z.string(),
+      exclude_fixed_shipping_products: z.boolean(),
+    }),
+    enabled: z.boolean(),
+  }),
+);
+
+// List of shipping zones for Store
+export const getShippingZones = async () => {
+  const response = await client.fetchShippingZones();
+  const parsedResponse = ShippingZonesSchema.safeParse(response);
+
+  if (parsedResponse.success) {
+    return parsedResponse.data;
+  }
+
+  throw new Error('Unable to get data on Shipping Zones: Invalid response');
+};

--- a/apps/core/client/mutations/add-checkout-shipping-info.ts
+++ b/apps/core/client/mutations/add-checkout-shipping-info.ts
@@ -1,0 +1,97 @@
+import { client } from '..';
+import { graphql } from '../generated';
+import { CheckoutAddressInput } from '../generated/graphql';
+
+export const ADD_CHECKOUT_SHIPPING_INFO_MUTATION = /* GraphQL */ `
+  mutation AddCheckoutShippingInfo($input: AddCheckoutShippingConsignmentsInput!) {
+    checkout {
+      addCheckoutShippingConsignments(input: $input) {
+        checkout {
+          entityId
+          handlingCostTotal {
+            currencyCode
+            value
+          }
+          shippingCostTotal {
+            value
+            currencyCode
+          }
+          shippingConsignments {
+            entityId
+            shippingCost {
+              value
+              currencyCode
+            }
+            handlingCost {
+              value
+              currencyCode
+            }
+            availableShippingOptions {
+              entityId
+              description
+              cost {
+                value
+                currencyCode
+              }
+              isRecommended
+              type
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+interface AddCheckoutShippingInfoProps {
+  cartId: string;
+  countryCode: CheckoutAddressInput['countryCode'];
+  stateOrProvince: CheckoutAddressInput['stateOrProvince'];
+  city: CheckoutAddressInput['city'];
+  postalCode: CheckoutAddressInput['postalCode'];
+  shouldSaveAddress?: CheckoutAddressInput['shouldSaveAddress'];
+  cartItems: Array<{ quantity: number; lineItemEntityId: string }>;
+}
+
+export const addCheckoutShippingInfo = async ({
+  cartId,
+  countryCode,
+  stateOrProvince,
+  city,
+  postalCode,
+  cartItems,
+  shouldSaveAddress = false,
+}: AddCheckoutShippingInfoProps) => {
+  const mutation = graphql(ADD_CHECKOUT_SHIPPING_INFO_MUTATION);
+
+  const response = await client.fetch({
+    document: mutation,
+    variables: {
+      input: {
+        checkoutEntityId: cartId,
+        data: {
+          consignments: [
+            {
+              address: {
+                countryCode,
+                city,
+                stateOrProvince,
+                shouldSaveAddress,
+                postalCode,
+              },
+              lineItems: cartItems,
+            },
+          ],
+        },
+      },
+    },
+  });
+
+  const checkout = response.data.checkout.addCheckoutShippingConsignments?.checkout;
+
+  if (checkout) {
+    return checkout;
+  }
+
+  return null;
+};

--- a/apps/core/client/mutations/select-checkout-shipping-option.ts
+++ b/apps/core/client/mutations/select-checkout-shipping-option.ts
@@ -1,0 +1,66 @@
+import { client } from '..';
+import { graphql } from '../generated';
+
+export const SELECT_CHECKOUT_SHIPPING_OPTION_MUTATION = /* GraphQL */ `
+  mutation SelectCheckoutShippingOption($input: SelectCheckoutShippingOptionInput!) {
+    checkout {
+      selectCheckoutShippingOption(input: $input) {
+        checkout {
+          entityId
+          shippingCostTotal {
+            value
+            currencyCode
+          }
+          handlingCostTotal {
+            value
+            currencyCode
+          }
+          shippingConsignments {
+            selectedShippingOption {
+              entityId
+              description
+              type
+              cost {
+                value
+                currencyCode
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const selectCheckoutShippingOption = async ({
+  checkoutEntityId,
+  consignmentEntityId,
+  shippingOptionEntityId,
+}: {
+  checkoutEntityId: string;
+  consignmentEntityId: string;
+  shippingOptionEntityId: string;
+}) => {
+  const mutation = graphql(SELECT_CHECKOUT_SHIPPING_OPTION_MUTATION);
+
+  const response = await client.fetch({
+    document: mutation,
+    variables: {
+      input: {
+        checkoutEntityId,
+        consignmentEntityId,
+        data: {
+          shippingOptionEntityId,
+        },
+      },
+    },
+  });
+
+  const shippingCosts = response.data.checkout.selectCheckoutShippingOption?.checkout;
+
+  if (shippingCosts) {
+    return shippingCosts;
+  }
+
+  return null;
+};


### PR DESCRIPTION
## What/Why?
This PR updates client on Core with
1. mutations:
- `addCheckoutShippingInfo`,
- `selectCheckoutShippingOption`

2. management:
- `getCountries`,
- `getCountryStates`,
- `getShippingZones`

## Testing
locally
