### PR TITLE
fix(reactant): CATALYST-277 prevent shrink of radio inputs

### DIFF
--- a/apps/docs/stories/PickList.stories.tsx
+++ b/apps/docs/stories/PickList.stories.tsx
@@ -17,22 +17,21 @@ const MOCKED_SIZE_OPTIONS = [
   {
     id: 's1',
     value: 'Pick list item 1',
-    imgSrc: '/gallery-img-01.jpg',
+    imgsrc: '/gallery-img-01.jpg',
   },
   {
     id: 's2',
     value: 'Pick list item 2',
-    imgSrc: '/gallery-img-02.jpg',
+    imgsrc: '/gallery-img-02.jpg',
   },
   {
     id: 's3',
     value: 'Pick list item 3',
-    imgSrc: 'gallery-img-03.jpg',
+    imgsrc: 'gallery-img-03.jpg',
   },
   {
     id: 's4',
     value: 'Pick list item 4',
-    disabled: true,
   },
 ];
 
@@ -42,12 +41,12 @@ export const BasicExample: Story = {
       <PickList defaultValue="Pick list item 2">
         {MOCKED_SIZE_OPTIONS.map((option) => (
           <div className="flex flex-row items-center p-4" key={option.id}>
-            {Boolean(option.imgSrc) && (
+            {Boolean(option.imgsrc) && (
               <img
                 alt={option.value}
                 aria-hidden="true"
                 className="me-6 h-12 w-12"
-                src={option.imgSrc}
+                src={option.imgsrc}
               />
             )}
             <PickListItem {...option} key={option.id} />

--- a/packages/reactant/src/components/PickList/PickList.tsx
+++ b/packages/reactant/src/components/PickList/PickList.tsx
@@ -29,7 +29,7 @@ const PickListItem = forwardRef<ElementRef<RadioItemType>, ComponentPropsWithRef
     return (
       <RadioGroupPrimitive.Item
         className={cn(
-          'flex h-6 w-6 items-center justify-center rounded-full border-2 border-gray-200',
+          'flex h-6 w-6 shrink-0 items-center justify-center rounded-full border-2 border-gray-200',
           'hover:border-blue-secondary',
           'focus:border-blue-primary focus:outline-none focus:ring-4 focus:ring-blue-primary/20',
           'focus:hover:border-blue-secondary',


### PR DESCRIPTION
## What/Why?
Fixes issue on shrunk radio inputs. Fixes errors in Storybook.

## Testing
Locally

![Screenshot 2024-01-31 at 2 07 54 PM](https://github.com/bigcommerce/catalyst/assets/196129/17c2c290-e2e2-496a-ad43-94842b40b689)

