### PR TITLE
Change "best selling products" to "newest products" on home page

### DIFF
--- a/apps/core/app/(default)/page.tsx
+++ b/apps/core/app/(default)/page.tsx
@@ -1,11 +1,11 @@
-import { getBestSellingProducts } from '~/client/queries/get-best-selling-products';
 import { getFeaturedProducts } from '~/client/queries/get-featured-products';
+import { getNewestProducts } from '~/client/queries/get-newest-products';
 import { Hero } from '~/components/hero';
 import { ProductCardCarousel } from '~/components/product-card-carousel';
 
 export default async function Home() {
-  const [bestSellingProducts, featuredProducts] = await Promise.all([
-    getBestSellingProducts({ imageWidth: 500, imageHeight: 500 }),
+  const [newestProducts, featuredProducts] = await Promise.all([
+    getNewestProducts({ imageWidth: 500, imageHeight: 500 }),
     getFeaturedProducts({ imageWidth: 500, imageHeight: 500 }),
   ]);
 
@@ -22,11 +22,11 @@ export default async function Home() {
           title="Featured products"
         />
         <ProductCardCarousel
-          products={bestSellingProducts}
+          products={newestProducts}
           showCart={false}
           showCompare={false}
           showReviews={false}
-          title="Popular products"
+          title="Newest products"
         />
       </div>
     </>

--- a/apps/core/client/queries/get-newest-products.ts
+++ b/apps/core/client/queries/get-newest-products.ts
@@ -6,10 +6,10 @@ import { getSessionCustomerId } from '~/auth';
 import { client } from '..';
 import { graphql } from '../generated';
 
-export const GET_BEST_SELLING_PRODUCTS_QUERY = /* GraphQL */ `
-  query getBestSellingProducts($first: Int, $imageHeight: Int!, $imageWidth: Int!) {
+export const GET_NEWEST_PRODUCTS_QUERY = /* GraphQL */ `
+  query getNewestProducts($first: Int, $imageHeight: Int!, $imageWidth: Int!) {
     site {
-      bestSellingProducts(first: $first) {
+      newestProducts(first: $first) {
         edges {
           node {
             ...ProductDetails
@@ -26,9 +26,9 @@ interface Options {
   imageHeight?: number;
 }
 
-export const getBestSellingProducts = cache(
+export const getNewestProducts = cache(
   async ({ first = 12, imageHeight = 300, imageWidth = 300 }: Options = {}) => {
-    const query = graphql(GET_BEST_SELLING_PRODUCTS_QUERY);
+    const query = graphql(GET_NEWEST_PRODUCTS_QUERY);
     const customerId = await getSessionCustomerId();
 
     const response = await client.fetch({
@@ -42,9 +42,9 @@ export const getBestSellingProducts = cache(
 
     const { site } = response.data;
 
-    return removeEdgesAndNodes(site.bestSellingProducts).map((bestSellingProduct) => ({
-      ...bestSellingProduct,
-      productOptions: removeEdgesAndNodes(bestSellingProduct.productOptions),
+    return removeEdgesAndNodes(site.newestProducts).map((product) => ({
+      ...product,
+      productOptions: removeEdgesAndNodes(product.productOptions),
     }));
   },
 );

--- a/packages/functional/tests/ui/core/components/Carousel.spec.ts
+++ b/packages/functional/tests/ui/core/components/Carousel.spec.ts
@@ -9,9 +9,12 @@ test.beforeEach(async ({ page }) => {
     .getByRole('tablist', { name: 'Slides' })
     .scrollIntoViewIfNeeded();
 
-  await page.getByRole('link', { name: '[Sample] Able Brewing System' }).scrollIntoViewIfNeeded();
+  await page
+    .getByRole('link', { name: '[Sample] Smith Journal 13' })
+    .first()
+    .scrollIntoViewIfNeeded();
 
-  await expect(page.getByRole('link', { name: '[Sample] Able Brewing System' })).toBeVisible();
+  await expect(page.getByRole('link', { name: '[Sample] Smith Journal 13' }).first()).toBeVisible();
 });
 
 test('Navigate to next set of products', async ({ page }) => {
@@ -47,8 +50,6 @@ test('Navigate to previous set of products', async ({ page }) => {
 });
 
 test('Navigation on set of products is cyclic', async ({ page }) => {
-  await expect(page.getByRole('link', { name: '[Sample] Smith Journal 13' })).toBeVisible();
-
   await page
     .getByRole('region')
     .filter({ has: page.getByRole('heading', { name: 'Featured products' }) })


### PR DESCRIPTION
## What/Why?
Today we use “best selling products” as one of our default home page panels, which works well with our sample data, because our sample data simulates these products having been sold.

However, for most new users of Catalyst, they’ll eventually delete their sample products and start to use a catalog with new products, and those products by default do not have any sales, which makes this panel blank.

Therefore, switching to "newest products" which will result in a better first-time user experience.

## Testing
Preview deployment:

<img width="1483" alt="image" src="https://github.com/bigcommerce/catalyst/assets/8922457/ecd18e69-2af2-4d03-9885-45453fbc859f">
