### PR TITLE
refactor(cli): more reliable check for storefront limits

### DIFF
--- a/packages/create-catalyst/src/commands/create.ts
+++ b/packages/create-catalyst/src/commands/create.ts
@@ -83,8 +83,8 @@ export const create = async (options: CreateCommandOptions) => {
     accessToken = credentials.accessToken;
   }
 
-  if (!projectName) throw new Error('Someting went wrong, projectName is not defined');
-  if (!projectDir) throw new Error('Someting went wrong, projectDir is not defined');
+  if (!projectName) throw new Error('Something went wrong, projectName is not defined');
+  if (!projectDir) throw new Error('Something went wrong, projectDir is not defined');
 
   if (!storeHash || !accessToken) {
     console.log(`\nCreating '${projectName}' at '${projectDir}'\n`);
@@ -109,8 +109,10 @@ export const create = async (options: CreateCommandOptions) => {
 
   if (!channelId || !customerImpersonationToken) {
     const bc = new Https({ bigCommerceApiUrl: bigcommerceApiUrl, storeHash, accessToken });
+    const availableChannels = await bc.channels('?available=true&type=storefront');
+    const storeInfo = await bc.storeInformation();
 
-    const canCreateChannel = checkStorefrontLimit(bc);
+    const canCreateChannel = checkStorefrontLimit(availableChannels, storeInfo);
 
     let shouldCreateChannel;
 
@@ -148,13 +150,11 @@ export const create = async (options: CreateCommandOptions) => {
     }
 
     if (!shouldCreateChannel) {
-      const { data: channels } = await bc.channels('?available=true&type=storefront');
-
       const channelSortOrder = ['catalyst', 'next', 'bigcommerce'];
 
       const existingChannel = await select({
         message: 'Which channel would you like to use?',
-        choices: channels
+        choices: availableChannels.data
           .sort(
             (a, b) => channelSortOrder.indexOf(a.platform) - channelSortOrder.indexOf(b.platform),
           )
@@ -179,9 +179,9 @@ export const create = async (options: CreateCommandOptions) => {
     }
   }
 
-  if (!channelId) throw new Error('Someting went wrong, channelId is not defined');
+  if (!channelId) throw new Error('Something went wrong, channelId is not defined');
   if (!customerImpersonationToken)
-    throw new Error('Someting went wrong, customerImpersonationToken is not defined');
+    throw new Error('Something went wrong, customerImpersonationToken is not defined');
 
   console.log(`\nCreating '${projectName}' at '${projectDir}'\n`);
 

--- a/packages/create-catalyst/src/utils/check-storefront-limit.spec.ts
+++ b/packages/create-catalyst/src/utils/check-storefront-limit.spec.ts
@@ -1,0 +1,70 @@
+import { checkStorefrontLimit } from './check-storefront-limit';
+
+jest.mock('chalk', () => ({
+  red: jest.fn((text: string) => text),
+  cyan: jest.fn((text: string) => text),
+}));
+
+console.error = jest.fn();
+
+describe('checkStorefrontLimit', () => {
+  it('should return true when storefront limit is not exceeded', () => {
+    const availableChannels = {
+      data: [
+        {
+          id: 1,
+          name: 'channel1',
+          status: 'active',
+          platform: 'bigcommerce',
+        },
+      ],
+      meta: {},
+    };
+
+    const storeInfo = {
+      features: {
+        storefront_limits: {
+          active: 2,
+          total_including_inactive: 2,
+        },
+      },
+    };
+
+    const canCreateChannel = checkStorefrontLimit(availableChannels, storeInfo);
+
+    expect(canCreateChannel).toBe(true);
+  });
+
+  it('should return false when storefront limit is exceeded', () => {
+    const availableChannels = {
+      data: [
+        {
+          id: 1,
+          name: 'channel1',
+          status: 'active',
+          platform: 'bigcommerce',
+        },
+        {
+          id: 2,
+          name: 'channel2',
+          status: 'active',
+          platform: 'bigcommerce',
+        },
+      ],
+      meta: {},
+    };
+
+    const storeInfo = {
+      features: {
+        storefront_limits: {
+          active: 2,
+          total_including_inactive: 2,
+        },
+      },
+    };
+
+    const canCreateChannel = checkStorefrontLimit(availableChannels, storeInfo);
+
+    expect(canCreateChannel).toBe(false);
+  });
+});

--- a/packages/create-catalyst/src/utils/check-storefront-limit.ts
+++ b/packages/create-catalyst/src/utils/check-storefront-limit.ts
@@ -1,4 +1,37 @@
-import { Https } from './https';
+import chalk from 'chalk';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const checkStorefrontLimit = (bc: Https) => true;
+import { type BigCommerceChannelsV3Response, type BigCommerceStoreInfo } from './https';
+
+export const checkStorefrontLimit = (
+  channels: BigCommerceChannelsV3Response,
+  storeInfo: BigCommerceStoreInfo,
+) => {
+  const { data: availableChannels } = channels;
+  const { features } = storeInfo;
+
+  if (availableChannels.length >= features.storefront_limits.total_including_inactive) {
+    console.error(
+      chalk.red(
+        `\nYou have reached the maximum number of storefronts allowed for your plan. Please purchase additional storefront seats in your BigCommerce Control Panel or contact BigCommerce Support: ${chalk.cyan(
+          'https://support.bigcommerce.com',
+        )}\n`,
+      ),
+    );
+
+    return false;
+  }
+
+  const activeChannels = availableChannels.filter((channel) => channel.status === 'active');
+
+  if (activeChannels.length >= features.storefront_limits.active) {
+    console.error(
+      chalk.red(
+        '\nYou have reached the maximum number of active storefronts allowed for your plan. Please de-activate an active channel or purchase additional storefront seats in your BigCommerce Control Panel.\n',
+      ),
+    );
+
+    return false;
+  }
+
+  return true;
+};

--- a/packages/create-catalyst/src/utils/https.ts
+++ b/packages/create-catalyst/src/utils/https.ts
@@ -29,6 +29,36 @@ interface HttpsConfig {
   accessToken?: string;
 }
 
+const BigCommerceStoreInfo = z.object({
+  features: z.object({
+    storefront_limits: z.object({
+      active: z.number(),
+      total_including_inactive: z.number(),
+    }),
+  }),
+});
+
+export type BigCommerceStoreInfo = z.infer<typeof BigCommerceStoreInfo>;
+
+const BigCommerceV3ApiResponseSchema = <T>(schema: z.ZodType<T>) =>
+  z.object({
+    data: schema,
+    meta: z.object({}),
+  });
+
+const BigCommerceChannelsV3ResponseSchema = BigCommerceV3ApiResponseSchema(
+  z.array(
+    z.object({
+      id: z.number(),
+      name: z.string(),
+      status: z.string(),
+      platform: z.string(),
+    }),
+  ),
+);
+
+export type BigCommerceChannelsV3Response = z.infer<typeof BigCommerceChannelsV3ResponseSchema>;
+
 export class Https {
   DEVICE_OAUTH_CLIENT_ID = 'acse0vvawm9r1n0evag4b8e1ea1fo90';
 
@@ -131,12 +161,6 @@ export class Https {
     return parse(await response.json(), DeviceCodeSuccessSchema);
   }
 
-  BigCommerceV3ApiResponseSchema = <T>(schema: z.ZodType<T>) =>
-    z.object({
-      data: schema,
-      meta: z.object({}),
-    });
-
   api(path: string, opts: RequestInit = {}) {
     if (!this.bigCommerceApiUrl || !this.storeHash || !this.accessToken) {
       throw new Error(
@@ -166,15 +190,6 @@ export class Https {
       process.exit(1);
     }
 
-    const BigCommerceStoreInfo = z.object({
-      features: z.object({
-        storefront_limits: z.object({
-          active: z.number(),
-          total_including_inactive: z.number(),
-        }),
-      }),
-    });
-
     return parse(await res.json(), BigCommerceStoreInfo);
   }
 
@@ -185,17 +200,6 @@ export class Https {
       console.error(chalk.red(`\nGET /v3/channels failed: ${res.status} ${res.statusText}\n`));
       process.exit(1);
     }
-
-    const BigCommerceChannelsV3ResponseSchema = this.BigCommerceV3ApiResponseSchema(
-      z.array(
-        z.object({
-          id: z.number(),
-          name: z.string(),
-          status: z.string(),
-          platform: z.string(),
-        }),
-      ),
-    );
 
     return parse(await res.json(), BigCommerceChannelsV3ResponseSchema);
   }


### PR DESCRIPTION
⚠️ Depends on #572 

## What/Why?
As mentioned in https://github.com/bigcommerce/catalyst/pull/572#discussion_r1492990903, this PR adds more reliable checks for active storefront limit, allowing the user the option to create a new channel if the store is allowed to (or use an existing channel), but forcing them to use an existing channel if the store cannot have any more channels created.

## Testing
CI