### PR TITLE
fix(core): change Reviews heading font size

### DIFF
--- a/apps/core/app/(default)/product/[slug]/_components/reviews.tsx
+++ b/apps/core/app/(default)/product/[slug]/_components/reviews.tsx
@@ -18,7 +18,7 @@ export const Reviews = async ({ productId }: Props) => {
 
   return (
     <>
-      <h3 className="mb-4 mt-8 text-xl font-bold">
+      <h3 className="mb-4 mt-8 text-xl font-bold md:text-2xl">
         Reviews
         {reviews.length > 0 && (
           <span className="ms-2 ps-1 text-gray-500">


### PR DESCRIPTION
## What/Why?
Designs were incorrect, this is the right size.

<img width="1093" alt="Screenshot 2024-02-14 at 10 46 15 AM" src="https://github.com/bigcommerce/catalyst/assets/196129/563db879-5246-46a7-a9ab-6a508c775a15">

## Testing
Locally.