### PR TITLE
chore(core): Remove v2_ prefix from kv keys

### DIFF
--- a/apps/core/app/api/revalidate/route/route.ts
+++ b/apps/core/app/api/revalidate/route/route.ts
@@ -19,7 +19,7 @@ const handler = async (request: NextRequest) => {
   const expiryTime = Date.now() + 1000 * 60 * 30; // 30 minutes;
 
   try {
-    await kv.set(`v2_${pathname}`, { node, expiryTime });
+    await kv.set(pathname, { node, expiryTime });
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error(error);

--- a/apps/core/app/api/revalidate/store-status/route.ts
+++ b/apps/core/app/api/revalidate/store-status/route.ts
@@ -5,7 +5,7 @@ import { kv } from '~/lib/kv';
 
 import { withInternalAuth } from '../../internal-auth';
 
-const STORE_STATUS_KEY = 'v2_storeStatus';
+const STORE_STATUS_KEY = 'storeStatus';
 
 const handler = async () => {
   const status = await getStoreStatus();

--- a/apps/core/middlewares/with-custom-urls.ts
+++ b/apps/core/middlewares/with-custom-urls.ts
@@ -18,7 +18,7 @@ interface RouteCache {
   expiryTime: number;
 }
 
-const STORE_STATUS_KEY = 'v2_storeStatus';
+const STORE_STATUS_KEY = 'storeStatus';
 
 interface StorefrontStatusCache {
   status: StorefrontStatusType;
@@ -48,7 +48,7 @@ const getExistingRouteInfo = async (request: NextRequest) => {
     const pathname = request.nextUrl.pathname;
 
     const [routeCache, statusCache] = await kv.mget<RouteCache | StorefrontStatusCache>(
-      `v2_${pathname}`,
+      pathname,
       STORE_STATUS_KEY,
     );
 
@@ -105,7 +105,7 @@ const setKvRoute = async (request: NextRequest, node: Node) => {
   try {
     const expiryTime = Date.now() + 1000 * 60 * 30; // 30 minutes;
 
-    await kv.set(`v2_${request.nextUrl.pathname}`, { node, expiryTime });
+    await kv.set(request.nextUrl.pathname, { node, expiryTime });
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error(error);


### PR DESCRIPTION
## What/Why?
Now that https://github.com/bigcommerce/catalyst/pull/476 has been merged to main, we can remove the `v2_` prefix, as all  branches will now be using the new format of the cache values. (Can probably hold off a day or so to merge this just to play nice with existing branches)

## Testing
Verified the KV store is still getting/setting properly, both on initial hydration and when revalidating.