### PR TITLE
fix(core): wrap thumbnails in Gallery and remove scrollIntoView

### DIFF
--- a/apps/core/app/(default)/product/[slug]/_components/gallery.tsx
+++ b/apps/core/app/(default)/product/[slug]/_components/gallery.tsx
@@ -46,7 +46,7 @@ export const Gallery = ({ images }: Props) => {
             </GalleryImage>
             <GalleryControls />
           </GalleryContent>
-          <GalleryThumbnailList className="px-6 sm:-mx-1 sm:px-1">
+          <GalleryThumbnailList className="px-6 sm:px-1">
             {images.map((image, index) => {
               return (
                 <GalleryThumbnailItem imageIndex={index} key={image.url}>

--- a/packages/components/src/components/gallery/gallery.tsx
+++ b/packages/components/src/components/gallery/gallery.tsx
@@ -7,7 +7,6 @@ import {
   forwardRef,
   useContext,
   useEffect,
-  useRef,
   useState,
 } from 'react';
 
@@ -171,7 +170,7 @@ const GalleryThumbnailList = forwardRef<ElementRef<'nav'>, ComponentPropsWithRef
       <nav
         aria-label="Thumbnail navigation"
         className={cn(
-          '-mx-1 mt-3 flex w-full flex-nowrap items-center gap-4 overflow-x-auto px-1 py-1 md:mt-5 md:gap-6',
+          'mt-3 flex w-full flex-wrap items-center gap-4 px-1 py-1 md:mt-5 md:gap-6',
           className,
         )}
         ref={ref}
@@ -199,7 +198,7 @@ const GalleryThumbnailItem = forwardRef<ElementRef<'button'>, GalleryThumbnailIt
         aria-label="Enlarge product image"
         aria-pressed={isActive}
         className={cn(
-          'inline-block h-24 w-24 flex-shrink-0 flex-grow-0 focus:outline-none focus:ring-4 focus:ring-blue-primary/20',
+          'inline-block h-12 w-12 flex-shrink-0 flex-grow-0 focus:outline-none focus:ring-4 focus:ring-blue-primary/20 md:h-24 md:w-24',
           className,
         )}
         onClick={(e) => {
@@ -228,22 +227,11 @@ interface GalleryThumbnailProps extends ComponentPropsWithRef<'img'> {
 }
 
 const GalleryThumbnail = forwardRef<ElementRef<'img'>, GalleryThumbnailProps>(
-  ({ asChild, className, ...props }, forwardedRef) => {
+  ({ asChild, className, ...props }, ref) => {
     const { selectedImageIndex } = useContext(GalleryContext);
     const { index } = useContext(ThumbnailContext);
 
-    const fallbackRef = useRef<HTMLImageElement | null>(null);
-    const ref = forwardedRef ?? fallbackRef;
-
     const isActive = selectedImageIndex === index;
-
-    useEffect(() => {
-      if (isActive) {
-        if (typeof ref !== 'function') {
-          ref.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-        }
-      }
-    }, [isActive, ref]);
 
     const Comp = asChild ? Slot : 'img';
 


### PR DESCRIPTION
## What/Why?

- Simplify the Gallery component by wrapping thumbnails instead of showing a scroll bar. No longer need to `scrollIntoView`.
- Decrease size of thumbnails for mobile viewport.

![Screenshot 2024-02-12 at 4 02 29 PM](https://github.com/bigcommerce/catalyst/assets/196129/37ad407c-aee0-4ed7-9a5e-dacd6297ede8)

![Screenshot 2024-02-12 at 4 02 16 PM](https://github.com/bigcommerce/catalyst/assets/196129/3450df94-511f-464c-8f42-0a4d7c1ad2b1)

## Testing
Locally.