### PR TITLE
feat(build): add changesets github action for releases

### DIFF
--- a/.github/workflows/changesets-release.yml
+++ b/.github/workflows/changesets-release.yml
@@ -1,0 +1,40 @@
+name: Changesets Release
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  changesets-release:
+    name: Changesets Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@main
+
+      - name: Setup Node.js
+        uses: actions/setup-node@main
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Packages
+        run: pnpm --filter "./packages/**" build
+
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          publish: pnpm exec changeset publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What/Why?
Introduces the `changesets` [release action](https://github.com/changesets/action?tab=readme-ov-file#changesets-release-action):

>This action for [Changesets](https://github.com/atlassian/changesets) creates a pull request with all of the package versions updated and changelogs updated and when there are new changesets on [your configured `baseBranch`](https://github.com/changesets/changesets/blob/main/docs/config-file-options.md#basebranch-git-branch-name), the PR will be updated. When you're ready, you can merge the pull request and you can either publish the packages to npm manually or setup the action to do it for you.

In our case, I've set this action up so that the action automatically publishes to NPM for us, removing the need to publish manually. 

There are some slight modifications, but this action largely follows the template provided in the [`changesets/action` README](https://github.com/changesets/action?tab=readme-ov-file#with-publishing).

## Testing
N/A