### PR TITLE
feat(core): CATALYST-268 use customerId in category queries

### DIFF
--- a/apps/core/client/queries/getCategory.ts
+++ b/apps/core/client/queries/getCategory.ts
@@ -1,6 +1,8 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
 import { cache } from 'react';
 
+import { getSessionCustomerId } from '~/auth';
+
 import { client } from '..';
 import { graphql } from '../generated';
 
@@ -67,12 +69,16 @@ export interface CategoryOptions {
 export const getCategory = cache(
   async ({ categoryId, limit = 9, before, after, breadcrumbDepth = 10 }: CategoryOptions) => {
     const query = graphql(GET_CATEGORY_QUERY);
+    const customerId = await getSessionCustomerId();
 
     const paginationArgs = before ? { last: limit, before } : { first: limit, after };
 
     const response = await client.fetch({
       document: query,
       variables: { categoryId, breadcrumbDepth, ...paginationArgs },
+      fetchOptions: {
+        cache: customerId ? 'no-store' : 'force-cache',
+      },
     });
 
     const category = response.data.site.category;

--- a/apps/core/client/queries/getCategoryTree.ts
+++ b/apps/core/client/queries/getCategoryTree.ts
@@ -1,5 +1,7 @@
 import { cache } from 'react';
 
+import { getSessionCustomerId } from '~/auth';
+
 import { client } from '..';
 import { graphql } from '../generated';
 
@@ -27,10 +29,14 @@ export const GET_CATEGORY_TREE_QUERY = /* GraphQL */ `
 
 export const getCategoryTree = cache(async (categoryId?: number) => {
   const query = graphql(GET_CATEGORY_TREE_QUERY);
+  const customerId = await getSessionCustomerId();
 
   const response = await client.fetch({
     document: query,
     variables: { categoryId },
+    fetchOptions: {
+      cache: customerId ? 'no-store' : 'force-cache',
+    },
   });
 
   return response.data.site.categoryTree;


### PR DESCRIPTION
## What/Why?
Pass customerId to all category queries.

Our initial caching strategy will be to make all queries with customerId as no-store cache to prevent over saturation of Data Cache. If no customerId is passed, it should default to force-cache as it is [the default in NextJS](https://nextjs.org/docs/app/api-reference/functions/fetch).

## Testing
Locally