### PR TITLE
fix: enforce next cache logic

### DIFF
--- a/apps/core/client/queries/getProductSearchResults.ts
+++ b/apps/core/client/queries/getProductSearchResults.ts
@@ -174,7 +174,7 @@ export const getProductSearchResults = cache(
       document: query,
       variables: { first: limit, after, filters, sort, imageHeight, imageWidth },
       customerId,
-      fetchOptions: { cache: customerId ? 'no-store' : undefined, next: { revalidate: 300 } },
+      fetchOptions: customerId ? { cache: 'no-store' } : { next: { revalidate: 300 } },
     });
 
     const { site } = response.data;


### PR DESCRIPTION
## What/Why?

Any `cache` value cannot be used in conjunction with the `revalidate` functionality as you can't revalidate cache when it's forced. This pulls out the customer-specific cache logic into it's own function in order to enforce the design of `cache` + `revalidate` functionality.