### PR TITLE
Make runtime configurable

### DIFF
--- a/apps/core/app/(default)/(faceted)/brand/[slug]/page.tsx
+++ b/apps/core/app/(default)/(faceted)/brand/[slug]/page.tsx
@@ -5,7 +5,6 @@ import { notFound } from 'next/navigation';
 import { getBrand } from '~/client/queries/get-brand';
 import { Link } from '~/components/link';
 import { ProductCard } from '~/components/product-card';
-import { envRuntime } from '~/runtime';
 
 import { FacetedSearch } from '../../_components/faceted-search';
 import { MobileSideNav } from '../../_components/mobile-side-nav';
@@ -122,4 +121,4 @@ export default async function Brand({ params, searchParams }: Props) {
   );
 }
 
-export const runtime = `${envRuntime}`;
+export const runtime = process.env.NEXTJS_RUNTIME ? process.env.NEXTJS_RUNTIME : 'edge';

--- a/apps/core/app/(default)/(faceted)/brand/[slug]/page.tsx
+++ b/apps/core/app/(default)/(faceted)/brand/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from 'next/navigation';
 import { getBrand } from '~/client/queries/get-brand';
 import { Link } from '~/components/link';
 import { ProductCard } from '~/components/product-card';
+import { envRuntime } from '~/runtime';
 
 import { FacetedSearch } from '../../_components/faceted-search';
 import { MobileSideNav } from '../../_components/mobile-side-nav';
@@ -121,4 +122,4 @@ export default async function Brand({ params, searchParams }: Props) {
   );
 }
 
-export const runtime = 'edge';
+export const runtime = `${envRuntime}`;

--- a/apps/core/app/(default)/(faceted)/brand/[slug]/static/page.tsx
+++ b/apps/core/app/(default)/(faceted)/brand/[slug]/static/page.tsx
@@ -1,5 +1,4 @@
 import { getBrands } from '~/client/queries/get-brands';
-import { envStaticRuntime } from '~/runtime';
 
 import BrandPage from '../page';
 
@@ -15,4 +14,6 @@ export async function generateStaticParams() {
 
 export const dynamic = 'force-static';
 export const revalidate = 600;
-export const runtime = `${envStaticRuntime}`;
+export const runtime = process.env.NEXTJS_STATIC_RUNTIME
+  ? process.env.NEXTJS_STATIC_RUNTIME
+  : 'nodejs';

--- a/apps/core/app/(default)/(faceted)/brand/[slug]/static/page.tsx
+++ b/apps/core/app/(default)/(faceted)/brand/[slug]/static/page.tsx
@@ -1,4 +1,5 @@
 import { getBrands } from '~/client/queries/get-brands';
+import { envStaticRuntime } from '~/runtime';
 
 import BrandPage from '../page';
 
@@ -14,3 +15,4 @@ export async function generateStaticParams() {
 
 export const dynamic = 'force-static';
 export const revalidate = 600;
+export const runtime = `${envStaticRuntime}`;

--- a/apps/core/app/(default)/(faceted)/category/[slug]/page.tsx
+++ b/apps/core/app/(default)/(faceted)/category/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from 'next/navigation';
 import { getCategory } from '~/client/queries/get-category';
 import { Link } from '~/components/link';
 import { ProductCard } from '~/components/product-card';
+import { envRuntime } from '~/runtime';
 
 import { Breadcrumbs } from '../../_components/breadcrumbs';
 import { FacetedSearch } from '../../_components/faceted-search';
@@ -130,4 +131,4 @@ export default async function Category({ params, searchParams }: Props) {
   );
 }
 
-export const runtime = 'edge';
+export const runtime = `${envRuntime}`;

--- a/apps/core/app/(default)/(faceted)/category/[slug]/page.tsx
+++ b/apps/core/app/(default)/(faceted)/category/[slug]/page.tsx
@@ -5,7 +5,6 @@ import { notFound } from 'next/navigation';
 import { getCategory } from '~/client/queries/get-category';
 import { Link } from '~/components/link';
 import { ProductCard } from '~/components/product-card';
-import { envRuntime } from '~/runtime';
 
 import { Breadcrumbs } from '../../_components/breadcrumbs';
 import { FacetedSearch } from '../../_components/faceted-search';
@@ -131,4 +130,4 @@ export default async function Category({ params, searchParams }: Props) {
   );
 }
 
-export const runtime = `${envRuntime}`;
+export const runtime = process.env.NEXTJS_RUNTIME ? process.env.NEXTJS_RUNTIME : 'edge';

--- a/apps/core/app/(default)/(faceted)/category/[slug]/static/page.tsx
+++ b/apps/core/app/(default)/(faceted)/category/[slug]/static/page.tsx
@@ -1,5 +1,6 @@
 import { getCategoryTree } from '~/client/queries/get-category-tree';
 import { ExistingResultType } from '~/client/util';
+import { envStaticRuntime } from '~/runtime';
 
 import CategoryPage from '../page';
 
@@ -26,3 +27,4 @@ export async function generateStaticParams() {
 
 export const dynamic = 'force-static';
 export const revalidate = 600;
+export const runtime = `${envStaticRuntime}`;

--- a/apps/core/app/(default)/(faceted)/category/[slug]/static/page.tsx
+++ b/apps/core/app/(default)/(faceted)/category/[slug]/static/page.tsx
@@ -1,6 +1,5 @@
 import { getCategoryTree } from '~/client/queries/get-category-tree';
 import { ExistingResultType } from '~/client/util';
-import { envStaticRuntime } from '~/runtime';
 
 import CategoryPage from '../page';
 
@@ -27,4 +26,6 @@ export async function generateStaticParams() {
 
 export const dynamic = 'force-static';
 export const revalidate = 600;
-export const runtime = `${envStaticRuntime}`;
+export const runtime = process.env.NEXTJS_STATIC_RUNTIME
+  ? process.env.NEXTJS_STATIC_RUNTIME
+  : 'nodejs';

--- a/apps/core/app/(default)/(faceted)/search/page.tsx
+++ b/apps/core/app/(default)/(faceted)/search/page.tsx
@@ -3,7 +3,6 @@ import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { Link } from '~/components/link';
 import { ProductCard } from '~/components/product-card';
 import { SearchForm } from '~/components/search-form';
-import { envRuntime } from '~/runtime';
 
 import { FacetedSearch } from '../_components/faceted-search';
 import { MobileSideNav } from '../_components/mobile-side-nav';
@@ -126,4 +125,4 @@ export default async function Search({ searchParams }: Props) {
   );
 }
 
-export const runtime = `${envRuntime}`;
+export const runtime = process.env.NEXTJS_RUNTIME ? process.env.NEXTJS_RUNTIME : 'edge';

--- a/apps/core/app/(default)/(faceted)/search/page.tsx
+++ b/apps/core/app/(default)/(faceted)/search/page.tsx
@@ -3,6 +3,7 @@ import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { Link } from '~/components/link';
 import { ProductCard } from '~/components/product-card';
 import { SearchForm } from '~/components/search-form';
+import { envRuntime } from '~/runtime';
 
 import { FacetedSearch } from '../_components/faceted-search';
 import { MobileSideNav } from '../_components/mobile-side-nav';
@@ -125,4 +126,4 @@ export default async function Search({ searchParams }: Props) {
   );
 }
 
-export const runtime = 'edge';
+export const runtime = `${envRuntime}`;

--- a/apps/core/app/(default)/(webpages)/[page]/page.tsx
+++ b/apps/core/app/(default)/(webpages)/[page]/page.tsx
@@ -4,7 +4,6 @@ import { notFound } from 'next/navigation';
 import { getReCaptchaSettings } from '~/client/queries/get-recaptcha-settings';
 import { getWebPage } from '~/client/queries/get-web-page';
 import { ContactUs } from '~/components/forms';
-import { envRuntime } from '~/runtime';
 
 import { PageContent } from '../_components/page-content';
 
@@ -61,4 +60,4 @@ export default async function WebPage({ params }: Props) {
   }
 }
 
-export const runtime = `${envRuntime}`;
+export const runtime = process.env.NEXTJS_RUNTIME ? process.env.NEXTJS_RUNTIME : 'edge';

--- a/apps/core/app/(default)/(webpages)/[page]/page.tsx
+++ b/apps/core/app/(default)/(webpages)/[page]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation';
 import { getReCaptchaSettings } from '~/client/queries/get-recaptcha-settings';
 import { getWebPage } from '~/client/queries/get-web-page';
 import { ContactUs } from '~/components/forms';
+import { envRuntime } from '~/runtime';
 
 import { PageContent } from '../_components/page-content';
 
@@ -60,4 +61,4 @@ export default async function WebPage({ params }: Props) {
   }
 }
 
-export const runtime = 'edge';
+export const runtime = `${envRuntime}`;

--- a/apps/core/app/(default)/blog/[blogId]/page.tsx
+++ b/apps/core/app/(default)/blog/[blogId]/page.tsx
@@ -13,7 +13,6 @@ import { notFound } from 'next/navigation';
 import { getBlogPost } from '~/client/queries/get-blost-post';
 import { Link } from '~/components/link';
 import { SharingLinks } from '~/components/sharing-links';
-import { envRuntime } from '~/runtime';
 
 interface Props {
   params: {
@@ -92,4 +91,4 @@ export default async function BlogPostPage({ params: { blogId } }: Props) {
   );
 }
 
-export const runtime = `${envRuntime}`;
+export const runtime = process.env.NEXTJS_RUNTIME ? process.env.NEXTJS_RUNTIME : 'edge';

--- a/apps/core/app/(default)/blog/[blogId]/page.tsx
+++ b/apps/core/app/(default)/blog/[blogId]/page.tsx
@@ -13,6 +13,7 @@ import { notFound } from 'next/navigation';
 import { getBlogPost } from '~/client/queries/get-blost-post';
 import { Link } from '~/components/link';
 import { SharingLinks } from '~/components/sharing-links';
+import { envRuntime } from '~/runtime';
 
 interface Props {
   params: {
@@ -91,4 +92,4 @@ export default async function BlogPostPage({ params: { blogId } }: Props) {
   );
 }
 
-export const runtime = 'edge';
+export const runtime = `${envRuntime}`;

--- a/apps/core/app/(default)/blog/page.tsx
+++ b/apps/core/app/(default)/blog/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from 'next/navigation';
 import { getBlogPosts } from '~/client/queries/get-blog-posts';
 import { BlogPostCard } from '~/components/blog-post-card';
 import { Link } from '~/components/link';
+import { envRuntime } from '~/runtime';
 
 interface Props {
   searchParams: { [key: string]: string | string[] | undefined };
@@ -67,4 +68,4 @@ export default async function BlogPostPage({ searchParams }: Props) {
   );
 }
 
-export const runtime = 'edge';
+export const runtime = `${envRuntime}`;

--- a/apps/core/app/(default)/blog/page.tsx
+++ b/apps/core/app/(default)/blog/page.tsx
@@ -5,7 +5,6 @@ import { notFound } from 'next/navigation';
 import { getBlogPosts } from '~/client/queries/get-blog-posts';
 import { BlogPostCard } from '~/components/blog-post-card';
 import { Link } from '~/components/link';
-import { envRuntime } from '~/runtime';
 
 interface Props {
   searchParams: { [key: string]: string | string[] | undefined };
@@ -68,4 +67,4 @@ export default async function BlogPostPage({ searchParams }: Props) {
   );
 }
 
-export const runtime = `${envRuntime}`;
+export const runtime = process.env.NEXTJS_RUNTIME ? process.env.NEXTJS_RUNTIME : 'edge';

--- a/apps/core/app/(default)/blog/tag/[tagId]/page.tsx
+++ b/apps/core/app/(default)/blog/tag/[tagId]/page.tsx
@@ -59,6 +59,4 @@ export default async function BlogPostPage({ params: { tagId }, searchParams }: 
   );
 }
 
-import { envRuntime } from '~/runtime';
-
-export const runtime = `${envRuntime}`;
+export const runtime = process.env.NEXTJS_RUNTIME ? process.env.NEXTJS_RUNTIME : 'edge';

--- a/apps/core/app/(default)/blog/tag/[tagId]/page.tsx
+++ b/apps/core/app/(default)/blog/tag/[tagId]/page.tsx
@@ -59,4 +59,6 @@ export default async function BlogPostPage({ params: { tagId }, searchParams }: 
   );
 }
 
-export const runtime = 'edge';
+import { envRuntime } from '~/runtime';
+
+export const runtime = `${envRuntime}`;

--- a/apps/core/app/(default)/cart/page.tsx
+++ b/apps/core/app/(default)/cart/page.tsx
@@ -6,6 +6,7 @@ import { Suspense } from 'react';
 
 import { getCheckoutUrl } from '~/client/management/get-checkout-url';
 import { getCart } from '~/client/queries/get-cart';
+import { envRuntime } from '~/runtime';
 
 import { removeProduct } from './_actions/remove-products';
 import { CartItemCounter } from './_components/cart-item-counter';
@@ -192,4 +193,4 @@ export default async function CartPage() {
   );
 }
 
-export const runtime = 'edge';
+export const runtime = `${envRuntime}`;

--- a/apps/core/app/(default)/cart/page.tsx
+++ b/apps/core/app/(default)/cart/page.tsx
@@ -6,7 +6,6 @@ import { Suspense } from 'react';
 
 import { getCheckoutUrl } from '~/client/management/get-checkout-url';
 import { getCart } from '~/client/queries/get-cart';
-import { envRuntime } from '~/runtime';
 
 import { removeProduct } from './_actions/remove-products';
 import { CartItemCounter } from './_components/cart-item-counter';
@@ -193,4 +192,4 @@ export default async function CartPage() {
   );
 }
 
-export const runtime = `${envRuntime}`;
+export const runtime = process.env.NEXTJS_RUNTIME ? process.env.NEXTJS_RUNTIME : 'edge';

--- a/apps/core/app/(default)/compare/page.tsx
+++ b/apps/core/app/(default)/compare/page.tsx
@@ -8,6 +8,7 @@ import { Link } from '~/components/link';
 import { Pricing } from '~/components/pricing';
 import { SearchForm } from '~/components/search-form';
 import { cn } from '~/lib/utils';
+import { envRuntime } from '~/runtime';
 
 import { AddToCartForm } from './_components/add-to-cart-form';
 
@@ -248,4 +249,4 @@ export default async function Compare({
   );
 }
 
-export const runtime = 'edge';
+export const runtime = `${envRuntime}`;

--- a/apps/core/app/(default)/compare/page.tsx
+++ b/apps/core/app/(default)/compare/page.tsx
@@ -8,7 +8,6 @@ import { Link } from '~/components/link';
 import { Pricing } from '~/components/pricing';
 import { SearchForm } from '~/components/search-form';
 import { cn } from '~/lib/utils';
-import { envRuntime } from '~/runtime';
 
 import { AddToCartForm } from './_components/add-to-cart-form';
 
@@ -249,4 +248,4 @@ export default async function Compare({
   );
 }
 
-export const runtime = `${envRuntime}`;
+export const runtime = process.env.NEXTJS_RUNTIME ? process.env.NEXTJS_RUNTIME : 'edge';

--- a/apps/core/app/(default)/layout.tsx
+++ b/apps/core/app/(default)/layout.tsx
@@ -4,6 +4,7 @@ import { Footer } from '~/components/footer/footer';
 import { Header } from '~/components/header';
 import { Cart } from '~/components/header/cart';
 import { ProductSheet } from '~/components/product-sheet';
+import { envRuntime } from '~/runtime';
 
 export default function DefaultLayout({ children }: PropsWithChildren) {
   return (
@@ -19,3 +20,5 @@ export default function DefaultLayout({ children }: PropsWithChildren) {
     </>
   );
 }
+
+export const runtime = `${envRuntime}`;

--- a/apps/core/app/(default)/layout.tsx
+++ b/apps/core/app/(default)/layout.tsx
@@ -4,7 +4,6 @@ import { Footer } from '~/components/footer/footer';
 import { Header } from '~/components/header';
 import { Cart } from '~/components/header/cart';
 import { ProductSheet } from '~/components/product-sheet';
-import { envRuntime } from '~/runtime';
 
 export default function DefaultLayout({ children }: PropsWithChildren) {
   return (
@@ -21,4 +20,4 @@ export default function DefaultLayout({ children }: PropsWithChildren) {
   );
 }
 
-export const runtime = `${envRuntime}`;
+export const runtime = process.env.NEXTJS_RUNTIME ? process.env.NEXTJS_RUNTIME : 'edge';

--- a/apps/core/app/(default)/login/page.tsx
+++ b/apps/core/app/(default)/login/page.tsx
@@ -1,7 +1,6 @@
 import { Button } from '@bigcommerce/components/button';
 
 import { Link } from '~/components/link';
-import { envRuntime } from '~/runtime';
 
 import { LoginForm } from './_components/login-form';
 
@@ -43,4 +42,4 @@ export default function Login() {
   );
 }
 
-export const runtime = `${envRuntime}`;
+export const runtime = process.env.NEXTJS_RUNTIME ? process.env.NEXTJS_RUNTIME : 'edge';

--- a/apps/core/app/(default)/login/page.tsx
+++ b/apps/core/app/(default)/login/page.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@bigcommerce/components/button';
 
 import { Link } from '~/components/link';
+import { envRuntime } from '~/runtime';
 
 import { LoginForm } from './_components/login-form';
 
@@ -42,4 +43,4 @@ export default function Login() {
   );
 }
 
-export const runtime = 'edge';
+export const runtime = `${envRuntime}`;

--- a/apps/core/app/(default)/page.tsx
+++ b/apps/core/app/(default)/page.tsx
@@ -2,7 +2,6 @@ import { getBestSellingProducts } from '~/client/queries/get-best-selling-produc
 import { getFeaturedProducts } from '~/client/queries/get-featured-products';
 import { Hero } from '~/components/hero';
 import { ProductCardCarousel } from '~/components/product-card-carousel';
-import { envRuntime } from '~/runtime';
 
 export default async function Home() {
   const [bestSellingProducts, featuredProducts] = await Promise.all([
@@ -34,4 +33,4 @@ export default async function Home() {
   );
 }
 
-export const runtime = `${envRuntime}`;
+export const runtime = process.env.NEXTJS_RUNTIME ? process.env.NEXTJS_RUNTIME : 'edge';

--- a/apps/core/app/(default)/page.tsx
+++ b/apps/core/app/(default)/page.tsx
@@ -2,6 +2,7 @@ import { getBestSellingProducts } from '~/client/queries/get-best-selling-produc
 import { getFeaturedProducts } from '~/client/queries/get-featured-products';
 import { Hero } from '~/components/hero';
 import { ProductCardCarousel } from '~/components/product-card-carousel';
+import { envRuntime } from '~/runtime';
 
 export default async function Home() {
   const [bestSellingProducts, featuredProducts] = await Promise.all([
@@ -33,4 +34,4 @@ export default async function Home() {
   );
 }
 
-export const runtime = 'edge';
+export const runtime = `${envRuntime}`;

--- a/apps/core/app/(default)/product/[slug]/page.tsx
+++ b/apps/core/app/(default)/product/[slug]/page.tsx
@@ -3,7 +3,6 @@ import { notFound } from 'next/navigation';
 import { Suspense } from 'react';
 
 import { getProduct } from '~/client/queries/get-product';
-import { envRuntime } from '~/runtime';
 
 import { BreadCrumbs } from './_components/breadcrumbs';
 import { Description } from './_components/description';
@@ -87,4 +86,4 @@ export default async function Product({ params, searchParams }: ProductPageProps
   );
 }
 
-export const runtime = `${envRuntime}`;
+export const runtime = process.env.NEXTJS_RUNTIME ? process.env.NEXTJS_RUNTIME : 'edge';

--- a/apps/core/app/(default)/product/[slug]/page.tsx
+++ b/apps/core/app/(default)/product/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation';
 import { Suspense } from 'react';
 
 import { getProduct } from '~/client/queries/get-product';
+import { envRuntime } from '~/runtime';
 
 import { BreadCrumbs } from './_components/breadcrumbs';
 import { Description } from './_components/description';
@@ -86,4 +87,4 @@ export default async function Product({ params, searchParams }: ProductPageProps
   );
 }
 
-export const runtime = 'edge';
+export const runtime = `${envRuntime}`;

--- a/apps/core/app/(default)/product/[slug]/static/page.tsx
+++ b/apps/core/app/(default)/product/[slug]/static/page.tsx
@@ -1,5 +1,4 @@
 import { getFeaturedProducts } from '~/client/queries/get-featured-products';
-import { envStaticRuntime } from '~/runtime';
 
 import ProductPage from '../page';
 
@@ -16,4 +15,6 @@ export async function generateStaticParams() {
 
 export const dynamic = 'force-static';
 export const revalidate = 600;
-export const runtime = `${envStaticRuntime}`;
+export const runtime = process.env.NEXTJS_STATIC_RUNTIME
+  ? process.env.NEXTJS_STATIC_RUNTIME
+  : 'nodejs';

--- a/apps/core/app/(default)/product/[slug]/static/page.tsx
+++ b/apps/core/app/(default)/product/[slug]/static/page.tsx
@@ -1,4 +1,5 @@
 import { getFeaturedProducts } from '~/client/queries/get-featured-products';
+import { envStaticRuntime } from '~/runtime';
 
 import ProductPage from '../page';
 
@@ -15,3 +16,4 @@ export async function generateStaticParams() {
 
 export const dynamic = 'force-static';
 export const revalidate = 600;
+export const runtime = `${envStaticRuntime}`;

--- a/apps/core/app/(default)/static/page.tsx
+++ b/apps/core/app/(default)/static/page.tsx
@@ -1,6 +1,9 @@
+import { envStaticRuntime } from '~/runtime';
+
 import HomePage from '../page';
 
 export default HomePage;
 
 export const dynamic = 'force-static';
 export const revalidate = 600;
+export const runtime = `${envStaticRuntime}`;

--- a/apps/core/app/(default)/static/page.tsx
+++ b/apps/core/app/(default)/static/page.tsx
@@ -1,9 +1,9 @@
-import { envStaticRuntime } from '~/runtime';
-
 import HomePage from '../page';
 
 export default HomePage;
 
 export const dynamic = 'force-static';
 export const revalidate = 600;
-export const runtime = `${envStaticRuntime}`;
+export const runtime = process.env.NEXTJS_STATIC_RUNTIME
+  ? process.env.NEXTJS_STATIC_RUNTIME
+  : 'nodejs';

--- a/apps/core/app/admin/route.ts
+++ b/apps/core/app/admin/route.ts
@@ -1,7 +1,5 @@
 import { redirect } from 'next/navigation';
 
-import { envRuntime } from '~/runtime';
-
 const canonicalDomain: string = process.env.BIGCOMMERCE_GRAPHQL_API_DOMAIN ?? 'mybigcommerce.com';
 const BIGCOMMERCE_STORE_HASH = process.env.BIGCOMMERCE_STORE_HASH;
 const ENABLE_ADMIN_ROUTE = process.env.ENABLE_ADMIN_ROUTE;
@@ -19,4 +17,4 @@ export const GET = () => {
   );
 };
 
-export const runtime = `${envRuntime}`;
+export const runtime = process.env.NEXTJS_RUNTIME ? process.env.NEXTJS_RUNTIME : 'edge';

--- a/apps/core/app/admin/route.ts
+++ b/apps/core/app/admin/route.ts
@@ -1,5 +1,7 @@
 import { redirect } from 'next/navigation';
 
+import { envRuntime } from '~/runtime';
+
 const canonicalDomain: string = process.env.BIGCOMMERCE_GRAPHQL_API_DOMAIN ?? 'mybigcommerce.com';
 const BIGCOMMERCE_STORE_HASH = process.env.BIGCOMMERCE_STORE_HASH;
 const ENABLE_ADMIN_ROUTE = process.env.ENABLE_ADMIN_ROUTE;
@@ -17,4 +19,4 @@ export const GET = () => {
   );
 };
 
-export const runtime = 'edge';
+export const runtime = `${envRuntime}`;

--- a/apps/core/app/api/product/[id]/route.ts
+++ b/apps/core/app/api/product/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { getProduct } from '~/client/queries/get-product';
+import { envRuntime } from '~/runtime';
 
 export const GET = async (request: NextRequest, { params }: { params: { id: string } }) => {
   const { id } = params;
@@ -22,4 +23,4 @@ export const GET = async (request: NextRequest, { params }: { params: { id: stri
   return new Response('Missing product id.', { status: 400 });
 };
 
-export const runtime = 'edge';
+export const runtime = `${envRuntime}`;

--- a/apps/core/app/api/product/[id]/route.ts
+++ b/apps/core/app/api/product/[id]/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { getProduct } from '~/client/queries/get-product';
-import { envRuntime } from '~/runtime';
 
 export const GET = async (request: NextRequest, { params }: { params: { id: string } }) => {
   const { id } = params;
@@ -23,4 +22,4 @@ export const GET = async (request: NextRequest, { params }: { params: { id: stri
   return new Response('Missing product id.', { status: 400 });
 };
 
-export const runtime = `${envRuntime}`;
+export const runtime = process.env.NEXTJS_RUNTIME ? process.env.NEXTJS_RUNTIME : 'edge';

--- a/apps/core/app/api/revalidate/route/route.ts
+++ b/apps/core/app/api/revalidate/route/route.ts
@@ -3,7 +3,6 @@ import { z } from 'zod';
 
 import { getRoute } from '~/client/queries/get-route';
 import { kv } from '~/lib/kv';
-import { envRuntime } from '~/runtime';
 
 import { withInternalAuth } from '../../internal-auth';
 
@@ -30,4 +29,4 @@ const handler = async (request: NextRequest) => {
 };
 
 export const POST = withInternalAuth(handler);
-export const runtime = `${envRuntime}`;
+export const runtime = process.env.NEXTJS_RUNTIME ? process.env.NEXTJS_RUNTIME : 'edge';

--- a/apps/core/app/api/revalidate/route/route.ts
+++ b/apps/core/app/api/revalidate/route/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 import { getRoute } from '~/client/queries/get-route';
 import { kv } from '~/lib/kv';
+import { envRuntime } from '~/runtime';
 
 import { withInternalAuth } from '../../internal-auth';
 
@@ -29,5 +30,4 @@ const handler = async (request: NextRequest) => {
 };
 
 export const POST = withInternalAuth(handler);
-
-export const runtime = 'edge';
+export const runtime = `${envRuntime}`;

--- a/apps/core/app/api/revalidate/store-status/route.ts
+++ b/apps/core/app/api/revalidate/store-status/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 
 import { getStoreStatus } from '~/client/queries/get-store-status';
 import { kv } from '~/lib/kv';
+import { envRuntime } from '~/runtime';
 
 import { withInternalAuth } from '../../internal-auth';
 
@@ -27,5 +28,4 @@ const handler = async () => {
 };
 
 export const POST = withInternalAuth(handler);
-
-export const runtime = 'edge';
+export const runtime = `${envRuntime}`;

--- a/apps/core/app/api/revalidate/store-status/route.ts
+++ b/apps/core/app/api/revalidate/store-status/route.ts
@@ -2,7 +2,6 @@ import { NextResponse } from 'next/server';
 
 import { getStoreStatus } from '~/client/queries/get-store-status';
 import { kv } from '~/lib/kv';
-import { envRuntime } from '~/runtime';
 
 import { withInternalAuth } from '../../internal-auth';
 
@@ -28,4 +27,4 @@ const handler = async () => {
 };
 
 export const POST = withInternalAuth(handler);
-export const runtime = `${envRuntime}`;
+export const runtime = process.env.NEXTJS_RUNTIME ? process.env.NEXTJS_RUNTIME : 'edge';

--- a/apps/core/app/layout.tsx
+++ b/apps/core/app/layout.tsx
@@ -7,7 +7,6 @@ import { PropsWithChildren } from 'react';
 import './globals.css';
 
 import { getStoreSettings } from '~/client/queries/get-store-settings';
-import { envRuntime } from '~/runtime';
 
 import { Notifications } from './notifications';
 import { Providers } from './providers';
@@ -50,4 +49,4 @@ export default function RootLayout({ children }: PropsWithChildren) {
   );
 }
 
-export const runtime = `${envRuntime}`;
+export const runtime = process.env.NEXTJS_RUNTIME ? process.env.NEXTJS_RUNTIME : 'edge';

--- a/apps/core/app/layout.tsx
+++ b/apps/core/app/layout.tsx
@@ -7,6 +7,7 @@ import { PropsWithChildren } from 'react';
 import './globals.css';
 
 import { getStoreSettings } from '~/client/queries/get-store-settings';
+import { envRuntime } from '~/runtime';
 
 import { Notifications } from './notifications';
 import { Providers } from './providers';
@@ -48,3 +49,5 @@ export default function RootLayout({ children }: PropsWithChildren) {
     </html>
   );
 }
+
+export const runtime = `${envRuntime}`;

--- a/apps/core/app/maintenance/page.tsx
+++ b/apps/core/app/maintenance/page.tsx
@@ -3,7 +3,6 @@ import { ReactNode } from 'react';
 
 import { getStoreSettings } from '~/client/queries/get-store-settings';
 import { StoreLogo } from '~/components/store-logo';
-import { envRuntime } from '~/runtime';
 
 const Container = ({ children }: { children: ReactNode }) => (
   <main className="mx-auto mt-[64px] px-6 md:px-10 lg:mt-[128px]">{children}</main>
@@ -53,4 +52,4 @@ export default async function MaintenancePage() {
   );
 }
 
-export const runtime = `${envRuntime}`;
+export const runtime = process.env.NEXTJS_RUNTIME ? process.env.NEXTJS_RUNTIME : 'edge';

--- a/apps/core/app/maintenance/page.tsx
+++ b/apps/core/app/maintenance/page.tsx
@@ -3,6 +3,7 @@ import { ReactNode } from 'react';
 
 import { getStoreSettings } from '~/client/queries/get-store-settings';
 import { StoreLogo } from '~/components/store-logo';
+import { envRuntime } from '~/runtime';
 
 const Container = ({ children }: { children: ReactNode }) => (
   <main className="mx-auto mt-[64px] px-6 md:px-10 lg:mt-[128px]">{children}</main>
@@ -52,4 +53,4 @@ export default async function MaintenancePage() {
   );
 }
 
-export const runtime = 'edge';
+export const runtime = `${envRuntime}`;

--- a/apps/core/app/not-found.tsx
+++ b/apps/core/app/not-found.tsx
@@ -7,6 +7,7 @@ import { Header } from '~/components/header';
 import { CartLink } from '~/components/header/cart';
 import { ProductCard } from '~/components/product-card';
 import { SearchForm } from '~/components/search-form';
+import { envRuntime } from '~/runtime';
 
 export const metadata = {
   title: 'Not Found',
@@ -56,4 +57,4 @@ export default async function NotFound() {
   );
 }
 
-export const runtime = 'edge';
+export const runtime = `${envRuntime}`;

--- a/apps/core/app/not-found.tsx
+++ b/apps/core/app/not-found.tsx
@@ -7,7 +7,6 @@ import { Header } from '~/components/header';
 import { CartLink } from '~/components/header/cart';
 import { ProductCard } from '~/components/product-card';
 import { SearchForm } from '~/components/search-form';
-import { envRuntime } from '~/runtime';
 
 export const metadata = {
   title: 'Not Found',
@@ -57,4 +56,4 @@ export default async function NotFound() {
   );
 }
 
-export const runtime = `${envRuntime}`;
+export const runtime = process.env.NEXTJS_RUNTIME ? process.env.NEXTJS_RUNTIME : 'edge';

--- a/apps/core/runtime.ts
+++ b/apps/core/runtime.ts
@@ -1,9 +1,0 @@
-// Default runtime to use for most pages. Setting this globally helps with making the
-// codebase compatible with certain hosting providers at the flip of a switch.
-export const envRuntime = process.env.NEXTJS_RUNTIME ? process.env.NEXTJS_RUNTIME : 'edge';
-
-// Default runtime to use for static pages. Static generation only works with nodejs
-// runtime, but using `edge` runtime for these pages is sometimes needed for compatibility.
-export const envStaticRuntime = process.env.NEXTJS_STATIC_RUNTIME
-  ? process.env.NEXTJS_STATIC_RUNTIME
-  : 'nodejs';

--- a/apps/core/runtime.ts
+++ b/apps/core/runtime.ts
@@ -1,0 +1,9 @@
+// Default runtime to use for most pages. Setting this globally helps with making the
+// codebase compatible with certain hosting providers at the flip of a switch.
+export const envRuntime = process.env.NEXTJS_RUNTIME ? process.env.NEXTJS_RUNTIME : 'edge';
+
+// Default runtime to use for static pages. Static generation only works with nodejs
+// runtime, but using `edge` runtime for these pages is sometimes needed for compatibility.
+export const envStaticRuntime = process.env.NEXTJS_STATIC_RUNTIME
+  ? process.env.NEXTJS_STATIC_RUNTIME
+  : 'nodejs';


### PR DESCRIPTION
## What/Why?
One part of making Catalyst more portable to other environments is making the runtime configurable. I am keeping the default to `edge` for now but this allows you to set it to `nodejs` (for very compatible deployment) or even things like `edge-experimental` for testing.

I could also extract this to a const referenced from a single file if desirable, let me know.

## Why am I doing this weird template string thing?

For some reason, you cannot reference an imported string directly as the runtime value, and you must deep-clone it.

I had a choice between referencing `process.env` everywhere or referencing it centrally and doing the string clone, so I chose that way of doing things because I think centralizing in `runtime.ts` is going to be nicer in the long term.

## Testing
Deployed to vercel with different env variables to confirm that traffic switched to serverless when set to `nodejs`