### PR TITLE
fix(core): CATALYST-0 show price instead of base price

### DIFF
--- a/apps/core/app/(default)/product/[slug]/page.tsx
+++ b/apps/core/app/(default)/product/[slug]/page.tsx
@@ -52,24 +52,20 @@ const ProductDetails = ({ product }: { product: NonNullable<Product> }) => {
                   </span>
                 </p>
               )}
-              {product.prices.basePrice?.value !== undefined && (
-                <p className="text-h4">
-                  {product.prices.salePrice?.value ? (
-                    <>
-                      Was:{' '}
-                      <span className="line-through">
-                        {currencyFormatter.format(product.prices.basePrice.value)}
-                      </span>
-                    </>
-                  ) : (
-                    currencyFormatter.format(product.prices.basePrice.value)
-                  )}
-                </p>
-              )}
-              {product.prices.salePrice?.value !== undefined && (
-                <p className="text-h4">
-                  Now: {currencyFormatter.format(product.prices.salePrice.value)}
-                </p>
+              {product.prices.salePrice?.value !== undefined &&
+              product.prices.basePrice?.value !== undefined ? (
+                <>
+                  Was:{' '}
+                  <span className="line-through">
+                    {currencyFormatter.format(product.prices.basePrice.value)}
+                  </span>
+                  <br />
+                  <>Now: {currencyFormatter.format(product.prices.salePrice.value)}</>
+                </>
+              ) : (
+                product.prices.price.value && (
+                  <>{currencyFormatter.format(product.prices.price.value)}</>
+                )
               )}
             </>
           )}

--- a/apps/core/components/Pricing/index.tsx
+++ b/apps/core/components/Pricing/index.tsx
@@ -32,20 +32,17 @@ export const Pricing = ({ prices }: { prices: Product['prices'] }) => {
               <br />
             </>
           )}
-          {prices.basePrice?.value !== undefined &&
-            (prices.salePrice?.value ? (
-              <>
-                Was:{' '}
-                <span className="line-through">
-                  {currencyFormatter.format(prices.basePrice.value)}
-                </span>
-                <br />
-              </>
-            ) : (
-              currencyFormatter.format(prices.basePrice.value)
-            ))}
-          {prices.salePrice?.value !== undefined && (
-            <>Now: {currencyFormatter.format(prices.salePrice.value)}</>
+          {prices.salePrice?.value !== undefined && prices.basePrice?.value !== undefined ? (
+            <>
+              Was:{' '}
+              <span className="line-through">
+                {currencyFormatter.format(prices.basePrice.value)}
+              </span>
+              <br />
+              <>Now: {currencyFormatter.format(prices.salePrice.value)}</>
+            </>
+          ) : (
+            prices.price?.value && <>{currencyFormatter.format(prices.price.value)}</>
           )}
         </>
       )}

--- a/apps/core/components/ProductSheet/index.tsx
+++ b/apps/core/components/ProductSheet/index.tsx
@@ -154,24 +154,20 @@ export const ProductSheetContent = ({ productId }: { productId: number }) => {
                         </span>
                       </p>
                     )}
-                    {product.prices.basePrice?.value !== undefined && (
-                      <p className="text-h4">
-                        {product.prices.salePrice?.value ? (
-                          <>
-                            Was:{' '}
-                            <span className="line-through">
-                              {currencyFormatter.format(product.prices.basePrice.value)}
-                            </span>
-                          </>
-                        ) : (
-                          currencyFormatter.format(product.prices.basePrice.value)
-                        )}
-                      </p>
-                    )}
-                    {product.prices.salePrice?.value !== undefined && (
-                      <p className="text-h4">
-                        Now: {currencyFormatter.format(product.prices.salePrice.value)}
-                      </p>
+                    {product.prices.salePrice?.value !== undefined &&
+                    product.prices.basePrice?.value !== undefined ? (
+                      <>
+                        Was:{' '}
+                        <span className="line-through">
+                          {currencyFormatter.format(product.prices.basePrice.value)}
+                        </span>
+                        <br />
+                        <>Now: {currencyFormatter.format(product.prices.salePrice.value)}</>
+                      </>
+                    ) : (
+                      product.prices.price.value && (
+                        <>{currencyFormatter.format(product.prices.price.value)}</>
+                      )
                     )}
                   </>
                 )}


### PR DESCRIPTION
## What/Why?
Instead of default displaying `basePrice`, we should now use `price` (since `basePrice` doesn't reflect customer group prices).

`basePrice` will still be used when there is a `salePrice`.

## Testing
Locally.