### PR TITLE
fix(a11y): fix carousel aria roles

### DIFF
--- a/apps/core/components/footer/footer-menus/base-footer-menu.tsx
+++ b/apps/core/components/footer/footer-menus/base-footer-menu.tsx
@@ -22,9 +22,9 @@ export const BaseFooterMenu = ({
       <h3 className="mb-4 text-lg font-bold">{title}</h3>
       <ul className="flex flex-col gap-4">
         {items.map((item) => (
-          <Link href={item.path} key={item.path}>
-            {item.name}
-          </Link>
+          <li key={item.path}>
+            <Link href={item.path}>{item.name}</Link>
+          </li>
         ))}
       </ul>
     </div>

--- a/apps/core/components/footer/social-icons.tsx
+++ b/apps/core/components/footer/social-icons.tsx
@@ -64,9 +64,11 @@ export const SocialIcons = async () => {
           }
 
           return (
-            <Link className="inline-block" href={link.url} key={link.name}>
-              <SocialIcon name={link.name} />
-            </Link>
+            <li key={link.name}>
+              <Link className="inline-block" href={link.url}>
+                <SocialIcon name={link.name} />
+              </Link>
+            </li>
           );
         })}
       </ul>

--- a/packages/components/src/components/carousel/carousel.tsx
+++ b/packages/components/src/components/carousel/carousel.tsx
@@ -93,7 +93,6 @@ const CarouselSlide = forwardRef<ElementRef<'li'>, CarouselSlideProps>(
           className,
         )}
         ref={ref}
-        role="tabpanel"
         {...props}
       >
         {children}


### PR DESCRIPTION
## What/Why?
Couple quick fixes to bring the a11y lighthouse score for `catalyst-demo.site` back up to 100

## Testing
<img width="1509" alt="Screenshot 2024-02-29 at 11 44 10 AM" src="https://github.com/bigcommerce/catalyst/assets/28374851/fc194a8f-5e2b-44af-bf5e-96e9417f34e1">
