### PR TITLE
feat(core): static generation for pdp, categories, and brands

### DIFF
--- a/apps/core/app/(default)/(faceted)/brand/[slug]/static/page.tsx
+++ b/apps/core/app/(default)/(faceted)/brand/[slug]/static/page.tsx
@@ -1,0 +1,15 @@
+import { getBrands } from '~/client/queries/getBrands';
+
+import BrandPage from '../page';
+
+export default BrandPage;
+
+export async function generateStaticParams() {
+  const brands = await getBrands();
+
+  return brands.map((brand) => ({
+    slug: brand.entityId.toString(),
+  }));
+}
+
+export const dynamic = 'force-static';

--- a/apps/core/app/(default)/(faceted)/category/[slug]/static/page.tsx
+++ b/apps/core/app/(default)/(faceted)/category/[slug]/static/page.tsx
@@ -1,0 +1,27 @@
+import { getCategoryTree } from '~/client/queries/getCategoryTree';
+import { ExistingResultType } from '~/client/util';
+
+import CategoryPage from '../page';
+
+export default CategoryPage;
+
+type Categories = ExistingResultType<typeof getCategoryTree>;
+type Category = Omit<Categories[number], 'children'> & { children?: Category[] };
+
+const getEntityIdsOfChildren = (categories: Category[] = []): number[] =>
+  categories.reduce<number[]>(
+    (acc, category) => acc.concat(category.entityId, getEntityIdsOfChildren(category.children)),
+    [],
+  );
+
+export async function generateStaticParams() {
+  const categories = await getCategoryTree();
+
+  const entityIds = getEntityIdsOfChildren(categories);
+
+  return entityIds.map((entityId) => ({
+    slug: entityId.toString(),
+  }));
+}
+
+export const dynamic = 'force-static';

--- a/apps/core/app/(default)/product/[slug]/static/page.tsx
+++ b/apps/core/app/(default)/product/[slug]/static/page.tsx
@@ -1,0 +1,16 @@
+import { getFeaturedProducts } from '~/client/queries/getFeaturedProducts';
+
+import ProductPage from '../page';
+
+export { generateMetadata } from '../page';
+export default ProductPage;
+
+export async function generateStaticParams() {
+  const products = await getFeaturedProducts();
+
+  return products.map((product) => ({
+    slug: product.entityId.toString(),
+  }));
+}
+
+export const dynamic = 'force-static';

--- a/apps/core/auth.ts
+++ b/apps/core/auth.ts
@@ -88,13 +88,17 @@ const config = {
 const { handlers, auth, signIn, signOut, update } = NextAuth(config);
 
 const getSessionCustomerId = async () => {
-  const session = await auth();
+  try {
+    const session = await auth();
 
-  if (!session?.user?.id) {
-    return;
+    if (!session?.user?.id) {
+      return;
+    }
+
+    return session.user.id;
+  } catch {
+    // No empty
   }
-
-  return session.user.id;
 };
 
 export { handlers, auth, signIn, signOut, update, getSessionCustomerId };

--- a/apps/core/middlewares/with-custom-urls.ts
+++ b/apps/core/middlewares/with-custom-urls.ts
@@ -1,5 +1,7 @@
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 
+import { getSessionCustomerId } from '~/auth';
 import { getRoute } from '~/client/queries/getRoute';
 
 import { kv } from '../lib/kv';
@@ -66,22 +68,29 @@ const getCustomUrlNode = async (request: NextRequest) => {
 export const withCustomUrls: MiddlewareFactory = (next) => {
   return async (request, event) => {
     const node = await getCustomUrlNode(request);
+    const customerId = await getSessionCustomerId();
+    const cartId = cookies().get('cartId');
+    let postfix = '';
+
+    if (!request.nextUrl.search && !customerId && !cartId && request.method === 'GET') {
+      postfix = '/static';
+    }
 
     switch (node?.__typename) {
       case 'Brand': {
-        const url = createRewriteUrl(`/brand/${node.entityId}`, request);
+        const url = createRewriteUrl(`/brand/${node.entityId}${postfix}`, request);
 
         return NextResponse.rewrite(url);
       }
 
       case 'Category': {
-        const url = createRewriteUrl(`/category/${node.entityId}`, request);
+        const url = createRewriteUrl(`/category/${node.entityId}${postfix}`, request);
 
         return NextResponse.rewrite(url);
       }
 
       case 'Product': {
-        const url = createRewriteUrl(`/product/${node.entityId}`, request);
+        const url = createRewriteUrl(`/product/${node.entityId}${postfix}`, request);
 
         return NextResponse.rewrite(url);
       }


### PR DESCRIPTION
Inspired by https://github.com/bigcommerce/catalyst/pull/485/

## What/Why?
Serve a `full route cache` version of pdp, categories, and brands when:
- User not logged in
- Cart empty
- No search params

This helps to reduce rendering cost and improve performance of these pages.

## TODO in other PRs:
- [ ] Revalidation
- [ ] Add homepage?

## Testing
Go the the preview, then go to a product page. Inspect the document request and the response headers come back with:
```
X-Vercel-Cache: HIT
```

Now add the product to cart and inspect the document again. 