### PR TITLE
Support 301 redirects

### DIFF
--- a/apps/core/app/api/revalidate/route/route.ts
+++ b/apps/core/app/api/revalidate/route/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 import { getRoute } from '~/client/queries/get-route';
 import { kv } from '~/lib/kv';
+import { routeCacheKvKey } from '~/lib/kv/keys';
 
 import { withInternalAuth } from '../../internal-auth';
 
@@ -19,7 +20,7 @@ const handler = async (request: NextRequest) => {
   const expiryTime = Date.now() + 1000 * 60 * 30; // 30 minutes;
 
   try {
-    await kv.set(pathname, { node, expiryTime });
+    await kv.set(routeCacheKvKey(pathname), { node, expiryTime });
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error(error);

--- a/apps/core/app/api/revalidate/store-status/route.ts
+++ b/apps/core/app/api/revalidate/store-status/route.ts
@@ -2,10 +2,9 @@ import { NextResponse } from 'next/server';
 
 import { getStoreStatus } from '~/client/queries/get-store-status';
 import { kv } from '~/lib/kv';
+import { STORE_STATUS_KEY } from '~/lib/kv/keys';
 
 import { withInternalAuth } from '../../internal-auth';
-
-const STORE_STATUS_KEY = 'storeStatus';
 
 const handler = async () => {
   const status = await getStoreStatus();

--- a/apps/core/client/queries/get-route.ts
+++ b/apps/core/client/queries/get-route.ts
@@ -1,10 +1,18 @@
 import { client } from '..';
 import { graphql } from '../generated';
+import { Route } from '../generated/graphql';
 
 export const GET_ROUTE_QUERY = /* GraphQL */ `
   query getRoute($path: String!) {
     site {
       route(path: $path) {
+        redirect {
+          __typename
+          to {
+            __typename
+          }
+          toUrl
+        }
         node {
           __typename
           ... on Product {
@@ -22,7 +30,7 @@ export const GET_ROUTE_QUERY = /* GraphQL */ `
   }
 `;
 
-export const getRoute = async (path: string) => {
+export const getRoute = async (path: string): Promise<Route> => {
   const query = graphql(GET_ROUTE_QUERY);
 
   const response = await client.fetch({
@@ -30,5 +38,5 @@ export const getRoute = async (path: string) => {
     variables: { path },
   });
 
-  return response.data.site.route.node;
+  return response.data.site.route;
 };

--- a/apps/core/client/queries/get-route.ts
+++ b/apps/core/client/queries/get-route.ts
@@ -1,6 +1,5 @@
 import { client } from '..';
 import { graphql } from '../generated';
-import { Route } from '../generated/graphql';
 
 export const GET_ROUTE_QUERY = /* GraphQL */ `
   query getRoute($path: String!) {
@@ -30,7 +29,7 @@ export const GET_ROUTE_QUERY = /* GraphQL */ `
   }
 `;
 
-export const getRoute = async (path: string): Promise<Route> => {
+export const getRoute = async (path: string) => {
   const query = graphql(GET_ROUTE_QUERY);
 
   const response = await client.fetch({

--- a/apps/core/lib/kv/keys.ts
+++ b/apps/core/lib/kv/keys.ts
@@ -1,0 +1,2 @@
+export const STORE_STATUS_KEY = 'storeStatus';
+export const routeCacheKvKey = (pathname: string) => `v3_${pathname}`;

--- a/apps/core/middlewares/with-routes.ts
+++ b/apps/core/middlewares/with-routes.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 
 import { getSessionCustomerId } from '~/auth';
-import { StorefrontStatusType } from '~/client/generated/graphql';
+import { Route, StorefrontStatusType } from '~/client/generated/graphql';
 import { getRoute } from '~/client/queries/get-route';
 import { getStoreStatus } from '~/client/queries/get-store-status';
 
@@ -38,8 +38,27 @@ const StorefrontStatusCacheSchema = z.object({
   expiryTime: z.number(),
 });
 
+const RedirectSchema = z.object({
+  __typename: z.string(),
+  to: z.object({
+    __typename: z.string(),
+  }),
+  toUrl: z.string(),
+});
+
+const NodeSchema = z.union([
+  z.object({ __typename: z.literal('Product'), entityId: z.number() }),
+  z.object({ __typename: z.literal('Category'), entityId: z.number() }),
+  z.object({ __typename: z.literal('Brand'), entityId: z.number() }),
+]);
+
+const RouteSchema = z.object({
+  redirect: z.nullable(RedirectSchema),
+  node: z.nullable(NodeSchema),
+});
+
 const RouteCacheSchema = z.object({
-  node: z.nullable(z.object({ __typename: z.string(), entityId: z.optional(z.number()) })),
+  route: z.nullable(RouteSchema),
   expiryTime: z.number(),
 });
 
@@ -76,7 +95,7 @@ const getExistingRouteInfo = async (request: NextRequest) => {
 
     return {
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      node: parsedRoute.success ? (parsedRoute.data.node as Node) : undefined,
+      route: parsedRoute.success ? (parsedRoute.data.route as Route) : undefined,
       status: parsedStatus.success ? parsedStatus.data.status : undefined,
     };
   } catch (error) {
@@ -84,7 +103,7 @@ const getExistingRouteInfo = async (request: NextRequest) => {
     console.error(error);
 
     return {
-      node: undefined,
+      route: undefined,
       status: undefined,
     };
   }
@@ -101,20 +120,22 @@ const setKvStatus = async (status?: StorefrontStatusType | null) => {
   }
 };
 
-const setKvRoute = async (request: NextRequest, node: Node) => {
+const setKvRoute = async (request: NextRequest, route: Route) => {
   try {
     const expiryTime = Date.now() + 1000 * 60 * 30; // 30 minutes;
 
-    await kv.set(request.nextUrl.pathname, { node, expiryTime });
+    await kv.set(request.nextUrl.pathname, { route, expiryTime });
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error(error);
   }
 };
 
-const getRouteInfo = async (request: NextRequest) => {
+const getRouteInfo = async (
+  request: NextRequest,
+): Promise<{ route: Route | undefined; status: StorefrontStatusType | undefined }> => {
   try {
-    let { node, status } = await getExistingRouteInfo(request);
+    let { status, route } = await getExistingRouteInfo(request);
 
     if (status === undefined) {
       const newStatus = await getStoreStatus();
@@ -125,20 +146,20 @@ const getRouteInfo = async (request: NextRequest) => {
       }
     }
 
-    if (node === undefined) {
-      const newNode = await getRoute(request.nextUrl.pathname);
+    if (route === undefined) {
+      const newRoute = await getRoute(request.nextUrl.pathname);
 
-      node = newNode;
-      await setKvRoute(request, node);
+      route = newRoute;
+      await setKvRoute(request, route);
     }
 
-    return { node, status };
+    return { route, status };
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error(error);
 
     return {
-      node: undefined,
+      route: undefined,
       status: undefined,
     };
   }
@@ -146,11 +167,35 @@ const getRouteInfo = async (request: NextRequest) => {
 
 export const withRoutes: MiddlewareFactory = (next) => {
   return async (request, event) => {
-    const { node, status } = await getRouteInfo(request);
+    const { route, status } = await getRouteInfo(request);
 
     if (status === 'MAINTENANCE') {
       // 503 status code not working - https://github.com/vercel/next.js/issues/50155
       return NextResponse.rewrite(new URL(`/maintenance`, request.url), { status: 503 });
+    }
+
+    // Follow redirects if found on the route
+    // Use 301 status code as it is more universally supported by crawlers
+    const redirectConfig = { status: 301 };
+
+    if (route?.redirect) {
+      switch (route.redirect.to.__typename) {
+        case 'ManualRedirect': {
+          // For manual redirects, redirect to the full URL to handle cases
+          // where the destination URL might be external to the site
+          return NextResponse.redirect(route.redirect.toUrl, redirectConfig);
+        }
+
+        default: {
+          // For all other cases, assume an internal redirect and construct the URL
+          // based on the current request URL to maintain internal redirection
+          // in non-production environments
+          const redirectPathname = new URL(route.redirect.toUrl).pathname;
+          const redirectUrl = new URL(redirectPathname, request.url);
+
+          return NextResponse.redirect(redirectUrl, redirectConfig);
+        }
+      }
     }
 
     const customerId = await getSessionCustomerId();
@@ -160,6 +205,8 @@ export const withRoutes: MiddlewareFactory = (next) => {
     if (!request.nextUrl.search && !customerId && !cartId && request.method === 'GET') {
       postfix = '/static';
     }
+
+    const node = route?.node;
 
     switch (node?.__typename) {
       case 'Brand': {


### PR DESCRIPTION
## What/Why?
Adds a lookup for existing 301 redirects on a Route and redirects as appropriate.

I have also versioned the keys to v3 out of an abundance of caution, based on our previous change in https://github.com/bigcommerce/catalyst/pull/518/files

## Testing
Confirmed that both manual and entity-targeted redirects work on a real store, and that existing Route functionality is unaffected.

Also confirmed new v3_ keys are correctly writing to KV.