### PR TITLE
Support Raw page type properly

### DIFF
--- a/apps/core/app/api/raw-page/[id]/route.ts
+++ b/apps/core/app/api/raw-page/[id]/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { getRawWebPageContent } from '~/client/queries/get-raw-web-page-content';
+
+export const GET = async (request: NextRequest, { params }: { params: { id: string } }) => {
+  const { id } = params;
+
+  if (id) {
+    const { node } = await getRawWebPageContent(id);
+
+    if (node && 'htmlBody' in node) {
+      // todo - support other content types
+      return new NextResponse(node.htmlBody, {
+        status: 200,
+        headers: { 'content-type': 'text/html' },
+      });
+    }
+
+    return new Response('Page not found.', { status: 404 });
+  }
+
+  return new Response('Missing page id.', { status: 400 });
+};
+
+export const runtime = 'edge';

--- a/apps/core/client/queries/get-raw-web-page-content.ts
+++ b/apps/core/client/queries/get-raw-web-page-content.ts
@@ -1,0 +1,25 @@
+import { cache } from 'react';
+
+import { client } from '..';
+import { graphql } from '../generated';
+
+export const GET_RAW_WEB_PAGE_CONTENT_QUERY = /* GraphQL */ `
+  query getRawWebPageContent($id: ID!) {
+    node(id: $id) {
+      ... on RawHtmlPage {
+        htmlBody
+      }
+    }
+  }
+`;
+
+export const getRawWebPageContent = cache(async (id: string) => {
+  const query = graphql(GET_RAW_WEB_PAGE_CONTENT_QUERY);
+
+  const response = await client.fetch({
+    document: query,
+    variables: { id },
+  });
+
+  return response.data;
+});

--- a/apps/core/client/queries/get-route.ts
+++ b/apps/core/client/queries/get-route.ts
@@ -23,6 +23,9 @@ export const GET_ROUTE_QUERY = /* GraphQL */ `
           ... on Brand {
             entityId
           }
+          ... on RawHtmlPage {
+            id
+          }
         }
       }
     }

--- a/apps/core/client/queries/get-web-page.ts
+++ b/apps/core/client/queries/get-web-page.ts
@@ -8,17 +8,6 @@ export const GET_WEB_PAGE_QUERY = /* GraphQL */ `
     site {
       route(path: $path) {
         node {
-          ... on RawHtmlPage {
-            path
-            htmlBody
-            plainTextSummary(characterLimit: $characterLimit)
-            seo {
-              pageTitle
-              metaKeywords
-              metaDescription
-            }
-            ...WebPage
-          }
           ... on ContactPage {
             contactFields
             path
@@ -81,7 +70,6 @@ export const getWebPage = cache(async ({ path, characterLimit = 120 }: Options) 
   switch (webpage.__typename) {
     case 'ContactPage':
     case 'NormalPage':
-    case 'RawHtmlPage':
       return webpage;
 
     default:

--- a/apps/core/middlewares/with-routes.ts
+++ b/apps/core/middlewares/with-routes.ts
@@ -49,6 +49,7 @@ const NodeSchema = z.union([
   z.object({ __typename: z.literal('Product'), entityId: z.number() }),
   z.object({ __typename: z.literal('Category'), entityId: z.number() }),
   z.object({ __typename: z.literal('Brand'), entityId: z.number() }),
+  z.object({ __typename: z.literal('RawHtmlPage'), id: z.string() }),
 ]);
 
 const RouteSchema = z.object({
@@ -188,6 +189,13 @@ export const withRoutes: MiddlewareFactory = (next) => {
 
       case 'Product': {
         const url = createRewriteUrl(`/product/${node.entityId}${postfix}`, request);
+
+        return NextResponse.rewrite(url);
+      }
+
+      case 'RawHtmlPage': {
+        // fast path for raw html pages
+        const url = createRewriteUrl(`/api/raw-page/${node.id}`, request);
 
         return NextResponse.rewrite(url);
       }


### PR DESCRIPTION
## What/Why?
Add proper support for Raw Web Pages, in which the user should be able to set 100% of the HTML content of the page, bypassing the framework or template.

Previously this was broken and trying to insert one HTML document inside of another; this fixes that.

I have opted to use the GQL global ID as the identifier on the API route, and I'd like to start moving towards GQL global IDs in general so this is intentional. I will look at moving the other objects over to this format in a later PR.

## Testing
Compare output on preview deployment vs prod

**Main (before this PR):**
This is a bootstrap HTML document weirdly embedded into the main one, polluting the styles of the page and doing weird stuff
<img width="1070" alt="image" src="https://github.com/bigcommerce/catalyst/assets/8922457/535aa1fc-e2cc-44a1-b9df-9422dac708ad">


**After this PR:**
HTML document is 100% what we get back from the API
<img width="792" alt="image" src="https://github.com/bigcommerce/catalyst/assets/8922457/ef9cf1bc-2b70-4edb-9093-1f961b9e6bc9">
<img width="954" alt="image" src="https://github.com/bigcommerce/catalyst/assets/8922457/306cde44-bc56-4cd4-8727-1b883533a3fc">


## Follow-up items
Raw Web Pages support other content types like application/json, but they aren't exposed in the GQL API. Once they are, I can set the content-type from the API response to support this properly.