### PR TITLE
fix(cli): adjust cart token scope to create checkout urls

### DIFF
--- a/packages/create-catalyst/src/utils/https.ts
+++ b/packages/create-catalyst/src/utils/https.ts
@@ -112,7 +112,7 @@ export class Https {
           'store_v2_content',
           'store_v2_information',
           'store_v2_products',
-          'store_cart_read_only',
+          'store_cart',
           'store_sites',
           'store_channel_settings',
           'store_storefront_api_customer_impersonation',


### PR DESCRIPTION
## What/Why?
It was reported that the following error occurred when attempting to access checkout on a new Catalyst storefront:

```
Error: An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.
```

Logs revealed the underlying error:

```
Error: Unable to get checkout URL: Forbidden
    at (node_modules/@bigcommerce/catalyst-client/dist/index.js:192:12)
    at (client/management/get-checkout-url.ts:15:19)
    at (app/(default)/cart/page.tsx:30:22)
```

This PR adjusts the `store_cart` scope so that it has `write` permissions in addition to `read` permissions.

## Testing
1. Run `pnpm create catalyst-storefront@latest`
2. `cd <catalyst_local_directory> && pnpm dev`
3. Add item to cart, navigate to cart page, and click checkout. 