### PR TITLE
fix(core): CATALYST-273 set min limit to cart items

### DIFF
--- a/apps/core/app/(default)/cart/CartItemCounter.tsx
+++ b/apps/core/app/(default)/cart/CartItemCounter.tsx
@@ -8,7 +8,6 @@ import {
   CartPhysicalItem,
   UpdateCartLineItemInput,
 } from '~/client/generated/graphql';
-import { deleteCartLineItem } from '~/client/mutations/deleteCartLineItem';
 
 import { updateProductQuantity } from './_actions/updateProductQuantity';
 
@@ -26,19 +25,7 @@ export const CartItemCounter = ({ itemData }: { itemData: CartItemData }) => {
   const [counterValue, setCounterValue] = useState<'' | number>(quantity);
   const handleCountUpdate = async (value: string | number) => {
     if (value === '') {
-      setCounterValue('');
-
-      return;
-    }
-
-    if (Number(value) === 0) {
-      setCounterValue(0);
-
-      return;
-    }
-
-    if (Number.isNaN(value)) {
-      setCounterValue(1);
+      setCounterValue(value);
 
       return;
     }

--- a/apps/docs/stories/Counter.stories.tsx
+++ b/apps/docs/stories/Counter.stories.tsx
@@ -20,6 +20,7 @@ export const Default: Story = {
     max: Infinity,
     min: 0,
     step: 1,
+    onChange: undefined,
   },
 };
 

--- a/packages/reactant/src/components/Counter/Counter.tsx
+++ b/packages/reactant/src/components/Counter/Counter.tsx
@@ -148,6 +148,10 @@ export const Counter = forwardRef<ElementRef<'div'>, CounterProps>(
           onBlur={(e) => {
             const valueAsNumber = e.target.valueAsNumber;
 
+            if (Number.isNaN(valueAsNumber)) {
+              return updateValue(min);
+            }
+
             if (valueAsNumber < min) {
               updateValue(min);
             } else if (valueAsNumber > max) {


### PR DESCRIPTION
## What/Why?
- Since we have a delete icon, prevent setting 0 as min value for cart items.
- This also includes a fix so that the input can accept empty strings as values for when the quantity is being inputed manually.

## Testing
Locally.

https://github.com/bigcommerce/catalyst/assets/196129/b32a8013-b09e-4936-a99c-66c8130f273a

