### PR TITLE
fix(core): price font size in pdp

### DIFF
--- a/apps/core/app/(default)/product/[slug]/page.tsx
+++ b/apps/core/app/(default)/product/[slug]/page.tsx
@@ -36,35 +36,38 @@ const ProductDetails = ({ product }: { product: NonNullable<Product> }) => {
       </Suspense>
 
       {product.prices && (
-        <div className="my-6">
+        <div className="my-6 text-h4">
           {showPriceRange ? (
-            <p className="text-h4">
+            <span>
               {currencyFormatter.format(product.prices.priceRange.min.value)} -{' '}
               {currencyFormatter.format(product.prices.priceRange.max.value)}
-            </p>
+            </span>
           ) : (
             <>
               {product.prices.retailPrice?.value !== undefined && (
-                <p className="text-h4">
+                <span>
                   MSRP:{' '}
                   <span className="line-through">
                     {currencyFormatter.format(product.prices.retailPrice.value)}
                   </span>
-                </p>
+                  <br />
+                </span>
               )}
               {product.prices.salePrice?.value !== undefined &&
               product.prices.basePrice?.value !== undefined ? (
                 <>
-                  Was:{' '}
-                  <span className="line-through">
-                    {currencyFormatter.format(product.prices.basePrice.value)}
+                  <span>
+                    Was:{' '}
+                    <span className="line-through">
+                      {currencyFormatter.format(product.prices.basePrice.value)}
+                    </span>
                   </span>
                   <br />
-                  <>Now: {currencyFormatter.format(product.prices.salePrice.value)}</>
+                  <span>Now: {currencyFormatter.format(product.prices.salePrice.value)}</span>
                 </>
               ) : (
                 product.prices.price.value && (
-                  <>{currencyFormatter.format(product.prices.price.value)}</>
+                  <span>{currencyFormatter.format(product.prices.price.value)}</span>
                 )
               )}
             </>


### PR DESCRIPTION
## What/Why?
Fixes issue with prices not being the right font size in PDP.

As suggested by @bc-0dp in #505, but with additional fixes for semantic html.

![Screenshot 2024-02-07 at 10 17 07 AM](https://github.com/bigcommerce/catalyst/assets/196129/057020aa-e059-479b-871d-660945718b90)

Closes #505

## Testing
Locally.