### PR TITLE
fix(gh): fix issue template link for docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Have questions?
-    url: https://catalyst.dev/docs
+    url: https://github.com/bigcommerce/catalyst/blob/main/README.md
     about: Explore the Catalyst Docs.
   - name: Need help with Catalyst?
     url: https://github.com/bigcommerce/catalyst/discussions/new?category=q-a


### PR DESCRIPTION
## What/Why?
Temporarily routing users to the README to get started, awaiting formal docs. 