### PR TITLE
fix: add accessible name to quick search

### DIFF
--- a/apps/core/components/QuickSearch/index.tsx
+++ b/apps/core/components/QuickSearch/index.tsx
@@ -9,6 +9,7 @@ import {
   SheetClose,
   SheetContent,
   SheetOverlay,
+  SheetTitle,
   SheetTrigger,
 } from '@bigcommerce/reactant/Sheet';
 import debounce from 'lodash.debounce';
@@ -97,6 +98,7 @@ export const QuickSearch = ({ children, initialTerm = '' }: SearchProps) => {
           )}
           side="top"
         >
+          <SheetTitle className="sr-only">Search bar</SheetTitle>
           <div className="grid grid-cols-5 items-center">
             <div className="me-2 hidden lg:block lg:justify-self-start">{children}</div>
             <Form

--- a/packages/functional/actions/search-actions.ts
+++ b/packages/functional/actions/search-actions.ts
@@ -2,6 +2,7 @@ import { Page } from '@playwright/test';
 
 export async function searchForProduct(page: Page, productName: string) {
   await page.getByLabel('Open search popup').click();
+  await page.getByRole('dialog', { name: 'Search bar' }).isVisible();
   await page.getByPlaceholder('Search...').fill(productName);
   await page.getByPlaceholder('Search...').press('Enter');
   await page.getByRole('link').filter({ hasText: productName }).isVisible();


### PR DESCRIPTION
## What/Why?
Adds an accessible `title`/`name` to the quick search bar.