### PR TITLE
chore: optimize react-simple-icons

### DIFF
--- a/apps/core/next.config.js
+++ b/apps/core/next.config.js
@@ -4,7 +4,7 @@ const cspHeader = `
   base-uri 'self';
   form-action 'self';
   frame-ancestors 'none';
-`
+`;
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -15,6 +15,9 @@ const nextConfig = {
         hostname: process.env.BIGCOMMERCE_CDN_HOSTNAME ?? '*.bigcommerce.com',
       },
     ],
+  },
+  experimental: {
+    optimizePackageImports: ['@icons-pack/react-simple-icons'],
   },
   transpilePackages: ['@bigcommerce/components'],
   typescript: {
@@ -37,8 +40,8 @@ const nextConfig = {
           },
         ],
       },
-    ]
-  }
+    ];
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## What/Why?
Was running into [this issue](https://github.com/phosphor-icons/react/issues/45) with `react-simple-icons` due to them only exporting a barrel file. This causes some issues when the runtime tries to build a page and has to handle a ton of files (or large files) at once.

Before this PR we have been bundling the full export of `@icons-pack/react-simple-icons`. With a recent version of Next.js, it introduces an automagical way of optimizing the imports, cutting down bundle size. This PR cuts down that packages import size while fixing any future versions of the issue I ran into.