### PR TITLE
Fix currency formatting on PDPs to use active currency

### DIFF
--- a/apps/core/app/(default)/product/[slug]/_components/details.tsx
+++ b/apps/core/app/(default)/product/[slug]/_components/details.tsx
@@ -8,14 +8,14 @@ import { ReviewSummary } from './review-summary';
 
 type Product = Awaited<ReturnType<typeof getProduct>>;
 
-const currencyFormatter = new Intl.NumberFormat('en-US', {
-  style: 'currency',
-  currency: 'USD',
-});
-
 export const Details = ({ product }: { product: NonNullable<Product> }) => {
   const showPriceRange =
     product.prices?.priceRange.min.value !== product.prices?.priceRange.max.value;
+
+  const currencyFormatter = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: product.prices?.price.currencyCode || 'USD',
+  });
 
   return (
     <div>


### PR DESCRIPTION
## What/Why?
Fix PDP currency formatting to use active currency instead of hardcoded USD.

This relies on the currency code returned on `prices.price`, which is guaranteed to be non-null as long as `prices` is returned.

## Testing
Before:
<img width="1268" alt="image" src="https://github.com/bigcommerce/catalyst/assets/8922457/da4c3188-3f2d-4687-983e-ab785b158abc">

After:
<img width="1263" alt="image" src="https://github.com/bigcommerce/catalyst/assets/8922457/d0479d81-b561-4d6b-a514-382f53d49703">
