### PR TITLE
test: fix renamed component tests

### DIFF
--- a/packages/functional/tests/visual-regression/reactant/components/BlogPostCard.spec.ts
+++ b/packages/functional/tests/visual-regression/reactant/components/BlogPostCard.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from '@playwright/test';
 import * as storyBookElements from '../StoryBookElements';
 
 test('blog post card', async ({ page }) => {
-  await page.goto(`${storyBookElements.storyUrl}/blogpostcard--blog-post-card-with-image`);
+  await page.goto(`${storyBookElements.storyUrl}/blog-post-card--blog-post-card-with-image`);
   await expect(
     page
       .frameLocator(storyBookElements.storyBookFrame)

--- a/packages/functional/tests/visual-regression/reactant/components/NavigationMenu.spec.ts
+++ b/packages/functional/tests/visual-regression/reactant/components/NavigationMenu.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from '@playwright/test';
 import * as storyBookElements from '../StoryBookElements';
 
 test('Basic navigation', async ({ page }) => {
-  await page.goto(`${storyBookElements.storyUrl}/navigationmenu--basic-example`);
+  await page.goto(`${storyBookElements.storyUrl}/navigation-menu--basic-example`);
   await page.getByRole('button', { name: 'Go full screen [F]' }).click();
   await expect(
     page.frameLocator(storyBookElements.storyBookFrame).getByRole('link', { name: 'Accessories' }),
@@ -14,7 +14,7 @@ test('Basic navigation', async ({ page }) => {
 });
 
 test('Navigation alignment left', async ({ page }) => {
-  await page.goto(`${storyBookElements.storyUrl}/navigationmenu--navigation-alignment-left`);
+  await page.goto(`${storyBookElements.storyUrl}/navigation-menu--navigation-alignment-left`);
   await page.getByRole('button', { name: 'Go full screen [F]' }).click();
   await expect(
     page.frameLocator(storyBookElements.storyBookFrame).getByRole('link', { name: 'Accessories' }),
@@ -25,7 +25,7 @@ test('Navigation alignment left', async ({ page }) => {
 });
 
 test('Navigation alignment right', async ({ page }) => {
-  await page.goto(`${storyBookElements.storyUrl}/navigationmenu--navigation-alignment-right`);
+  await page.goto(`${storyBookElements.storyUrl}/navigation-menu--navigation-alignment-right`);
   await page.getByRole('button', { name: 'Go full screen [F]' }).click();
   await expect(
     page.frameLocator(storyBookElements.storyBookFrame).getByRole('link', { name: 'Accessories' }),
@@ -36,7 +36,7 @@ test('Navigation alignment right', async ({ page }) => {
 });
 
 test('Logo centered', async ({ page }) => {
-  await page.goto(`${storyBookElements.storyUrl}/navigationmenu--logo-centered`);
+  await page.goto(`${storyBookElements.storyUrl}/navigation-menu--logo-centered`);
   await page.getByRole('button', { name: 'Go full screen [F]' }).click();
   await expect(
     page.frameLocator(storyBookElements.storyBookFrame).getByRole('link', { name: 'Accessories' }),
@@ -47,7 +47,7 @@ test('Logo centered', async ({ page }) => {
 });
 
 test('Bottom navigation left', async ({ page }) => {
-  await page.goto(`${storyBookElements.storyUrl}/navigationmenu--bottom-navigation-left`);
+  await page.goto(`${storyBookElements.storyUrl}/navigation-menu--bottom-navigation-left`);
   await page.getByRole('button', { name: 'Go full screen [F]' }).click();
   await expect(
     page.frameLocator(storyBookElements.storyBookFrame).getByRole('link', { name: 'Accessories' }),
@@ -58,7 +58,7 @@ test('Bottom navigation left', async ({ page }) => {
 });
 
 test('Bottom navigation center', async ({ page }) => {
-  await page.goto(`${storyBookElements.storyUrl}/navigationmenu--bottom-navigation-center`);
+  await page.goto(`${storyBookElements.storyUrl}/navigation-menu--bottom-navigation-center`);
   await page.getByRole('button', { name: 'Go full screen [F]' }).click();
   await expect(
     page.frameLocator(storyBookElements.storyBookFrame).getByRole('link', { name: 'Accessories' }),
@@ -69,7 +69,7 @@ test('Bottom navigation center', async ({ page }) => {
 });
 
 test('Bottom navigation right', async ({ page }) => {
-  await page.goto(`${storyBookElements.storyUrl}/navigationmenu--bottom-navigation-right`);
+  await page.goto(`${storyBookElements.storyUrl}/navigation-menu--bottom-navigation-right`);
   await page.getByRole('button', { name: 'Go full screen [F]' }).click();
   await expect(
     page.frameLocator(storyBookElements.storyBookFrame).getByRole('link', { name: 'Accessories' }),
@@ -80,7 +80,7 @@ test('Bottom navigation right', async ({ page }) => {
 });
 
 test('Navigation with badge', async ({ page }) => {
-  await page.goto(`${storyBookElements.storyUrl}/navigationmenu--navigation-with-badge`);
+  await page.goto(`${storyBookElements.storyUrl}/navigation-menu--navigation-with-badge`);
   await page.getByRole('button', { name: 'Go full screen [F]' }).click();
   await expect(
     page.frameLocator(storyBookElements.storyBookFrame).getByRole('link', { name: 'Accessories' }),
@@ -91,7 +91,7 @@ test('Navigation with badge', async ({ page }) => {
 });
 
 test('Custom navigation menu toggle', async ({ page }) => {
-  await page.goto(`${storyBookElements.storyUrl}/navigationmenu--custom-navigation-menu-toggle`);
+  await page.goto(`${storyBookElements.storyUrl}/navigation-menu--custom-navigation-menu-toggle`);
   await page.getByRole('button', { name: 'Go full screen [F]' }).click();
   await expect(
     page.frameLocator(storyBookElements.storyBookFrame).getByRole('link', { name: 'Accessories' }),

--- a/packages/functional/tests/visual-regression/reactant/components/ProductCard.spec.ts
+++ b/packages/functional/tests/visual-regression/reactant/components/ProductCard.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from '@playwright/test';
 import * as storyBookElements from '../StoryBookElements';
 
 test('Basic product card', async ({ page }) => {
-  await page.goto(`${storyBookElements.storyUrl}/productcard--basic-example`);
+  await page.goto(`${storyBookElements.storyUrl}/product-card--basic-example`);
   await expect(
     page.frameLocator(storyBookElements.storyBookFrame).locator(storyBookElements.storyBook),
   ).toBeVisible();

--- a/packages/functional/tests/visual-regression/reactant/components/RadioGroup.spec.ts
+++ b/packages/functional/tests/visual-regression/reactant/components/RadioGroup.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from '@playwright/test';
 import * as storyBookElements from '../StoryBookElements';
 
 test('Base radio group', async ({ page }) => {
-  await page.goto(`${storyBookElements.storyUrl}/radiogroup--base-radio-group`);
+  await page.goto(`${storyBookElements.storyUrl}/radio-group--base-radio-group`);
   await expect(
     page.frameLocator(storyBookElements.storyBookFrame).locator(storyBookElements.storyBook),
   ).toBeVisible();
@@ -13,7 +13,7 @@ test('Base radio group', async ({ page }) => {
 });
 
 test('Radio group with icon', async ({ page }) => {
-  await page.goto(`${storyBookElements.storyUrl}/radiogroup--radio-group-with-icon`);
+  await page.goto(`${storyBookElements.storyUrl}/radio-group--radio-group-with-icon`);
   await expect(
     page.frameLocator(storyBookElements.storyBookFrame).locator(storyBookElements.storyBook),
   ).toBeVisible();

--- a/packages/functional/tests/visual-regression/reactant/components/RectangleList.spec.ts
+++ b/packages/functional/tests/visual-regression/reactant/components/RectangleList.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from '@playwright/test';
 import * as storyBookElements from '../StoryBookElements';
 
 test('Basic rectangle list', async ({ page }) => {
-  await page.goto(`${storyBookElements.storyUrl}/rectanglelist--basic-example`);
+  await page.goto(`${storyBookElements.storyUrl}/rectangle-list--basic-example`);
   await expect(
     page.frameLocator(storyBookElements.storyBookFrame).locator(storyBookElements.storyBook),
   ).toBeVisible();

--- a/packages/functional/tests/visual-regression/reactant/components/TextArea.spec.ts
+++ b/packages/functional/tests/visual-regression/reactant/components/TextArea.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from '@playwright/test';
 import * as storyBookElements from '../StoryBookElements';
 
 test('Text area default', async ({ page }) => {
-  await page.goto(`${storyBookElements.storyUrl}/textarea--default`);
+  await page.goto(`${storyBookElements.storyUrl}/text-area--default`);
   await page.getByRole('button', { name: 'Go full screen [F]' }).click();
   await expect(
     page.frameLocator(storyBookElements.storyBookFrame).getByPlaceholder('Placeholder...'),
@@ -14,7 +14,7 @@ test('Text area default', async ({ page }) => {
 });
 
 test('Text area success', async ({ page }) => {
-  await page.goto(`${storyBookElements.storyUrl}/textarea--success`);
+  await page.goto(`${storyBookElements.storyUrl}/text-area--success`);
   await page.getByRole('button', { name: 'Go full screen [F]' }).click();
   await expect(
     page.frameLocator(storyBookElements.storyBookFrame).getByPlaceholder('Placeholder...'),
@@ -25,7 +25,7 @@ test('Text area success', async ({ page }) => {
 });
 
 test('Text area error', async ({ page }) => {
-  await page.goto(`${storyBookElements.storyUrl}/textarea--error`);
+  await page.goto(`${storyBookElements.storyUrl}/text-area--error`);
   await page.getByRole('button', { name: 'Go full screen [F]' }).click();
   await expect(
     page.frameLocator(storyBookElements.storyBookFrame).getByPlaceholder('Placeholder...'),


### PR DESCRIPTION
## What/Why?
Uses the correct urls after the doc files got renamed.

## Testing

> [!NOTE]
> The `Zero rating` test failed due to a 1px difference.

![screencapture-localhost-9323-2024-02-08-14_36_13](https://github.com/bigcommerce/catalyst/assets/10539418/69af4756-37ce-4562-aa11-f0b6ab300735)
