### PR TITLE
fix(cli): handle npm script flag passthrough

### DIFF
--- a/packages/create-catalyst/src/commands/create.ts
+++ b/packages/create-catalyst/src/commands/create.ts
@@ -204,7 +204,7 @@ export const create = async (options: CreateCommandOptions) => {
     failText: (err) => chalk.red(`Failed to generate GraphQL types: ${err.message}`),
   });
 
-  await spinner(exec(`${packageManager} run lint --fix`, { cwd: projectDir }), {
+  await spinner(exec(`${packageManager} run lint -- --fix`, { cwd: projectDir }), {
     text: 'Linting to validate generated types...',
     successText: 'GraphQL types validated successfully',
     failText: (err) => chalk.red(`Failed to validate GraphQL types: ${err.message}`),


### PR DESCRIPTION
## What/Why?
Surfaced by #436 

Adds an extra `--` when passing the `--fix` flag to the `lint` script. Since the extra `--` is compatible with both `yarn` and `pnpm`, we shouldn't need to modify this command depending on package manager, we should be able to just pass the extra `--` no matter which package manager is being used. 

## Testing
![Screenshot 2024-02-21 at 3 47 56 PM](https://github.com/bigcommerce/catalyst/assets/28374851/a6900c37-4be0-4b0b-bf04-99a8c44be033)
