### PR TITLE
chore(core): run eslint on all dirs

### DIFF
--- a/apps/core/.eslintrc.cjs
+++ b/apps/core/.eslintrc.cjs
@@ -26,6 +26,7 @@ const config = {
       },
     ],
   },
+  ignorePatterns: ['client/generated/**/*.ts'],
 };
 
 module.exports = config;

--- a/apps/core/next.config.js
+++ b/apps/core/next.config.js
@@ -16,6 +16,7 @@ const nextConfig = {
   },
   eslint: {
     ignoreDuringBuilds: !!process.env.CI,
+    dirs: ['app', 'client', 'components', 'lib', 'middlewares'],
   },
   // default URL generation in BigCommerce uses trailing slash
   trailingSlash: process.env.TRAILING_SLASH !== 'false',


### PR DESCRIPTION
## What/Why?
`next lint` doesn't run by default on all directories.