### PR TITLE
feat(core): add check is recaptcha enabled for contact us form

### DIFF
--- a/apps/core/client/queries/get-recaptcha-settings.ts
+++ b/apps/core/client/queries/get-recaptcha-settings.ts
@@ -6,6 +6,7 @@ const GET_RECAPTCHA_SETTINGS_QUERY = /* GraphQL */ `
     site {
       settings {
         reCaptcha {
+          isEnabledOnStorefront
           siteKey
         }
       }

--- a/apps/core/components/forms/contact-us.tsx
+++ b/apps/core/components/forms/contact-us.tsx
@@ -27,12 +27,10 @@ interface ContactUsProps {
   fields: string[];
   pageEntityId: number;
   reCaptchaSettings?: {
+    isEnabledOnStorefront: boolean;
     siteKey: string;
   };
 }
-
-// TODO: replace mocked var when enabled field will be added to GraphQL api
-const IS_RECAPTCHA_ENABLED = true;
 
 const fieldNameMapping = {
   fullname: 'Full name',
@@ -89,8 +87,7 @@ export const ContactUs = ({ fields, pageEntityId, reCaptchaSettings }: ContactUs
   };
 
   const onSubmit = async (formData: FormData) => {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (IS_RECAPTCHA_ENABLED && !reCaptchaToken) {
+    if (reCaptchaSettings?.isEnabledOnStorefront && !reCaptchaToken) {
       return setReCaptchaValid(false);
     }
 
@@ -202,23 +199,20 @@ export const ContactUs = ({ fields, pageEntityId, reCaptchaSettings }: ContactUs
             </FieldMessage>
           </Field>
         </>
-        {
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-          IS_RECAPTCHA_ENABLED && (
-            <Field className="relative col-span-full max-w-full space-y-2 pb-7" name="ReCAPTCHA">
-              <ReCAPTCHA
-                onChange={onReCatpchaChange}
-                ref={reCaptchaRef}
-                sitekey={reCaptchaSettings?.siteKey ?? ''}
-              />
-              {!isReCaptchaValid && (
-                <span className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-red-200">
-                  Pass ReCAPTCHA check
-                </span>
-              )}
-            </Field>
-          )
-        }
+        {reCaptchaSettings?.isEnabledOnStorefront && (
+          <Field className="relative col-span-full max-w-full space-y-2 pb-7" name="ReCAPTCHA">
+            <ReCAPTCHA
+              onChange={onReCatpchaChange}
+              ref={reCaptchaRef}
+              sitekey={reCaptchaSettings.siteKey}
+            />
+            {!isReCaptchaValid && (
+              <span className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-red-200">
+                Pass ReCAPTCHA check
+              </span>
+            )}
+          </Field>
+        )}
         <Submit />
       </Form>
     </>


### PR DESCRIPTION
## What/Why?
This pr adds `isEnabledOnStorefront` field for `get-recaptcha-settings` query to respect reCaptcha settings from control panel

## Testing
Locally
<img width="1449" alt="contact-us" src="https://github.com/bigcommerce/catalyst/assets/66325265/d11d15a9-e054-4c7f-bb8b-52d5dd226fc6">
