### PR TITLE
feat(cli): introduce types to commander

### DIFF
--- a/.github/workflows/cli-integration.yml
+++ b/.github/workflows/cli-integration.yml
@@ -45,11 +45,11 @@ jobs:
       - name: Run CLI
         run: |
           node dist/index.js \
-          --ghRef ${{ github.sha }} \
-          --projectDir ${{ runner.temp }} \
-          --projectName catalyst-integration-test \
-          --channelId 1 \
-          --accessToken some_access_token \
-          --storeHash ${{ secrets.BIGCOMMERCE_STORE_HASH }} \
-          --customerImpersonationToken ${{ secrets.BIGCOMMERCE_CUSTOMER_IMPERSONATION_TOKEN }}
+          --gh-ref ${{ github.sha }} \
+          --project-dir ${{ runner.temp }} \
+          --project-name catalyst-integration-test \
+          --channel-id 1 \
+          --access-token some_access_token \
+          --store-hash ${{ secrets.BIGCOMMERCE_STORE_HASH }} \
+          --customer-impersonation-token ${{ secrets.BIGCOMMERCE_CUSTOMER_IMPERSONATION_TOKEN }}
         working-directory: packages/create-catalyst

--- a/packages/create-catalyst/README.md
+++ b/packages/create-catalyst/README.md
@@ -5,13 +5,13 @@ Create a new Catalyst project, optionally connect the project to a BigCommerce s
 ## NPM
 
 ```sh
-npm create catalyst-storefront@latest --storeHash your_store_hash --accessToken your_access_token
+npm create catalyst-storefront@latest
 ```
 
 ## PNPM
 
 ```sh
-pnpm create catalyst-storefront@latest --storeHash your_store_hash --accessToken your_access_token
+pnpm create catalyst-storefront@latest
 ```
 
 # To Do

--- a/packages/create-catalyst/package.json
+++ b/packages/create-catalyst/package.json
@@ -17,9 +17,10 @@
     "node": ">=18.17.0"
   },
   "dependencies": {
+    "@commander-js/extra-typings": "^12.0.0",
     "@inquirer/prompts": "^3.3.0",
     "chalk": "^5.3.0",
-    "commander": "^11.1.0",
+    "commander": "^12.0.0",
     "fs-extra": "^11.2.0",
     "giget": "^1.2.1",
     "lodash.kebabcase": "^4.1.1",

--- a/packages/create-catalyst/src/commands/create.ts
+++ b/packages/create-catalyst/src/commands/create.ts
@@ -2,50 +2,22 @@ import { input, select } from '@inquirer/prompts';
 import chalk from 'chalk';
 import { exec as execCallback } from 'child_process';
 import { promisify } from 'util';
-import { z } from 'zod';
 
+import { type CreateCommandOptions } from '../index.js';
 import { cloneCatalyst } from '../utils/clone-catalyst.js';
 import { Https } from '../utils/https.js';
 import { installDependencies } from '../utils/install-dependencies.js';
 import { login } from '../utils/login.js';
-import { parse } from '../utils/parse.js';
-import { getPackageManager } from '../utils/pm.js';
 import { projectConfig } from '../utils/project-config.js';
 import { spinner } from '../utils/spinner.js';
 import { writeEnv } from '../utils/write-env.js';
 
 const exec = promisify(execCallback);
 
-export const create = async (opts: unknown) => {
-  const ProjectNameSchema = z.string().optional();
-  const ProjectDirSchema = z.string().optional();
-  const BigCommerceHostnameSchema = z.string().min(1);
-  const SampleDataApiUrlSchema = z.string().url();
-  const PackageManagerSchema = z.enum(['npm', 'pnpm', 'yarn']).optional();
-  const GhRefSchema = z.string();
-  const StoreHashSchema = z.string().optional();
-  const AccessTokenSchema = z.string().optional();
-  const ChannelIdSchema = z.string().optional();
-  const CustomerImpersonationTokenSchema = z.string().optional();
-
-  const OptionsSchema = z.object({
-    projectName: ProjectNameSchema,
-    projectDir: ProjectDirSchema,
-    bigCommerceHostname: BigCommerceHostnameSchema,
-    sampleDataApiUrl: SampleDataApiUrlSchema,
-    packageManager: PackageManagerSchema,
-    ghRef: GhRefSchema,
-    storeHash: StoreHashSchema,
-    accessToken: AccessTokenSchema,
-    channelId: ChannelIdSchema,
-    customerImpersonationToken: CustomerImpersonationTokenSchema,
-  });
-
-  const options = parse(opts, OptionsSchema);
-
-  const pm = getPackageManager(options.packageManager);
-  const bigCommerceApiUrl = `https://api.${options.bigCommerceHostname}`;
-  const bigCommerceAuthUrl = `https://login.${options.bigCommerceHostname}`;
+export const create = async (options: CreateCommandOptions) => {
+  const pm = options.packageManager;
+  const bigCommerceApiUrl = `https://api.${options.bigcommerceHostname}`;
+  const bigCommerceAuthUrl = `https://login.${options.bigcommerceHostname}`;
   const { projectName, projectDir } = await projectConfig({
     projectDir: options.projectDir,
     projectName: options.projectName,

--- a/packages/create-catalyst/src/commands/init.ts
+++ b/packages/create-catalyst/src/commands/init.ts
@@ -1,30 +1,15 @@
 import { input, select } from '@inquirer/prompts';
 import chalk from 'chalk';
-import * as z from 'zod';
 
+import { type InitCommandOptions } from '../index.js';
 import { Https } from '../utils/https.js';
 import { login } from '../utils/login.js';
-import { parse } from '../utils/parse.js';
 import { writeEnv } from '../utils/write-env.js';
 
-export const init = async (opts: unknown) => {
-  const BigCommerceHostnameSchema = z.string().min(1);
-  const SampleDataApiUrlSchema = z.string().url();
-  const StoreHashSchema = z.string().optional();
-  const AccessTokenSchema = z.string().optional();
-
-  const OptionsSchema = z.object({
-    bigCommerceHostname: BigCommerceHostnameSchema,
-    sampleDataApiUrl: SampleDataApiUrlSchema,
-    storeHash: StoreHashSchema,
-    accessToken: AccessTokenSchema,
-  });
-
-  const options = parse(opts, OptionsSchema);
-
-  const bigCommerceApiUrl = `https://api.${options.bigCommerceHostname}`;
-  const bigCommerceAuthUrl = `https://login.${options.bigCommerceHostname}`;
+export const init = async (options: InitCommandOptions) => {
   const projectDir = process.cwd();
+  const bigCommerceApiUrl = `https://api.${options.bigcommerceHostname}`;
+  const bigCommerceAuthUrl = `https://login.${options.bigcommerceHostname}`;
   const { storeHash, accessToken } = await login(
     bigCommerceAuthUrl,
     options.storeHash,

--- a/packages/create-catalyst/tsup.config.ts
+++ b/packages/create-catalyst/tsup.config.ts
@@ -3,7 +3,6 @@ import { defineConfig, Options } from 'tsup';
 export default defineConfig((options: Options) => ({
   entry: ['src/index.ts'],
   format: ['esm'],
-  dts: true,
   clean: !options.watch,
   ...options,
 }));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -393,6 +393,9 @@ importers:
 
   packages/create-catalyst:
     dependencies:
+      '@commander-js/extra-typings':
+        specifier: ^12.0.0
+        version: 12.0.0(commander@12.0.0)
       '@inquirer/prompts':
         specifier: ^3.3.0
         version: 3.3.0
@@ -400,8 +403,8 @@ importers:
         specifier: ^5.3.0
         version: 5.3.0
       commander:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^12.0.0
+        version: 12.0.0
       fs-extra:
         specifier: ^11.2.0
         version: 11.2.0
@@ -1921,6 +1924,14 @@ packages:
     engines: {node: '>=0.1.90'}
     requiresBuild: true
     optional: true
+
+  /@commander-js/extra-typings@12.0.0(commander@12.0.0):
+    resolution: {integrity: sha512-7zGCwtRKOJ978LCuEZbQ9ZmLdrRkNNASphEO5i9MZb6HfOk7KfsA3f4oXqYDhko4tNrU3GmZTlHqQ/nRlYtYSw==}
+    peerDependencies:
+      commander: ~12.0.0
+    dependencies:
+      commander: 12.0.0
+    dev: false
 
   /@discoveryjs/json-ext@0.5.7:
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
@@ -6186,6 +6197,7 @@ packages:
     resolution: {integrity: sha512-k5fggr14DwAytoA/t8rPrIz++lXK7/DqckthCmoZOKNsEbJkId4Z//BqgApXBUGrGddrigYa1oqheo/7YmW4rg==}
     dependencies:
       undici-types: 5.26.5
+    dev: true
 
   /@types/node@18.19.8:
     resolution: {integrity: sha512-g1pZtPhsvGVTwmeVoexWZLTQaOvXwoSq//pTL0DHeNzUDrFnir4fgETdhjhIxjVnN+hKOuh98+E1eMLnUXstFg==}
@@ -7645,9 +7657,9 @@ packages:
     dependencies:
       delayed-stream: 1.0.0
 
-  /commander@11.1.0:
-    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
-    engines: {node: '>=16'}
+  /commander@12.0.0:
+    resolution: {integrity: sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==}
+    engines: {node: '>=18'}
     dev: false
 
   /commander@2.20.3:
@@ -7806,6 +7818,7 @@ packages:
       - babel-plugin-macros
       - supports-color
       - ts-node
+    dev: true
 
   /create-jest@29.7.0(@types/node@18.19.8):
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
@@ -7824,7 +7837,6 @@ packages:
       - babel-plugin-macros
       - supports-color
       - ts-node
-    dev: true
 
   /cross-fetch@3.1.8:
     resolution: {integrity: sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==}
@@ -8697,7 +8709,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.14.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.55.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.59.8)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.55.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -8737,7 +8749,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 5.59.8(@typescript-eslint/parser@5.59.8)(eslint@8.55.0)(typescript@5.3.3)
       '@typescript-eslint/utils': 5.59.8(eslint@8.55.0)(typescript@5.3.3)
       eslint: 8.55.0
-      jest: 29.7.0(@types/node@18.19.3)
+      jest: 29.7.0(@types/node@18.19.8)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -10430,6 +10442,7 @@ packages:
       - babel-plugin-macros
       - supports-color
       - ts-node
+    dev: true
 
   /jest-cli@29.7.0(@types/node@18.19.8):
     resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
@@ -10457,7 +10470,6 @@ packages:
       - babel-plugin-macros
       - supports-color
       - ts-node
-    dev: true
 
   /jest-config@29.7.0(@types/node@18.19.3):
     resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
@@ -10497,6 +10509,7 @@ packages:
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
+    dev: true
 
   /jest-config@29.7.0(@types/node@18.19.8):
     resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
@@ -10848,6 +10861,7 @@ packages:
       - babel-plugin-macros
       - supports-color
       - ts-node
+    dev: true
 
   /jest@29.7.0(@types/node@18.19.8):
     resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
@@ -10868,7 +10882,6 @@ packages:
       - babel-plugin-macros
       - supports-color
       - ts-node
-    dev: true
 
   /jiti@1.21.0:
     resolution: {integrity: sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==}


### PR DESCRIPTION
## What/Why?
Previously, `zod` was being used to ensure that the options passed via CLI flags were typed correctly. Commander also maintains https://www.npmjs.com/package/@commander-js/extra-typings which allows us to remove a lot of unnecessary `zod` logic. 

## Testing
CI