### PR TITLE
feat(core): CATALYST-271 remove cart fetching in 404 page

### DIFF
--- a/apps/core/app/(default)/layout.tsx
+++ b/apps/core/app/(default)/layout.tsx
@@ -2,11 +2,12 @@ import { PropsWithChildren } from 'react';
 
 import { Footer } from '~/components/Footer/Footer';
 import { Header } from '~/components/Header';
+import { Cart } from '~/components/Header/cart';
 
 export default function DefaultLayout({ children }: PropsWithChildren) {
   return (
     <>
-      <Header />
+      <Header cart={<Cart />} />
       <main className="flex-1 px-6 2xl:container sm:px-10 lg:px-12 2xl:mx-auto 2xl:px-0">
         {children}
       </main>

--- a/apps/core/app/not-found.tsx
+++ b/apps/core/app/not-found.tsx
@@ -5,7 +5,6 @@ import { SearchForm } from 'components/SearchForm';
 import { getFeaturedProducts } from '~/client/queries/getFeaturedProducts';
 import { Footer } from '~/components/Footer/Footer';
 import { Header } from '~/components/Header';
-import { CartLink } from '~/components/Header/cart';
 import { ProductCard } from '~/components/ProductCard';
 
 export default async function NotFound() {
@@ -13,13 +12,7 @@ export default async function NotFound() {
 
   return (
     <>
-      <Header
-        cart={
-          <CartLink>
-            <ShoppingCart aria-label="cart" />
-          </CartLink>
-        }
-      />
+      <Header cart={<ShoppingCart aria-label="cart" />} />
       <main className="mx-auto mb-10 max-w-[835px] space-y-8 px-6 sm:px-10 lg:px-0">
         <Message className="flex-col gap-8 px-0 py-16">
           <h2 className="text-h2">We couldn't find that page!</h2>

--- a/apps/core/components/Header/cart.tsx
+++ b/apps/core/components/Header/cart.tsx
@@ -1,30 +1,14 @@
 import { Badge } from '@bigcommerce/reactant/Badge';
-import { NavigationMenuLink } from '@bigcommerce/reactant/NavigationMenu';
 import { ShoppingCart } from 'lucide-react';
 import { cookies } from 'next/headers';
-import { PropsWithChildren } from 'react';
 
 import { getCart } from '~/client/queries/getCart';
-
-import { Link } from '../Link';
-
-export const CartLink = ({ children }: PropsWithChildren) => (
-  <NavigationMenuLink asChild>
-    <Link className="relative" href="/cart">
-      {children}
-    </Link>
-  </NavigationMenuLink>
-);
 
 export const Cart = async () => {
   const cartId = cookies().get('cartId')?.value;
 
   if (!cartId) {
-    return (
-      <CartLink>
-        <ShoppingCart aria-label="cart" />
-      </CartLink>
-    );
+    return <ShoppingCart aria-label="cart" />;
   }
 
   const cart = await getCart(cartId);
@@ -32,12 +16,10 @@ export const Cart = async () => {
   const count = cart?.lineItems.totalQuantity;
 
   return (
-    <CartLink>
-      <p role="status">
-        <span className="sr-only">Cart Items</span>
-        <ShoppingCart aria-hidden="true" />
-        {Boolean(count) && <Badge>{count}</Badge>}
-      </p>
-    </CartLink>
+    <p role="status">
+      <span className="sr-only">Cart Items</span>
+      <ShoppingCart aria-hidden="true" />
+      {Boolean(count) && <Badge>{count}</Badge>}
+    </p>
   );
 };

--- a/apps/core/components/Header/index.tsx
+++ b/apps/core/components/Header/index.tsx
@@ -9,8 +9,8 @@ import {
   NavigationMenuToggle,
   NavigationMenuTrigger,
 } from '@bigcommerce/reactant/NavigationMenu';
-import { ChevronDown, LogOut, ShoppingCart, User } from 'lucide-react';
-import { ReactNode, Suspense } from 'react';
+import { ChevronDown, LogOut, User } from 'lucide-react';
+import { ReactNode } from 'react';
 
 import { getSessionCustomerId } from '~/auth';
 import { getCategoryTree } from '~/client/queries/getCategoryTree';
@@ -21,7 +21,6 @@ import { QuickSearch } from '../QuickSearch';
 import { StoreLogo } from '../StoreLogo';
 
 import { logout } from './_actions/logout';
-import { Cart } from './cart';
 
 const HeaderNav = async ({
   className,
@@ -109,7 +108,7 @@ const HeaderNav = async ({
   );
 };
 
-export const Header = async ({ cart }: { cart?: ReactNode }) => {
+export const Header = async ({ cart }: { cart: ReactNode }) => {
   const customerId = await getSessionCustomerId();
 
   return (
@@ -153,11 +152,11 @@ export const Header = async ({ cart }: { cart?: ReactNode }) => {
               )}
             </NavigationMenuItem>
             <NavigationMenuItem>
-              {cart || (
-                <Suspense fallback={<ShoppingCart aria-hidden="true" />}>
-                  <Cart />
-                </Suspense>
-              )}
+              <NavigationMenuLink asChild>
+                <Link className="relative" href="/cart">
+                  {cart}
+                </Link>
+              </NavigationMenuLink>
             </NavigationMenuItem>
           </NavigationMenuList>
           <NavigationMenuToggle className="ms-2 lg:hidden" />


### PR DESCRIPTION
## What/Why?
When reaching 404 page, we want to keep it as cached as possible for guest experience. With this change, cart will not get fetched (non cached request) so page should be [Full Route cached](https://nextjs.org/docs/app/building-your-application/caching#full-route-cache).

Miscellaneous: style fixes

## Testing
Locally