### PR TITLE
Add .vercel to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist
 .vscode/**/*
 !.vscode/settings.example.json
 .idea
+.vercel
 .env
 .env*.local
 test-results/


### PR DESCRIPTION
## What/Why?
```
> Why do I have a folder named ".vercel" in my project?
The ".vercel" folder is created when you link a directory to a Vercel project.

> What does the "project.json" file contain?
The "project.json" file contains:
- The ID of the Vercel project that you linked ("projectId")
- The ID of the user or team your Vercel project is owned by ("orgId")

> Should I commit the ".vercel" folder?
No, you should not share the ".vercel" folder with anyone.
Upon creation, it will be automatically added to your ".gitignore" file.
```

This `.gitignore` entry is necessary to use the Vercel CLI, so we might as well have it in there in advance.