### PR TITLE
feat(core): add ring style to Link wrapper

### DIFF
--- a/apps/core/components/Footer/ContactInformation.tsx
+++ b/apps/core/components/Footer/ContactInformation.tsx
@@ -21,7 +21,10 @@ export const ContactInformation = async () => {
         ))}
       </address>
       {contact.phone ? (
-        <a href={`tel:${contact.phone}`}>
+        <a
+          className="hover:text-blue-primary focus:outline-none focus:ring-4 focus:ring-blue-primary/20"
+          href={`tel:${contact.phone}`}
+        >
           <p>{contact.phone}</p>
         </a>
       ) : null}

--- a/apps/core/components/Footer/SocialIcons.tsx
+++ b/apps/core/components/Footer/SocialIcons.tsx
@@ -66,7 +66,7 @@ export const SocialIcons = async () => {
 
           return (
             <FooterNavLink asChild key={link.name}>
-              <Link href={link.url}>
+              <Link className="inline-block" href={link.url}>
                 <SocialIcon name={link.name} />
               </Link>
             </FooterNavLink>

--- a/apps/core/components/Link/index.tsx
+++ b/apps/core/components/Link/index.tsx
@@ -2,15 +2,26 @@
 import NextLink, { type LinkProps } from 'next/link';
 import { ElementRef, forwardRef } from 'react';
 
+import { cn } from '~/lib/utils';
+
 type LinkType = Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, keyof LinkProps> &
   LinkProps & {
     children?: React.ReactNode;
   } & React.RefAttributes<HTMLAnchorElement>;
 
 export const Link = forwardRef<ElementRef<'a'>, LinkType>(
-  ({ href, prefetch = false, children, ...rest }, ref) => {
+  ({ href, prefetch = false, children, className, ...rest }, ref) => {
     return (
-      <NextLink href={href} prefetch={prefetch} ref={ref} {...rest}>
+      <NextLink
+        className={cn(
+          ' hover:text-blue-primary focus:outline-none focus:ring-4 focus:ring-blue-primary/20',
+          className,
+        )}
+        href={href}
+        prefetch={prefetch}
+        ref={ref}
+        {...rest}
+      >
         {children}
       </NextLink>
     );


### PR DESCRIPTION
## What/Why?
Noticed links don't have a ring like other components. Now that we have a Link wrapper we can add styling directly to it to have some consistency on look.

https://github.com/bigcommerce/catalyst/assets/196129/3c0b753b-7004-4945-8404-fad6c4fc7a5b

## Testing
Locally