### PR TITLE
fix(core): CATALYST-0 pass customerId in category queries

### DIFF
--- a/apps/core/client/queries/getCategory.ts
+++ b/apps/core/client/queries/getCategory.ts
@@ -76,6 +76,7 @@ export const getCategory = cache(
     const response = await client.fetch({
       document: query,
       variables: { categoryId, breadcrumbDepth, ...paginationArgs },
+      customerId,
       fetchOptions: {
         cache: customerId ? 'no-store' : 'force-cache',
       },

--- a/apps/core/client/queries/getCategoryTree.ts
+++ b/apps/core/client/queries/getCategoryTree.ts
@@ -34,6 +34,7 @@ export const getCategoryTree = cache(async (categoryId?: number) => {
   const response = await client.fetch({
     document: query,
     variables: { categoryId },
+    customerId,
     fetchOptions: {
       cache: customerId ? 'no-store' : 'force-cache',
     },


### PR DESCRIPTION
## What/Why?
I missed passing in the actual value.

## Testing
Locally.