### PR TITLE
Add selected variant price styling

### DIFF
--- a/apps/core/app/(default)/product/[slug]/page.tsx
+++ b/apps/core/app/(default)/product/[slug]/page.tsx
@@ -64,7 +64,7 @@ const ProductDetails = ({ product }: { product: NonNullable<Product> }) => {
                 </>
               ) : (
                 product.prices.price.value && (
-                  <>{currencyFormatter.format(product.prices.price.value)}</>
+                  <p className="text-h4">{currencyFormatter.format(product.prices.price.value)}</p>
                 )
               )}
             </>


### PR DESCRIPTION
## What/Why?
When navigating to a product with variants, upon selecting a variant the the price is updated but the price becomes unstyled. This PR adds the missing styling to the product price.

## Testing
1. Navigate to a product with variants.
1. Select a variant.
1. Observe that the price styling does not change.

<img width="774" alt="Screenshot 2024-02-07 at 11 35 16" src="https://github.com/bigcommerce/catalyst/assets/106064302/c06f064a-c039-4ecb-b52e-3d91546b31e9">
