### PR TITLE
fix(core): correct Cart link element order to include styles

### DIFF
--- a/apps/core/app/not-found.tsx
+++ b/apps/core/app/not-found.tsx
@@ -5,7 +5,7 @@ import { SearchForm } from 'components/SearchForm';
 import { getFeaturedProducts } from '~/client/queries/getFeaturedProducts';
 import { Footer } from '~/components/Footer/Footer';
 import { Header } from '~/components/Header';
-import { Link } from '~/components/Link';
+import { CartLink } from '~/components/Header/cart';
 import { ProductCard } from '~/components/ProductCard';
 
 export default async function NotFound() {
@@ -15,9 +15,9 @@ export default async function NotFound() {
     <>
       <Header
         cart={
-          <Link href="/cart">
+          <CartLink>
             <ShoppingCart aria-label="cart" />
-          </Link>
+          </CartLink>
         }
       />
       <main className="mx-auto mb-10 max-w-[835px] space-y-8 px-6 sm:px-10 lg:px-0">

--- a/apps/core/components/Header/cart.tsx
+++ b/apps/core/components/Header/cart.tsx
@@ -1,18 +1,28 @@
 import { Badge } from '@bigcommerce/reactant/Badge';
+import { NavigationMenuLink } from '@bigcommerce/reactant/NavigationMenu';
 import { ShoppingCart } from 'lucide-react';
 import { cookies } from 'next/headers';
+import { ReactNode } from 'react';
 
 import { getCart } from '~/client/queries/getCart';
 import { Link } from '~/components/Link';
+
+export const CartLink = ({ children }: { children: ReactNode }) => (
+  <NavigationMenuLink asChild>
+    <Link className="relative" href="/cart">
+      {children}
+    </Link>
+  </NavigationMenuLink>
+);
 
 export const Cart = async () => {
   const cartId = cookies().get('cartId')?.value;
 
   if (!cartId) {
     return (
-      <Link href="/cart">
+      <CartLink>
         <ShoppingCart aria-label="cart" />
-      </Link>
+      </CartLink>
     );
   }
 
@@ -21,10 +31,10 @@ export const Cart = async () => {
   const count = cart?.lineItems.totalQuantity;
 
   return (
-    <Link href="/cart">
+    <CartLink>
       <span className="sr-only">Cart Items</span>
       <ShoppingCart aria-hidden="true" />
       {Boolean(count) && <Badge> {count}</Badge>}
-    </Link>
+    </CartLink>
   );
 };

--- a/apps/core/components/Header/index.tsx
+++ b/apps/core/components/Header/index.tsx
@@ -152,9 +152,7 @@ export const Header = async ({ cart }: { cart: ReactNode }) => {
               )}
             </NavigationMenuItem>
             <NavigationMenuItem>
-              <NavigationMenuLink asChild className="relative">
-                <p role="status">{cart}</p>
-              </NavigationMenuLink>
+              <p role="status">{cart}</p>
             </NavigationMenuItem>
           </NavigationMenuList>
           <NavigationMenuToggle className="ms-2 lg:hidden" />


### PR DESCRIPTION
## What/Why?
We need `Link` to slot for `NavigationMenuLink` for proper styles.

## Testing
Locally