### PR TITLE
refactor(cli): more reliable package manager detection types

### DIFF
--- a/packages/create-catalyst/src/commands/create.ts
+++ b/packages/create-catalyst/src/commands/create.ts
@@ -15,7 +15,7 @@ import { writeEnv } from '../utils/write-env';
 const exec = promisify(execCallback);
 
 export const create = async (options: CreateCommandOptions) => {
-  const pm = options.packageManager;
+  const { packageManager } = options;
   const bigCommerceApiUrl = `https://api.${options.bigcommerceHostname}`;
   const bigCommerceAuthUrl = `https://login.${options.bigcommerceHostname}`;
   const { projectName, projectDir } = await projectConfig({
@@ -33,9 +33,9 @@ export const create = async (options: CreateCommandOptions) => {
 
     await cloneCatalyst({ projectDir, projectName, ghRef: options.ghRef });
 
-    console.log(`\nUsing ${chalk.bold(pm)}\n`);
+    console.log(`\nUsing ${chalk.bold(packageManager)}\n`);
 
-    await installDependencies(projectDir, pm);
+    await installDependencies(projectDir, packageManager);
 
     console.log(
       [
@@ -133,17 +133,17 @@ export const create = async (options: CreateCommandOptions) => {
     customerImpersonationToken,
   });
 
-  console.log(`\nUsing ${chalk.bold(pm)}\n`);
+  console.log(`\nUsing ${chalk.bold(packageManager)}\n`);
 
-  await installDependencies(projectDir, pm);
+  await installDependencies(projectDir, packageManager);
 
-  await spinner(exec(`${pm} run codegen`, { cwd: projectDir }), {
+  await spinner(exec(`${packageManager} run codegen`, { cwd: projectDir }), {
     text: 'Generating GraphQL types...',
     successText: 'GraphQL types generated successfully',
     failText: (err) => chalk.red(`Failed to generate GraphQL types: ${err.message}`),
   });
 
-  await spinner(exec(`${pm} run lint --fix`, { cwd: projectDir }), {
+  await spinner(exec(`${packageManager} run lint --fix`, { cwd: projectDir }), {
     text: 'Linting to validate generated types...',
     successText: 'GraphQL types validated successfully',
     failText: (err) => chalk.red(`Failed to validate GraphQL types: ${err.message}`),
@@ -152,6 +152,6 @@ export const create = async (options: CreateCommandOptions) => {
   console.log(
     `\n${chalk.green('Success!')} Created '${projectName}' at '${projectDir}'\n`,
     '\nNext steps:\n',
-    chalk.yellow(`\ncd ${projectName} && ${pm} run dev\n`),
+    chalk.yellow(`\ncd ${projectName} && ${packageManager} run dev\n`),
   );
 };

--- a/packages/create-catalyst/src/index.ts
+++ b/packages/create-catalyst/src/index.ts
@@ -8,7 +8,7 @@ import PACKAGE_INFO from '../package.json';
 
 import { create } from './commands/create';
 import { init } from './commands/init';
-import { getPackageManager } from './utils/pm';
+import { getPackageManager, packageManagerChoices } from './utils/pm';
 
 if (!satisfies(process.version, PACKAGE_INFO.engines.node)) {
   console.error(
@@ -55,7 +55,7 @@ const createCommand = program
   )
   .addOption(
     new Option('--package-manager <pm>', 'Override detected package manager')
-      .choices(['npm', 'pnpm', 'yarn'] as const)
+      .choices(packageManagerChoices)
       .default(getPackageManager())
       .hideHelp(),
   )

--- a/packages/create-catalyst/src/utils/pm.ts
+++ b/packages/create-catalyst/src/utils/pm.ts
@@ -12,9 +12,9 @@
 
 export type PackageManager = 'npm' | 'pnpm' | 'yarn';
 
-export function getPackageManager(packageManager?: PackageManager): PackageManager {
-  if (packageManager) return packageManager;
+export const packageManagerChoices: PackageManager[] = ['npm', 'pnpm', 'yarn'];
 
+export function getPackageManager(): PackageManager {
   const userAgent = process.env.npm_config_user_agent || '';
 
   if (userAgent.startsWith('yarn')) {


### PR DESCRIPTION
## What/Why?
* Previously, the available options for the `--package-manager` flag were set outside of the type boundaries defined by `pm.ts`. Someone could accidentally add a new package manager to the CLI option choices and forget to add it to the `pm.ts` module.
* Better variable naming

## Testing
CI