### PR TITLE
fix(core): Remove product carousel looping to fix layout shift

### DIFF
--- a/packages/components/src/components/carousel/carousel.tsx
+++ b/packages/components/src/components/carousel/carousel.tsx
@@ -19,7 +19,7 @@ const CarouselContext = createContext<UseEmblaCarouselType>([() => null, undefin
 
 const Carousel = forwardRef<ElementRef<'section'>, ComponentPropsWithRef<'section'>>(
   ({ children, className, ...props }, ref) => {
-    const [emblaRef, emblaApi] = useEmblaCarousel({ loop: true });
+    const [emblaRef, emblaApi] = useEmblaCarousel({ loop: false });
 
     return (
       <CarouselContext.Provider value={[emblaRef, emblaApi]}>


### PR DESCRIPTION
## What/Why?
Removing the looping behavior on the product carousels, as it is causing layout shifts. This seems non-critical enough functionality that I think we should consider removing looping until we can address this.
