### PR TITLE
fix(core): Do not run playwright ui tests on catalyst-core

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -47,7 +47,7 @@ jobs:
     name: Playwright UI Tests
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    if: ${{ github.event.deployment_status.state == 'success' && ! contains(github.event.deployment_status.target_url, 'storybook') }}
+    if: ${{ github.event.deployment_status.state == 'success' && ! contains(github.event.deployment_status.target_url, 'storybook') && ! contains(github.event.deployment_status.target_url, 'core') }}
     steps:
       - name: Checkout code
         uses: actions/checkout@main


### PR DESCRIPTION
## What/Why?
It's been noticed that the playwright UI tests are running against two deployments which are https://catalyst-* and https://catalyst-core-*. The latter ends up in timeout as navigating to that site requires additional access on vercel. Also, I don't see why we should be running the same set of tests against both of these deployments. This change modifies the workflows such that we run the tests only against https://catalyst-*.

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->