### PR TITLE
feat(core): Hit proxy api instead of our graphql client

### DIFF
--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -115,11 +115,13 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
   }
 
   private getEndpoint() {
-    if (!this.config.channelId || this.config.channelId === '1') {
-      return `https://store-${this.config.storeHash}.${graphqlApiDomain}/graphql`;
-    }
+    // if (!this.config.channelId || this.config.channelId === '1') {
+    //   return `https://store-${this.config.storeHash}.${graphqlApiDomain}/graphql`;
+    // }
 
-    return `https://store-${this.config.storeHash}-${this.config.channelId}.${graphqlApiDomain}/graphql`;
+    // return `https://store-${this.config.storeHash}-${this.config.channelId}.${graphqlApiDomain}/graphql`;
+
+    return `https://crimson-waterfall-7b82.bigcommerce-testing-7727.workers.dev/?storeHash=${this.config.storeHash}&channelId=${this.config.channelId}`
   }
 
   private requestLogger<TResult, TVariables>(


### PR DESCRIPTION
!!DO NOT MERGE!!

## What/Why?
Experimental branch that hits a proxy API instead of hitting our storefront graphql directly. This proxy is deployed on a cloudflare worker, and uses cloudflare KV to cache all API responses (currently indefinitely), responding w/ a static 500ms response time when the cache hits (when it misses, it just responds as quickly as the storefront api does, this could be improved).

Currently not handling headers, so will not handle logged in customer-specific data (again, could be improved though).

Worker code is here: https://github.com/christensenep/cloudflare-graphql-proxy

