### PR TITLE
chore: Add CHANGELOG to core, client, and create-catalyst

### DIFF
--- a/apps/core/CHANGELOG.md
+++ b/apps/core/CHANGELOG.md
@@ -1,0 +1,2 @@
+# Changelog
+All notable changes to this project will be documented in this file.

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,0 +1,2 @@
+# Changelog
+All notable changes to this project will be documented in this file.

--- a/packages/create-catalyst/CHANGELOG.md
+++ b/packages/create-catalyst/CHANGELOG.md
@@ -1,0 +1,2 @@
+# Changelog
+All notable changes to this project will be documented in this file.


### PR DESCRIPTION
## What/Why?
Add CHANGELOG.md to core, client and create-catalyst. A release will not be tagged yet, likely we will move to using changesets for the first release.

## Testing
Documentation change.