### PR TITLE
chore(reactant): CATALYST-261 Rename Reactant to Components

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -34,7 +34,7 @@ jobs:
           PLAYWRIGHT_TEST_BASE_URL: ${{ github.event.deployment_status.target_url }}
         run: |
           cd packages/functional
-          npx playwright test tests/visual-regression/reactant/components/ --project=tests-chromium 
+          npx playwright test tests/visual-regression/reactant/components/ --project=tests-chromium
 
       - uses: actions/upload-artifact@v3
         if: failure()

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 > [!WARNING]
 > - Catalyst is in development and should not be used in production environments.
 
-**Catalyst** is a composable, fully customizable headless storefront that offers a set of opinionated defaults. It is intended to fit the needs of modern developers, merchants, and shoppers. Catalyst is built with [Next.js (nextjs.org)](https://nextjs.org/) and uses our [React.js-based (react.dev)](https://react.dev/) **Reactant** storefront components.
+**Catalyst** is a composable, fully customizable headless storefront that offers a set of opinionated defaults. It is intended to fit the needs of modern developers, merchants, and shoppers. Catalyst is built with [Next.js (nextjs.org)](https://nextjs.org/) and uses our [React.js-based (react.dev)](https://react.dev/) storefront components.
 
 The Catalyst monorepo contains the following:
 
 * The core **Catalyst** Next.js storefront, in [apps/core](apps/core).
-* The **Reactant** storefront component library, in [packages/reactant](packages/reactant).
+* The storefront component library, in [packages/components](packages/components).
 * The BigCommerce [GraphQL Storefront API (BigCommerce Dev Center)](https://developer.bigcommerce.com/docs/graphql-storefront) client, in [packages/client](packages/client).
 
 ## Requirements
@@ -83,7 +83,7 @@ The `dev` script runs all packages and apps in watch mode. The following table l
 | Process | URL with port |
 |:--------|:--------------|
 | Core Catalyst storefront | http://localhost:3000 |
-| Reactant Storybook | http://localhost:6006 |
+| Components Storybook | http://localhost:6006 |
 
 Happy developing! Let us know how things are going in the dedicated Slack channel.
 

--- a/apps/core/README.md
+++ b/apps/core/README.md
@@ -1,6 +1,6 @@
 # Catalyst
 
-Catalyst is the next generation of storefronts at BigCommerce. It aims to be composable and powerful to meet the needs of our enterprise customers, exceeding performance of Stencil and Blueprint themes. Catalyst is built with [Next.js](https://nextjs.org/) using our React.js storefront component library called Reactant.
+Catalyst is the next generation of storefronts at BigCommerce. It aims to be composable and powerful to meet the needs of our enterprise customers, exceeding performance of Stencil and Blueprint themes. Catalyst is built with [Next.js](https://nextjs.org/) using our React.js storefront component library.
 
 ## Getting Started
 

--- a/apps/core/app/(default)/(faceted)/_components/breadcrumbs.tsx
+++ b/apps/core/app/(default)/(faceted)/_components/breadcrumbs.tsx
@@ -1,8 +1,8 @@
 import {
   BreadcrumbDivider,
   BreadcrumbItem,
-  Breadcrumbs as ReactantBreadcrumbs,
-} from '@bigcommerce/reactant/Breadcrumbs';
+  Breadcrumbs as ComponentsBreadcrumbs,
+} from '@bigcommerce/components/Breadcrumbs';
 import { ChevronRight } from 'lucide-react';
 import { Fragment } from 'react';
 
@@ -18,7 +18,7 @@ interface Props {
 }
 
 export const Breadcrumbs = ({ breadcrumbs, category }: Props) => (
-  <ReactantBreadcrumbs className="py-4">
+  <ComponentsBreadcrumbs className="py-4">
     {breadcrumbs.map(({ name, entityId, path }, index) => {
       if (!path || breadcrumbs.length - 1 === index) {
         return (
@@ -39,5 +39,5 @@ export const Breadcrumbs = ({ breadcrumbs, category }: Props) => (
         </Fragment>
       );
     })}
-  </ReactantBreadcrumbs>
+  </ComponentsBreadcrumbs>
 );

--- a/apps/core/app/(default)/(faceted)/_components/facets.tsx
+++ b/apps/core/app/(default)/(faceted)/_components/facets.tsx
@@ -5,12 +5,12 @@ import {
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
-} from '@bigcommerce/reactant/Accordion';
-import { Button } from '@bigcommerce/reactant/Button';
-import { Checkbox } from '@bigcommerce/reactant/Checkbox';
-import { Input } from '@bigcommerce/reactant/Input';
-import { Label } from '@bigcommerce/reactant/Label';
-import { Rating } from '@bigcommerce/reactant/Rating';
+} from '@bigcommerce/components/Accordion';
+import { Button } from '@bigcommerce/components/Button';
+import { Checkbox } from '@bigcommerce/components/Checkbox';
+import { Input } from '@bigcommerce/components/Input';
+import { Label } from '@bigcommerce/components/Label';
+import { Rating } from '@bigcommerce/components/Rating';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { FormEvent, useRef } from 'react';
 

--- a/apps/core/app/(default)/(faceted)/_components/mobile-side-nav.tsx
+++ b/apps/core/app/(default)/(faceted)/_components/mobile-side-nav.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Button } from '@bigcommerce/reactant/Button';
+import { Button } from '@bigcommerce/components/Button';
 import {
   Sheet,
   SheetClose,
@@ -9,7 +9,7 @@ import {
   SheetOverlay,
   SheetTitle,
   SheetTrigger,
-} from '@bigcommerce/reactant/Sheet';
+} from '@bigcommerce/components/Sheet';
 import { Filter } from 'lucide-react';
 import { PropsWithChildren, useEffect, useState } from 'react';
 

--- a/apps/core/app/(default)/(faceted)/_components/refine-by.tsx
+++ b/apps/core/app/(default)/(faceted)/_components/refine-by.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Tag, TagAction, TagContent } from '@bigcommerce/reactant/Tag';
+import { Tag, TagAction, TagContent } from '@bigcommerce/components/Tag';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
 import type { Facet, PageType, PublicParamKeys } from '../types';

--- a/apps/core/app/(default)/(faceted)/_components/skeleton-ui.tsx
+++ b/apps/core/app/(default)/(faceted)/_components/skeleton-ui.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from '@bigcommerce/reactant/Skeleton';
+import { Skeleton } from '@bigcommerce/components/Skeleton';
 
 export const SkeletonIU = () => (
   <div>

--- a/apps/core/app/(default)/(faceted)/_components/sort-by.tsx
+++ b/apps/core/app/(default)/(faceted)/_components/sort-by.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Select, SelectContent, SelectItem } from '@bigcommerce/reactant/Select';
+import { Select, SelectContent, SelectItem } from '@bigcommerce/components/Select';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
 export function SortBy() {

--- a/apps/core/app/(default)/blog/[blogId]/page.tsx
+++ b/apps/core/app/(default)/blog/[blogId]/page.tsx
@@ -4,8 +4,8 @@ import {
   BlogPostDate,
   BlogPostImage,
   BlogPostTitle,
-} from '@bigcommerce/reactant/BlogPostCard';
-import { Tag, TagContent } from '@bigcommerce/reactant/Tag';
+} from '@bigcommerce/components/BlogPostCard';
+import { Tag, TagContent } from '@bigcommerce/components/Tag';
 import type { Metadata } from 'next';
 import Image from 'next/image';
 import { notFound } from 'next/navigation';

--- a/apps/core/app/(default)/cart/CartItemCounter.tsx
+++ b/apps/core/app/(default)/cart/CartItemCounter.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Counter } from '@bigcommerce/reactant/Counter';
+import { Counter } from '@bigcommerce/components/Counter';
 import { useState } from 'react';
 
 import {

--- a/apps/core/app/(default)/cart/page.tsx
+++ b/apps/core/app/(default)/cart/page.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@bigcommerce/reactant/Button';
+import { Button } from '@bigcommerce/components/Button';
 import { Trash2 as Trash } from 'lucide-react';
 import { cookies } from 'next/headers';
 import Image from 'next/image';

--- a/apps/core/app/(default)/compare/AddToCart.tsx
+++ b/apps/core/app/(default)/compare/AddToCart.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Button } from '@bigcommerce/reactant/Button';
+import { Button } from '@bigcommerce/components/Button';
 import { Loader2 as Spinner } from 'lucide-react';
 import { useFormStatus } from 'react-dom';
 

--- a/apps/core/app/(default)/compare/page.tsx
+++ b/apps/core/app/(default)/compare/page.tsx
@@ -1,5 +1,5 @@
-import { Button } from '@bigcommerce/reactant/Button';
-import { Rating } from '@bigcommerce/reactant/Rating';
+import { Button } from '@bigcommerce/components/Button';
+import { Rating } from '@bigcommerce/components/Rating';
 import Image from 'next/image';
 import * as z from 'zod';
 

--- a/apps/core/app/(default)/login/LoginForm.tsx
+++ b/apps/core/app/(default)/login/LoginForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Button } from '@bigcommerce/reactant/Button';
+import { Button } from '@bigcommerce/components/Button';
 import {
   Field,
   FieldControl,
@@ -8,9 +8,9 @@ import {
   FieldMessage,
   Form,
   FormSubmit,
-} from '@bigcommerce/reactant/Form';
-import { Input } from '@bigcommerce/reactant/Input';
-import { Message } from '@bigcommerce/reactant/Message';
+} from '@bigcommerce/components/Form';
+import { Input } from '@bigcommerce/components/Input';
+import { Message } from '@bigcommerce/components/Message';
 import { Loader2 as Spinner } from 'lucide-react';
 import { ChangeEvent, useState } from 'react';
 import { useFormState, useFormStatus } from 'react-dom';

--- a/apps/core/app/(default)/login/page.tsx
+++ b/apps/core/app/(default)/login/page.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@bigcommerce/reactant/Button';
+import { Button } from '@bigcommerce/components/Button';
 
 import { Link } from '~/components/Link';
 

--- a/apps/core/app/(default)/product/[slug]/_components/Gallery.tsx
+++ b/apps/core/app/(default)/product/[slug]/_components/Gallery.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import {
+  Gallery as ComponentsGallery,
   GalleryContent,
   GalleryControls,
   GalleryImage,
   GalleryThumbnail,
   GalleryThumbnailItem,
   GalleryThumbnailList,
-  Gallery as ReactantGallery,
-} from '@bigcommerce/reactant/Gallery';
+} from '@bigcommerce/components/Gallery';
 import Image from 'next/image';
 
 import { getProduct } from '~/client/queries/getProduct';
@@ -24,7 +24,7 @@ export const Gallery = ({ images }: Props) => {
   return (
     <div className="-mx-6 mb-10 sm:-mx-0 md:mb-12">
       <div className="lg:sticky lg:top-0">
-        <ReactantGallery defaultImageIndex={defaultImageIndex} images={images}>
+        <ComponentsGallery defaultImageIndex={defaultImageIndex} images={images}>
           <GalleryContent>
             <GalleryImage>
               {({ selectedImage }) =>
@@ -57,7 +57,7 @@ export const Gallery = ({ images }: Props) => {
               );
             })}
           </GalleryThumbnailList>
-        </ReactantGallery>
+        </ComponentsGallery>
       </div>
     </div>
   );

--- a/apps/core/app/(default)/product/[slug]/_components/ReviewSummary.tsx
+++ b/apps/core/app/(default)/product/[slug]/_components/ReviewSummary.tsx
@@ -1,4 +1,4 @@
-import { Rating } from '@bigcommerce/reactant/Rating';
+import { Rating } from '@bigcommerce/components/Rating';
 import { useId } from 'react';
 
 import { getProductReviews } from '~/client/queries/getProductReviews';

--- a/apps/core/app/(default)/product/[slug]/_components/Reviews.tsx
+++ b/apps/core/app/(default)/product/[slug]/_components/Reviews.tsx
@@ -1,4 +1,4 @@
-import { Rating } from '@bigcommerce/reactant/Rating';
+import { Rating } from '@bigcommerce/components/Rating';
 
 import { getProductReviews } from '~/client/queries/getProductReviews';
 

--- a/apps/core/app/(default)/product/[slug]/loading.tsx
+++ b/apps/core/app/(default)/product/[slug]/loading.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from '@bigcommerce/reactant/Skeleton';
+import { Skeleton } from '@bigcommerce/components/Skeleton';
 
 export default function Loading() {
   return (

--- a/apps/core/app/not-found.tsx
+++ b/apps/core/app/not-found.tsx
@@ -1,4 +1,4 @@
-import { Message } from '@bigcommerce/reactant/Message';
+import { Message } from '@bigcommerce/components/Message';
 import { ShoppingCart } from 'lucide-react';
 
 import { SearchForm } from 'components/SearchForm';

--- a/apps/core/components/BlogPostCard/index.tsx
+++ b/apps/core/components/BlogPostCard/index.tsx
@@ -5,8 +5,8 @@ import {
   BlogPostDate,
   BlogPostImage,
   BlogPostTitle,
-  BlogPostCard as ReactantBlogPostCard,
-} from '@bigcommerce/reactant/BlogPostCard';
+  BlogPostCard as ComponentsBlogPostCard,
+} from '@bigcommerce/components/BlogPostCard';
 import Image from 'next/image';
 
 import { getBlogPosts } from '~/client/queries/getBlogPosts';
@@ -18,7 +18,7 @@ interface BlogPostCardProps {
 }
 
 export const BlogPostCard = ({ blogPost }: BlogPostCardProps) => (
-  <ReactantBlogPostCard>
+  <ComponentsBlogPostCard>
     {blogPost.thumbnailImage ? (
       <BlogPostImage>
         <Link className="block w-full" href={`/blog/${blogPost.entityId}`}>
@@ -52,5 +52,5 @@ export const BlogPostCard = ({ blogPost }: BlogPostCardProps) => (
       {new Intl.DateTimeFormat('en-US').format(new Date(blogPost.publishedDate.utc))}
     </BlogPostDate>
     {blogPost.author ? <BlogPostAuthor>, by {blogPost.author}</BlogPostAuthor> : null}
-  </ReactantBlogPostCard>
+  </ComponentsBlogPostCard>
 );

--- a/apps/core/components/CompareDrawer/index.tsx
+++ b/apps/core/components/CompareDrawer/index.tsx
@@ -5,8 +5,8 @@ import {
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
-} from '@bigcommerce/reactant/Accordion';
-import { Button } from '@bigcommerce/reactant/Button';
+} from '@bigcommerce/components/Accordion';
+import { Button } from '@bigcommerce/components/Button';
 import { X } from 'lucide-react';
 import Image from 'next/image';
 import { usePathname } from 'next/navigation';

--- a/apps/core/components/Footer/Footer.tsx
+++ b/apps/core/components/Footer/Footer.tsx
@@ -1,4 +1,8 @@
-import { FooterNav, FooterSection, Footer as ReactantFooter } from '@bigcommerce/reactant/Footer';
+import {
+  Footer as ComponentsFooter,
+  FooterNav,
+  FooterSection,
+} from '@bigcommerce/components/Footer';
 import React from 'react';
 
 import { AvailableWebPages, getWebPages } from '~/client/queries/getWebPages';
@@ -48,7 +52,7 @@ const WebPageFooterMenu = () => {
 
 export const Footer = () => {
   return (
-    <ReactantFooter>
+    <ComponentsFooter>
       <FooterSection>
         <FooterNav>
           <CategoryFooterMenu />
@@ -67,6 +71,6 @@ export const Footer = () => {
         <PaymentMethods />
         <Copyright />
       </FooterSection>
-    </ReactantFooter>
+    </ComponentsFooter>
   );
 };

--- a/apps/core/components/Footer/FooterMenus/BaseFooterMenu.tsx
+++ b/apps/core/components/Footer/FooterMenus/BaseFooterMenu.tsx
@@ -1,4 +1,4 @@
-import { FooterNavGroupList, FooterNavLink } from '@bigcommerce/reactant/Footer';
+import { FooterNavGroupList, FooterNavLink } from '@bigcommerce/components/Footer';
 import React, { ComponentPropsWithoutRef } from 'react';
 
 import { Link } from '~/components/Link';

--- a/apps/core/components/Footer/SocialIcons.tsx
+++ b/apps/core/components/Footer/SocialIcons.tsx
@@ -1,4 +1,4 @@
-import { FooterNav, FooterNavGroupList, FooterNavLink } from '@bigcommerce/reactant/Footer';
+import { FooterNav, FooterNavGroupList, FooterNavLink } from '@bigcommerce/components/Footer';
 import {
   SiFacebook,
   SiInstagram,

--- a/apps/core/components/Forbidden/index.tsx
+++ b/apps/core/components/Forbidden/index.tsx
@@ -1,4 +1,4 @@
-import { Message } from '@bigcommerce/reactant/Message';
+import { Message } from '@bigcommerce/components/Message';
 
 import { SearchForm } from 'components/SearchForm';
 import { getFeaturedProducts } from '~/client/queries/getFeaturedProducts';

--- a/apps/core/components/Forms/ContactUs.tsx
+++ b/apps/core/components/Forms/ContactUs.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@bigcommerce/reactant/Button';
+import { Button } from '@bigcommerce/components/Button';
 import {
   Field,
   FieldControl,
@@ -6,10 +6,10 @@ import {
   FieldMessage,
   Form,
   FormSubmit,
-} from '@bigcommerce/reactant/Form';
-import { Input } from '@bigcommerce/reactant/Input';
-import { Message } from '@bigcommerce/reactant/Message';
-import { TextArea } from '@bigcommerce/reactant/TextArea';
+} from '@bigcommerce/components/Form';
+import { Input } from '@bigcommerce/components/Input';
+import { Message } from '@bigcommerce/components/Message';
+import { TextArea } from '@bigcommerce/components/TextArea';
 import { Loader2 as Spinner } from 'lucide-react';
 import { ChangeEvent, useRef, useState } from 'react';
 import { useFormStatus } from 'react-dom';

--- a/apps/core/components/Header/cart.tsx
+++ b/apps/core/components/Header/cart.tsx
@@ -1,5 +1,5 @@
-import { Badge } from '@bigcommerce/reactant/Badge';
-import { NavigationMenuLink } from '@bigcommerce/reactant/NavigationMenu';
+import { Badge } from '@bigcommerce/components/Badge';
+import { NavigationMenuLink } from '@bigcommerce/components/NavigationMenu';
 import { ShoppingCart } from 'lucide-react';
 import { cookies } from 'next/headers';
 import { ReactNode } from 'react';

--- a/apps/core/components/Header/index.tsx
+++ b/apps/core/components/Header/index.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@bigcommerce/reactant/Button';
+import { Button } from '@bigcommerce/components/Button';
 import {
   NavigationMenu,
   NavigationMenuCollapsed,
@@ -8,7 +8,7 @@ import {
   NavigationMenuList,
   NavigationMenuToggle,
   NavigationMenuTrigger,
-} from '@bigcommerce/reactant/NavigationMenu';
+} from '@bigcommerce/components/NavigationMenu';
 import { ChevronDown, LogOut, ShoppingCart, User } from 'lucide-react';
 import { ReactNode, Suspense } from 'react';
 

--- a/apps/core/components/Hero/index.tsx
+++ b/apps/core/components/Hero/index.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@bigcommerce/reactant/Button';
+import { Button } from '@bigcommerce/components/Button';
 import {
   Slideshow,
   SlideshowAutoplayControl,
@@ -8,7 +8,7 @@ import {
   SlideshowPagination,
   SlideshowPreviousIndicator,
   SlideshowSlide,
-} from '@bigcommerce/reactant/Slideshow';
+} from '@bigcommerce/components/Slideshow';
 import Image from 'next/image';
 
 import SlideshowBG from './slideshow-bg-01.jpg';

--- a/apps/core/components/ProductCard/AddToCart.tsx
+++ b/apps/core/components/ProductCard/AddToCart.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Button } from '@bigcommerce/reactant/Button';
+import { Button } from '@bigcommerce/components/Button';
 import { Loader2 as Spinner } from 'lucide-react';
 import { useFormStatus } from 'react-dom';
 

--- a/apps/core/components/ProductCard/Compare.tsx
+++ b/apps/core/components/ProductCard/Compare.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Checkbox } from '@bigcommerce/reactant/Checkbox';
-import { Label } from '@bigcommerce/reactant/Label';
+import { Checkbox } from '@bigcommerce/components/Checkbox';
+import { Label } from '@bigcommerce/components/Label';
 import { useEffect, useId, useState } from 'react';
 
 import { useCompareProductsContext } from '../../app/contexts/CompareProductsContext';

--- a/apps/core/components/ProductCard/index.tsx
+++ b/apps/core/components/ProductCard/index.tsx
@@ -1,12 +1,12 @@
 import {
+  ProductCard as ComponentsProductCard,
   ProductCardImage,
   ProductCardInfo,
   ProductCardInfoBrandName,
   ProductCardInfoPrice,
   ProductCardInfoProductName,
-  ProductCard as ReactantProductCard,
-} from '@bigcommerce/reactant/ProductCard';
-import { Rating } from '@bigcommerce/reactant/Rating';
+} from '@bigcommerce/components/ProductCard';
+import { Rating } from '@bigcommerce/components/Rating';
 import Image from 'next/image';
 import { useId } from 'react';
 
@@ -89,7 +89,7 @@ export const ProductCard = ({
   }
 
   return (
-    <ReactantProductCard key={product.entityId}>
+    <ComponentsProductCard key={product.entityId}>
       <ProductCardImage>
         <div
           className={cn('relative flex-auto', {
@@ -165,6 +165,6 @@ export const ProductCard = ({
         </div>
       </ProductCardInfo>
       {showCart && <Cart product={product} />}
-    </ReactantProductCard>
+    </ComponentsProductCard>
   );
 };

--- a/apps/core/components/ProductCardCarousel/Pagination.tsx
+++ b/apps/core/components/ProductCardCarousel/Pagination.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CarouselPagination, CarouselPaginationTab } from '@bigcommerce/reactant/Carousel';
+import { CarouselPagination, CarouselPaginationTab } from '@bigcommerce/components/Carousel';
 
 import { Product } from '../ProductCard';
 

--- a/apps/core/components/ProductCardCarousel/index.tsx
+++ b/apps/core/components/ProductCardCarousel/index.tsx
@@ -4,7 +4,7 @@ import {
   CarouselNextIndicator,
   CarouselPreviousIndicator,
   CarouselSlide,
-} from '@bigcommerce/reactant/Carousel';
+} from '@bigcommerce/components/Carousel';
 import { useId } from 'react';
 
 import { Product, ProductCard } from '../ProductCard';

--- a/apps/core/components/ProductForm/AddToCart.tsx
+++ b/apps/core/components/ProductForm/AddToCart.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Button } from '@bigcommerce/reactant/Button';
+import { Button } from '@bigcommerce/components/Button';
 import { ShoppingCart, Loader2 as Spinner } from 'lucide-react';
 import { useFormContext } from 'react-hook-form';
 

--- a/apps/core/components/ProductForm/Fields/CheckboxField.tsx
+++ b/apps/core/components/ProductForm/Fields/CheckboxField.tsx
@@ -1,5 +1,5 @@
-import { Checkbox } from '@bigcommerce/reactant/Checkbox';
-import { Label } from '@bigcommerce/reactant/Label';
+import { Checkbox } from '@bigcommerce/components/Checkbox';
+import { Label } from '@bigcommerce/components/Label';
 
 import { getProduct } from '~/client/queries/getProduct';
 import { ExistingResultType, Unpacked } from '~/client/util';

--- a/apps/core/components/ProductForm/Fields/DateField.tsx
+++ b/apps/core/components/ProductForm/Fields/DateField.tsx
@@ -1,5 +1,5 @@
-import { DatePicker } from '@bigcommerce/reactant/DatePicker';
-import { Label } from '@bigcommerce/reactant/Label';
+import { DatePicker } from '@bigcommerce/components/DatePicker';
+import { Label } from '@bigcommerce/components/Label';
 
 import { getProduct } from '~/client/queries/getProduct';
 import { ExistingResultType, Unpacked } from '~/client/util';

--- a/apps/core/components/ProductForm/Fields/MultiLineTextField.tsx
+++ b/apps/core/components/ProductForm/Fields/MultiLineTextField.tsx
@@ -1,5 +1,5 @@
-import { Label } from '@bigcommerce/reactant/Label';
-import { TextArea } from '@bigcommerce/reactant/TextArea';
+import { Label } from '@bigcommerce/components/Label';
+import { TextArea } from '@bigcommerce/components/TextArea';
 
 import { getProduct } from '~/client/queries/getProduct';
 import { ExistingResultType, Unpacked } from '~/client/util';

--- a/apps/core/components/ProductForm/Fields/MultipleChoiceField.tsx
+++ b/apps/core/components/ProductForm/Fields/MultipleChoiceField.tsx
@@ -1,9 +1,9 @@
-import { Label } from '@bigcommerce/reactant/Label';
-import { PickList, PickListItem } from '@bigcommerce/reactant/PickList';
-import { RadioGroup, RadioItem } from '@bigcommerce/reactant/RadioGroup';
-import { RectangleList, RectangleListItem } from '@bigcommerce/reactant/RectangleList';
-import { Select, SelectContent, SelectItem } from '@bigcommerce/reactant/Select';
-import { Swatch, SwatchItem } from '@bigcommerce/reactant/Swatch';
+import { Label } from '@bigcommerce/components/Label';
+import { PickList, PickListItem } from '@bigcommerce/components/PickList';
+import { RadioGroup, RadioItem } from '@bigcommerce/components/RadioGroup';
+import { RectangleList, RectangleListItem } from '@bigcommerce/components/RectangleList';
+import { Select, SelectContent, SelectItem } from '@bigcommerce/components/Select';
+import { Swatch, SwatchItem } from '@bigcommerce/components/Swatch';
 import Image from 'next/image';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 

--- a/apps/core/components/ProductForm/Fields/NumberField.tsx
+++ b/apps/core/components/ProductForm/Fields/NumberField.tsx
@@ -1,5 +1,5 @@
-import { Counter } from '@bigcommerce/reactant/Counter';
-import { Label } from '@bigcommerce/reactant/Label';
+import { Counter } from '@bigcommerce/components/Counter';
+import { Label } from '@bigcommerce/components/Label';
 
 import { getProduct } from '~/client/queries/getProduct';
 import { ExistingResultType, Unpacked } from '~/client/util';

--- a/apps/core/components/ProductForm/Fields/QuantityField.tsx
+++ b/apps/core/components/ProductForm/Fields/QuantityField.tsx
@@ -1,5 +1,5 @@
-import { Counter } from '@bigcommerce/reactant/Counter';
-import { Label } from '@bigcommerce/reactant/Label';
+import { Counter } from '@bigcommerce/components/Counter';
+import { Label } from '@bigcommerce/components/Label';
 
 import { useProductFieldController } from '../useProductForm';
 

--- a/apps/core/components/ProductForm/Fields/TextField.tsx
+++ b/apps/core/components/ProductForm/Fields/TextField.tsx
@@ -1,5 +1,5 @@
-import { Input } from '@bigcommerce/reactant/Input';
-import { Label } from '@bigcommerce/reactant/Label';
+import { Input } from '@bigcommerce/components/Input';
+import { Label } from '@bigcommerce/components/Label';
 
 import { getProduct } from '~/client/queries/getProduct';
 import { ExistingResultType, Unpacked } from '~/client/util';

--- a/apps/core/components/ProductForm/index.tsx
+++ b/apps/core/components/ProductForm/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Button } from '@bigcommerce/reactant/Button';
+import { Button } from '@bigcommerce/components/Button';
 import { AlertCircle, Check, Heart } from 'lucide-react';
 import { FormProvider } from 'react-hook-form';
 import { toast } from 'react-hot-toast';

--- a/apps/core/components/ProductSheet/index.tsx
+++ b/apps/core/components/ProductSheet/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Button } from '@bigcommerce/reactant/Button';
-import { Rating } from '@bigcommerce/reactant/Rating';
+import { Button } from '@bigcommerce/components/Button';
+import { Rating } from '@bigcommerce/components/Rating';
 import {
   Sheet,
   SheetClose,
@@ -10,7 +10,7 @@ import {
   SheetOverlay,
   SheetTitle,
   SheetTrigger,
-} from '@bigcommerce/reactant/Sheet';
+} from '@bigcommerce/components/Sheet';
 import { Loader2 as Spinner } from 'lucide-react';
 import Image from 'next/image';
 import { useSearchParams } from 'next/navigation';

--- a/apps/core/components/QuickSearch/index.tsx
+++ b/apps/core/components/QuickSearch/index.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { Button } from '@bigcommerce/reactant/Button';
-import { Field, FieldControl, Form } from '@bigcommerce/reactant/Form';
-import { Input, InputIcon } from '@bigcommerce/reactant/Input';
+import { Button } from '@bigcommerce/components/Button';
+import { Field, FieldControl, Form } from '@bigcommerce/components/Form';
+import { Input, InputIcon } from '@bigcommerce/components/Input';
 import {
   Sheet,
   SheetClose,
@@ -10,7 +10,7 @@ import {
   SheetOverlay,
   SheetTitle,
   SheetTrigger,
-} from '@bigcommerce/reactant/Sheet';
+} from '@bigcommerce/components/Sheet';
 import debounce from 'lodash.debounce';
 import { Search, Loader2 as Spinner, X } from 'lucide-react';
 import Image from 'next/image';

--- a/apps/core/components/SearchForm/index.tsx
+++ b/apps/core/components/SearchForm/index.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { Button } from '@bigcommerce/reactant/Button';
-import { Field, FieldControl, Form, FormSubmit } from '@bigcommerce/reactant/Form';
-import { Input } from '@bigcommerce/reactant/Input';
+import { Button } from '@bigcommerce/components/Button';
+import { Field, FieldControl, Form, FormSubmit } from '@bigcommerce/components/Form';
+import { Input } from '@bigcommerce/components/Input';
 import { Loader2 as Spinner } from 'lucide-react';
 import { useFormStatus } from 'react-dom';
 

--- a/apps/core/next.config.js
+++ b/apps/core/next.config.js
@@ -10,7 +10,7 @@ const nextConfig = {
       },
     ],
   },
-  transpilePackages: ['@bigcommerce/reactant'],
+  transpilePackages: ['@bigcommerce/components'],
   typescript: {
     ignoreBuildErrors: !!process.env.CI,
   },

--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@bigcommerce/catalyst-client": "workspace:^",
-    "@bigcommerce/reactant": "workspace:^",
+    "@bigcommerce/components": "workspace:^",
     "@graphql-typed-document-node/core": "^3.2.0",
     "@icons-pack/react-simple-icons": "^9.2.0",
     "@vercel/analytics": "^1.1.1",

--- a/apps/core/tailwind.config.js
+++ b/apps/core/tailwind.config.js
@@ -1,12 +1,12 @@
-const reactantPreset = require('@bigcommerce/reactant/tailwind-config');
+const componentsPreset = require('@bigcommerce/components/tailwind-config');
 
 /** @type {import('tailwindcss').Config} */
 const config = {
-  presets: [reactantPreset],
+  presets: [componentsPreset],
   content: [
     './app/**/*.{ts,tsx}',
     './components/**/*.{ts,tsx}',
-    './node_modules/@bigcommerce/reactant/src/**/*.{ts,tsx}',
+    './node_modules/@bigcommerce/components/src/**/*.{ts,tsx}',
   ],
   plugins: [require('@tailwindcss/container-queries')],
 };

--- a/apps/core/tsconfig.json
+++ b/apps/core/tsconfig.json
@@ -27,7 +27,7 @@
     "baseUrl": ".",
     "paths": {
       "~/*": ["./*"],
-      "@bigcommerce/reactant/*": ["./node_modules/@bigcommerce/reactant/*"]
+      "@bigcommerce/components/*": ["./node_modules/@bigcommerce/components/*"]
     },
     "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json"
   },

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/docs",
-  "description": "Reactant docs",
+  "description": "Components docs",
   "version": "0.1.0",
   "private": true,
   "scripts": {
@@ -9,7 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@bigcommerce/reactant": "workspace:^",
+    "@bigcommerce/components": "workspace:^",
     "clsx": "^2.0.0",
     "lucide-react": "^0.294.0",
     "react": "^18.2.0",

--- a/apps/docs/stories/Accordion.stories.tsx
+++ b/apps/docs/stories/Accordion.stories.tsx
@@ -3,7 +3,7 @@ import {
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
-} from '@bigcommerce/reactant/Accordion';
+} from '@bigcommerce/components/Accordion';
 import type { Meta, StoryObj } from '@storybook/react';
 import { Info } from 'lucide-react';
 

--- a/apps/docs/stories/Badge.stories.tsx
+++ b/apps/docs/stories/Badge.stories.tsx
@@ -1,4 +1,4 @@
-import { Badge } from '@bigcommerce/reactant/Badge';
+import { Badge } from '@bigcommerce/components/Badge';
 import type { Meta, StoryObj } from '@storybook/react';
 import { ShoppingCart } from 'lucide-react';
 

--- a/apps/docs/stories/BlogPostCard.stories.tsx
+++ b/apps/docs/stories/BlogPostCard.stories.tsx
@@ -6,7 +6,7 @@ import {
   BlogPostDate,
   BlogPostImage,
   BlogPostTitle,
-} from '@bigcommerce/reactant/BlogPostCard';
+} from '@bigcommerce/components/BlogPostCard';
 import { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof BlogPostCard> = {

--- a/apps/docs/stories/Breadcrumbs.stories.tsx
+++ b/apps/docs/stories/Breadcrumbs.stories.tsx
@@ -1,4 +1,4 @@
-import { BreadcrumbDivider, BreadcrumbItem, Breadcrumbs } from '@bigcommerce/reactant/Breadcrumbs';
+import { BreadcrumbDivider, BreadcrumbItem, Breadcrumbs } from '@bigcommerce/components/Breadcrumbs';
 import type { Meta, StoryObj } from '@storybook/react';
 import { ChevronRight } from 'lucide-react';
 

--- a/apps/docs/stories/Button.stories.tsx
+++ b/apps/docs/stories/Button.stories.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@bigcommerce/reactant/Button';
+import { Button } from '@bigcommerce/components/Button';
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof Button> = {

--- a/apps/docs/stories/Calendar.stories.tsx
+++ b/apps/docs/stories/Calendar.stories.tsx
@@ -1,4 +1,4 @@
-import { Calendar } from '@bigcommerce/reactant/Calendar';
+import { Calendar } from '@bigcommerce/components/Calendar';
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 

--- a/apps/docs/stories/Carousel.stories.tsx
+++ b/apps/docs/stories/Carousel.stories.tsx
@@ -6,7 +6,7 @@ import {
   CarouselPaginationTab,
   CarouselPreviousIndicator,
   CarouselSlide,
-} from '@bigcommerce/reactant/Carousel';
+} from '@bigcommerce/components/Carousel';
 import {
   ProductCard,
   ProductCardBadge,
@@ -15,7 +15,7 @@ import {
   ProductCardInfoBrandName,
   ProductCardInfoPrice,
   ProductCardInfoProductName,
-} from '@bigcommerce/reactant/ProductCard';
+} from '@bigcommerce/components/ProductCard';
 import { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof Carousel> = {

--- a/apps/docs/stories/Checkbox.stories.tsx
+++ b/apps/docs/stories/Checkbox.stories.tsx
@@ -1,5 +1,5 @@
-import { Checkbox } from '@bigcommerce/reactant/Checkbox';
-import { Label } from '@bigcommerce/reactant/Label';
+import { Checkbox } from '@bigcommerce/components/Checkbox';
+import { Label } from '@bigcommerce/components/Label';
 import type { Meta, StoryObj } from '@storybook/react';
 import { X } from 'lucide-react';
 

--- a/apps/docs/stories/Counter.stories.tsx
+++ b/apps/docs/stories/Counter.stories.tsx
@@ -1,4 +1,4 @@
-import { Counter } from '@bigcommerce/reactant/Counter';
+import { Counter } from '@bigcommerce/components/Counter';
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof Counter> = {

--- a/apps/docs/stories/DatePicker.stories.tsx
+++ b/apps/docs/stories/DatePicker.stories.tsx
@@ -1,4 +1,4 @@
-import { DatePicker } from '@bigcommerce/reactant/DatePicker';
+import { DatePicker } from '@bigcommerce/components/DatePicker';
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof DatePicker> = {

--- a/apps/docs/stories/FileChooser.stories.tsx
+++ b/apps/docs/stories/FileChooser.stories.tsx
@@ -1,5 +1,5 @@
-import { FileChooser } from '@bigcommerce/reactant/FileChooser';
-import { Label } from '@bigcommerce/reactant/Label';
+import { FileChooser } from '@bigcommerce/components/FileChooser';
+import { Label } from '@bigcommerce/components/Label';
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof FileChooser> = {

--- a/apps/docs/stories/Footer.stories.tsx
+++ b/apps/docs/stories/Footer.stories.tsx
@@ -4,7 +4,7 @@ import {
   FooterNavGroupList,
   FooterNavLink,
   FooterSection,
-} from '@bigcommerce/reactant/Footer';
+} from '@bigcommerce/components/Footer';
 import { Meta, StoryObj } from '@storybook/react';
 import { FacebookIcon, InstagramIcon, TwitterIcon } from 'lucide-react';
 

--- a/apps/docs/stories/Form.stories.tsx
+++ b/apps/docs/stories/Form.stories.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@bigcommerce/reactant/Button';
+import { Button } from '@bigcommerce/components/Button';
 import {
   BuiltInValidityState,
   Field,
@@ -8,10 +8,10 @@ import {
   FieldValidation,
   Form,
   FormSubmit,
-} from '@bigcommerce/reactant/Form';
-import { Input } from '@bigcommerce/reactant/Input';
-import { Select, SelectContent, SelectItem } from '@bigcommerce/reactant/Select';
-import { TextArea } from '@bigcommerce/reactant/TextArea';
+} from '@bigcommerce/components/Form';
+import { Input } from '@bigcommerce/components/Input';
+import { Select, SelectContent, SelectItem } from '@bigcommerce/components/Select';
+import { TextArea } from '@bigcommerce/components/TextArea';
 import type { Meta, StoryObj } from '@storybook/react';
 import { FormEvent } from 'react';
 

--- a/apps/docs/stories/Gallery.stories.tsx
+++ b/apps/docs/stories/Gallery.stories.tsx
@@ -8,7 +8,7 @@ import {
   GalleryThumbnail,
   GalleryThumbnailItem,
   GalleryThumbnailList,
-} from '@bigcommerce/reactant/Gallery';
+} from '@bigcommerce/components/Gallery';
 import type { Meta, StoryObj } from '@storybook/react';
 import { ArrowLeftCircle, ArrowRightCircle } from 'lucide-react';
 

--- a/apps/docs/stories/Input.stories.tsx
+++ b/apps/docs/stories/Input.stories.tsx
@@ -1,4 +1,4 @@
-import { Input, InputIcon } from '@bigcommerce/reactant/Input';
+import { Input, InputIcon } from '@bigcommerce/components/Input';
 import type { Meta, StoryObj } from '@storybook/react';
 import { CheckCircle } from 'lucide-react';
 

--- a/apps/docs/stories/Label.stories.tsx
+++ b/apps/docs/stories/Label.stories.tsx
@@ -1,5 +1,5 @@
-import { Input } from '@bigcommerce/reactant/Input';
-import { Label } from '@bigcommerce/reactant/Label';
+import { Input } from '@bigcommerce/components/Input';
+import { Label } from '@bigcommerce/components/Label';
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof Label> = {

--- a/apps/docs/stories/Message.stories.tsx
+++ b/apps/docs/stories/Message.stories.tsx
@@ -1,4 +1,4 @@
-import { Message } from '@bigcommerce/reactant/Message';
+import { Message } from '@bigcommerce/components/Message';
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof Message> = {

--- a/apps/docs/stories/NavigationMenu.stories.tsx
+++ b/apps/docs/stories/NavigationMenu.stories.tsx
@@ -1,5 +1,5 @@
-import { Badge } from '@bigcommerce/reactant/Badge';
-import { cn } from '@bigcommerce/reactant/cn';
+import { Badge } from '@bigcommerce/components/Badge';
+import { cn } from '@bigcommerce/components/cn';
 import {
   NavigationMenu,
   NavigationMenuCollapsed,
@@ -9,7 +9,7 @@ import {
   NavigationMenuList,
   NavigationMenuToggle,
   NavigationMenuTrigger,
-} from '@bigcommerce/reactant/NavigationMenu';
+} from '@bigcommerce/components/NavigationMenu';
 import type { Meta, StoryObj } from '@storybook/react';
 import { ChevronDown, MenuSquare, Search, ShoppingCart, User, XSquare } from 'lucide-react';
 

--- a/apps/docs/stories/PickList.stories.tsx
+++ b/apps/docs/stories/PickList.stories.tsx
@@ -1,5 +1,5 @@
-import { Label } from '@bigcommerce/reactant/Label';
-import { PickList, PickListIndicator, PickListItem } from '@bigcommerce/reactant/PickList';
+import { Label } from '@bigcommerce/components/Label';
+import { PickList, PickListIndicator, PickListItem } from '@bigcommerce/components/PickList';
 import type { Meta, StoryObj } from '@storybook/react';
 import { Paintbrush } from 'lucide-react';
 import { Fragment } from 'react';

--- a/apps/docs/stories/Popover.stories.tsx
+++ b/apps/docs/stories/Popover.stories.tsx
@@ -1,5 +1,5 @@
-import { Button } from '@bigcommerce/reactant/Button';
-import { Popover, PopoverContent, PopoverTrigger } from '@bigcommerce/reactant/Popover';
+import { Button } from '@bigcommerce/components/Button';
+import { Popover, PopoverContent, PopoverTrigger } from '@bigcommerce/components/Popover';
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof Popover> = {

--- a/apps/docs/stories/ProductCard.stories.tsx
+++ b/apps/docs/stories/ProductCard.stories.tsx
@@ -6,7 +6,7 @@ import {
   ProductCardInfoBrandName,
   ProductCardInfoPrice,
   ProductCardInfoProductName,
-} from '@bigcommerce/reactant/ProductCard';
+} from '@bigcommerce/components/ProductCard';
 import { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof ProductCard> = {

--- a/apps/docs/stories/RadioGroup.stories.tsx
+++ b/apps/docs/stories/RadioGroup.stories.tsx
@@ -1,5 +1,5 @@
-import { Label } from '@bigcommerce/reactant/Label';
-import { RadioGroup, RadioIndicator, RadioItem } from '@bigcommerce/reactant/RadioGroup';
+import { Label } from '@bigcommerce/components/Label';
+import { RadioGroup, RadioIndicator, RadioItem } from '@bigcommerce/components/RadioGroup';
 import type { Meta, StoryObj } from '@storybook/react';
 import { Paintbrush } from 'lucide-react';
 

--- a/apps/docs/stories/Rating.stories.tsx
+++ b/apps/docs/stories/Rating.stories.tsx
@@ -1,4 +1,4 @@
-import { Rating } from '@bigcommerce/reactant/Rating';
+import { Rating } from '@bigcommerce/components/Rating';
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof Rating> = {

--- a/apps/docs/stories/RectangleList.stories.tsx
+++ b/apps/docs/stories/RectangleList.stories.tsx
@@ -1,5 +1,5 @@
-import { Label } from '@bigcommerce/reactant/Label';
-import { RectangleList, RectangleListItem } from '@bigcommerce/reactant/RectangleList';
+import { Label } from '@bigcommerce/components/Label';
+import { RectangleList, RectangleListItem } from '@bigcommerce/components/RectangleList';
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof RectangleList> = {

--- a/apps/docs/stories/Select.stories.tsx
+++ b/apps/docs/stories/Select.stories.tsx
@@ -1,4 +1,4 @@
-import { Select, SelectContent, SelectItem } from '@bigcommerce/reactant/Select';
+import { Select, SelectContent, SelectItem } from '@bigcommerce/components/Select';
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof Select> = {

--- a/apps/docs/stories/Sheet.stories.tsx
+++ b/apps/docs/stories/Sheet.stories.tsx
@@ -7,7 +7,7 @@ import {
   SheetOverlay,
   SheetTitle,
   SheetTrigger,
-} from '@bigcommerce/reactant/Sheet';
+} from '@bigcommerce/components/Sheet';
 import type { Meta, StoryObj } from '@storybook/react';
 
 // We need to remove these once we get variant types working with cva

--- a/apps/docs/stories/Skeleton.stories.tsx
+++ b/apps/docs/stories/Skeleton.stories.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from '@bigcommerce/reactant/Skeleton';
+import { Skeleton } from '@bigcommerce/components/Skeleton';
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof Skeleton> = {

--- a/apps/docs/stories/Slideshow.stories.tsx
+++ b/apps/docs/stories/Slideshow.stories.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@bigcommerce/reactant/Button';
+import { Button } from '@bigcommerce/components/Button';
 import {
   Slideshow,
   SlideshowAutoplayControl,
@@ -8,7 +8,7 @@ import {
   SlideshowPagination,
   SlideshowPreviousIndicator,
   SlideshowSlide,
-} from '@bigcommerce/reactant/Slideshow';
+} from '@bigcommerce/components/Slideshow';
 import type { Meta, StoryObj } from '@storybook/react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 

--- a/apps/docs/stories/Swatch.stories.tsx
+++ b/apps/docs/stories/Swatch.stories.tsx
@@ -1,5 +1,5 @@
-import { Label } from '@bigcommerce/reactant/Label';
-import { Swatch, SwatchItem } from '@bigcommerce/reactant/Swatch';
+import { Label } from '@bigcommerce/components/Label';
+import { Swatch, SwatchItem } from '@bigcommerce/components/Swatch';
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof Swatch> = {

--- a/apps/docs/stories/Tag.stories.tsx
+++ b/apps/docs/stories/Tag.stories.tsx
@@ -1,4 +1,4 @@
-import { Tag, TagAction, TagContent, TagProps } from '@bigcommerce/reactant/Tag';
+import { Tag, TagAction, TagContent, TagProps } from '@bigcommerce/components/Tag';
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof Tag> = {

--- a/apps/docs/stories/TextArea.stories.tsx
+++ b/apps/docs/stories/TextArea.stories.tsx
@@ -1,4 +1,4 @@
-import { TextArea } from '@bigcommerce/reactant/TextArea';
+import { TextArea } from '@bigcommerce/components/TextArea';
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof TextArea> = {

--- a/apps/docs/tailwind.config.js
+++ b/apps/docs/tailwind.config.js
@@ -1,9 +1,9 @@
-const reactantPreset = require('@bigcommerce/reactant/tailwind-config');
+const componentsPreset = require('@bigcommerce/components/tailwind-config');
 
 /** @type {import('tailwindcss').Config} */
 const config = {
-  presets: [reactantPreset],
-  content: ['./stories/**/*.{ts,tsx}', './node_modules/@bigcommerce/reactant/src/**/*.{ts,tsx}'],
+  presets: [componentsPreset],
+  content: ['./stories/**/*.{ts,tsx}', './node_modules/@bigcommerce/components/src/**/*.{ts,tsx}'],
   plugins: [],
 };
 

--- a/packages/create-catalyst/README.md
+++ b/packages/create-catalyst/README.md
@@ -42,7 +42,7 @@ While developing `create-catalyst` locally, it's essential to test your changes 
 
 > ⚠️ **IMPORTANT:** NPM registry data is immutable, meaning once published, a package cannot change. Be careful to ensure that you do not run commands such as `publish` against the default NPM registry if your work is not ready to be published. Always explicitly pass `--registry=http://localhost:<VERDACCIO_PORT>` with commands that modify the registry (such as `publish`) to ensure you only publish to Verdaccio when working locally.
 
-4. If necessary, run `pnpm build` and `pnpm publish --registry=http://localhost:4873` in each Catalyst-scoped package required by relevant examples listed in `apps/` (e.g., Catalyst `core` examples require `@bigcommerce/reactant`, `@bigcommerce/eslint-config-catalyst`, `@bigcommerce/catalyst-configs`, `@bigcommerce/catalyst-client`)
+4. If necessary, run `pnpm build` and `pnpm publish --registry=http://localhost:4873` in each Catalyst-scoped package required by relevant examples listed in `apps/` (e.g., Catalyst `core` examples require `@bigcommerce/components`, `@bigcommerce/eslint-config-catalyst`, `@bigcommerce/catalyst-configs`, `@bigcommerce/catalyst-client`)
 5. Run `pnpm build` and `pnpm publish --registry=http://localhost:4873` in the `@bigcommerce/create-catalyst` package
 6. Confirm published packages are listed in Verdaccio: http://localhost:4873
 

--- a/packages/reactant/package.json
+++ b/packages/reactant/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@bigcommerce/reactant",
+  "name": "@bigcommerce/components",
   "description": "BigCommerce components for Catalyst.",
   "version": "0.1.0",
   "private": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ importers:
       '@bigcommerce/catalyst-client':
         specifier: workspace:^
         version: link:../../packages/client
-      '@bigcommerce/reactant':
+      '@bigcommerce/components':
         specifier: workspace:^
         version: link:../../packages/reactant
       '@graphql-typed-document-node/core':
@@ -65,12 +65,12 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
-      react-hook-form:
-        specifier: ^7.49.3
-        version: 7.49.3(react@18.2.0)
       react-google-recaptcha:
         specifier: ^3.1.0
         version: 3.1.0(react@18.2.0)
+      react-hook-form:
+        specifier: ^7.49.3
+        version: 7.49.3(react@18.2.0)
       react-hot-toast:
         specifier: ^2.4.1
         version: 2.4.1(csstype@3.1.3)(react-dom@18.2.0)(react@18.2.0)
@@ -165,7 +165,7 @@ importers:
 
   apps/docs:
     dependencies:
-      '@bigcommerce/reactant':
+      '@bigcommerce/components':
         specifier: workspace:^
         version: link:../../packages/reactant
       clsx:
@@ -12096,13 +12096,6 @@ packages:
       react-is: 18.1.0
     dev: true
 
-  /react-hook-form@7.49.3(react@18.2.0):
-    resolution: {integrity: sha512-foD6r3juidAT1cOZzpmD/gOKt7fRsDhXXZ0y28+Al1CHgX+AY1qIN9VSIIItXRq1dN68QrRwl1ORFlwjBaAqeQ==}
-    engines: {node: '>=18', pnpm: '8'}
-    peerDependencies:
-      react: ^16.8.0 || ^17 || ^18
-    dependencies:
-      react: 18.2.0
   /react-google-recaptcha@3.1.0(react@18.2.0):
     resolution: {integrity: sha512-cYW2/DWas8nEKZGD7SCu9BSuVz8iOcOLHChHyi7upUuVhkpkhYG/6N3KDiTQ3XAiZ2UAZkfvYKMfAHOzBOcGEg==}
     peerDependencies:
@@ -12111,6 +12104,15 @@ packages:
       prop-types: 15.8.1
       react: 18.2.0
       react-async-script: 1.2.0(react@18.2.0)
+    dev: false
+
+  /react-hook-form@7.49.3(react@18.2.0):
+    resolution: {integrity: sha512-foD6r3juidAT1cOZzpmD/gOKt7fRsDhXXZ0y28+Al1CHgX+AY1qIN9VSIIItXRq1dN68QrRwl1ORFlwjBaAqeQ==}
+    engines: {node: '>=18', pnpm: '8'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18
+    dependencies:
+      react: 18.2.0
     dev: false
 
   /react-hot-toast@2.4.1(csstype@3.1.3)(react-dom@18.2.0)(react@18.2.0):


### PR DESCRIPTION
## What/Why?
[CATALYST-261](https://bigcommercecloud.atlassian.net/browse/CATALYST-261)

Change the reactant package to simply be called components (open to other names), and update code/docs as needed.

## Testing
It builds and runs!

[CATALYST-261]: https://bigcommercecloud.atlassian.net/browse/CATALYST-261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ