### PR TITLE
Clarify Channel 1 in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,10 @@ BIGCOMMERCE_ACCESS_TOKEN=
 # See https://developer.bigcommerce.com/docs/rest-authentication/tokens/customer-impersonation-token
 BIGCOMMERCE_CUSTOMER_IMPERSONATION_TOKEN=
 
-# The channel ID for the Catalyst storefront's dedicated channel.
+# The Channel ID for the selling channel being serviced by this Catalyst storefront.
+# Channel ID 1 will allow you to load the same data being used on the default Stencil storefront on your store,
+# but it is strongly recommended to create a new channel instead for production. 
+# The CLI can do this for you.
 BIGCOMMERCE_CHANNEL_ID=1
 
 # Set to true to allow the /admin route to redirect to the BigCommerce control panel.


### PR DESCRIPTION
## What/Why?
Clarify defaulting to Channel 1 and recommend against it.

Headless storefronts like Catalyst work best when they have their own [channel ID, Site URL, Checkout Site URL](https://developer.bigcommerce.com/docs/storefront/headless/channels), and [Routes](https://developer.bigcommerce.com/docs/rest-management/sites/site-routes#create-a-site-route).