### PR TITLE
chore(core): Update README.md to point to new docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Learn more about Catalyst at [catalyst.dev](https://catalyst.dev).
 
 ## Resources
 
-- [/docs](/docs/) in this repository
+- [Catalyst Documentation](https://catalyst.dev/docs/)
 - [GraphQL Storefront API Playground](https://developer.bigcommerce.com/graphql-storefront/playground)
 - [GraphQL Storefront API Explorer](https://developer.bigcommerce.com/graphql-storefront/explorer)
 - [BigCommerce DevDocs](https://developer.bigcommerce.com/docs/build)


### PR DESCRIPTION
## What/Why?
Updates the README docs link to point to catalyst.dev/docs rather than the /docs directory in this repo.

