### PR TITLE
fix: CATALYST-270 use logical properties in classes

### DIFF
--- a/apps/core/app/(default)/blog/[blogId]/page.tsx
+++ b/apps/core/app/(default)/blog/[blogId]/page.tsx
@@ -64,7 +64,7 @@ export default async function BlogPostPage({ params: { blogId } }: Props) {
       <div className="mb-10 flex">
         {blogPost.tags.map((tag) => (
           <Link
-            className="mr-3 block cursor-pointer focus:outline-none focus:ring-4 focus:ring-blue-primary/20"
+            className="me-3 block cursor-pointer focus:outline-none focus:ring-4 focus:ring-blue-primary/20"
             href={`/blog/tag/${tag}`}
             key={tag}
           >

--- a/apps/core/app/(default)/compare/page.tsx
+++ b/apps/core/app/(default)/compare/page.tsx
@@ -152,7 +152,7 @@ export default async function Compare({
           </thead>
           <tbody>
             <tr className="absolute mt-6">
-              <th className="sticky left-0 top-0 m-0 pl-4 text-left" id="product-description">
+              <th className="sticky start-0 top-0 m-0 ps-4 text-start" id="product-description">
                 Description
               </th>
             </tr>
@@ -167,7 +167,7 @@ export default async function Compare({
               ))}
             </tr>
             <tr className="absolute mt-6">
-              <th className="sticky left-0 top-0 m-0 pl-4 text-left" id="product-rating">
+              <th className="sticky start-0 top-0 m-0 ps-4 text-start" id="product-rating">
                 Rating
               </th>
             </tr>
@@ -197,7 +197,7 @@ export default async function Compare({
               ))}
             </tr>
             <tr className="absolute mt-6">
-              <th className="sticky left-0 top-0 m-0 pl-4 text-left" id="product-availability">
+              <th className="sticky start-0 top-0 m-0 ps-4 text-start" id="product-availability">
                 Availability
               </th>
             </tr>

--- a/apps/core/app/not-found.tsx
+++ b/apps/core/app/not-found.tsx
@@ -22,7 +22,7 @@ export default async function NotFound() {
         </Message>
         <SearchForm />
         <section className={cn('w-full')}>
-          <h3 className={cn('mb-10 text-center text-h3 sm:text-left')}>Featured Products</h3>
+          <h3 className={cn('mb-10 text-center text-h3 sm:text-start')}>Featured Products</h3>
           <div className={cn('grid grid-cols-2 gap-x-8 gap-y-8 md:grid-cols-4')}>
             {featuredProducts.map((product) => (
               <ProductCard key={product.entityId} product={product} />

--- a/apps/core/components/CompareDrawer/index.tsx
+++ b/apps/core/components/CompareDrawer/index.tsx
@@ -73,7 +73,7 @@ export const CompareDrawer = () => {
   }
 
   return (
-    <div className="fixed bottom-0 left-0 w-full border-t border-gray-200 bg-white p-6 md:pe-0">
+    <div className="fixed bottom-0 start-0 w-full border-t border-gray-200 bg-white p-6 md:pe-0">
       <div className="hidden md:flex">
         <CompareLink products={products} />
         <ul className="flex overflow-auto">

--- a/apps/core/components/Forbidden/index.tsx
+++ b/apps/core/components/Forbidden/index.tsx
@@ -10,7 +10,7 @@ const FeaturedProducts = async () => {
 
   return (
     <section className={cn('w-full')}>
-      <h3 className={cn('mb-10 text-center text-h3 sm:text-left')}>Featured Products</h3>
+      <h3 className={cn('mb-10 text-center text-h3 sm:text-start')}>Featured Products</h3>
       <div className={cn('grid grid-cols-2 gap-x-8 gap-y-8 md:grid-cols-4')}>
         {featuredProducts.map((product) => (
           <ProductCard key={product.entityId} product={product} />

--- a/apps/core/components/SharingLinks/index.tsx
+++ b/apps/core/components/SharingLinks/index.tsx
@@ -21,7 +21,7 @@ export const SharingLinks = ({
   const encodedUrl = encodeURIComponent(`${vanityUrl}/blog/${blogPostId}/`);
 
   return (
-    <div className="mb-10 flex items-center [&>*:not(:last-child)]:mr-2.5">
+    <div className="mb-10 flex items-center [&>*:not(:last-child)]:me-2.5">
       <h3 className="text-h5">Share</h3>
       <a
         href={`https://facebook.com/sharer/sharer.php?u=${encodedUrl}`}

--- a/apps/core/components/VariantSelector/MultipleChoiceField.tsx
+++ b/apps/core/components/VariantSelector/MultipleChoiceField.tsx
@@ -182,7 +182,7 @@ export const MultipleChoiceField = ({
                     {Boolean(value.defaultImage) && (
                       <Image
                         alt={value.defaultImage?.altText || ''}
-                        className="mr-6"
+                        className="me-6"
                         height={48}
                         src={value.defaultImage?.url || ''}
                         width={48}

--- a/apps/docs/stories/PickList.stories.tsx
+++ b/apps/docs/stories/PickList.stories.tsx
@@ -46,7 +46,7 @@ export const BasicExample: Story = {
               <img
                 alt={option.value}
                 aria-hidden="true"
-                className="mr-6 h-12 w-12"
+                className="me-6 h-12 w-12"
                 src={option.imgSrc}
               />
             )}

--- a/packages/reactant/src/components/Slideshow/Slideshow.tsx
+++ b/packages/reactant/src/components/Slideshow/Slideshow.tsx
@@ -165,7 +165,7 @@ const SlideshowControls = forwardRef<ElementRef<'div'>, ComponentPropsWithRef<'d
 
     return (
       <div
-        className={cs('absolute bottom-12 left-12 flex items-center gap-4', className)}
+        className={cs('absolute bottom-12 start-12 flex items-center gap-4', className)}
         ref={ref}
         {...props}
       >


### PR DESCRIPTION
## What/Why?
We had already done a pass at this but this should resolve all outstanding elements not using logical properties (with the exception of `tailwindcss-animate` custom classes which don't have logical values for now).