### PR TITLE
feat(core): Catalyst 242 add Shipping Info to Cart

### DIFF
--- a/apps/core/app/(default)/cart/_actions/get-shipping-countries.ts
+++ b/apps/core/app/(default)/cart/_actions/get-shipping-countries.ts
@@ -1,0 +1,40 @@
+import { getCountries } from '~/client/management/get-countries';
+import { getShippingZones } from '~/client/management/get-shipping-zones';
+
+export const getShippingCountries = async () => {
+  const shippingZones = await getShippingZones();
+  const uniqueCountryZones = shippingZones.reduce<string[]>((zones, item) => {
+    item.locations.forEach(({ country_iso2 }) => {
+      if (zones.length === 0) {
+        zones.push(country_iso2);
+
+        return zones;
+      }
+
+      const isAvailable = zones.length > 0 && zones.some((zone) => zone === country_iso2);
+
+      if (!isAvailable) {
+        zones.push(country_iso2);
+      }
+
+      return zones;
+    });
+
+    return zones;
+  }, []);
+
+  const allCountries = await getCountries();
+  const shippingCountries = allCountries.flatMap((countryDetails) => {
+    const isCountryInTheList = uniqueCountryZones.includes(countryDetails.country_iso2);
+
+    if (isCountryInTheList) {
+      const { id, country: name, country_iso2: countryCode } = countryDetails;
+
+      return { id, name, countryCode };
+    }
+
+    return [];
+  });
+
+  return shippingCountries;
+};

--- a/apps/core/app/(default)/cart/_actions/remove-products.ts
+++ b/apps/core/app/(default)/cart/_actions/remove-products.ts
@@ -21,9 +21,10 @@ export async function removeProduct(formData: FormData) {
   const updatedCart = await deleteCartLineItem(cartId, lineItemEntityId.toString());
 
   // If we remove the last item in a cart the cart is deleted
-  // so we need to remove the cartId cookie
+  // so we need to remove the cartId cookie and clear shipping data
   if (!updatedCart) {
     cookies().delete('cartId');
+    cookies().delete('shippingCosts');
     revalidateTag('cart');
   }
 

--- a/apps/core/app/(default)/cart/_components/checkout-summary.tsx
+++ b/apps/core/app/(default)/cart/_components/checkout-summary.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { createContext, Dispatch, SetStateAction, useState } from 'react';
+
+import { getCart } from '~/client/queries/get-cart';
+import { ExistingResultType } from '~/client/util';
+
+import { getShippingCountries } from '../_actions/get-shipping-countries';
+
+import { ShippingEstimator } from './shipping-estimator';
+
+export const createCurrencyFormatter = (currencyCode: string) =>
+  new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: currencyCode,
+  });
+
+type CartSummary = ExistingResultType<typeof getCart>;
+export type CheckoutSummary = CartSummary & {
+  shippingCostTotal: {
+    currencyCode: string;
+    value: number;
+  };
+  handlingCostTotal: {
+    currencyCode: string;
+    value: number;
+  };
+};
+export interface ShippingCosts {
+  shippingCostTotal: number;
+  handlingCostTotal: number;
+}
+type ShippingCountries = ExistingResultType<typeof getShippingCountries>;
+
+export const CheckoutContext = createContext<{
+  availableShippingCountries: ShippingCountries;
+  checkoutEntityId: string;
+  shippingCosts: ShippingCosts | null;
+  currencyCode: string;
+  isShippingMethodSelected: boolean;
+  setIsShippingMethodSelected: (newIsShippingMethodSelected: boolean) => void;
+  updateCheckoutSummary: Dispatch<SetStateAction<CheckoutSummary>>;
+}>({
+  availableShippingCountries: [],
+  checkoutEntityId: '',
+  currencyCode: '',
+  isShippingMethodSelected: false,
+  setIsShippingMethodSelected: () => undefined,
+  shippingCosts: null,
+  updateCheckoutSummary: () => undefined,
+});
+
+export const CheckoutSummary = ({
+  cart,
+  shippingCountries,
+  shippingCosts,
+}: {
+  cart: NonNullable<CartSummary>;
+  shippingCountries: ShippingCountries;
+  shippingCosts: {
+    shippingCostTotal: number;
+    handlingCostTotal: number;
+  } | null;
+}) => {
+  const [isShippingMethodSelected, setIsShippingMethodSelected] = useState(false);
+  const [checkoutSummary, updateCheckoutSummary] = useState<CheckoutSummary>({
+    ...cart,
+    shippingCostTotal: {
+      currencyCode: cart.currencyCode,
+      value: shippingCosts?.shippingCostTotal ?? 0,
+    },
+    handlingCostTotal: {
+      currencyCode: cart.currencyCode,
+      value: shippingCosts?.handlingCostTotal ?? 0,
+    },
+  });
+
+  const currencyFormatter = createCurrencyFormatter(checkoutSummary.currencyCode);
+  const extractCartlineItemsData = ({
+    entityId,
+    productEntityId,
+    quantity,
+    variantEntityId,
+  }: (typeof cart.lineItems.physicalItems)[number]) => ({
+    lineItemEntityId: entityId,
+    productEntityId,
+    quantity,
+    variantEntityId,
+  });
+
+  return (
+    <CheckoutContext.Provider
+      value={{
+        availableShippingCountries: shippingCountries,
+        checkoutEntityId: checkoutSummary.entityId,
+        currencyCode: checkoutSummary.currencyCode,
+        isShippingMethodSelected,
+        setIsShippingMethodSelected,
+        shippingCosts,
+        updateCheckoutSummary,
+      }}
+    >
+      <div className="flex justify-between border-t border-t-gray-200 py-4">
+        <span className="text-base font-semibold">Subtotal</span>
+        <span className="text-base">
+          {currencyFormatter.format(checkoutSummary.totalExtendedListPrice.value)}
+        </span>
+      </div>
+
+      <ShippingEstimator
+        shippingItems={checkoutSummary.lineItems.physicalItems.reduce<
+          Array<{ quantity: number; lineItemEntityId: string }>
+        >((items, product) => {
+          const { lineItemEntityId, quantity } = extractCartlineItemsData(product);
+
+          items.push({ quantity, lineItemEntityId });
+
+          return items;
+        }, [])}
+      />
+
+      <div className="flex justify-between border-t border-t-gray-200 py-4">
+        <span className="text-base font-semibold">Discounts</span>
+        <span className="text-base">
+          {currencyFormatter.format(checkoutSummary.totalDiscountedAmount.value)}
+        </span>
+      </div>
+
+      <div className="flex justify-between border-t border-t-gray-200 py-4">
+        <span className="text-h5">Grand total</span>
+        <span className="text-h5">
+          {currencyFormatter.format(
+            checkoutSummary.totalExtendedSalePrice.value +
+              checkoutSummary.shippingCostTotal.value +
+              checkoutSummary.handlingCostTotal.value,
+          )}
+        </span>
+      </div>
+    </CheckoutContext.Provider>
+  );
+};

--- a/apps/core/app/(default)/cart/_components/shipping-estimator.tsx
+++ b/apps/core/app/(default)/cart/_components/shipping-estimator.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { Button } from '@bigcommerce/components/button';
+import { useContext, useEffect, useState } from 'react';
+
+import { ShippingInfo } from '~/components/forms';
+
+import { CheckoutContext, createCurrencyFormatter } from './checkout-summary';
+
+export const ShippingEstimator = ({
+  shippingItems,
+}: {
+  shippingItems: Array<{ quantity: number; lineItemEntityId: string }>;
+}) => {
+  const { isShippingMethodSelected, shippingCosts, currencyCode } = useContext(CheckoutContext);
+  const [isOpened, setIsOpened] = useState(false);
+  const currencyFormatter = createCurrencyFormatter(currencyCode);
+
+  useEffect(() => {
+    if (isShippingMethodSelected) {
+      setIsOpened(false);
+    }
+  }, [setIsOpened, isShippingMethodSelected]);
+
+  return shippingCosts ? (
+    <div className="flex flex-col justify-between gap-4 border-t border-t-gray-200 py-4">
+      {/* TODO: Add updateShipping functionality later */}
+      <div className="flex w-full justify-between" data-test="shipping-estimator">
+        <span className="text-base font-semibold">Shipping Cost</span>
+        <span className="text-base">
+          {currencyFormatter.format(shippingCosts.shippingCostTotal)}
+        </span>
+      </div>
+      <div className="inline-flex justify-between border-t border-t-gray-200 pt-4">
+        <span className="text-base font-semibold">Handling Cost</span>
+        <span className="text-base">
+          {currencyFormatter.format(shippingCosts.handlingCostTotal)}
+        </span>
+      </div>
+    </div>
+  ) : (
+    <div className="flex flex-col justify-between gap-4 border-t border-t-gray-200 py-4">
+      <div className="inline-flex w-full flex-col justify-between">
+        <div className="inline-flex items-center justify-between">
+          <span className="text-base font-semibold">Shipping</span>
+          <Button
+            className="w-fit p-0 text-base text-blue-primary"
+            onClick={() => setIsOpened((open) => !open)}
+            variant="subtle"
+          >
+            {isOpened ? 'Cancel' : 'Add'}
+          </Button>
+        </div>
+        <ShippingInfo cartItems={shippingItems} isVisible={isOpened} />
+      </div>
+    </div>
+  );
+};

--- a/apps/core/components/forms/_actions/get-shipping-states.ts
+++ b/apps/core/components/forms/_actions/get-shipping-states.ts
@@ -1,0 +1,17 @@
+'use server';
+
+import { getCountryStates } from '~/client/management/get-country-states';
+
+export async function getShippingStates(id: number) {
+  try {
+    const response = await getCountryStates(id);
+
+    return { status: 'success', data: response };
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      return { status: 'failed', error: error.message };
+    }
+
+    return { status: 'failed', error };
+  }
+}

--- a/apps/core/components/forms/_actions/submit-shipping-costs.ts
+++ b/apps/core/components/forms/_actions/submit-shipping-costs.ts
@@ -1,0 +1,53 @@
+'use server';
+
+import { revalidateTag } from 'next/cache';
+import { cookies } from 'next/headers';
+import { z } from 'zod';
+
+import { selectCheckoutShippingOption } from '~/client/mutations/select-checkout-shipping-option';
+
+const ShippingCostSchema = z.object({
+  shippingOption: z.string(),
+});
+
+export const submitShippingCosts = async (
+  formData: FormData,
+  checkoutEntityId: string,
+  consignmentEntityId: string,
+) => {
+  try {
+    const parsedData = ShippingCostSchema.parse({
+      shippingOption: formData.get('shippingOption'),
+    });
+
+    const shippingCost = await selectCheckoutShippingOption({
+      checkoutEntityId,
+      consignmentEntityId,
+      shippingOptionEntityId: parsedData.shippingOption,
+    });
+
+    const shippingCosts = {
+      shippingCostTotal: shippingCost?.shippingCostTotal?.value ?? 0,
+      handlingCostTotal: shippingCost?.handlingCostTotal?.value ?? 0,
+    };
+
+    cookies().set({
+      name: 'shippingCosts',
+      value: JSON.stringify(shippingCosts),
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: true,
+      path: '/',
+    });
+
+    revalidateTag('cart');
+
+    return { status: 'success', data: shippingCost };
+  } catch (e: unknown) {
+    if (e instanceof Error || e instanceof z.ZodError) {
+      return { status: 'failed', error: e.message };
+    }
+
+    return { status: 'failed' };
+  }
+};

--- a/apps/core/components/forms/_actions/submit-shipping-info.ts
+++ b/apps/core/components/forms/_actions/submit-shipping-info.ts
@@ -1,0 +1,47 @@
+'use server';
+
+import { z } from 'zod';
+
+import { addCheckoutShippingInfo } from '~/client/mutations/add-checkout-shipping-info';
+
+const ShippingInfoSchema = z.object({
+  country: z.string(),
+  state: z.string().optional(),
+  city: z.string().optional(),
+  zipcode: z.string().optional(),
+});
+
+export const submitShippingInfo = async (
+  formData: FormData,
+  cartData: {
+    cartId: string;
+    cartItems: Array<{ quantity: number; lineItemEntityId: string }>;
+  },
+) => {
+  try {
+    const parsedData = ShippingInfoSchema.parse({
+      country: formData.get('country'),
+      state: formData.get('state'),
+      city: formData.get('city'),
+      zipcode: formData.get('zip'),
+    });
+    const { cartId, cartItems } = cartData;
+
+    const res = await addCheckoutShippingInfo({
+      cartId,
+      cartItems,
+      countryCode: parsedData.country.split('-')[0] ?? '',
+      stateOrProvince: parsedData.state,
+      city: parsedData.city,
+      postalCode: parsedData.zipcode,
+    });
+
+    return { status: 'success', data: res };
+  } catch (e: unknown) {
+    if (e instanceof Error || e instanceof z.ZodError) {
+      return { status: 'failed', error: e.message };
+    }
+
+    return { status: 'failed' };
+  }
+};

--- a/apps/core/components/forms/index.ts
+++ b/apps/core/components/forms/index.ts
@@ -1,3 +1,4 @@
 'use client';
 
 export * from './contact-us';
+export * from './shipping-info';

--- a/apps/core/components/forms/shipping-cost.tsx
+++ b/apps/core/components/forms/shipping-cost.tsx
@@ -1,0 +1,137 @@
+import { Button } from '@bigcommerce/components/button';
+import { Field, FieldLabel, Form, FormSubmit } from '@bigcommerce/components/form';
+import { Label } from '@bigcommerce/components/label';
+import { RadioGroup, RadioItem } from '@bigcommerce/components/radio-group';
+import { Loader2 as Spinner } from 'lucide-react';
+import { useContext } from 'react';
+import { useFormStatus } from 'react-dom';
+
+import {
+  CheckoutContext,
+  createCurrencyFormatter,
+} from '~/app/(default)/cart/_components/checkout-summary';
+import { addCheckoutShippingInfo } from '~/client/mutations/add-checkout-shipping-info';
+import { ExistingResultType } from '~/client/util';
+import { cn } from '~/lib/utils';
+
+import { submitShippingCosts } from './_actions/submit-shipping-costs';
+
+type ShippingConsignments = ExistingResultType<
+  typeof addCheckoutShippingInfo
+>['shippingConsignments'];
+
+const SubmitFormButton = () => {
+  const { pending } = useFormStatus();
+
+  return (
+    <Button className="w-full items-center px-8 py-2" disabled={pending} variant="secondary">
+      {pending ? (
+        <>
+          <Spinner aria-hidden="true" className="animate-spin" />
+          <span className="sr-only">Submitting...</span>
+        </>
+      ) : (
+        <span>Update shipping costs</span>
+      )}
+    </Button>
+  );
+};
+
+export const ShippingCost = ({
+  consignmentEntityId,
+  shippingConsignments,
+}: {
+  consignmentEntityId: string;
+  shippingConsignments: ShippingConsignments;
+}) => {
+  const extractShippingOptions = (consignments: ShippingConsignments) => {
+    if (consignments) {
+      return consignments.flatMap(({ availableShippingOptions }) => {
+        const shippingOptionsRes = availableShippingOptions
+          ? availableShippingOptions.map(
+              ({ cost, description, entityId: shippingOptionEntityId, isRecommended }) => ({
+                cost: cost.value,
+                description,
+                shippingOptionEntityId,
+                isDefault: isRecommended,
+              }),
+            )
+          : [];
+
+        return shippingOptionsRes;
+      });
+    }
+
+    return null;
+  };
+  const shippingOptions = shippingConsignments ? extractShippingOptions(shippingConsignments) : [];
+  const { checkoutEntityId, currencyCode, setIsShippingMethodSelected, updateCheckoutSummary } =
+    useContext(CheckoutContext);
+  const currencyFormatter = createCurrencyFormatter(currencyCode);
+
+  const onSubmit = async (formData: FormData) => {
+    const { status, data } = await submitShippingCosts(
+      formData,
+      checkoutEntityId,
+      consignmentEntityId,
+    );
+
+    if (status === 'success' && data) {
+      setIsShippingMethodSelected(true);
+
+      const { shippingCostTotal, handlingCostTotal } = data;
+
+      updateCheckoutSummary((prevCheckoutSummary) => ({
+        ...prevCheckoutSummary,
+        shippingCostTotal: {
+          value: shippingCostTotal?.value ?? 0,
+          currencyCode,
+        },
+        handlingCostTotal: {
+          value: handlingCostTotal?.value ?? 0,
+          currencyCode,
+        },
+      }));
+    }
+
+    return null;
+  };
+
+  return (
+    <Form action={onSubmit} className={cn('mx-auto mb-4 mt-4 grid w-full grid-cols-1 gap-y-4')}>
+      <Field className={cn('relative space-y-2')} id="shipping-option" name="option">
+        <FieldLabel htmlFor="shipping-option">Available options</FieldLabel>
+        <RadioGroup
+          aria-label="Available shipping options"
+          defaultValue={shippingOptions?.find((option) => option.isDefault)?.shippingOptionEntityId}
+          name="shippingOption"
+          required={true}
+        >
+          {shippingOptions &&
+            shippingOptions.map((option) => {
+              return (
+                <div className="mb-2 flex" key={option.shippingOptionEntityId}>
+                  <RadioItem
+                    id={option.shippingOptionEntityId}
+                    value={option.shippingOptionEntityId}
+                  />
+                  <Label
+                    className="w-full cursor-pointer ps-4 font-normal"
+                    htmlFor={option.shippingOptionEntityId}
+                  >
+                    <p className="inline-flex w-full justify-between">
+                      <span>{option.description}</span>
+                      <span>{currencyFormatter.format(option.cost)}</span>
+                    </p>
+                  </Label>
+                </div>
+              );
+            })}
+        </RadioGroup>
+      </Field>
+      <FormSubmit asChild>
+        <SubmitFormButton />
+      </FormSubmit>
+    </Form>
+  );
+};

--- a/apps/core/components/forms/shipping-info.tsx
+++ b/apps/core/components/forms/shipping-info.tsx
@@ -1,0 +1,218 @@
+import { Button } from '@bigcommerce/components/button';
+import { Field, FieldControl, FieldLabel, Form, FormSubmit } from '@bigcommerce/components/form';
+import { Input } from '@bigcommerce/components/input';
+import { Select, SelectContent, SelectItem } from '@bigcommerce/components/select';
+import { Loader2 as Spinner } from 'lucide-react';
+import { Dispatch, SetStateAction, useContext, useEffect, useState } from 'react';
+import { useFormStatus } from 'react-dom';
+
+import { CheckoutContext } from '~/app/(default)/cart/_components/checkout-summary';
+import { ExistingResultType } from '~/client/util';
+import { cn } from '~/lib/utils';
+
+import { getShippingStates } from './_actions/get-shipping-states';
+import { submitShippingInfo } from './_actions/submit-shipping-info';
+import { ShippingCost } from './shipping-cost';
+
+type StatesList = Array<{
+  id: number;
+  state: string;
+  state_abbreviation: string;
+  country_id: number;
+}>;
+
+type ShippingInfoData = ExistingResultType<typeof submitShippingInfo>['data'];
+
+async function fetchStatesOnCountrySelect(
+  countryId: number | null,
+  SetterFn: Dispatch<SetStateAction<StatesList | null>>,
+) {
+  if (countryId) {
+    const res = await getShippingStates(countryId);
+    const states = res.status === 'success' && res.data ? res.data : null;
+
+    SetterFn(states);
+  }
+}
+
+const SubmitFormButton = () => {
+  const { pending } = useFormStatus();
+
+  return (
+    <Button className="w-full items-center px-8 py-2" disabled={pending} variant="secondary">
+      {pending ? (
+        <>
+          <Spinner aria-hidden="true" className="animate-spin" />
+          <span className="sr-only">Submitting...</span>
+        </>
+      ) : (
+        <span>Estimate shipping</span>
+      )}
+    </Button>
+  );
+};
+
+export const ShippingInfo = ({
+  isVisible,
+  cartItems,
+}: {
+  isVisible: boolean;
+  cartItems: Array<{ quantity: number; lineItemEntityId: string }>;
+}) => {
+  const {
+    availableShippingCountries,
+    checkoutEntityId,
+    setIsShippingMethodSelected,
+    updateCheckoutSummary,
+    currencyCode,
+  } = useContext(CheckoutContext);
+  const [selectedCountry, setSelectedCountry] = useState('');
+  const [selectedCity, setSelectedCity] = useState('');
+  const [selectedZipCode, setSelectedZipCode] = useState('');
+  const [selectedStates, setSelectedStates] = useState<StatesList | null>(null);
+  const [shippingInfo, setShippingInfo] = useState<ShippingInfoData | null>(null);
+
+  const onSubmit = async (formData: FormData) => {
+    const { status, data } = await submitShippingInfo(formData, {
+      cartId: checkoutEntityId,
+      cartItems,
+    });
+
+    if (status === 'success' && data) {
+      setShippingInfo(data);
+    }
+  };
+
+  useEffect(() => {
+    if (selectedCountry) {
+      // TODO: rename method later
+      void fetchStatesOnCountrySelect(
+        selectedCountry ? Number(selectedCountry) : null,
+        setSelectedStates,
+      );
+
+      // clear rest fields on Country change
+      setSelectedCity('');
+      setSelectedZipCode('');
+      setIsShippingMethodSelected(false);
+      setShippingInfo(null);
+      updateCheckoutSummary((prevCehckoutSummary) => ({
+        ...prevCehckoutSummary,
+        shippingCostTotal: {
+          value: 0,
+          currencyCode,
+        },
+        handlingCostTotal: {
+          value: 0,
+          currencyCode,
+        },
+      }));
+    } else {
+      setSelectedStates(null);
+    }
+  }, [currencyCode, selectedCountry, setIsShippingMethodSelected, updateCheckoutSummary]);
+
+  return (
+    <>
+      <Form
+        action={onSubmit}
+        className={cn('mx-auto mb-4 mt-4 hidden w-full grid-cols-1 gap-y-4', isVisible && 'grid')}
+      >
+        <>
+          <Field className={cn('relative space-y-2')} name="country">
+            <FieldLabel>Country</FieldLabel>
+            <FieldControl asChild>
+              <Select
+                autoComplete="country"
+                onValueChange={(value: string) => {
+                  const countryId = value.split('-')[1];
+
+                  if (countryId) {
+                    setSelectedCountry(countryId);
+                  } else {
+                    setSelectedCountry('');
+                  }
+                }}
+                placeholder="Select county"
+              >
+                <SelectContent>
+                  {availableShippingCountries.map(({ id, countryCode, name }) => {
+                    return (
+                      <SelectItem key={id} value={`${countryCode}-${id}`}>
+                        {name}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
+              </Select>
+            </FieldControl>
+          </Field>
+          <Field className={cn('relative space-y-2')} name="state">
+            <FieldLabel>State/province</FieldLabel>
+            <FieldControl asChild>
+              {selectedStates ? (
+                <Select placeholder="State/province...">
+                  <SelectContent>
+                    {selectedStates.map(({ id, state }) => {
+                      return (
+                        <SelectItem key={id} value={state}>
+                          {state}
+                        </SelectItem>
+                      );
+                    })}
+                  </SelectContent>
+                </Select>
+              ) : (
+                <Input autoComplete="address-level1" placeholder="State/province..." type="text" />
+              )}
+            </FieldControl>
+          </Field>
+          <Field className={cn('relative space-y-2')} name="city">
+            <FieldLabel htmlFor="city-field">Suburb/city</FieldLabel>
+            <FieldControl asChild>
+              <Input
+                autoComplete="address-level2"
+                id="city-field"
+                onChange={(e) => setSelectedCity(e.target.value)}
+                placeholder="Suburb/city..."
+                type="text"
+                value={selectedCity}
+              />
+            </FieldControl>
+          </Field>
+          <Field className={cn('relative space-y-2')} name="zip">
+            <FieldLabel htmlFor="zip-field">Zip/Postcode</FieldLabel>
+            <FieldControl asChild>
+              <Input
+                autoComplete="postal-code"
+                id="zip-field"
+                onChange={(e) => setSelectedZipCode(e.target.value)}
+                placeholder="Zip/Postcode..."
+                type="number"
+                value={selectedZipCode}
+              />
+            </FieldControl>
+          </Field>
+        </>
+        <FormSubmit asChild>
+          <SubmitFormButton />
+        </FormSubmit>
+      </Form>
+      <div className="flex w-full flex-col">
+        {isVisible &&
+          shippingInfo &&
+          shippingInfo.shippingConsignments &&
+          shippingInfo.shippingConsignments.length > 0 &&
+          shippingInfo.shippingConsignments.map(({ entityId }) => {
+            return (
+              <ShippingCost
+                consignmentEntityId={entityId}
+                key={entityId}
+                shippingConsignments={shippingInfo.shippingConsignments}
+              />
+            );
+          })}
+      </div>
+    </>
+  );
+};


### PR DESCRIPTION
## What/Why?
This PR adds components to Core that enable adding Shipping Costs to Cart.

It's based on 2 other PRs:

- [catalyst-242b](https://github.com/bigcommerce/catalyst/pull/435)
- [catalyst-242c](https://github.com/bigcommerce/catalyst/pull/436)

## Testing
locally

https://github.com/bigcommerce/catalyst/assets/67792608/5163d130-4575-43e9-b9b8-78984364f696
