### PR TITLE
feat: add noop adapter for no-KV setup

### DIFF
--- a/apps/core/lib/kv/adapters/noop.ts
+++ b/apps/core/lib/kv/adapters/noop.ts
@@ -1,0 +1,31 @@
+/* eslint-disable @typescript-eslint/require-await */
+import { KvAdapter } from '../types';
+
+export class NoopKvAdapter implements KvAdapter {
+  constructor() {
+    // eslint-disable-next-line no-console
+    console.log(`
+[BigCommerce] --------------------------------
+[BigCommerce] KV WARNING: Using NoopKvAdapter.
+[BigCommerce] This KV adapter does nothing and requests will be uncached.
+[BigCommerce] --------------------------------
+`);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async get<Data>(_key: string) {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    return null as Data;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async mget<Data>(..._keys: string[]) {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    return [] as Data[];
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async set<Data>(_key: string, value: Data, _options: { ex?: number } = {}) {
+    return value;
+  }
+}

--- a/apps/core/lib/kv/index.ts
+++ b/apps/core/lib/kv/index.ts
@@ -77,9 +77,15 @@ async function createKVAdapter() {
     return new DevKvAdapter();
   }
 
-  const { VercelKvAdapter } = await import('./adapters/vercel');
+  if (process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN) {
+    const { VercelKvAdapter } = await import('./adapters/vercel');
 
-  return new VercelKvAdapter();
+    return new VercelKvAdapter();
+  }
+
+  const { NoopKvAdapter } = await import('./adapters/noop');
+
+  return new NoopKvAdapter();
 }
 
 const adapterInstance = new KV(createKVAdapter, {


### PR DESCRIPTION
## What/Why?
Adds a `NoopKvAdapter` in case you don't have KV setup in Vercel. This will be a big tank on site speed if merchants don't want to use any sort of KV.

## Testing
![Screenshot 2024-02-27 at 17 39 41](https://github.com/bigcommerce/catalyst/assets/10539418/a5b03b49-a9c9-4e49-a20a-b6a5b03ad25a)
