### PR TITLE
feat(component): add default 'Info' variant to Message component

### DIFF
--- a/apps/core/app/[locale]/not-found.tsx
+++ b/apps/core/app/[locale]/not-found.tsx
@@ -1,4 +1,3 @@
-import { Message } from '@bigcommerce/components/message';
 import { ShoppingCart } from 'lucide-react';
 import { NextIntlClientProvider } from 'next-intl';
 import { getLocale, getMessages, getTranslations } from 'next-intl/server';
@@ -35,10 +34,10 @@ export default async function NotFound() {
         }
       />
       <main className="mx-auto mb-10 max-w-[835px] space-y-8 px-6 sm:px-10 lg:px-0">
-        <Message className="flex-col gap-8 px-0 py-16">
+        <div className="flex flex-col gap-8 px-0 py-16">
           <h2 className="text-4xl font-black lg:text-5xl">{t('heading')}</h2>
           <p className="text-lg">{t('message')}</p>
-        </Message>
+        </div>
         <NextIntlClientProvider locale={locale} messages={{ NotFound: messages.NotFound ?? {} }}>
           <SearchForm />
         </NextIntlClientProvider>

--- a/apps/core/components/forbidden/index.tsx
+++ b/apps/core/components/forbidden/index.tsx
@@ -1,5 +1,3 @@
-import { Message } from '@bigcommerce/components/message';
-
 import { getFeaturedProducts } from '~/client/queries/get-featured-products';
 import { ProductCard } from '~/components/product-card';
 import { SearchForm } from '~/components/search-form';
@@ -24,10 +22,10 @@ const FeaturedProducts = async () => {
 export const Forbidden = () => {
   return (
     <main className="mx-auto mb-10 flex max-w-[835px] flex-col justify-center gap-10 px-6 sm:px-10 lg:px-0 2xl:px-0">
-      <Message className="flex-col gap-8 px-0 py-16">
+      <div className="flex flex-col gap-8 px-0 py-16">
         <h2 className="text-4xl font-black lg:text-5xl">There was a problem!</h2>
         <p className="text-lg">It looks like the page you requested can't be accessed.</p>
-      </Message>
+      </div>
       <SearchForm />
       <FeaturedProducts />
     </main>

--- a/apps/docs/stories/message.stories.tsx
+++ b/apps/docs/stories/message.stories.tsx
@@ -5,7 +5,10 @@ const meta: Meta<typeof Message> = {
   component: Message,
   tags: ['autodocs'],
   argTypes: {
-    variant: { control: 'select', options: ['success', 'error'] },
+    variant: { control: 'select', options: ['info', 'success', 'error'], defaultValue: 'info' },
+  },
+  args: {
+    variant: 'info',
   },
 };
 
@@ -13,7 +16,7 @@ export default meta;
 
 type Story = StoryObj<typeof Message>;
 
-export const Default: Story = {
+export const Info: Story = {
   args: {
     children: <p>Here is your message for Users</p>,
   },

--- a/apps/docs/stories/message.stories.tsx
+++ b/apps/docs/stories/message.stories.tsx
@@ -15,6 +15,12 @@ type Story = StoryObj<typeof Message>;
 
 export const Default: Story = {
   args: {
+    children: <p>Here is your message for Users</p>,
+  },
+};
+
+export const Success: Story = {
+  args: {
     children: (
       <p>
         Here is your message for Users on<strong> Successful Action</strong>

--- a/packages/components/src/components/message/message.tsx
+++ b/packages/components/src/components/message/message.tsx
@@ -4,26 +4,24 @@ import { ComponentPropsWithRef, ElementRef, forwardRef } from 'react';
 
 import { cn } from '~/lib/utils';
 
-const messageVariants = cva(
-  'flex w-full gap-x-2.5 justify-start p-3 text-base bg-secondary/[.15] [&>svg]:text-primary',
-  {
-    variants: {
-      variant: {
-        success: 'bg-success-secondary/[.15] [&>svg]:text-success',
-        error: 'bg-error-secondary/[.15] [&>svg]:text-error',
-      },
+const messageVariants = cva('flex w-full gap-x-2.5 justify-start p-3 text-base', {
+  variants: {
+    variant: {
+      info: 'bg-secondary/[.15] [&>svg]:text-primary',
+      success: 'bg-success-secondary/[.15] [&>svg]:text-success',
+      error: 'bg-error-secondary/[.15] [&>svg]:text-error',
     },
   },
-);
+});
 
 interface MessageProps extends ComponentPropsWithRef<'div'> {
-  readonly variant?: 'error' | 'success';
+  readonly variant?: 'info' | 'error' | 'success';
 }
 
 export const Message = forwardRef<ElementRef<'div'>, MessageProps>(
-  ({ className, children, variant, ...props }, ref) => (
+  ({ className, children, variant = 'info', ...props }, ref) => (
     <div className={cn(messageVariants({ variant, className }))} ref={ref} {...props}>
-      {!variant && <Info className="flex-none" />}
+      {variant === 'info' && <Info className="flex-none" />}
       {variant === 'error' && <AlertCircle className="flex-none" />}
       {variant === 'success' && <Check className="flex-none" />}
       {children}

--- a/packages/components/src/components/message/message.tsx
+++ b/packages/components/src/components/message/message.tsx
@@ -1,17 +1,20 @@
 import { cva } from 'class-variance-authority';
-import { AlertCircle, Check } from 'lucide-react';
+import { AlertCircle, Check, Info } from 'lucide-react';
 import { ComponentPropsWithRef, ElementRef, forwardRef } from 'react';
 
 import { cn } from '~/lib/utils';
 
-const messageVariants = cva('flex w-full gap-x-2.5 justify-start p-3 text-base', {
-  variants: {
-    variant: {
-      success: 'bg-success-secondary/[.15] [&>svg]:text-success',
-      error: 'bg-error-secondary/[.15] [&>svg]:text-error',
+const messageVariants = cva(
+  'flex w-full gap-x-2.5 justify-start p-3 text-base bg-secondary/[.15] [&>svg]:text-primary',
+  {
+    variants: {
+      variant: {
+        success: 'bg-success-secondary/[.15] [&>svg]:text-success',
+        error: 'bg-error-secondary/[.15] [&>svg]:text-error',
+      },
     },
   },
-});
+);
 
 interface MessageProps extends ComponentPropsWithRef<'div'> {
   readonly variant?: 'error' | 'success';
@@ -20,6 +23,7 @@ interface MessageProps extends ComponentPropsWithRef<'div'> {
 export const Message = forwardRef<ElementRef<'div'>, MessageProps>(
   ({ className, children, variant, ...props }, ref) => (
     <div className={cn(messageVariants({ variant, className }))} ref={ref} {...props}>
+      {!variant && <Info className="flex-none" />}
       {variant === 'error' && <AlertCircle className="flex-none" />}
       {variant === 'success' && <Check className="flex-none" />}
       {children}

--- a/packages/functional/tests/visual-regression/reactant/components/Message.spec.ts
+++ b/packages/functional/tests/visual-regression/reactant/components/Message.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test';
 
 import * as storyBookElements from '../StoryBookElements';
 
-test('Primary message', async ({ page }) => {
+test('Default message', async ({ page }) => {
   await page.goto(`${storyBookElements.storyUrl}/message--default`);
   await expect(
     page.frameLocator(storyBookElements.storyBookFrame).getByText('Here is your message for Users'),

--- a/packages/functional/tests/visual-regression/reactant/components/Message.spec.ts
+++ b/packages/functional/tests/visual-regression/reactant/components/Message.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test';
 
 import * as storyBookElements from '../StoryBookElements';
 
-test('Default message', async ({ page }) => {
+test('Info message', async ({ page }) => {
   await page.goto(`${storyBookElements.storyUrl}/message--info`);
   await expect(
     page.frameLocator(storyBookElements.storyBookFrame).getByText('Here is your message for Users'),

--- a/packages/functional/tests/visual-regression/reactant/components/Message.spec.ts
+++ b/packages/functional/tests/visual-regression/reactant/components/Message.spec.ts
@@ -2,8 +2,18 @@ import { expect, test } from '@playwright/test';
 
 import * as storyBookElements from '../StoryBookElements';
 
-test('Default message', async ({ page }) => {
+test('Primary message', async ({ page }) => {
   await page.goto(`${storyBookElements.storyUrl}/message--default`);
+  await expect(
+    page.frameLocator(storyBookElements.storyBookFrame).getByText('Here is your message for Users'),
+  ).toBeVisible();
+  await expect(
+    page.frameLocator(storyBookElements.storyBookFrame).locator(storyBookElements.storyBook),
+  ).toHaveScreenshot();
+});
+
+test('Success message', async ({ page }) => {
+  await page.goto(`${storyBookElements.storyUrl}/message--success`);
   await expect(
     page
       .frameLocator(storyBookElements.storyBookFrame)

--- a/packages/functional/tests/visual-regression/reactant/components/Message.spec.ts
+++ b/packages/functional/tests/visual-regression/reactant/components/Message.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from '@playwright/test';
 import * as storyBookElements from '../StoryBookElements';
 
 test('Default message', async ({ page }) => {
-  await page.goto(`${storyBookElements.storyUrl}/message--default`);
+  await page.goto(`${storyBookElements.storyUrl}/message--info`);
   await expect(
     page.frameLocator(storyBookElements.storyBookFrame).getByText('Here is your message for Users'),
   ).toBeVisible();


### PR DESCRIPTION
## What/Why?
<img width="1052" alt="Screenshot 2024-03-08 at 11 14 27 AM" src="https://github.com/bigcommerce/catalyst/assets/196129/a990df81-3ec9-46a9-b5d3-e0b9c78c68f9">

**Extra**: Additionally removed some unnecessary use cases of the Message component.

## Testing
Locally