### PR TITLE
feat(core): adds prefetch and prefetchKind to Link

### DIFF
--- a/apps/core/app/(default)/compare/_components/add-to-cart-form.tsx
+++ b/apps/core/app/(default)/compare/_components/add-to-cart-form.tsx
@@ -34,7 +34,7 @@ export const AddToCartForm = ({
           <div className="flex items-center gap-3">
             <span>
               {quantity} {quantity === 1 ? 'Item' : 'Items'} added to{' '}
-              <Link className="font-semibold text-blue-primary" href="/cart" prefetch={false}>
+              <Link className="font-semibold text-blue-primary" href="/cart" prefetch="none">
                 your cart
               </Link>
             </span>

--- a/apps/core/app/(default)/compare/page.tsx
+++ b/apps/core/app/(default)/compare/page.tsx
@@ -222,7 +222,7 @@ export default async function Compare({
                   return (
                     <td className="border-b px-4 pb-24 pt-12" key={product.entityId}>
                       <Button aria-label={product.name} asChild className="hover:text-white">
-                        <Link href={product.path} prefetch={false}>
+                        <Link href={product.path} prefetch="none">
                           Choose options
                         </Link>
                       </Button>

--- a/apps/core/components/link/index.tsx
+++ b/apps/core/components/link/index.tsx
@@ -1,13 +1,46 @@
+'use client';
+
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import NextLink from 'next/link';
-import { ComponentPropsWithRef, ElementRef, forwardRef } from 'react';
+import { useRouter } from 'next/navigation';
+import { ComponentPropsWithRef, ElementRef, forwardRef, useReducer } from 'react';
 
 import { cn } from '~/lib/utils';
 
-type Props = ComponentPropsWithRef<typeof NextLink>;
+type NextLinkProps = Omit<ComponentPropsWithRef<typeof NextLink>, 'prefetch'>;
 
+interface PrefetchOptions {
+  prefetch?: 'hover' | 'viewport' | 'none';
+  prefetchKind?: 'auto' | 'full';
+}
+
+type Props = NextLinkProps & PrefetchOptions;
+
+/**
+ * This custom `Link` component extends Next.js's `Link` with additional prefetching controls, making
+ * navigation prefetching more adaptable to different use cases. By offering `prefetch` and `prefetchKind`
+ * props, it grants explicit management over when and how prefetching occurs, defaulting to 'hover' for
+ * prefetch behavior and 'auto' for prefetch kind. This approach provides a balance between optimizing
+ * page load performance and resource usage. https://nextjs.org/docs/app/api-reference/components/link#prefetch
+ */
 export const Link = forwardRef<ElementRef<'a'>, Props>(
-  ({ href, prefetch = false, children, className, ...rest }, ref) => {
+  ({ href, prefetch = 'hover', prefetchKind = 'auto', children, className, ...rest }, ref) => {
+    const router = useRouter();
+    const [prefetched, setPrefetched] = useReducer(() => true, false);
+    const computedPrefetch = computePrefetchProp({ prefetch, prefetchKind });
+
+    const triggerPrefetch = () => {
+      if (prefetched) {
+        return;
+      }
+
+      // PrefetchKind enum is not exported
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
+      router.prefetch(href.toString(), { kind: prefetchKind });
+      setPrefetched();
+    };
+
     return (
       <NextLink
         className={cn(
@@ -15,7 +48,9 @@ export const Link = forwardRef<ElementRef<'a'>, Props>(
           className,
         )}
         href={href}
-        prefetch={prefetch}
+        onMouseEnter={prefetch === 'hover' ? triggerPrefetch : undefined}
+        onTouchStart={prefetch === 'hover' ? triggerPrefetch : undefined}
+        prefetch={computedPrefetch}
         ref={ref}
         {...rest}
       >
@@ -24,3 +59,18 @@ export const Link = forwardRef<ElementRef<'a'>, Props>(
     );
   },
 );
+
+function computePrefetchProp({
+  prefetch,
+  prefetchKind,
+}: Required<PrefetchOptions>): boolean | undefined {
+  if (prefetch !== 'viewport') {
+    return false;
+  }
+
+  if (prefetchKind === 'auto') {
+    return undefined;
+  }
+
+  return true;
+}

--- a/apps/core/components/product-card/cart.tsx
+++ b/apps/core/components/product-card/cart.tsx
@@ -50,7 +50,7 @@ export const Cart = ({ product }: { product: Partial<Product> }) => {
             <div className="flex items-center gap-3">
               <span>
                 {quantity} {quantity === 1 ? 'Item' : 'Items'} added to{' '}
-                <Link className="font-semibold text-blue-primary" href="/cart" prefetch={false}>
+                <Link className="font-semibold text-blue-primary" href="/cart" prefetch="none">
                   your cart
                 </Link>
               </span>


### PR DESCRIPTION
## What/Why?
Adds the following props to our  custom `Link` component

```ts
interface PrefetchOptions {
  prefetch?: 'hover' | 'viewport' | 'none';
  prefetchKind?: 'auto' | 'full';
}
```

Defaults are `hover` and `auto` for now.

These props give more flexibility to Next.js' `Link` component. They do deviate from their `Link` api. Their `prefetch` prop IMO is hard to follow (eg: `false` and `undefined` doing different things). Adding `hover` was going to make this prop even weirder, went the explicit way.