### PR TITLE
fix(core): send product options when updating cart item

### DIFF
--- a/apps/core/app/(default)/cart/_actions/update-product-quantity.ts
+++ b/apps/core/app/(default)/cart/_actions/update-product-quantity.ts
@@ -15,6 +15,7 @@ export async function updateProductQuantity({
   productEntityId,
   quantity,
   variantEntityId,
+  selectedOptions,
 }: UpdateProductQuantityParams) {
   const cartId = cookies().get('cartId')?.value;
 
@@ -29,6 +30,7 @@ export async function updateProductQuantity({
   const cartLineItemData = Object.assign(
     { quantity, productEntityId },
     variantEntityId && { variantEntityId },
+    selectedOptions && { selectedOptions },
   );
 
   const updatedCart = await updateCartLineItem(cartId, lineItemEntityId, {

--- a/apps/core/app/(default)/cart/_components/cart-item-counter.tsx
+++ b/apps/core/app/(default)/cart/_components/cart-item-counter.tsx
@@ -6,12 +6,19 @@ import { useState } from 'react';
 import {
   CartLineItemInput,
   CartPhysicalItem,
+  CartSelectedOptionsInput,
   UpdateCartLineItemInput,
 } from '~/client/generated/graphql';
+import { getCart } from '~/client/queries/get-cart';
 
 import { updateProductQuantity } from '../_actions/update-product-quantity';
 
-type CartItemData = Pick<CartPhysicalItem, 'quantity' | 'productEntityId' | 'variantEntityId'> & {
+type Cart = NonNullable<Awaited<ReturnType<typeof getCart>>>;
+
+type CartItemData = Pick<
+  Cart['lineItems']['physicalItems'][number],
+  'quantity' | 'productEntityId' | 'variantEntityId' | 'selectedOptions'
+> & {
   lineItemEntityId: CartPhysicalItem['entityId'];
 };
 
@@ -19,8 +26,108 @@ interface UpdateProductQuantityData extends CartLineItemInput {
   lineItemEntityId: UpdateCartLineItemInput['lineItemEntityId'];
 }
 
+const parseSelectedOptions = (selectedOptions: CartItemData['selectedOptions']) => {
+  return selectedOptions.reduce<CartSelectedOptionsInput>((accum, option) => {
+    let multipleChoicesOptionInput;
+    let checkboxOptionInput;
+    let numberFieldOptionInput;
+    let textFieldOptionInput;
+    let multiLineTextFieldOptionInput;
+    let dateFieldOptionInput;
+
+    switch (option.__typename) {
+      case 'CartSelectedMultipleChoiceOption':
+        multipleChoicesOptionInput = {
+          optionEntityId: option.entityId,
+          optionValueEntityId: option.valueEntityId,
+        };
+
+        if (accum.multipleChoices) {
+          return {
+            ...accum,
+            multipleChoices: [...accum.multipleChoices, multipleChoicesOptionInput],
+          };
+        }
+
+        return { ...accum, multipleChoices: [multipleChoicesOptionInput] };
+
+      case 'CartSelectedCheckboxOption':
+        checkboxOptionInput = {
+          optionEntityId: option.entityId,
+          optionValueEntityId: option.valueEntityId,
+        };
+
+        if (accum.checkboxes) {
+          return { ...accum, checkboxes: [...accum.checkboxes, checkboxOptionInput] };
+        }
+
+        return { ...accum, checkboxes: [checkboxOptionInput] };
+
+      case 'CartSelectedNumberFieldOption':
+        numberFieldOptionInput = {
+          optionEntityId: option.entityId,
+          number: option.number,
+        };
+
+        if (accum.numberFields) {
+          return { ...accum, numberFields: [...accum.numberFields, numberFieldOptionInput] };
+        }
+
+        return { ...accum, numberFields: [numberFieldOptionInput] };
+
+      case 'CartSelectedTextFieldOption':
+        textFieldOptionInput = {
+          optionEntityId: option.entityId,
+          text: option.text,
+        };
+
+        if (accum.textFields) {
+          return {
+            ...accum,
+            textFields: [...accum.textFields, textFieldOptionInput],
+          };
+        }
+
+        return { ...accum, textFields: [textFieldOptionInput] };
+
+      case 'CartSelectedMultiLineTextFieldOption':
+        multiLineTextFieldOptionInput = {
+          optionEntityId: option.entityId,
+          text: option.text,
+        };
+
+        if (accum.multiLineTextFields) {
+          return {
+            ...accum,
+            multiLineTextFields: [...accum.multiLineTextFields, multiLineTextFieldOptionInput],
+          };
+        }
+
+        return { ...accum, multiLineTextFields: [multiLineTextFieldOptionInput] };
+
+      case 'CartSelectedDateFieldOption':
+        dateFieldOptionInput = {
+          optionEntityId: option.entityId,
+          date: new Date(String(option.date.utc)).toISOString(),
+        };
+
+        if (accum.dateFields) {
+          return {
+            ...accum,
+            dateFields: [...accum.dateFields, dateFieldOptionInput],
+          };
+        }
+
+        return { ...accum, dateFields: [dateFieldOptionInput] };
+    }
+
+    return accum;
+  }, {});
+};
+
 export const CartItemCounter = ({ itemData }: { itemData: CartItemData }) => {
-  const { quantity, lineItemEntityId, productEntityId, variantEntityId } = itemData;
+  const { quantity, lineItemEntityId, productEntityId, variantEntityId, selectedOptions } =
+    itemData;
 
   const [counterValue, setCounterValue] = useState<'' | number>(quantity);
   const handleCountUpdate = async (value: string | number) => {
@@ -33,7 +140,12 @@ export const CartItemCounter = ({ itemData }: { itemData: CartItemData }) => {
     setCounterValue(Number(value));
 
     const productData: UpdateProductQuantityData = Object.assign(
-      { lineItemEntityId, productEntityId, quantity: Number(value) },
+      {
+        lineItemEntityId,
+        productEntityId,
+        quantity: Number(value),
+        selectedOptions: parseSelectedOptions(selectedOptions),
+      },
       variantEntityId && { variantEntityId },
     );
 

--- a/apps/core/app/(default)/cart/page.tsx
+++ b/apps/core/app/(default)/cart/page.tsx
@@ -62,11 +62,13 @@ export default async function CartPage() {
     productEntityId,
     quantity,
     variantEntityId,
+    selectedOptions,
   }: (typeof cart.lineItems.physicalItems)[number]) => ({
     lineItemEntityId: entityId,
     productEntityId,
     quantity,
     variantEntityId,
+    selectedOptions,
   });
 
   return (

--- a/apps/core/client/queries/get-cart.ts
+++ b/apps/core/client/queries/get-cart.ts
@@ -37,9 +37,11 @@ export const GET_CART_QUERY = /* GraphQL */ `
               name
               ... on CartSelectedMultipleChoiceOption {
                 value
+                valueEntityId
               }
               ... on CartSelectedCheckboxOption {
                 value
+                valueEntityId
               }
               ... on CartSelectedNumberFieldOption {
                 number


### PR DESCRIPTION
## What/Why?
Currently, when a product has a required product modifier, I can't update the quantity without an error. This is because on the backend we require all modifiers to be sent back if we're updating a product, any missing modifiers will be deleted. Because we have a required modifiers it errors out, since it needs to be passed in.

With these changes we pass all product options that are returned from cart and we're able to update product succesfully.

## Testing
Locally.