### PR TITLE
chore(cli): bump installed version of @bigcommerce/catalyst-client

### DIFF
--- a/packages/create-catalyst/src/utils/clone-catalyst.ts
+++ b/packages/create-catalyst/src/utils/clone-catalyst.ts
@@ -65,7 +65,7 @@ export const cloneCatalyst = async ({
   unset(packageJson, 'devDependencies.react'); // will go away
   unset(packageJson, 'devDependencies.react-dom'); // will go away
 
-  set(packageJson, 'dependencies.@bigcommerce/catalyst-client', `^0.1.0`);
+  set(packageJson, 'dependencies.@bigcommerce/catalyst-client', `^0.1.1`);
   set(packageJson, 'devDependencies.@bigcommerce/eslint-config-catalyst', `^0.1.0`);
 
   writeJsonSync(join(projectDir, 'package.json'), packageJson, { spaces: 2 });


### PR DESCRIPTION
## What/Why?
Installs latest version of `@bigcommerce/catalyst-client` when running `<pm> create catalyst-storefront@latest` in response to #606

## Testing
N/A