### PR TITLE
fix(core): Remove extraneous middleware matcher for home page

### DIFF
--- a/apps/core/middleware.ts
+++ b/apps/core/middleware.ts
@@ -15,6 +15,5 @@ export const config = {
      * - favicon.ico (favicon file)
      */
     '/((?!api|_next/static|_next/image|_vercel|favicon.ico).*)',
-    '/',
   ],
 };


### PR DESCRIPTION
[](url)## What/Why?
Our middleware had an extraneous matcher for the home page `/` which is already captured by the primary regex matcher. I *believe* this is what was causing two passthroughs of the middleware on our vercel deploys (interestingly, this did not seem to be happening locally).

## Testing
Verified that the home page still passes through middleware both locally and on a vercel deploy.

This did indeed fix the double-middleware issue. Previous to this change, a request to the home page looked like:

![Screenshot 2024-02-19 at 9 15 47 AM](https://github.com/bigcommerce/catalyst/assets/32500994/86002fb9-0eb7-4c88-85f7-01e0d331d262)

Now it looks like:

![Screenshot 2024-02-19 at 9 15 52 AM](https://github.com/bigcommerce/catalyst/assets/32500994/90d30312-587c-44ee-893b-2a78c62f4b96)

(like every other pages does/did)
