### PR TITLE
fix(core): skip empty options when adding to cart

### DIFF
--- a/apps/core/components/product-form/_actions/add-to-cart.ts
+++ b/apps/core/components/product-form/_actions/add-to-cart.ts
@@ -31,6 +31,9 @@ export async function handleAddToCart(data: ProductFormData) {
       let multiLineTextFieldOptionInput;
       let dateFieldOptionInput;
 
+      // Skip empty strings since option is empty
+      if (optionValueEntityId === '') return accum;
+
       switch (option.__typename) {
         case 'MultipleChoiceOption':
           multipleChoicesOptionInput = {
@@ -105,8 +108,6 @@ export async function handleAddToCart(data: ProductFormData) {
           return { ...accum, multiLineTextFields: [multiLineTextFieldOptionInput] };
 
         case 'DateFieldOption':
-          if (!optionValueEntityId) return accum;
-
           dateFieldOptionInput = {
             optionEntityId: option.entityId,
             date: new Date(String(optionValueEntityId)).toISOString(),


### PR DESCRIPTION
## What/Why?
In some scenario, passing an empty string was still appending a value to the option (like in numbers). With this change completely skip entry strings from the form.

## Testing
Locally.