### PR TITLE
fix: Update tests to match product changes

### DIFF
--- a/packages/functional/tests/ui/core/components/RadioGroup.spec.ts
+++ b/packages/functional/tests/ui/core/components/RadioGroup.spec.ts
@@ -12,21 +12,21 @@ test('Changing selection on radio button options should update query parameters'
 
   await expect(page).toHaveURL('shop-all/');
 
-  await page.getByRole('button', { name: 'Quick add' }).first().click();
+  await page.getByRole('link', { name: 'Quick add' }).first().click();
 
   await expect(page.getByRole('dialog', { name: 'Choose options' })).toBeVisible();
 
   await page.getByLabel('Radio').getByText('1').click();
 
-  await expect(page).toHaveURL('shop-all/?134=139');
+  await expect(page).toHaveURL('shop-all/?showQuickAdd=77&134=139');
 
   await expect(page.getByRole('dialog', { name: 'Choose options' })).toBeVisible();
 
   await page.getByLabel('Radio').getByText('2').click();
 
-  await expect(page).toHaveURL('shop-all/?134=140');
+  await expect(page).toHaveURL('shop-all/?showQuickAdd=77&134=140');
 
   await page.getByLabel('Radio').getByText('3').click();
 
-  await expect(page).toHaveURL('shop-all/?134=141');
+  await expect(page).toHaveURL('shop-all/?showQuickAdd=77&134=141');
 });

--- a/packages/functional/tests/ui/core/components/Swatch.spec.ts
+++ b/packages/functional/tests/ui/core/components/Swatch.spec.ts
@@ -12,21 +12,21 @@ test('Selecting various options on color panel should update query parameters', 
 
   await expect(page).toHaveURL('shop-all/');
 
-  await page.getByRole('button', { name: 'Quick add' }).first().click();
+  await page.getByRole('link', { name: 'Quick add' }).first().click();
 
   await expect(page.getByRole('dialog', { name: 'Choose options' })).toBeVisible();
 
   await page.getByRole('radio', { name: 'Color Silver' }).click();
 
-  await expect(page).toHaveURL('shop-all/?109=103');
+  await expect(page).toHaveURL('shop-all/?showQuickAdd=77&109=103');
 
   await expect(page.getByRole('dialog', { name: 'Choose options' })).toBeVisible();
 
   await page.getByRole('radio', { name: 'Color Purple' }).click();
 
-  await expect(page).toHaveURL('shop-all/?109=105');
+  await expect(page).toHaveURL('shop-all/?showQuickAdd=77&109=105');
 
   await page.getByRole('radio', { name: 'Color Orange' }).click();
 
-  await expect(page).toHaveURL('shop-all/?109=109');
+  await expect(page).toHaveURL('shop-all/?showQuickAdd=77&109=109');
 });


### PR DESCRIPTION
## What/Why?
Looks like we had some product changes that require test updates. This change should take care of that.

## Testing
Tested against latest build.

<img width="818" alt="Screenshot 2024-02-13 at 2 38 49 PM" src="https://github.com/bigcommerce/catalyst/assets/58529077/fa0eab5b-013b-4e3c-922a-ca50c66a709a">
