### PR TITLE
Add .catalyst to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist
 !.vscode/settings.example.json
 .idea
 .vercel
+.catalyst
 .env
 .env*.local
 test-results/

--- a/apps/core/.gitignore
+++ b/apps/core/.gitignore
@@ -38,3 +38,6 @@ next-env.d.ts
 # generated
 client/generated
 schema.graphql
+
+# secrets
+.catalyst


### PR DESCRIPTION
Prepping for having a secrets file by adding it to `.gitignore` early.

Can be used for more durable storage of things like access tokens in a way that they do not need to leave the local development environment, and in a way that they can be used to re-generate `.local.env` files themselves (therefore they need to be separate). This will be used by the CLI in the future, but I want to get the `.gitignore` entry in early to make sure as many customers as possible have this ignored from version control to minimize the risk of committing secrets to code.