### PR TITLE
refactor: remove custom font classes

### DIFF
--- a/apps/core/app/(default)/(faceted)/_components/breadcrumbs.tsx
+++ b/apps/core/app/(default)/(faceted)/_components/breadcrumbs.tsx
@@ -22,7 +22,7 @@ export const Breadcrumbs = ({ breadcrumbs, category }: Props) => (
     {breadcrumbs.map(({ name, entityId, path }, index) => {
       if (!path || breadcrumbs.length - 1 === index) {
         return (
-          <BreadcrumbItem isActive={category === name} key={entityId}>
+          <BreadcrumbItem className="font-extrabold" isActive={category === name} key={entityId}>
             {name}
           </BreadcrumbItem>
         );

--- a/apps/core/app/(default)/(faceted)/_components/facets.tsx
+++ b/apps/core/app/(default)/(faceted)/_components/facets.tsx
@@ -115,7 +115,11 @@ export const Facets = ({ facets, pageType }: Props) => {
                           onCheckedChange={submitForm}
                           value={brand.entityId}
                         />
-                        <Label className="cursor-pointer ps-3" htmlFor={id} id={labelId}>
+                        <Label
+                          className="cursor-pointer ps-3 font-normal"
+                          htmlFor={id}
+                          id={labelId}
+                        >
                           {brand.name}
                           <ProductCount
                             count={brand.productCount}
@@ -154,7 +158,11 @@ export const Facets = ({ facets, pageType }: Props) => {
                           onCheckedChange={submitForm}
                           value={category.entityId}
                         />
-                        <Label className="cursor-pointer ps-3" htmlFor={id} id={labelId}>
+                        <Label
+                          className="cursor-pointer ps-3 font-normal"
+                          htmlFor={id}
+                          id={labelId}
+                        >
                           {category.name}
                           <ProductCount
                             count={category.productCount}
@@ -198,7 +206,11 @@ export const Facets = ({ facets, pageType }: Props) => {
                           onCheckedChange={submitForm}
                           value={attribute.value}
                         />
-                        <Label className="cursor-pointer ps-3" htmlFor={id} id={labelId}>
+                        <Label
+                          className="cursor-pointer ps-3 font-normal"
+                          htmlFor={id}
+                          id={labelId}
+                        >
                           {attribute.value}
                           <ProductCount
                             count={attribute.productCount}
@@ -219,7 +231,7 @@ export const Facets = ({ facets, pageType }: Props) => {
                 <AccordionTrigger>
                   <h3>{facet.name}</h3>
                 </AccordionTrigger>
-                <AccordionContent>
+                <AccordionContent className="overflow-visible">
                   {facet.ratings
                     .filter((rating) => rating.value !== '5')
                     .sort(sortRatingsDescending)
@@ -307,7 +319,7 @@ export const Facets = ({ facets, pageType }: Props) => {
                         value="free_shipping"
                       />
                       <Label
-                        className="cursor-pointer ps-3"
+                        className="cursor-pointer ps-3 font-normal"
                         htmlFor="shipping-free_shipping"
                         id="shipping-free_shipping-label"
                       >
@@ -329,7 +341,7 @@ export const Facets = ({ facets, pageType }: Props) => {
                         onCheckedChange={submitForm}
                       />
                       <Label
-                        className="cursor-pointer ps-3"
+                        className="cursor-pointer ps-3 font-normal"
                         htmlFor="isFeatured"
                         id="isFeatured-label"
                       >
@@ -352,7 +364,7 @@ export const Facets = ({ facets, pageType }: Props) => {
                         value="in_stock"
                       />
                       <Label
-                        className="cursor-pointer ps-3"
+                        className="cursor-pointer ps-3 font-normal"
                         htmlFor="stock-in_stock"
                         id="stock-in_stock-label"
                       >

--- a/apps/core/app/(default)/(faceted)/_components/refine-by.tsx
+++ b/apps/core/app/(default)/(faceted)/_components/refine-by.tsx
@@ -131,7 +131,7 @@ export const RefineBy = (props: Props) => {
   return (
     <div>
       <div className="flex flex-row items-center justify-between pb-2">
-        <h3 className="text-h5">Refine by</h3>
+        <h3 className="text-2xl font-bold">Refine by</h3>
         {/* TODO: Make subtle variant */}
         <button className="font-semibold text-blue-primary" onClick={clearAllRefinements}>
           Clear all

--- a/apps/core/app/(default)/(faceted)/_components/sub-categories.tsx
+++ b/apps/core/app/(default)/(faceted)/_components/sub-categories.tsx
@@ -14,9 +14,9 @@ export async function SubCategories({ categoryId }: Props) {
 
   return (
     <div className="mb-8">
-      <h3 className="mb-3 text-h5">Categories</h3>
+      <h3 className="mb-3 text-2xl font-bold">Categories</h3>
 
-      <ul className="flex flex-col gap-4 text-base">
+      <ul className="flex flex-col gap-4">
         {categoryTree.children.map((category) => (
           <li key={category.entityId}>
             <Link href={category.path}>{category.name}</Link>

--- a/apps/core/app/(default)/(faceted)/brand/[slug]/page.tsx
+++ b/apps/core/app/(default)/(faceted)/brand/[slug]/page.tsx
@@ -52,7 +52,7 @@ export default async function Brand({ params, searchParams }: Props) {
   return (
     <div>
       <div className="md:mb-8 lg:flex lg:flex-row lg:items-center lg:justify-between">
-        <h1 className="mb-4 text-h2 lg:mb-0">{brand.name}</h1>
+        <h1 className="mb-4 text-4xl font-black lg:mb-0 lg:text-5xl">{brand.name}</h1>
 
         <div className="flex flex-col items-center gap-3 whitespace-nowrap md:flex-row">
           <MobileSideNav>

--- a/apps/core/app/(default)/(faceted)/category/[slug]/page.tsx
+++ b/apps/core/app/(default)/(faceted)/category/[slug]/page.tsx
@@ -57,7 +57,7 @@ export default async function Category({ params, searchParams }: Props) {
       <Breadcrumbs breadcrumbs={category.breadcrumbs.items} category={category.name} />
 
       <div className="md:mb-8 lg:flex lg:flex-row lg:items-center lg:justify-between">
-        <h1 className="mb-4 text-h2 lg:mb-0">{category.name}</h1>
+        <h1 className="mb-4 text-4xl font-black lg:mb-0 lg:text-5xl">{category.name}</h1>
 
         <div className="flex flex-col items-center gap-3 whitespace-nowrap md:flex-row">
           <MobileSideNav>

--- a/apps/core/app/(default)/(faceted)/search/page.tsx
+++ b/apps/core/app/(default)/(faceted)/search/page.tsx
@@ -23,7 +23,7 @@ export default async function Search({ searchParams }: Props) {
   if (!searchTerm) {
     return (
       <>
-        <h1 className="mb-3 text-h2">Search</h1>
+        <h1 className="mb-3 text-4xl font-black lg:text-5xl">Search</h1>
         <SearchForm />
       </>
     );
@@ -37,7 +37,7 @@ export default async function Search({ searchParams }: Props) {
   if (products.length === 0) {
     return (
       <div>
-        <h1 className="mb-3 text-h2">Search</h1>
+        <h1 className="mb-3 text-4xl font-black lg:text-5xl">Search</h1>
 
         <SearchForm initialTerm={searchTerm} />
 
@@ -55,7 +55,7 @@ export default async function Search({ searchParams }: Props) {
       <div className="md:mb-8 lg:flex lg:flex-row lg:items-center lg:justify-between">
         <h1 className="mb-3 text-base">
           Search results for <br />
-          <b className="text-h4">"{searchTerm}"</b>
+          <b className="text-2xl font-bold lg:text-3xl">"{searchTerm}"</b>
         </h1>
 
         <div className="flex flex-col items-center gap-3 whitespace-nowrap md:flex-row">

--- a/apps/core/app/(default)/(webpages)/_components/page-content.tsx
+++ b/apps/core/app/(default)/(webpages)/_components/page-content.tsx
@@ -9,7 +9,7 @@ interface Props {
 export const PageContent = ({ className, content, title }: Props) => {
   return (
     <div className={cn('mx-auto mb-10 flex flex-col justify-center gap-8 lg:w-2/3', className)}>
-      <h1 className="text-h3 lg:text-h2">{title}</h1>
+      <h1 className="text-4xl font-black lg:text-5xl">{title}</h1>
       <div dangerouslySetInnerHTML={{ __html: content }} />
     </div>
   );

--- a/apps/core/app/(default)/blog/[blogId]/page.tsx
+++ b/apps/core/app/(default)/blog/[blogId]/page.tsx
@@ -39,7 +39,7 @@ export default async function BlogPostPage({ params: { blogId } }: Props) {
 
   return (
     <div className="mx-auto max-w-4xl">
-      <h1 className="mb-2 text-h3 lg:text-h2">{blogPost.name}</h1>
+      <h1 className="mb-2 text-3xl font-black lg:text-5xl">{blogPost.name}</h1>
 
       <div className="mb-8 flex">
         <BlogPostDate className="mb-0">
@@ -60,10 +60,10 @@ export default async function BlogPostPage({ params: { blogId } }: Props) {
         </BlogPostImage>
       ) : (
         <BlogPostBanner className="mb-6 h-40 sm:h-80 lg:h-96">
-          <BlogPostTitle className="text-h4" variant="inBanner">
+          <BlogPostTitle variant="inBanner">
             <span className="text-blue-primary">{blogPost.name}</span>
           </BlogPostTitle>
-          <BlogPostDate className="text-h5" variant="inBanner">
+          <BlogPostDate variant="inBanner">
             <span className="text-blue-primary">
               {new Intl.DateTimeFormat('en-US').format(new Date(blogPost.publishedDate.utc))}
             </span>

--- a/apps/core/app/(default)/blog/page.tsx
+++ b/apps/core/app/(default)/blog/page.tsx
@@ -29,7 +29,7 @@ export default async function BlogPostPage({ searchParams }: Props) {
 
   return (
     <div className="mx-auto max-w-screen-xl">
-      <h1 className="mb-8 text-h3 lg:text-h2">{blogPosts.name}</h1>
+      <h1 className="mb-8 text-3xl font-black lg:text-5xl">{blogPosts.name}</h1>
 
       <div className="grid grid-cols-1 gap-10 sm:grid-cols-2 lg:grid-cols-3 lg:gap-8">
         {blogPosts.posts.items.map((post) => {

--- a/apps/core/app/(default)/blog/tag/[tagId]/page.tsx
+++ b/apps/core/app/(default)/blog/tag/[tagId]/page.tsx
@@ -21,7 +21,7 @@ export default async function BlogPostPage({ params: { tagId }, searchParams }: 
 
   return (
     <div className="mx-auto max-w-screen-xl">
-      <h1 className="mb-8 text-h3 lg:text-h2">{blogPosts.name}</h1>
+      <h1 className="mb-8 text-3xl font-black lg:text-5xl">{blogPosts.name}</h1>
 
       <div className="grid grid-cols-1 gap-10 sm:grid-cols-2 lg:grid-cols-3 lg:gap-8">
         {blogPosts.posts.items.map((post) => {

--- a/apps/core/app/(default)/cart/page.tsx
+++ b/apps/core/app/(default)/cart/page.tsx
@@ -16,9 +16,9 @@ export const metadata = {
 
 const EmptyCart = () => (
   <div className="flex h-full flex-col">
-    <h1 className="pb-6 text-h2 lg:pb-10">Your cart</h1>
+    <h1 className="pb-6 text-4xl font-black lg:pb-10 lg:text-5xl">Your cart</h1>
     <div className="flex grow flex-col items-center justify-center gap-6 border-t border-t-gray-200 py-20">
-      <h2 className="text-h5">Your cart is empty</h2>
+      <h2 className="text-xl font-bold lg:text-2xl">Your cart is empty</h2>
       <p className="text-center">
         Looks like you have not addded anything to your cart. Go ahead & explore top categories.
       </p>
@@ -67,7 +67,7 @@ export default async function CartPage() {
 
   return (
     <div>
-      <h1 className="pb-6 text-h2 lg:pb-10">Your cart</h1>
+      <h1 className="pb-6 text-4xl font-black lg:pb-10 lg:text-5xl">Your cart</h1>
       <div className="pb-12 md:grid md:grid-cols-2 md:gap-8 lg:grid-cols-3">
         <ul className="col-span-2">
           {cart.lineItems.physicalItems.map((product) => (
@@ -79,7 +79,7 @@ export default async function CartPage() {
 
                 <div className="flex-1">
                   <p className="text-base text-gray-500">{product.brand}</p>
-                  <p className="text-h5">{product.name}</p>
+                  <p className="text-xl font-bold lg:text-2xl">{product.name}</p>
 
                   {product.selectedOptions.length > 0 && (
                     <div className="mt-2">
@@ -145,7 +145,7 @@ export default async function CartPage() {
                 <CartItemCounter itemData={extractCartlineItemsData(product)} />
 
                 <div>
-                  <p className="inline-flex w-24 justify-center text-base font-bold">
+                  <p className="inline-flex w-24 justify-center text-lg font-bold">
                     ${product.extendedSalePrice.value}
                   </p>
                 </div>
@@ -177,8 +177,8 @@ export default async function CartPage() {
           </div>
 
           <div className="flex justify-between border-t border-t-gray-200 py-4">
-            <span className="text-h5">Grand total</span>
-            <span className="text-h5">
+            <span className="text-xl font-bold lg:text-2xl">Grand total</span>
+            <span className="text-xl font-bold lg:text-2xl">
               {currencyFormatter.format(cart.totalExtendedSalePrice.value)}
             </span>
           </div>

--- a/apps/core/app/(default)/compare/_components/add-to-cart.tsx
+++ b/apps/core/app/(default)/compare/_components/add-to-cart.tsx
@@ -14,7 +14,7 @@ export const AddToCart = ({
   const { pending } = useFormStatus();
 
   return (
-    <Button aria-label={productName} className="mt-2" disabled={disabled || pending} type="submit">
+    <Button aria-label={productName} disabled={disabled || pending} type="submit">
       {pending ? (
         <>
           <Spinner aria-hidden="true" className="animate-spin" />

--- a/apps/core/app/(default)/compare/page.tsx
+++ b/apps/core/app/(default)/compare/page.tsx
@@ -51,7 +51,7 @@ export default async function Compare({
     return (
       <div className="flex w-full justify-center py-16 align-middle">
         <div className="flex max-w-2xl flex-col gap-8 pb-8">
-          <h1 className="text-h2">Well, there's nothing to compare!</h1>
+          <h1 className="text-4xl font-black lg:text-5xl">Well, there's nothing to compare!</h1>
           <p className="text-lg">
             You somehow managed to land here, but you need to select a few products first.
           </p>
@@ -63,7 +63,7 @@ export default async function Compare({
 
   return (
     <>
-      <h1 className="pb-8 text-h2">Comparing {products.length} products</h1>
+      <h1 className="pb-8 text-4xl font-black lg:text-5xl">Comparing {products.length} products</h1>
 
       <div className="-mx-6 overflow-auto overscroll-x-contain px-6 sm:-mx-10 sm:px-10 lg:-mx-12 lg:px-12">
         <table className="mx-auto w-full max-w-full table-fixed text-base md:w-fit">
@@ -118,7 +118,7 @@ export default async function Compare({
             </tr>
             <tr>
               {products.map((product) => (
-                <td className="px-4 align-top text-h5" key={product.entityId}>
+                <td className="px-4 align-top text-xl font-bold lg:text-2xl" key={product.entityId}>
                   <Link href={product.path}>{product.name}</Link>
                 </td>
               ))}
@@ -135,8 +135,8 @@ export default async function Compare({
                 if (product.productOptions.length) {
                   return (
                     <td className="border-b px-4 pb-12" key={product.entityId}>
-                      <Button aria-label={product.name} asChild>
-                        <Link href={product.path}>Choose Options</Link>
+                      <Button aria-label={product.name} asChild className="hover:text-white">
+                        <Link href={product.path}>Choose options</Link>
                       </Button>
                     </td>
                   );
@@ -221,9 +221,9 @@ export default async function Compare({
                 if (product.productOptions.length) {
                   return (
                     <td className="border-b px-4 pb-24 pt-12" key={product.entityId}>
-                      <Button aria-label={product.name} asChild>
+                      <Button aria-label={product.name} asChild className="hover:text-white">
                         <Link href={product.path} prefetch={false}>
-                          Choose Options
+                          Choose options
                         </Link>
                       </Button>
                     </td>

--- a/apps/core/app/(default)/login/_components/login-form.tsx
+++ b/apps/core/app/(default)/login/_components/login-form.tsx
@@ -72,7 +72,7 @@ export const LoginForm = () => {
             />
           </FieldControl>
           <FieldMessage
-            className="absolute inset-x-0 bottom-0 inline-flex w-full text-sm text-red-200"
+            className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-red-200"
             match="valueMissing"
           >
             Enter your email.
@@ -91,7 +91,7 @@ export const LoginForm = () => {
             />
           </FieldControl>
           <FieldMessage
-            className="absolute inset-x-0 bottom-0 inline-flex w-full text-sm text-red-200"
+            className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-red-200"
             match="valueMissing"
           >
             Enter your password.

--- a/apps/core/app/(default)/login/page.tsx
+++ b/apps/core/app/(default)/login/page.tsx
@@ -11,11 +11,11 @@ export const metadata = {
 export default function Login() {
   return (
     <div className="mx-auto my-6 max-w-4xl">
-      <h2 className="mb-8 text-h2">Log In</h2>
+      <h2 className="mb-8 text-4xl font-black lg:text-5xl">Log In</h2>
       <div className="mb-12 grid grid-cols-1 lg:grid-cols-2 lg:gap-x-8">
         <LoginForm />
         <div className="flex flex-col gap-4 bg-gray-100 p-8">
-          <h3 className="mb-3 text-h5">New customer?</h3>
+          <h3 className="mb-3 text-xl font-bold lg:text-2xl">New customer?</h3>
           <p className="text-base font-semibold">
             Create an account with us and you'll be able to:
           </p>

--- a/apps/core/app/(default)/product/[slug]/_components/reviews.tsx
+++ b/apps/core/app/(default)/product/[slug]/_components/reviews.tsx
@@ -18,7 +18,7 @@ export const Reviews = async ({ productId }: Props) => {
 
   return (
     <>
-      <h3 className="mb-4 mt-8 text-h5">
+      <h3 className="mb-4 mt-8 text-xl font-bold">
         Reviews
         {reviews.length > 0 && (
           <span className="ms-2 ps-1 text-gray-500">

--- a/apps/core/app/(default)/product/[slug]/page.tsx
+++ b/apps/core/app/(default)/product/[slug]/page.tsx
@@ -29,14 +29,14 @@ const ProductDetails = ({ product }: { product: NonNullable<Product> }) => {
         <p className="mb-2 font-semibold uppercase text-gray-500">{product.brand.name}</p>
       )}
 
-      <h1 className="mb-4 text-h2">{product.name}</h1>
+      <h1 className="mb-4 text-4xl font-black lg:text-5xl">{product.name}</h1>
 
       <Suspense fallback="Loading...">
         <ReviewSummary productId={product.entityId} />
       </Suspense>
 
       {product.prices && (
-        <div className="my-6 text-h4">
+        <div className="my-6 text-2xl font-bold lg:text-3xl">
           {showPriceRange ? (
             <span>
               {currencyFormatter.format(product.prices.priceRange.min.value)} -{' '}
@@ -78,47 +78,47 @@ const ProductDetails = ({ product }: { product: NonNullable<Product> }) => {
       <ProductForm product={product} />
 
       <div className="my-12">
-        <h2 className="mb-4 text-h5">Additional details</h2>
+        <h2 className="mb-4 text-xl font-bold md:text-2xl">Additional details</h2>
         <div className="grid gap-3 sm:grid-cols-2">
           {Boolean(product.sku) && (
             <div>
-              <h3 className="text-base font-bold">SKU</h3>
+              <h3 className="font-semibold">SKU</h3>
               <p>{product.sku}</p>
             </div>
           )}
           {Boolean(product.upc) && (
             <div>
-              <h3 className="text-base font-bold">UPC</h3>
+              <h3 className="font-semibold">UPC</h3>
               <p>{product.upc}</p>
             </div>
           )}
           {Boolean(product.minPurchaseQuantity) && (
             <div>
-              <h3 className="text-base font-bold">Minimum purchase</h3>
+              <h3 className="font-semibold">Minimum purchase</h3>
               <p>{product.minPurchaseQuantity}</p>
             </div>
           )}
           {Boolean(product.maxPurchaseQuantity) && (
             <div>
-              <h3 className="text-base font-bold">Maxiumum purchase</h3>
+              <h3 className="font-semibold">Maxiumum purchase</h3>
               <p>{product.maxPurchaseQuantity}</p>
             </div>
           )}
           {Boolean(product.availabilityV2.description) && (
             <div>
-              <h3 className="text-base font-bold">Availability</h3>
+              <h3 className="font-semibold">Availability</h3>
               <p>{product.availabilityV2.description}</p>
             </div>
           )}
           {Boolean(product.condition) && (
             <div>
-              <h3 className="text-base font-bold">Condition</h3>
+              <h3 className="font-semibold">Condition</h3>
               <p>{product.condition}</p>
             </div>
           )}
           {Boolean(product.weight) && (
             <div>
-              <h3 className="text-base font-bold">Weight</h3>
+              <h3 className="font-semibold">Weight</h3>
               <p>
                 {product.weight?.value} {product.weight?.unit}
               </p>
@@ -127,7 +127,7 @@ const ProductDetails = ({ product }: { product: NonNullable<Product> }) => {
           {Boolean(product.customFields) &&
             product.customFields.map((customField) => (
               <div key={customField.entityId}>
-                <h3 className="text-base font-bold">{customField.name}</h3>
+                <h3 className="font-semibold">{customField.name}</h3>
                 <p>{customField.value}</p>
               </div>
             ))}
@@ -143,14 +143,14 @@ const ProductDescriptionAndReviews = ({ product }: { product: NonNullable<Produc
     <div className="lg:col-span-2">
       {Boolean(product.description) && (
         <>
-          <h2 className="mb-4 text-h5">Description</h2>
+          <h2 className="mb-4 text-xl font-bold md:text-2xl">Description</h2>
           <div dangerouslySetInnerHTML={{ __html: product.description }} />
         </>
       )}
 
       {Boolean(product.warranty) && (
         <>
-          <h2 className="mb-4 mt-8 text-h5">Warranty</h2>
+          <h2 className="mb-4 mt-8 text-xl font-bold md:text-2xl">Warranty</h2>
           <p>{product.warranty}</p>
         </>
       )}

--- a/apps/core/app/error.tsx
+++ b/apps/core/app/error.tsx
@@ -8,7 +8,7 @@ export default function Error() {
   return (
     <div className="h-full px-10 py-12 lg:py-24">
       <div className="mx-auto max-w-3xl">
-        <h1 className="mb-8 text-h3 lg:text-h2">There was a server error!</h1>
+        <h1 className="mb-8 text-3xl font-black lg:text-5xl">There was a server error!</h1>
         <p className="text-base">Please try again later.</p>
       </div>
     </div>

--- a/apps/core/app/maintenance/page.tsx
+++ b/apps/core/app/maintenance/page.tsx
@@ -18,7 +18,7 @@ export default async function MaintenancePage() {
   if (!storeSettings) {
     return (
       <Container>
-        <h1 className="my-4 text-h2">We are down for maintenance</h1>
+        <h1 className="my-4 text-4xl font-black lg:text-5xl">We are down for maintenance</h1>
       </Container>
     );
   }
@@ -29,7 +29,7 @@ export default async function MaintenancePage() {
     <Container>
       <StoreLogo />
 
-      <h1 className="my-8 text-h2">We are down for maintenance</h1>
+      <h1 className="my-8 text-4xl font-black lg:text-5xl">We are down for maintenance</h1>
 
       {Boolean(statusMessage) && <p className="mb-4">{statusMessage}</p>}
 

--- a/apps/core/app/not-found.tsx
+++ b/apps/core/app/not-found.tsx
@@ -26,14 +26,14 @@ export default async function NotFound() {
       />
       <main className="mx-auto mb-10 max-w-[835px] space-y-8 px-6 sm:px-10 lg:px-0">
         <Message className="flex-col gap-8 px-0 py-16">
-          <h2 className="text-h2">We couldn't find that page!</h2>
+          <h2 className="text-4xl font-black lg:text-5xl">We couldn't find that page!</h2>
           <p className="text-lg">
             It looks like the page you requested has moved or no longer exists.
           </p>
         </Message>
         <SearchForm />
         <section>
-          <h3 className="mb-8 text-h3">Featured Products</h3>
+          <h3 className="mb-8 text-3xl font-black lg:text-4xl">Featured products</h3>
           <div className="grid grid-cols-2 gap-x-8 gap-y-8 md:grid-cols-4">
             {featuredProducts.map((product) => (
               <ProductCard key={product.entityId} product={product} />

--- a/apps/core/components/compare-drawer/index.tsx
+++ b/apps/core/components/compare-drawer/index.tsx
@@ -16,7 +16,10 @@ import { Link } from '~/components/link';
 
 const CompareLink = ({ products }: { products: CheckedProduct[] }) => {
   return (
-    <Button asChild className="me-4 h-12 w-auto grow whitespace-nowrap px-8 md:grow-0">
+    <Button
+      asChild
+      className="me-4 h-12 w-auto grow whitespace-nowrap px-8 hover:text-white md:grow-0"
+    >
       <Link href={`/compare?ids=${products.map(({ id }) => id).join(',')}`}>
         Compare ({products.length})
       </Link>

--- a/apps/core/components/footer/footer-menus/base-footer-menu.tsx
+++ b/apps/core/components/footer/footer-menus/base-footer-menu.tsx
@@ -20,7 +20,7 @@ export const BaseFooterMenu = ({
 }: Props & ComponentPropsWithoutRef<'div'>) => {
   return (
     <div {...props}>
-      <h3 className="mb-4 font-bold">{title}</h3>
+      <h3 className="mb-4 text-lg font-bold">{title}</h3>
       <FooterNavGroupList>
         {items.map((item) => (
           <FooterNavLink asChild key={item.path}>

--- a/apps/core/components/forbidden/index.tsx
+++ b/apps/core/components/forbidden/index.tsx
@@ -9,7 +9,9 @@ const FeaturedProducts = async () => {
 
   return (
     <section className="w-full">
-      <h3 className="mb-10 text-center text-h3 sm:text-start">Featured Products</h3>
+      <h3 className="mb-10 text-center text-3xl font-black sm:text-start lg:text-4xl">
+        Featured Products
+      </h3>
       <div className="grid grid-cols-2 gap-x-8 gap-y-8 md:grid-cols-4">
         {featuredProducts.map((product) => (
           <ProductCard key={product.entityId} product={product} />
@@ -23,7 +25,7 @@ export const Forbidden = () => {
   return (
     <main className="mx-auto mb-10 flex max-w-[835px] flex-col justify-center gap-10 px-6 sm:px-10 lg:px-0 2xl:px-0">
       <Message className="flex-col gap-8 px-0 py-16">
-        <h2 className="text-h2">There was a problem!</h2>
+        <h2 className="text-4xl font-black lg:text-5xl">There was a problem!</h2>
         <p className="text-lg">It looks like the page you requested can't be accessed.</p>
       </Message>
       <SearchForm />

--- a/apps/core/components/forms/contact-us.tsx
+++ b/apps/core/components/forms/contact-us.tsx
@@ -165,13 +165,13 @@ export const ContactUs = ({ fields, pageEntityId, reCaptchaSettings }: ContactUs
               />
             </FieldControl>
             <FieldMessage
-              className="absolute inset-x-0 bottom-0 inline-flex w-full text-sm text-red-200"
+              className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-red-200"
               match="valueMissing"
             >
               Enter a valid email such as name@domain.com
             </FieldMessage>
             <FieldMessage
-              className="absolute inset-x-0 bottom-0 inline-flex w-full text-sm text-red-200"
+              className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-red-200"
               match="typeMismatch"
             >
               Enter a valid email such as name@domain.com
@@ -195,7 +195,7 @@ export const ContactUs = ({ fields, pageEntityId, reCaptchaSettings }: ContactUs
               />
             </FieldControl>
             <FieldMessage
-              className="absolute inset-x-0 bottom-0 inline-flex w-full text-sm text-red-200"
+              className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-red-200"
               match="valueMissing"
             >
               Please provide a valid Comments
@@ -212,7 +212,7 @@ export const ContactUs = ({ fields, pageEntityId, reCaptchaSettings }: ContactUs
                 sitekey={reCaptchaSettings?.siteKey ?? ''}
               />
               {!isReCaptchaValid && (
-                <span className="absolute inset-x-0 bottom-0 inline-flex w-full text-sm text-red-200">
+                <span className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-red-200">
                   Pass ReCAPTCHA check
                 </span>
               )}

--- a/apps/core/components/hero/index.tsx
+++ b/apps/core/components/hero/index.tsx
@@ -26,7 +26,7 @@ export const Hero = () => (
             src={SlideshowBG}
           />
           <div className="flex flex-col gap-4 px-12 pb-48 pt-36">
-            <h2 className="text-h1">25% Off Sale</h2>
+            <h2 className="text-5xl font-black lg:text-6xl">25% Off Sale</h2>
             <p className="max-w-xl">
               Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
               incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
@@ -39,7 +39,7 @@ export const Hero = () => (
       </SlideshowSlide>
       <SlideshowSlide>
         <div className="flex flex-col gap-4 bg-gray-100 px-12 pb-48 pt-36">
-          <h2 className="text-h1">Great Deals</h2>
+          <h2 className="text-5xl font-black lg:text-6xl">Great Deals</h2>
           <p className="max-w-xl">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
             incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
@@ -51,7 +51,7 @@ export const Hero = () => (
       </SlideshowSlide>
       <SlideshowSlide>
         <div className="flex flex-col gap-4 bg-gray-100 px-12 pb-48 pt-36">
-          <h2 className="text-h1">Low Prices</h2>
+          <h2 className="text-5xl font-black lg:text-6xl">Low Prices</h2>
           <p className="max-w-xl">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
             incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.

--- a/apps/core/components/product-card-carousel/index.tsx
+++ b/apps/core/components/product-card-carousel/index.tsx
@@ -45,7 +45,7 @@ export const ProductCardCarousel = ({
   return (
     <Carousel aria-labelledby="title" className="mb-14">
       <div className="flex items-center justify-between">
-        <h2 className="text-h3" id="title">
+        <h2 className="text-3xl font-black lg:text-4xl" id="title">
           {title}
         </h2>
         <span className="no-wrap flex">

--- a/apps/core/components/product-card/index.tsx
+++ b/apps/core/components/product-card/index.tsx
@@ -138,7 +138,7 @@ export const ProductCard = ({
               <Rating size={16} value={product.reviewSummary.averageRating || 0} />
             </p>
 
-            <div className="text-sm text-gray-500" id={summaryId}>
+            <div className="text-xs font-normal text-gray-500" id={summaryId}>
               {product.reviewSummary.averageRating !== 0 && (
                 <>
                   <span className="sr-only">Rating:</span>

--- a/apps/core/components/product-form/fields/shared/error-message.tsx
+++ b/apps/core/components/product-form/fields/shared/error-message.tsx
@@ -1,3 +1,3 @@
 export const ErrorMessage = ({ children }: { children: React.ReactNode }) => (
-  <p className="mt-2 text-sm text-red-100">{children}</p>
+  <p className="mt-2 text-xs font-normal text-red-100">{children}</p>
 );

--- a/apps/core/components/product-sheet/index.tsx
+++ b/apps/core/components/product-sheet/index.tsx
@@ -111,7 +111,7 @@ export const ProductSheetContent = ({ productId }: { productId: number }) => {
               <p className="mb-2 font-semibold uppercase text-gray-500">{product.brand.name}</p>
             )}
 
-            <h5 className="mb-2 text-h5">{product.name}</h5>
+            <h5 className="mb-2 text-xl font-bold lg:text-2xl">{product.name}</h5>
 
             <div className="mb-2 flex items-center gap-3">
               <p
@@ -124,7 +124,7 @@ export const ProductSheetContent = ({ productId }: { productId: number }) => {
                 <Rating size={16} value={product.reviewSummary.averageRating || 0} />
               </p>
 
-              <div className="text-sm text-gray-500" id={summaryId}>
+              <div className="text-xs font-normal text-gray-500" id={summaryId}>
                 {product.reviewSummary.averageRating !== 0 && (
                   <>
                     <span className="sr-only">Rating:</span>
@@ -140,14 +140,14 @@ export const ProductSheetContent = ({ productId }: { productId: number }) => {
             {product.prices && (
               <div>
                 {showPriceRange ? (
-                  <p className="text-h4">
+                  <p className="text-2xl font-bold lg:text-3xl">
                     {currencyFormatter.format(product.prices.priceRange.min.value)} -{' '}
                     {currencyFormatter.format(product.prices.priceRange.max.value)}
                   </p>
                 ) : (
                   <>
                     {product.prices.retailPrice?.value !== undefined && (
-                      <p className="text-h4">
+                      <p className="text-2xl font-bold lg:text-3xl">
                         MSRP:{' '}
                         <span className="line-through">
                           {currencyFormatter.format(product.prices.retailPrice.value)}

--- a/apps/core/components/quick-search/index.tsx
+++ b/apps/core/components/quick-search/index.tsx
@@ -155,7 +155,9 @@ export const QuickSearch = ({ children, initialTerm = '' }: SearchProps) => {
           {searchResults && searchResults.products.length > 0 && (
             <div className="mt-8 grid overflow-auto px-1 lg:grid-cols-3 lg:gap-6">
               <section>
-                <h3 className="mb-6 border-b border-gray-200 pb-3 text-h5">Categories</h3>
+                <h3 className="mb-6 border-b border-gray-200 pb-3 text-xl font-bold lg:text-2xl">
+                  Categories
+                </h3>
                 <ul id="categories" role="listbox">
                   {Object.entries(
                     searchResults.products.reduce<Record<string, string>>((categories, product) => {
@@ -182,7 +184,9 @@ export const QuickSearch = ({ children, initialTerm = '' }: SearchProps) => {
                 </ul>
               </section>
               <section>
-                <h3 className="mb-6 border-b border-gray-200 pb-3 text-h5">Products</h3>
+                <h3 className="mb-6 border-b border-gray-200 pb-3 text-xl font-bold lg:text-2xl">
+                  Products
+                </h3>
                 <ul id="products" role="listbox">
                   {searchResults.products.map((product) => {
                     return (
@@ -200,13 +204,13 @@ export const QuickSearch = ({ children, initialTerm = '' }: SearchProps) => {
                               width={80}
                             />
                           ) : (
-                            <span className="flex h-20 w-20 flex-shrink-0 items-center justify-center bg-gray-200 text-h6 text-gray-500">
+                            <span className="flex h-20 w-20 flex-shrink-0 items-center justify-center bg-gray-200 text-lg font-bold text-gray-500">
                               Photo
                             </span>
                           )}
 
                           <span className="flex flex-col">
-                            <p className="text-h5">{product.name}</p>
+                            <p className="text-lg font-bold lg:text-2xl">{product.name}</p>
                             <Pricing prices={product.prices} />
                           </span>
                         </a>
@@ -216,7 +220,9 @@ export const QuickSearch = ({ children, initialTerm = '' }: SearchProps) => {
                 </ul>
               </section>
               <section>
-                <h3 className="mb-6 border-b border-gray-200 pb-3 text-h5">Brands</h3>
+                <h3 className="mb-6 border-b border-gray-200 pb-3 text-xl font-bold lg:text-2xl">
+                  Brands
+                </h3>
                 <ul id="brands" role="listbox">
                   {Object.entries(
                     searchResults.products.reduce<Record<string, string>>((brands, product) => {

--- a/apps/core/components/search-form/index.tsx
+++ b/apps/core/components/search-form/index.tsx
@@ -15,7 +15,7 @@ export const SearchForm = ({ initialTerm = '' }: Props) => {
 
   return (
     <div className="flex flex-col gap-8">
-      <h3 className="text-h3">Search our store</h3>
+      <h3 className="text-3xl font-black lg:text-4xl">Search for products</h3>
       <Form action="/search" className="flex" method="get">
         <Field className="me-4 w-full" name="search">
           <FieldControl asChild>

--- a/apps/core/components/sharing-links/index.tsx
+++ b/apps/core/components/sharing-links/index.tsx
@@ -22,7 +22,7 @@ export const SharingLinks = ({
 
   return (
     <div className="mb-10 flex items-center [&>*:not(:last-child)]:me-2.5">
-      <h3 className="text-h5">Share</h3>
+      <h3 className="text-xl font-bold lg:text-2xl">Share</h3>
       <a
         className="hover:text-blue-primary focus:outline-none focus:ring-4 focus:ring-blue-primary/20"
         href={`https://facebook.com/sharer/sharer.php?u=${encodedUrl}`}

--- a/apps/core/components/store-logo/index.tsx
+++ b/apps/core/components/store-logo/index.tsx
@@ -12,7 +12,7 @@ export const StoreLogo = async () => {
   const { logoV2: logo, storeName } = settings;
 
   if (logo.__typename === 'StoreTextLogo') {
-    return <span className="text-h4 font-black">{logo.text}</span>;
+    return <span className="text-2xl font-black">{logo.text}</span>;
   }
 
   return (

--- a/apps/docs/stories/blog-post-card.stories.tsx
+++ b/apps/docs/stories/blog-post-card.stories.tsx
@@ -28,7 +28,7 @@ export const BlogPostCardWithImage: Story = {
               className="block w-full focus:outline-none focus:ring-4 focus:ring-blue-primary/20"
               href="/"
             >
-              <div className="flex h-full w-full items-center justify-center bg-gray-200 text-h4">
+              <div className="flex h-full w-full items-center justify-center bg-gray-200 text-2xl font-bold lg:text-3xl">
                 Image
               </div>
             </a>

--- a/apps/docs/stories/carousel.stories.tsx
+++ b/apps/docs/stories/carousel.stories.tsx
@@ -31,7 +31,7 @@ export const MultipleSlides: Story = {
   render: () => (
     <Carousel aria-labelledby="title">
       <div className="flex items-center justify-between">
-        <h2 className="text-h3" id="title">
+        <h2 className="text-3xl font-black lg:text-4xl" id="title">
           Related Products
         </h2>
         <span className="no-wrap flex">
@@ -163,7 +163,7 @@ export const SingleSlide: Story = {
   render: () => (
     <Carousel aria-labelledby="title">
       <div className="flex items-center justify-between">
-        <h2 className="text-h3" id="title">
+        <h2 className="text-3xl font-black lg:text-4xl" id="title">
           Related Products
         </h2>
         <span className="no-wrap flex">

--- a/apps/docs/stories/file-chooser.stories.tsx
+++ b/apps/docs/stories/file-chooser.stories.tsx
@@ -26,7 +26,7 @@ export const Default: Story = {
       <Label className="my-2 inline-block" htmlFor="file-chooser">
         File Upload
       </Label>
-      <p className="pb-2 text-sm text-gray-500" id="file-chooser-description">
+      <p className="pb-2 text-xs font-normal text-gray-500" id="file-chooser-description">
         Upload a file no larger than 500MB in PNG/JPEG format.
       </p>
       <FileChooser aria-describedby="file-chooser-description" id="file-chooser" {...args} />

--- a/apps/docs/stories/footer.stories.tsx
+++ b/apps/docs/stories/footer.stories.tsx
@@ -69,7 +69,7 @@ export const BasicExample: Story = {
           </div>
         </FooterNav>
         <div className="flex shrink-0 grow flex-col gap-4 md:order-first">
-          <span className="text-h4 font-black">Catalyst Store</span>
+          <span className="text-2xl font-black font-bold lg:text-3xl">Catalyst Store</span>
           <address className="not-italic">
             24 Wisteria Lane, Fairview, Eagle <br />
             01234 United States
@@ -176,7 +176,7 @@ export const MultiRowFooterNav: Story = {
           </div>
         </FooterNav>
         <div className="flex shrink-0 grow flex-col gap-4 md:order-first">
-          <span className="text-h4 font-black">Catalyst Store</span>
+          <span className="text-2xl font-black font-bold lg:text-3xl">Catalyst Store</span>
           <address className="not-italic">
             24 Wisteria Lane, Fairview, Eagle <br />
             01234 United States
@@ -343,7 +343,7 @@ export const NoAddendum: Story = {
           </div>
         </FooterNav>
         <div className="flex shrink-0 grow flex-col gap-4 md:order-first">
-          <span className="text-h4 font-black">Catalyst Store</span>
+          <span className="text-2xl font-black font-bold lg:text-3xl">Catalyst Store</span>
           <address className="not-italic">
             24 Wisteria Lane, Fairview, Eagle <br />
             01234 United States

--- a/apps/docs/stories/form.stories.tsx
+++ b/apps/docs/stories/form.stories.tsx
@@ -52,7 +52,7 @@ export const Default: Story = {
           </Select>
         </FieldControl>
         <FieldMessage
-          className="absolute inset-x-0 bottom-0 inline-flex w-full text-sm text-red-200"
+          className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-red-200"
           match="typeMismatch"
         >
           Show explonation on failed validation
@@ -64,7 +64,7 @@ export const Default: Story = {
           <TextArea />
         </FieldControl>
         <FieldMessage
-          className="absolute inset-x-0 bottom-0 inline-flex w-full text-sm text-red-200"
+          className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-red-200"
           match="typeMismatch"
         >
           Show explonation on failed validation
@@ -91,13 +91,13 @@ export const WithValidation: Story = {
           <Input required type="email" />
         </FieldControl>
         <FieldMessage
-          className="absolute inset-x-0 bottom-0 inline-flex w-full text-sm text-red-200"
+          className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-red-200"
           match="valueMissing"
         >
           Enter your email as a name@domain.com
         </FieldMessage>
         <FieldMessage
-          className="absolute inset-x-0 bottom-0 inline-flex w-full text-sm text-red-200"
+          className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-red-200"
           match="typeMismatch"
         >
           Enter your email as a name@domain.com
@@ -138,13 +138,13 @@ export const ValidityStateWrapper: Story = {
                   <Input onChange={handleControlValidation} required type="email" />
                 </FieldControl>
                 <FieldMessage
-                  className="absolute inset-x-0 bottom-0 inline-flex w-full text-sm text-red-200"
+                  className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-red-200"
                   match="valueMissing"
                 >
                   Enter your email as a name@domain.com
                 </FieldMessage>
                 <FieldMessage
-                  className="absolute inset-x-0 bottom-0 inline-flex w-full text-sm text-red-200"
+                  className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-red-200"
                   match="typeMismatch"
                 >
                   Enter your email as a name@domain.com

--- a/apps/docs/stories/navigation-menu.stories.tsx
+++ b/apps/docs/stories/navigation-menu.stories.tsx
@@ -196,7 +196,7 @@ const mockLinks = [
 export const BasicExample: Story = {
   render: () => (
     <NavigationMenu className="gap-6 lg:gap-8">
-      <NavigationMenuLink className="px-0 text-h4 font-black" href="/home">
+      <NavigationMenuLink className="px-0 text-2xl font-black font-bold lg:text-3xl" href="/home">
         Catalyst Store
       </NavigationMenuLink>
       <NavigationMenuList className="hidden md:flex lg:gap-4">
@@ -306,7 +306,7 @@ export const BasicExample: Story = {
 export const NavigationAlignmentLeft: Story = {
   render: () => (
     <NavigationMenu className="gap-6 lg:gap-8">
-      <NavigationMenuLink className="px-0 text-h4 font-black" href="/home">
+      <NavigationMenuLink className="px-0 text-2xl font-black font-bold lg:text-3xl" href="/home">
         Catalyst Store
       </NavigationMenuLink>
       <div className="flex flex-auto">
@@ -418,7 +418,7 @@ export const NavigationAlignmentLeft: Story = {
 export const NavigationAlignmentRight: Story = {
   render: () => (
     <NavigationMenu className="gap-6 lg:gap-8">
-      <NavigationMenuLink className="px-0 text-h4 font-black" href="/home">
+      <NavigationMenuLink className="px-0 text-2xl font-black font-bold lg:text-3xl" href="/home">
         Catalyst Store
       </NavigationMenuLink>
       <div className="flex flex-auto justify-end">
@@ -569,7 +569,10 @@ export const LogoCentered: Story = {
           ))}
         </NavigationMenuList>
       </div>
-      <a className="flex flex-auto justify-center px-0 text-h4 font-black" href="/home">
+      <a
+        className="flex flex-auto justify-center px-0 text-2xl font-black font-bold lg:text-3xl"
+        href="/home"
+      >
         Catalyst Store
       </a>
       <div className="flex-1">
@@ -646,7 +649,7 @@ export const BottomNavigationLeft: Story = {
     return (
       <NavigationMenu className="flex-col">
         <div className="flex min-h-[92px] w-full items-center justify-between">
-          <a className="px-0 text-h4 font-black" href="/home">
+          <a className="px-0 text-2xl font-black font-bold lg:text-3xl" href="/home">
             Catalyst Store
           </a>
           <NavigationMenuList className="hidden gap-2 md:flex">
@@ -761,7 +764,7 @@ export const BottomNavigationCenter: Story = {
   render: () => (
     <NavigationMenu className="flex-col">
       <div className="flex min-h-[92px] w-full items-center justify-between">
-        <a className="px-0 text-h4 font-black" href="/home">
+        <a className="px-0 text-2xl font-black font-bold lg:text-3xl" href="/home">
           Catalyst Store
         </a>
         <NavigationMenuList className="hidden gap-2 md:flex">
@@ -875,7 +878,7 @@ export const BottomNavigationRight: Story = {
   render: () => (
     <NavigationMenu className="flex-col">
       <div className="flex min-h-[92px] w-full items-center justify-between">
-        <a className="px-0 text-h4 font-black" href="/home">
+        <a className="px-0 text-2xl font-black font-bold lg:text-3xl" href="/home">
           Catalyst Store
         </a>
         <NavigationMenuList className="hidden gap-2 md:flex">
@@ -991,7 +994,7 @@ export const NavigationWithBadge: Story = {
   },
   render: ({ children }) => (
     <NavigationMenu className="mx-5 gap-6 lg:gap-8">
-      <NavigationMenuLink className="px-0 text-h4 font-black" href="/home">
+      <NavigationMenuLink className="px-0 text-2xl font-black font-bold lg:text-3xl" href="/home">
         Catalyst Store
       </NavigationMenuLink>
       <NavigationMenuList className="hidden md:flex lg:gap-4">
@@ -1109,7 +1112,7 @@ export const NavigationWithBadge: Story = {
 export const CustomNavigationMenuToggle: Story = {
   render: () => (
     <NavigationMenu className="gap-6 lg:gap-8">
-      <NavigationMenuLink className="px-0 text-h4 font-black" href="/home">
+      <NavigationMenuLink className="px-0 text-2xl font-black font-bold lg:text-3xl" href="/home">
         Catalyst Store
       </NavigationMenuLink>
       <NavigationMenuList className="hidden md:flex lg:gap-4">

--- a/apps/docs/stories/sheet.stories.tsx
+++ b/apps/docs/stories/sheet.stories.tsx
@@ -29,7 +29,7 @@ type Story = StoryObj<typeof meta>;
 
 const Content = () => (
   <>
-    <h3 className="mb-2 text-h5">Categories</h3>
+    <h3 className="mb-2 text-xl font-bold lg:text-2xl">Categories</h3>
 
     <ul className="flex flex-col">
       <li>

--- a/apps/docs/stories/slideshow.stories.tsx
+++ b/apps/docs/stories/slideshow.stories.tsx
@@ -33,7 +33,7 @@ export const MultipleSlides: Story = {
               src="/slideshow-bg-01.jpg"
             />
             <div className="flex flex-col gap-4 px-12 pb-48 pt-36">
-              <h2 className="text-h1">25% Off Sale</h2>
+              <h2 className="text-5xl font-black lg:text-6xl">25% Off Sale</h2>
               <p className="max-w-xl">
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
                 incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
@@ -46,7 +46,7 @@ export const MultipleSlides: Story = {
         </SlideshowSlide>
         <SlideshowSlide>
           <div className="flex flex-col gap-4 bg-gray-100 px-12 pb-48 pt-36">
-            <h2 className="text-h1">Great Deals</h2>
+            <h2 className="text-5xl font-black lg:text-6xl">Great Deals</h2>
             <p className="max-w-xl">
               Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
               incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
@@ -58,7 +58,7 @@ export const MultipleSlides: Story = {
         </SlideshowSlide>
         <SlideshowSlide>
           <div className="flex flex-col gap-4 bg-gray-100 px-12 pb-48 pt-36">
-            <h2 className="text-h1">Low Prices</h2>
+            <h2 className="text-5xl font-black lg:text-6xl">Low Prices</h2>
             <p className="max-w-xl">
               Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
               incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
@@ -92,7 +92,7 @@ export const SingleSlide: Story = {
               src="/slideshow-bg-01.jpg"
             />
             <div className="flex flex-col gap-4 px-12 pb-48 pt-36">
-              <h2 className="text-h1">25% Off Sale</h2>
+              <h2 className="text-5xl font-black lg:text-6xl">25% Off Sale</h2>
               <p className="max-w-xl">
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
                 incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
@@ -127,7 +127,7 @@ export const CustomControlsAndInterval: Story = {
               src="/slideshow-bg-01.jpg"
             />
             <div className="flex flex-col gap-4 px-12 pb-48 pt-36">
-              <h2 className="text-h1">25% Off Sale</h2>
+              <h2 className="text-5xl font-black lg:text-6xl">25% Off Sale</h2>
               <p className="max-w-xl">
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
                 incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
@@ -140,7 +140,7 @@ export const CustomControlsAndInterval: Story = {
         </SlideshowSlide>
         <SlideshowSlide>
           <div className="flex flex-col gap-4 bg-gray-100 px-12 pb-48 pt-36">
-            <h2 className="text-h1">Great Deals</h2>
+            <h2 className="text-5xl font-black lg:text-6xl">Great Deals</h2>
             <p className="max-w-xl">
               Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
               incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.

--- a/packages/components/src/components/accordion/accordion.tsx
+++ b/packages/components/src/components/accordion/accordion.tsx
@@ -22,7 +22,7 @@ const AccordionTrigger = React.forwardRef<
   <AccordionPrimitive.Header className="flex">
     <AccordionPrimitive.Trigger
       className={cn(
-        'flex flex-1 items-center justify-between py-[9.5px] text-h6 outline-none transition-all hover:text-blue-secondary focus:text-blue-secondary [&[data-state=open]>svg]:rotate-180',
+        'flex flex-1 items-center justify-between py-[9.5px] text-lg font-bold outline-none transition-all hover:text-blue-secondary focus:text-blue-secondary [&[data-state=open]>svg]:rotate-180',
         className,
       )}
       ref={ref}

--- a/packages/components/src/components/badge/badge.tsx
+++ b/packages/components/src/components/badge/badge.tsx
@@ -7,7 +7,7 @@ export const Badge = forwardRef<ElementRef<'span'>, ComponentPropsWithRef<'span'
     return (
       <span
         className={cn(
-          'absolute end-0 top-0 min-w-[24px] rounded-[28px] border-2 border-white bg-blue-primary px-1 py-px text-center text-sm font-bold leading-normal text-white',
+          'absolute end-0 top-0 min-w-[24px] rounded-[28px] border-2 border-white bg-blue-primary px-1 py-px text-center text-xs font-bold font-normal leading-normal text-white',
           className,
         )}
         ref={ref}

--- a/packages/components/src/components/blog-post-card/blog-post-card.tsx
+++ b/packages/components/src/components/blog-post-card/blog-post-card.tsx
@@ -55,10 +55,10 @@ interface TitleProps extends ComponentPropsWithRef<'h3'> {
   variant?: 'inBanner';
 }
 
-const titleVariants = cva('mb-2 text-h5', {
+const titleVariants = cva('mb-2 text-2xl font-bold', {
   variants: {
     variant: {
-      inBanner: 'mb-0 flex-none basis-1/2 self-start text-h4',
+      inBanner: 'mb-0 flex-none basis-1/2 self-start text-3xl font-bold',
     },
   },
 });
@@ -96,7 +96,7 @@ interface DateProps extends ComponentPropsWithRef<'small'> {
 const dateVariants = cva('mb-2 text-base text-gray-500', {
   variants: {
     variant: {
-      inBanner: 'mb-0 flex-none self-end text-h5',
+      inBanner: 'mb-0 flex-none self-end text-xl font-bold',
     },
   },
 });

--- a/packages/components/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/components/src/components/breadcrumbs/breadcrumbs.tsx
@@ -27,7 +27,7 @@ const BreadcrumbItem = forwardRef<ElementRef<'li'>, BreadcrumbItemProps>(
     const Comp = asChild ? Slot : 'a';
 
     return (
-      <li className={cn('flex items-center text-sm text-black')} ref={ref}>
+      <li className={cn('flex items-center text-xs font-semibold text-black')} ref={ref}>
         <Comp
           aria-current={isActive ? `page` : undefined}
           className={cn(

--- a/packages/components/src/components/calendar/calendar.tsx
+++ b/packages/components/src/components/calendar/calendar.tsx
@@ -26,10 +26,10 @@ export const Calendar = ({
         nav_button_previous: 'absolute start-1',
         nav_button_next: 'absolute end-1',
         head_row: 'flex',
-        head_cell: 'text-gray-400 w-10 text-sm font-normal',
+        head_cell: 'text-gray-400 w-10 text-xs font-normal font-normal',
         row: 'flex w-full',
         cell: cn(
-          'relative flex h-10 w-10 items-center justify-center p-0 text-center text-sm focus-within:relative focus-within:z-20 focus-within:rounded focus-within:border focus-within:border-blue-primary/20',
+          'relative flex h-10 w-10 items-center justify-center p-0 text-center text-xs font-normal focus-within:relative focus-within:z-20 focus-within:rounded focus-within:border focus-within:border-blue-primary/20',
         ),
         day: cn(
           'h-8 w-8 p-0 text-base hover:bg-blue-secondary/10 focus:outline-none aria-selected:bg-blue-primary aria-selected:text-white aria-selected:hover:bg-blue-primary aria-selected:hover:text-white',

--- a/packages/components/src/components/form/form.tsx
+++ b/packages/components/src/components/form/form.tsx
@@ -72,7 +72,9 @@ const FieldLabel = forwardRef<ElementRef<typeof Label>, FieldLabelProps>(
       {...props}
     >
       <span>{children}</span>
-      {isRequired && <span className="text-sm font-normal text-gray-500">Required</span>}
+      {isRequired && (
+        <span className="text-xs font-normal font-normal text-gray-500">Required</span>
+      )}
     </Label>
   ),
 );

--- a/packages/components/src/components/product-card/product-card.tsx
+++ b/packages/components/src/components/product-card/product-card.tsx
@@ -73,7 +73,7 @@ ProductCardInfoBrandName.displayName = 'ProductCardInfoBrandName';
 const ProductCardInfoProductName = forwardRef<ElementRef<'h3'>, ComponentPropsWithRef<'h3'>>(
   ({ children, className, ...props }, ref) => {
     return (
-      <h3 className={cn('text-h5', className)} ref={ref} {...props}>
+      <h3 className={cn('text-xl font-bold lg:text-2xl', className)} ref={ref} {...props}>
         {children}
       </h3>
     );

--- a/packages/components/src/components/sheet/sheet.tsx
+++ b/packages/components/src/components/sheet/sheet.tsx
@@ -105,7 +105,7 @@ const SheetTitle = forwardRef<
   ElementRef<typeof SheetPrimitive.Title>,
   ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
 >(({ className, ...props }, ref) => (
-  <SheetPrimitive.Title className={cn('text-h4', className)} ref={ref} {...props} />
+  <SheetPrimitive.Title className={cn('text-2xl font-bold', className)} ref={ref} {...props} />
 ));
 
 SheetTitle.displayName = SheetPrimitive.Title.displayName;

--- a/packages/components/tailwind.config.js
+++ b/packages/components/tailwind.config.js
@@ -45,36 +45,6 @@ const config = {
         revealVertical: 'revealVertical 400ms forwards cubic-bezier(0, 1, 0.25, 1)',
       },
     },
-    fontSize: {
-      // Temp workaround while we chat with design about our font sizes
-      // Generated using https://chrisburnell.com/clamp-calculator/ for fluid size
-      // Using 640px as smallest viewport and 1536px as max
-      h1: [
-        'clamp(3.052rem, 2.226rem + 2.066vw, 4.209rem)',
-        { lineHeight: '1.3', fontWeight: '900' },
-      ],
-      h2: [
-        'clamp(2.441rem, 1.93rem + 1.279vw, 3.158rem)',
-        { lineHeight: '1.3', fontWeight: '900' },
-      ],
-      h3: [
-        'clamp(1.953rem, 1.656rem + 0.742vw, 2.369rem)',
-        { lineHeight: '1.3', fontWeight: '900' },
-      ],
-      h4: [
-        'clamp(1.563rem, 1.409rem + 0.383vw, 1.777rem)',
-        { lineHeight: '1.3', fontWeight: '700' },
-      ],
-      h5: [
-        'clamp(1.25rem, 1.191rem + 0.148vw, 1.333rem)',
-        { lineHeight: '1.3', fontWeight: '700' },
-      ],
-      h6: ['1rem', { lineHeight: '1.3', fontWeight: '700' }],
-      sm: ['.75rem', { lineHeight: '1.7' }],
-      base: ['1rem', { lineHeight: '1.7' }],
-      lg: ['1.25rem', { lineHeight: '1.7' }],
-      li: ['1rem', { lineHeight: '1.7' }],
-    },
   },
   // @ts-ignore
   // eslint-disable-next-line global-require


### PR DESCRIPTION
## What/Why?
Use tailwind classes instead of the custom classes we have. This should enable easier development and a more standard approach to using Tailwind.

## New values
Config class name (old) | New class name | Font size (desktop) | Font size (tablet, mobile) | Font weight
-- | -- | -- | -- | --
h1 | heading 1 | text-6xl | text-5xl | font-black
h2 | heading 2 | text-5xl | text-4xl | font-black
h3 | heading 3 | text-4xl | text-3xl | font-black
h4 | heading 4 | text-3xl | text-2xl | font-bold
h5 | heading 5 | text-2xl | text-xl | font-bold
h6 | heading 6 | text-lg | text-lg | font-bold
base | base-regular | text-base | text-base | font-normal
sm | small-regular | text-xs | text-xs | font-normal



## Testing
Locally