### PR TITLE
fix: add sizes on homepage images

### DIFF
--- a/apps/core/components/hero/index.tsx
+++ b/apps/core/components/hero/index.tsx
@@ -23,6 +23,7 @@ export const Hero = () => (
             className="absolute -z-10 object-cover"
             fill
             priority
+            sizes="(max-width: 1536px) 100vw, 1536px"
             src={SlideshowBG}
           />
           <div className="flex flex-col gap-4 px-12 pb-48 pt-36">

--- a/apps/core/components/product-card/index.tsx
+++ b/apps/core/components/product-card/index.tsx
@@ -106,6 +106,7 @@ export const ProductCard = ({
               className="object-contain"
               fill
               priority={imagePriority}
+              sizes="(max-width: 768px) 50vw, (max-width: 1536px) 25vw, 500px"
               src={product.defaultImage.url ?? ''}
             />
           ) : (


### PR DESCRIPTION
## What/Why?
Adds missing `sizes` property to `Image` components rendered on homepage. No more warnings on dev.