### PR TITLE
feat(core): Add env var to control default prefetch behavior

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,8 @@ AUTH_SECRET=
 # https://turbo.build/repo/docs/core-concepts/remote-caching#artifact-integrity-and-authenticity-verification
 # This can also be generated with `openssl rand -hex 32`, but do not re-use the value from AUTH_SECRET
 TURBO_REMOTE_CACHE_SIGNATURE_KEY=
+
+# Controls the default behavior of Link components when a `prefetch` prop is not provided.
+# If set to `true`, Link components will default to `prefetch=true`.
+# Otherwise, Link components will default to `prefetch=false`.
+NEXT_PUBLIC_DEFAULT_PREFETCH_BEHAVIOR=false

--- a/apps/core/components/link/index.tsx
+++ b/apps/core/components/link/index.tsx
@@ -9,8 +9,10 @@ type LinkType = Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, keyof LinkPr
     children?: React.ReactNode;
   } & React.RefAttributes<HTMLAnchorElement>;
 
+const prefetchDefault = process.env.DEFAULT_PREFETCH_BEHAVIOR === 'true';
+
 export const Link = forwardRef<ElementRef<'a'>, LinkType>(
-  ({ href, prefetch = false, children, className, ...rest }, ref) => {
+  ({ href, prefetch = prefetchDefault, children, className, ...rest }, ref) => {
     return (
       <NextLink
         className={cn(


### PR DESCRIPTION
## What/Why?
Adds support for the `DEFAULT_PREFETCH_BEHAVIOR` environment variable. If set to `true`, `Link` components will default to `prefetch=true` when a `prefetch` prop is not provided. Otherwise, they will default to `prefetch=false`, which is the current behavior.

## Testing
Tested locally, verifying that prefetching is globally disabled when `DEEFAULT_PREFETCH_BEHAVIOR` is any value other than `true`, and enabled if it is set to `true`.