### PR TITLE
Add .idea to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist
 .turbo
 .vscode/**/*
 !.vscode/settings.example.json
+.idea
 .env
 .env*.local
 test-results/


### PR DESCRIPTION
## What/Why?
Add `.idea` to gitignore to make things easier for users of IntelliJ and other Jetbrains IDEs.