### PR TITLE
feat: CATALYST-273 add eslint rule to base to standarize naming scheme

### DIFF
--- a/apps/core/.eslintrc.cjs
+++ b/apps/core/.eslintrc.cjs
@@ -25,6 +25,8 @@ const config = {
         ],
       },
     ],
+    'check-file/filename-naming-convention': 'off',
+    'check-file/folder-naming-convention': 'off',
   },
 };
 

--- a/apps/docs/.eslintrc.cjs
+++ b/apps/docs/.eslintrc.cjs
@@ -17,6 +17,7 @@ const config = {
         allow: ['__typename'],
       },
     ],
+    'check-file/filename-naming-convention': 'off',
   },
 };
 

--- a/packages/client/.eslintrc.cjs
+++ b/packages/client/.eslintrc.cjs
@@ -8,6 +8,7 @@ const config = {
     '@typescript-eslint/consistent-type-assertions': 'off',
     '@typescript-eslint/naming-convention': 'off',
     'no-underscore-dangle': ['error', { allow: ['__typename'] }],
+    'check-file/filename-naming-convention': 'off',
   },
   ignorePatterns: ['/src/generated/**', '/dist/**'],
 };

--- a/packages/eslint-config-catalyst/base.js
+++ b/packages/eslint-config-catalyst/base.js
@@ -1,6 +1,7 @@
 /** @type {import("eslint").Linter.Config} */
 const config = {
   extends: ['@bigcommerce/eslint-config/configs/base', 'prettier'],
+  plugins: ['check-file'],
   overrides: [
     {
       files: ['*.ts', '*.tsx'],
@@ -10,6 +11,24 @@ const config = {
   env: {
     es2022: true,
     node: true,
+  },
+  rules: {
+    'check-file/filename-naming-convention': [
+      'error',
+      {
+        '**/*.{jsx,tsx}': 'KEBAB_CASE',
+        '**/*.{js,ts}': 'KEBAB_CASE',
+      },
+      {
+        ignoreMiddleExtensions: true,
+      },
+    ],
+    "check-file/folder-naming-convention": [
+      "error",
+      {
+        "**": "KEBAB_CASE",
+      }
+    ]
   },
 };
 

--- a/packages/eslint-config-catalyst/package.json
+++ b/packages/eslint-config-catalyst/package.json
@@ -13,6 +13,7 @@
     "@bigcommerce/eslint-config": "^2.7.0",
     "@next/eslint-plugin-next": "^14.0.4",
     "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-check-file": "^2.6.2",
     "eslint-plugin-prettier": "^5.0.1"
   },
   "peerDependencies": {

--- a/packages/functional/.eslintrc.cjs
+++ b/packages/functional/.eslintrc.cjs
@@ -4,6 +4,9 @@
 const config = {
   root: true,
   extends: ['@bigcommerce/catalyst/base', '@bigcommerce/catalyst/prettier'],
+  rules: {
+    'check-file/filename-naming-convention': 'off',
+  },
 };
 
 module.exports = config;

--- a/packages/reactant/.eslintrc.cjs
+++ b/packages/reactant/.eslintrc.cjs
@@ -14,6 +14,8 @@ const config = {
     '@next/next/no-html-link-for-pages': 'off',
     'import/dynamic-import-chunkname': 'off',
     'no-underscore-dangle': ['error', { allow: ['__typename'] }],
+    'check-file/filename-naming-convention': 'off',
+    'check-file/folder-naming-convention': 'off',
   },
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,12 +65,12 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
-      react-hook-form:
-        specifier: ^7.49.3
-        version: 7.49.3(react@18.2.0)
       react-google-recaptcha:
         specifier: ^3.1.0
         version: 3.1.0(react@18.2.0)
+      react-hook-form:
+        specifier: ^7.49.3
+        version: 7.49.3(react@18.2.0)
       react-hot-toast:
         specifier: ^2.4.1
         version: 2.4.1(csstype@3.1.3)(react-dom@18.2.0)(react@18.2.0)
@@ -344,6 +344,9 @@ importers:
       eslint-config-prettier:
         specifier: ^9.1.0
         version: 9.1.0(eslint@8.55.0)
+      eslint-plugin-check-file:
+        specifier: ^2.6.2
+        version: 2.6.2(eslint@8.55.0)
       eslint-plugin-prettier:
         specifier: ^5.0.1
         version: 5.0.1(eslint-config-prettier@9.1.0)(eslint@8.55.0)(prettier@3.2.4)
@@ -8319,6 +8322,17 @@ packages:
       - supports-color
     dev: true
 
+  /eslint-plugin-check-file@2.6.2(eslint@8.55.0):
+    resolution: {integrity: sha512-z3Rur4JjOdNH0fia1IH7JQseo9NLuFVtw9j8P6z2c5XmXWemH7/qGpmMB8XbOt9bJBNpmPlNAGJty9b3EervPw==}
+    engines: {node: 14.x || >= 16}
+    peerDependencies:
+      eslint: '>=7.28.0'
+    dependencies:
+      eslint: 8.55.0
+      is-glob: 4.0.3
+      micromatch: 4.0.5
+    dev: false
+
   /eslint-plugin-gettext@1.2.0:
     resolution: {integrity: sha512-k7jSJD1nETfGYk94VS7AxHXPe7AZN7LvTfhBEnpyUx6DR98/5Bffovuw5vGk4axFBgKqzzfIV7ASTz/lnVd2qQ==}
     engines: {node: '>=6.0.0'}
@@ -8378,7 +8392,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.59.8)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.55.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.14.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.55.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -12096,13 +12110,6 @@ packages:
       react-is: 18.1.0
     dev: true
 
-  /react-hook-form@7.49.3(react@18.2.0):
-    resolution: {integrity: sha512-foD6r3juidAT1cOZzpmD/gOKt7fRsDhXXZ0y28+Al1CHgX+AY1qIN9VSIIItXRq1dN68QrRwl1ORFlwjBaAqeQ==}
-    engines: {node: '>=18', pnpm: '8'}
-    peerDependencies:
-      react: ^16.8.0 || ^17 || ^18
-    dependencies:
-      react: 18.2.0
   /react-google-recaptcha@3.1.0(react@18.2.0):
     resolution: {integrity: sha512-cYW2/DWas8nEKZGD7SCu9BSuVz8iOcOLHChHyi7upUuVhkpkhYG/6N3KDiTQ3XAiZ2UAZkfvYKMfAHOzBOcGEg==}
     peerDependencies:
@@ -12111,6 +12118,15 @@ packages:
       prop-types: 15.8.1
       react: 18.2.0
       react-async-script: 1.2.0(react@18.2.0)
+    dev: false
+
+  /react-hook-form@7.49.3(react@18.2.0):
+    resolution: {integrity: sha512-foD6r3juidAT1cOZzpmD/gOKt7fRsDhXXZ0y28+Al1CHgX+AY1qIN9VSIIItXRq1dN68QrRwl1ORFlwjBaAqeQ==}
+    engines: {node: '>=18', pnpm: '8'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18
+    dependencies:
+      react: 18.2.0
     dev: false
 
   /react-hot-toast@2.4.1(csstype@3.1.3)(react-dom@18.2.0)(react@18.2.0):


### PR DESCRIPTION
## What/Why?
We want to standardize naming scheme for files and folders to use kebab case.

- Added `check-file` plugin that allows me to set these rules.
- Set rules in base at `eslint-config-catalyst`
- Set rules to off when needed to merge this and then incrementally create PRs to update folder/file names.

## Testing
Locally eslint passes.