### PR TITLE
feat(core): Add CSP, minus upgrade-insecure-requests

### DIFF
--- a/apps/core/next.config.js
+++ b/apps/core/next.config.js
@@ -1,5 +1,11 @@
 // @ts-check
 
+const cspHeader = `
+  base-uri 'self';
+  form-action 'self';
+  frame-ancestors 'none';
+`
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
@@ -20,6 +26,19 @@ const nextConfig = {
   },
   // default URL generation in BigCommerce uses trailing slash
   trailingSlash: process.env.TRAILING_SLASH !== 'false',
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: cspHeader.replace(/\n/g, ''),
+          },
+        ],
+      },
+    ]
+  }
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## What/Why?
Adds a basic CSP to Catalyst. This omits `upgrade-insecure-requests` as that was breaking Quick Add in a local environment. Will add that back separately once fixed.

## Testing
Tested locally, Quick Add works without `upgrade-insecure-requests`.