### PR TITLE
fix(core): colocate gitignore lines specific to apps/core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,3 @@ dist
 test-results/
 playwright-report/
 playwright/.cache/
-apps/core/client/generated
-apps/core/schema.graphql

--- a/apps/core/.gitignore
+++ b/apps/core/.gitignore
@@ -34,3 +34,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# generated
+client/generated
+schema.graphql


### PR DESCRIPTION
## What/Why?
In the monorepo, `apps/core` can inherit necessary `.gitignore` lines from the root `.gitignore`. 

Once cloned via `create-catalyst`, it can no longer do that. This PR moves relevant `.gitignore` lines from root to `apps/core/.gitignore`.
