### PR TITLE
feat(core): add mutations for reset password

### DIFF
--- a/.changeset/shiny-hornets-move.md
+++ b/.changeset/shiny-hornets-move.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Add mutations for reset password

--- a/apps/core/client/mutations/submit-change-password.ts
+++ b/apps/core/client/mutations/submit-change-password.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+
+import { client } from '..';
+import { graphql } from '../generated';
+
+export const ChangePasswordSchema = z.object({
+  newPassword: z.string(),
+  confirmPassword: z.string(),
+});
+
+interface SubmitChangePassword {
+  newPassword: z.infer<typeof ChangePasswordSchema>['newPassword'];
+  token: string;
+  customerEntityId: number;
+}
+
+const SUBMIT_CHANGE_PASSWORD_MUTATION = /* GraphQL */ `
+  mutation ChangePassword($input: ResetPasswordInput!) {
+    customer {
+      resetPassword(input: $input) {
+        __typename
+        errors {
+          __typename
+          ... on Error {
+            message
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const submitChangePassword = async ({
+  newPassword,
+  token,
+  customerEntityId,
+}: SubmitChangePassword) => {
+  const mutation = graphql(SUBMIT_CHANGE_PASSWORD_MUTATION);
+
+  const variables = {
+    input: {
+      token,
+      customerEntityId,
+      newPassword,
+    },
+  };
+
+  const response = await client.fetch({
+    document: mutation,
+    variables,
+  });
+
+  return response.data;
+};

--- a/apps/core/client/mutations/submit-reset-password.ts
+++ b/apps/core/client/mutations/submit-reset-password.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+
+import { client } from '..';
+import { graphql } from '../generated';
+
+export const ResetPasswordSchema = z.object({
+  email: z.string().email(),
+});
+
+type SubmitResetPassword = z.infer<typeof ResetPasswordSchema> & {
+  reCaptchaToken?: string;
+};
+
+const SUBMIT_RESET_PASSWORD_MUTATION = /* GraphQL */ `
+  mutation ResetPassword($input: RequestResetPasswordInput!, $reCaptcha: ReCaptchaV2Input) {
+    customer {
+      requestResetPassword(input: $input, reCaptchaV2: $reCaptcha) {
+        __typename
+        errors {
+          __typename
+          ... on Error {
+            message
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const submitResetPassword = async ({ email, reCaptchaToken }: SubmitResetPassword) => {
+  const mutation = graphql(SUBMIT_RESET_PASSWORD_MUTATION);
+
+  const variables = {
+    input: {
+      email,
+    },
+    ...(reCaptchaToken && { reCaptchaV2: { token: reCaptchaToken } }),
+  };
+
+  const response = await client.fetch({
+    document: mutation,
+    variables,
+  });
+
+  return response.data;
+};


### PR DESCRIPTION
## What/Why?
This PR adds 2 mutations for reset password pages (Registered  customer flow):
- `submitResetPassword` is being used for sending a link on provided email,
-  `submitChangePassword` is aimed to updating existing password with new one.

## Testing
locally