### PR TITLE
Default to trailing slash to match default platform behavior

### DIFF
--- a/apps/core/next.config.js
+++ b/apps/core/next.config.js
@@ -17,6 +17,8 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: !!process.env.CI,
   },
+  // default URL generation in BigCommerce uses trailing slash
+  trailingSlash: process.env.TRAILING_SLASH !== 'false',
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## What/Why?
Next.js has a [global config](https://nextjs.org/docs/app/api-reference/next-config-js/trailingSlash) as to whether URLs use a trailing slash.

In BigCommerce, our default URL generation for most entities uses a trailing slash in the out-of-the-box configuration of a new store, although this can be changed by end users to use any format they wish.

Example of default settings on a new store:

<img width="978" alt="image" src="https://github.com/bigcommerce/catalyst/assets/8922457/1e4761a1-777b-4721-819a-f9c1fbfb7a69">


Therefore, it is a stronger default for most customers to enable trailing slashes in Next.js to reduce the number of redirects that are required to use default URLs.

Customers may disable this if they wish via environment variable.

In the future, we can consider making this a storefront setting and exposing it in the API to make it automatically configured.

## Testing
Tested locally with and without `TRAILING_SLASH=false` in `.env.local`