### PR TITLE
fix(core): limit image logo size

### DIFF
--- a/apps/core/components/store-logo/index.tsx
+++ b/apps/core/components/store-logo/index.tsx
@@ -18,6 +18,7 @@ export const StoreLogo = async () => {
   return (
     <Image
       alt={logo.image.altText ? logo.image.altText : storeName}
+      className="max-h-16 object-contain"
       height={32}
       priority
       src={logo.image.url}


### PR DESCRIPTION
## What/Why?
This pr covers the case when logo is an image and its height bigger than its width

## Testing
**Header Before**

<img width="1237" alt="header-vertical-logo-bug" src="https://github.com/bigcommerce/catalyst/assets/66325265/4fb5488d-de86-4720-90d9-6dac249b4437">

**Footer Before**

<img width="1237" alt="footer-vertical-logo-bug" src="https://github.com/bigcommerce/catalyst/assets/66325265/965672a2-04fa-48e2-a00c-8045527aed71">

**Header After**

<img width="1237" alt="header-vertical-logo-fix" src="https://github.com/bigcommerce/catalyst/assets/66325265/97dd5a23-d195-4ebe-af85-7df73b35c893">

**Footer After**

<img width="1237" alt="footer-vertical-logo-fix" src="https://github.com/bigcommerce/catalyst/assets/66325265/80f097fc-2310-4bd7-a070-ccec66763eb0">


