### PR TITLE
fix(core): allow previous page navigation in pagination

### DIFF
--- a/apps/core/app/[locale]/(default)/(faceted)/fetch-faceted-search.ts
+++ b/apps/core/app/[locale]/(default)/(faceted)/fetch-faceted-search.ts
@@ -152,10 +152,11 @@ export const PublicToPrivateParams = PublicSearchParamsSchema.catchall(SearchPar
 export const fetchFacetedSearch = cache(
   // We need to make sure the reference passed into this function is the same if we want it to be memoized.
   async (params: z.input<typeof PublicSearchParamsSchema>) => {
-    const { after, limit = 9, sort, filters } = PublicToPrivateParams.parse(params);
+    const { after, before, limit = 9, sort, filters } = PublicToPrivateParams.parse(params);
 
     return getProductSearchResults({
       after,
+      before,
       limit,
       sort,
       filters,

--- a/apps/core/client/queries/get-product-search-results.ts
+++ b/apps/core/client/queries/get-product-search-results.ts
@@ -21,7 +21,9 @@ interface ProductSearch {
 const GET_PRODUCT_SEARCH_RESULTS_QUERY = /* GraphQL */ `
   query getProductSearchResults(
     $first: Int
+    $last: Int
     $after: String
+    $before: String
     $filters: SearchProductsFiltersInput!
     $sort: SearchProductsSortInput
     $imageHeight: Int!
@@ -30,7 +32,7 @@ const GET_PRODUCT_SEARCH_RESULTS_QUERY = /* GraphQL */ `
     site {
       search {
         searchProducts(filters: $filters, sort: $sort) {
-          products(first: $first, after: $after) {
+          products(first: $first, after: $after, last: $last, before: $before) {
             pageInfo {
               ...PageDetails
             }
@@ -163,6 +165,7 @@ export const getProductSearchResults = cache(
   async ({
     limit = 9,
     after,
+    before,
     sort,
     filters,
     imageHeight = 300,
@@ -173,7 +176,23 @@ export const getProductSearchResults = cache(
 
     const response = await client.fetch({
       document: query,
-      variables: { first: limit, after, filters, sort, imageHeight, imageWidth },
+      variables: before
+        ? {
+            last: limit,
+            before,
+            filters,
+            sort,
+            imageHeight,
+            imageWidth,
+          }
+        : {
+            first: limit,
+            after,
+            filters,
+            sort,
+            imageHeight,
+            imageWidth,
+          },
       customerId,
       fetchOptions: customerId ? { cache: 'no-store' } : { next: { revalidate: 300 } },
     });


### PR DESCRIPTION
## What/Why?
Pass in `before` variable from query params to navigate to previous pages in navigation. With `before` we have to use `last` to only fetch the limit desired. We can't pass in `first` and `last` in the same query.

https://github.com/bigcommerce/catalyst/assets/196129/f2abdeea-a741-47ba-abf0-a916188cbab8

## Testing
Locally.