### PR TITLE
feat(core): CATALYST-269 Add convenience route for /admin to access control panel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,4 +4,9 @@ BIGCOMMERCE_ACCESS_TOKEN=
 BIGCOMMERCE_CUSTOMER_IMPERSONATION_TOKEN=
 BIGCOMMERCE_CHANNEL_ID=1
 
+# Set to true to allow the /admin route to redirect to the BigCommerce control panel.
+# `false` is recommended for production. Defaults to false when not specified.
+# You may also delete /admin/route.ts if you wish.
+ENABLE_ADMIN_ROUTE=true
+
 AUTH_SECRET= # Generate one typing `openssl rand -hex 32` in your terminal

--- a/apps/core/app/admin/route.ts
+++ b/apps/core/app/admin/route.ts
@@ -1,0 +1,20 @@
+import { redirect } from 'next/navigation';
+
+const canonicalDomain: string = process.env.BIGCOMMERCE_GRAPHQL_API_DOMAIN ?? 'mybigcommerce.com';
+const BIGCOMMERCE_STORE_HASH = process.env.BIGCOMMERCE_STORE_HASH;
+const ENABLE_ADMIN_ROUTE = process.env.ENABLE_ADMIN_ROUTE;
+
+export const GET = () => {
+  // This route should not work unless explicitly enabled
+  if (ENABLE_ADMIN_ROUTE !== 'true') {
+    return redirect('/');
+  }
+
+  return redirect(
+    BIGCOMMERCE_STORE_HASH
+      ? `https://store-${BIGCOMMERCE_STORE_HASH}.${canonicalDomain}/admin`
+      : 'https://login.bigcommerce.com',
+  );
+};
+
+export const runtime = 'edge';


### PR DESCRIPTION
## What/Why?
Adding a similar convenience function as Stencil to access the control panel for the connected store via `/admin`. This is on for dev in `.env.example` but encouraged to be disabled for production, and defaults to disabled when not specified.

This is a nice feature for agency developers who may be hopping back and forth between many different storefronts and offers an easy way to get to the relevant CP.

## Testing
Tested locally