### PR TITLE
fix(build): setup pnpm before referencing pnpm cache

### DIFF
--- a/.github/workflows/changesets-release.yml
+++ b/.github/workflows/changesets-release.yml
@@ -15,14 +15,14 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@main
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+
       - name: Setup Node.js
         uses: actions/setup-node@main
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v2
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## What/Why?
`pnpm` needs to be setup before `setup-node` can reference it.

Fixes: https://github.com/bigcommerce/catalyst/actions/runs/8256068021/job/22583927115#step:3:20

## Testing
CI