### PR TITLE
fix(build): refactor out eslint-disable comment

### DIFF
--- a/apps/core/components/forms/contact-us.tsx
+++ b/apps/core/components/forms/contact-us.tsx
@@ -13,8 +13,7 @@ import { TextArea } from '@bigcommerce/components/text-area';
 import { Loader2 as Spinner } from 'lucide-react';
 import { ChangeEvent, useRef, useState } from 'react';
 import { useFormStatus } from 'react-dom';
-// eslint-disable-next-line import/no-named-as-default
-import ReCAPTCHA from 'react-google-recaptcha';
+import { ReCAPTCHA } from 'react-google-recaptcha';
 
 import { submitContactForm } from './_actions/submit-contact-form';
 


### PR DESCRIPTION
## What/Why?
Removes `eslint-disable` comment by using the named export instead of naming the default export a named member (that's a mouthful 😅). 

This will fix one of the eslint issues preventing: https://github.com/bigcommerce/catalyst/actions/runs/8007584319/job/21872352776?pr=436
from passing.

## Testing
Run `npm create catalyst-storefront@latest`, allow `lint` task to run, verify `lint` task fixed all issues by running `cd <name_of_your_catalyst_directory> && <package_manager> run lint`