### PR TITLE
fix(component): properly merge classes in radioGroupVariants

### DIFF
--- a/packages/components/src/components/radio-group/radio-group.tsx
+++ b/packages/components/src/components/radio-group/radio-group.tsx
@@ -45,7 +45,7 @@ const RadioItem = forwardRef<ElementRef<RadioItemType>, RadioItemProps>(
   ({ children, className, variant, ...props }, ref) => {
     return (
       <RadioGroupPrimitive.Item
-        className={radioGroupVariants({ variant, className })}
+        className={cn(radioGroupVariants({ variant, className }))}
         ref={ref}
         {...props}
       >


### PR DESCRIPTION
## What/Why?
Missed wrapping in `cn` to properly merge classes when overriden.

## Testing
Locally.