### PR TITLE
feat(core): CATALYST-221  add client query and mutation for contact us form

### DIFF
--- a/apps/core/client/mutations/submitContactForm.ts
+++ b/apps/core/client/mutations/submitContactForm.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod';
+
+import { client } from '..';
+import { graphql } from '../generated';
+
+export const ContactUsSchema = z.object({
+  companyName: z.string().optional(),
+  fullName: z.string().optional(),
+  phoneNumber: z.string().optional(),
+  orderNumber: z.string().optional(),
+  rmaNumber: z.string().optional(),
+  email: z.string().email(),
+  comments: z.string().trim(),
+});
+
+interface SubmitContactForm {
+  formFields: z.infer<typeof ContactUsSchema>;
+  pageEntityId: number;
+  reCaptchaToken?: string;
+}
+
+const SUBMIT_CONTACT_FORM_MUTATION = /* GraphQL */ `
+  mutation submitContactUs($input: SubmitContactUsInput!, $reCaptchaV2: ReCaptchaV2Input) {
+    submitContactUs(input: $input, reCaptchaV2: $reCaptchaV2) {
+      __typename
+      errors {
+        __typename
+        ... on Error {
+          message
+        }
+      }
+    }
+  }
+`;
+
+export const submitContactForm = async ({
+  formFields,
+  pageEntityId,
+  reCaptchaToken,
+}: SubmitContactForm) => {
+  const mutation = graphql(SUBMIT_CONTACT_FORM_MUTATION);
+
+  const variables = {
+    input: {
+      pageEntityId,
+      data: formFields,
+    },
+    ...(reCaptchaToken && { reCaptchaV2: { token: reCaptchaToken } }),
+  };
+
+  const response = await client.fetch({
+    document: mutation,
+    variables,
+  });
+
+  return response.data;
+};

--- a/apps/core/client/queries/getReCaptchaSettings.ts
+++ b/apps/core/client/queries/getReCaptchaSettings.ts
@@ -1,0 +1,21 @@
+import { client } from '..';
+import { graphql } from '../generated';
+
+const GET_RECAPTCHA_SETTINGS_QUERY = /* GraphQL */ `
+  query getReCaptchaSettings {
+    site {
+      settings {
+        reCaptcha {
+          siteKey
+        }
+      }
+    }
+  }
+`;
+
+export const getReCaptchaSettings = async () => {
+  const query = graphql(GET_RECAPTCHA_SETTINGS_QUERY);
+  const response = await client.fetch({ document: query });
+
+  return response.data.site.settings?.reCaptcha;
+};


### PR DESCRIPTION
## What/Why?
This pr adds `submitContactForm` mutation and `getReCaptchaSettings` query to the client.
Form submission implemented in related [pr](https://github.com/bigcommerce/catalyst/pull/417)

## Testing
Locally