### PR TITLE
feat(core): add support for more document nodes

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -17,7 +17,6 @@
     "dist"
   ],
   "dependencies": {
-    "@graphql-typed-document-node/core": "^3.2.0",
     "std-env": "^3.7.0"
   },
   "peerDependencies": {

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -1,0 +1,19 @@
+// Taken from gql.tada repo
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export interface DocumentDecoration<
+  Result = {
+    [key: string]: any;
+  },
+  Variables = {
+    [key: string]: any;
+  },
+> {
+  /** Type to support `@graphql-typed-document-node/core`
+   * @internal
+   */
+  __apiType?: (variables: Variables) => Result;
+  /** Type to support `TypedQueryDocumentNode` from `graphql`
+   * @internal
+   */
+  __ensureTypesOfVariablesAndResultMatching?: (variables: Variables) => Result;
+}

--- a/packages/client/src/utils/getOperationName.ts
+++ b/packages/client/src/utils/getOperationName.ts
@@ -1,13 +1,11 @@
-import { DocumentTypeDecoration } from '@graphql-typed-document-node/core';
 import { DefinitionNode, OperationDefinitionNode, parse } from 'graphql';
 
 function isOperationDefinitionNode(node: DefinitionNode): node is OperationDefinitionNode {
   return node.kind === 'OperationDefinition';
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const getOperationInfo = (document: DocumentTypeDecoration<any, any>) => {
-  const documentNode = parse(document.toString());
+export const getOperationInfo = (document: string) => {
+  const documentNode = parse(document);
 
   const operationInfo = documentNode.definitions.filter(isOperationDefinitionNode).map((def) => {
     return {

--- a/packages/client/src/utils/normalizeQuery.ts
+++ b/packages/client/src/utils/normalizeQuery.ts
@@ -1,0 +1,20 @@
+import { DocumentNode, print } from 'graphql';
+
+import { DocumentDecoration } from '../types';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function normalizeQuery(query: string | DocumentNode | DocumentDecoration<any, any>) {
+  if (typeof query === 'string') {
+    return query;
+  }
+
+  if (query instanceof String) {
+    return query.toString();
+  }
+
+  if ('kind' in query) {
+    return print(query);
+  }
+
+  throw new Error('Invalid query type');
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,9 +259,6 @@ importers:
 
   packages/client:
     dependencies:
-      '@graphql-typed-document-node/core':
-        specifier: ^3.2.0
-        version: 3.2.0(graphql@16.8.1)
       std-env:
         specifier: ^3.7.0
         version: 3.7.0


### PR DESCRIPTION
## What/Why?
~Builds on top of https://github.com/bigcommerce/catalyst/pull/615~

Currently our client only works with `TypedDocumentString` from gql codegen. This PR adds support for `TypedDocumentNode` and tada's `DocumentNode`.