### PR TITLE
refactor(cli): change log color to communicate warning instead of error

### DIFF
--- a/packages/create-catalyst/src/utils/check-storefront-limit.spec.ts
+++ b/packages/create-catalyst/src/utils/check-storefront-limit.spec.ts
@@ -1,7 +1,7 @@
 import { checkStorefrontLimit } from './check-storefront-limit';
 
 jest.mock('chalk', () => ({
-  red: jest.fn((text: string) => text),
+  yellow: jest.fn((text: string) => text),
   cyan: jest.fn((text: string) => text),
 }));
 

--- a/packages/create-catalyst/src/utils/check-storefront-limit.ts
+++ b/packages/create-catalyst/src/utils/check-storefront-limit.ts
@@ -11,8 +11,8 @@ export const checkStorefrontLimit = (
 
   if (availableChannels.length >= features.storefront_limits.total_including_inactive) {
     console.error(
-      chalk.red(
-        `\nYou have reached the maximum number of storefronts allowed for your plan. Please purchase additional storefront seats in your BigCommerce Control Panel or contact BigCommerce Support: ${chalk.cyan(
+      chalk.yellow(
+        `You have reached the maximum number of storefronts allowed for your plan. Please select an existing channel below, purchase additional storefront seats in your BigCommerce Control Panel, or contact BigCommerce Support: ${chalk.cyan(
           'https://support.bigcommerce.com',
         )}\n`,
       ),
@@ -25,8 +25,8 @@ export const checkStorefrontLimit = (
 
   if (activeChannels.length >= features.storefront_limits.active) {
     console.error(
-      chalk.red(
-        '\nYou have reached the maximum number of active storefronts allowed for your plan. Please de-activate an active channel or purchase additional storefront seats in your BigCommerce Control Panel.\n',
+      chalk.yellow(
+        'You have reached the maximum number of active storefronts allowed for your plan. Please select an existing channel below, de-activate an active channel, or purchase additional storefront seats in your BigCommerce Control Panel.\n',
       ),
     );
 


### PR DESCRIPTION
## What/Why?
Previously, these logs were printed to console in `red`, which makes it look like an error at first glance; after using the CLI in a few edge cases (such as the authenticated store having existing channels available for connection), I realize this log should be in yellow, to convey that this is more of an "important note" than an error.

## Testing
`npm create catalyst-storefront@latest`