### PR TITLE
feat(core): use focus-visible instead of focus

### DIFF
--- a/.changeset/empty-icons-fold.md
+++ b/.changeset/empty-icons-fold.md
@@ -1,0 +1,7 @@
+---
+"@bigcommerce/components": patch
+"@bigcommerce/catalyst-core": patch
+"@bigcommerce/docs": patch
+---
+
+Use focus-visible instead of focus for focus-related styling

--- a/apps/core/app/[locale]/(default)/account/page.tsx
+++ b/apps/core/app/[locale]/(default)/account/page.tsx
@@ -17,7 +17,7 @@ interface AccountItem {
 const AccountItem = ({ children, title, description, href }: AccountItem) => {
   return (
     <Link
-      className="flex items-center border border-gray-200 p-6 focus:outline-none focus:ring-4 focus:ring-primary/20"
+      className="flex items-center border border-gray-200 p-6 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20"
       href={href}
     >
       {children}

--- a/apps/core/app/[locale]/(default)/blog/page.tsx
+++ b/apps/core/app/[locale]/(default)/blog/page.tsx
@@ -44,7 +44,7 @@ export default async function BlogPostPage({ params: { locale }, searchParams }:
       <nav aria-label="Pagination" className="mb-12 mt-10 flex justify-center text-primary">
         {blogPosts.posts.pageInfo.hasPreviousPage ? (
           <Link
-            className="focus:outline-none focus:ring-4 focus:ring-primary/20"
+            className="focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20"
             href={`/blog?before=${String(blogPosts.posts.pageInfo.startCursor)}`}
             scroll={false}
           >
@@ -56,7 +56,7 @@ export default async function BlogPostPage({ params: { locale }, searchParams }:
         )}
         {blogPosts.posts.pageInfo.hasNextPage ? (
           <Link
-            className="focus:outline-none focus:ring-4 focus:ring-primary/20"
+            className="focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20"
             href={`/blog?after=${String(blogPosts.posts.pageInfo.endCursor)}`}
             scroll={false}
           >

--- a/apps/core/app/[locale]/(default)/blog/tag/[tagId]/page.tsx
+++ b/apps/core/app/[locale]/(default)/blog/tag/[tagId]/page.tsx
@@ -35,7 +35,7 @@ export default async function BlogPostPage({ params: { tagId, locale }, searchPa
       <nav aria-label="Pagination" className="mb-12 mt-10 flex justify-center text-primary">
         {blogPosts.posts.pageInfo.hasPreviousPage ? (
           <Link
-            className="focus:outline-none focus:ring-4 focus:ring-primary/20"
+            className="focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20"
             href={`/blog/tag/${tagId}?before=${String(blogPosts.posts.pageInfo.startCursor)}`}
             scroll={false}
           >
@@ -47,7 +47,7 @@ export default async function BlogPostPage({ params: { tagId, locale }, searchPa
         )}
         {blogPosts.posts.pageInfo.hasNextPage ? (
           <Link
-            className="focus:outline-none focus:ring-4 focus:ring-primary/20"
+            className="focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20"
             href={`/blog/tag/${tagId}?after=${String(blogPosts.posts.pageInfo.endCursor)}`}
             scroll={false}
           >

--- a/apps/core/app/[locale]/maintenance/page.tsx
+++ b/apps/core/app/[locale]/maintenance/page.tsx
@@ -40,7 +40,7 @@ export default async function MaintenancePage() {
           <p className="flex items-center gap-2">
             <Phone aria-hidden="true" />
             <a
-              className="text-primary hover:text-secondary focus:outline-none focus:ring-4 focus:ring-primary/20"
+              className="text-primary hover:text-secondary focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20"
               href={`tel:${contact.phone}`}
             >
               {contact.phone}

--- a/apps/core/components/compare-drawer/index.tsx
+++ b/apps/core/components/compare-drawer/index.tsx
@@ -62,7 +62,7 @@ const CompareItem = ({
       </small>
       <Button
         aria-label={t('removeProductAriaLabel', { product: product.name })}
-        className="grow-1 ms-auto w-auto border-0 bg-transparent p-0 text-black hover:bg-transparent hover:text-primary focus:text-primary"
+        className="grow-1 ms-auto w-auto border-0 bg-transparent p-0 text-black hover:bg-transparent hover:text-primary focus-visible:text-primary"
         onClick={removeItem}
         type="button"
       >

--- a/apps/core/components/footer/contact-information.tsx
+++ b/apps/core/components/footer/contact-information.tsx
@@ -22,7 +22,7 @@ export const ContactInformation = async () => {
       </address>
       {contact.phone ? (
         <a
-          className="hover:text-primary focus:outline-none focus:ring-4 focus:ring-primary/20"
+          className="hover:text-primary focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20"
           href={`tel:${contact.phone}`}
         >
           <p>{contact.phone}</p>

--- a/apps/core/components/header/index.tsx
+++ b/apps/core/components/header/index.tsx
@@ -48,7 +48,7 @@ export const Header = async ({ cart }: { cart: ReactNode }) => {
                 <div className="group/account flex cursor-pointer items-center">
                   <Link
                     aria-label="Account"
-                    className="p-3 focus:outline-none focus:ring-4 focus:ring-primary/20"
+                    className="p-3 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20"
                     href="/account"
                   >
                     <User aria-hidden="true" />
@@ -57,7 +57,7 @@ export const Header = async ({ cart }: { cart: ReactNode }) => {
                   <ul className="absolute -right-12 top-full z-10 hidden cursor-default bg-white p-6 pb-8 shadow-md group-hover/account:block [&>li]:mb-2">
                     <li>
                       <Link
-                        className="whitespace-nowrap font-semibold focus:outline-none focus:ring-4 focus:ring-primary/20"
+                        className="whitespace-nowrap font-semibold focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20"
                         href="/account"
                       >
                         My account
@@ -65,7 +65,7 @@ export const Header = async ({ cart }: { cart: ReactNode }) => {
                     </li>
                     <li>
                       <Link
-                        className="whitespace-nowrap focus:outline-none focus:ring-4"
+                        className="whitespace-nowrap focus-visible:outline-none focus-visible:ring-4"
                         href="/account/orders"
                       >
                         Orders
@@ -73,7 +73,7 @@ export const Header = async ({ cart }: { cart: ReactNode }) => {
                     </li>
                     <li>
                       <Link
-                        className="whitespace-nowrap focus:outline-none focus:ring-4"
+                        className="whitespace-nowrap focus-visible:outline-none focus-visible:ring-4"
                         href="/account/messages"
                       >
                         Messages
@@ -81,7 +81,7 @@ export const Header = async ({ cart }: { cart: ReactNode }) => {
                     </li>
                     <li>
                       <Link
-                        className="whitespace-nowrap focus:outline-none focus:ring-4"
+                        className="whitespace-nowrap focus-visible:outline-none focus-visible:ring-4"
                         href="/account/addresses"
                       >
                         Addresses
@@ -89,7 +89,7 @@ export const Header = async ({ cart }: { cart: ReactNode }) => {
                     </li>
                     <li>
                       <Link
-                        className="whitespace-nowrap focus:outline-none focus:ring-4"
+                        className="whitespace-nowrap focus-visible:outline-none focus-visible:ring-4"
                         href="/account/wishlists"
                       >
                         Wish lists
@@ -97,7 +97,7 @@ export const Header = async ({ cart }: { cart: ReactNode }) => {
                     </li>
                     <li>
                       <Link
-                        className="whitespace-nowrap focus:outline-none focus:ring-4"
+                        className="whitespace-nowrap focus-visible:outline-none focus-visible:ring-4"
                         href="/account/recently-viewed"
                       >
                         Recently viewed
@@ -105,7 +105,7 @@ export const Header = async ({ cart }: { cart: ReactNode }) => {
                     </li>
                     <li>
                       <Link
-                        className="whitespace-nowrap focus:outline-none focus:ring-4"
+                        className="whitespace-nowrap focus-visible:outline-none focus-visible:ring-4"
                         href="/account/settings"
                       >
                         Account Settings

--- a/apps/core/components/link/index.tsx
+++ b/apps/core/components/link/index.tsx
@@ -46,7 +46,7 @@ export const Link = forwardRef<ElementRef<'a'>, Props>(
     return (
       <NavLink
         className={cn(
-          ' hover:text-primary focus:outline-none focus:ring-4 focus:ring-primary/20',
+          ' hover:text-primary focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20',
           className,
         )}
         href={href}

--- a/apps/core/components/product-card/index.tsx
+++ b/apps/core/components/product-card/index.tsx
@@ -121,7 +121,7 @@ export const ProductCard = ({
         <ProductCardInfoProductName>
           {product.path ? (
             <Link
-              className="focus:outline focus:outline-4 focus:outline-offset-2 focus:outline-primary/20 focus:ring-0"
+              className="focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-2 focus-visible:outline-primary/20 focus-visible:ring-0"
               href={product.path}
             >
               <span aria-hidden="true" className="absolute inset-0 bottom-20" />

--- a/apps/core/components/quick-search/index.tsx
+++ b/apps/core/components/quick-search/index.tsx
@@ -85,7 +85,7 @@ export const QuickSearch = ({ children, initialTerm = '' }: SearchProps) => {
       <SheetTrigger asChild>
         <Button
           aria-label="Open search popup"
-          className="border-0 bg-transparent p-3 text-black hover:bg-transparent hover:text-primary focus:text-primary"
+          className="border-0 bg-transparent p-3 text-black hover:bg-transparent hover:text-primary focus-visible:text-primary"
         >
           <Search />
         </Button>
@@ -119,13 +119,13 @@ export const QuickSearch = ({ children, initialTerm = '' }: SearchProps) => {
                     role="combobox"
                     value={term}
                   >
-                    <InputIcon className="start-3 peer-hover:text-primary peer-focus:text-primary">
+                    <InputIcon className="start-3 peer-hover:text-primary peer-focus-visible:text-primary">
                       <Search />
                     </InputIcon>
                     {term.length > 0 && !pending && (
                       <Button
                         aria-label="Clear search"
-                        className="absolute end-1.5 top-1/2 w-auto -translate-y-1/2 border-0 bg-transparent p-1.5 text-black hover:bg-transparent hover:text-primary focus:text-primary peer-hover:text-primary peer-focus:text-primary"
+                        className="absolute end-1.5 top-1/2 w-auto -translate-y-1/2 border-0 bg-transparent p-1.5 text-black hover:bg-transparent hover:text-primary focus-visible:text-primary peer-hover:text-primary peer-focus-visible:text-primary"
                         onClick={handleTermClear}
                         type="button"
                       >
@@ -145,7 +145,7 @@ export const QuickSearch = ({ children, initialTerm = '' }: SearchProps) => {
             <SheetClose asChild>
               <Button
                 aria-label="Close search popup"
-                className="w-auto justify-self-end border-0 bg-transparent p-2.5 text-black hover:bg-transparent hover:text-primary focus:text-primary peer-hover:text-primary peer-focus:text-primary"
+                className="w-auto justify-self-end border-0 bg-transparent p-2.5 text-black hover:bg-transparent hover:text-primary focus-visible:text-primary peer-hover:text-primary peer-focus-visible:text-primary"
               >
                 <small className="me-2 hidden text-base md:inline-flex">Close</small>
                 <X />
@@ -173,7 +173,7 @@ export const QuickSearch = ({ children, initialTerm = '' }: SearchProps) => {
                     return (
                       <li className="mb-3 last:mb-6" key={name}>
                         <a
-                          className="align-items mb-6 flex gap-x-6 focus:outline-none focus:ring-4 focus:ring-primary/20"
+                          className="align-items mb-6 flex gap-x-6 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20"
                           href={path}
                         >
                           {name}
@@ -192,7 +192,7 @@ export const QuickSearch = ({ children, initialTerm = '' }: SearchProps) => {
                     return (
                       <li key={product.entityId}>
                         <a
-                          className="align-items mb-6 flex gap-x-6 focus:outline-none focus:ring-4 focus:ring-primary/20"
+                          className="align-items mb-6 flex gap-x-6 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20"
                           href={product.path}
                         >
                           {product.defaultImage ? (
@@ -236,7 +236,7 @@ export const QuickSearch = ({ children, initialTerm = '' }: SearchProps) => {
                     return (
                       <li className="mb-3 last:mb-6" key={name}>
                         <a
-                          className="align-items mb-6 flex gap-x-6 focus:outline-none focus:ring-4 focus:ring-primary/20"
+                          className="align-items mb-6 flex gap-x-6 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20"
                           href={path}
                         >
                           {name}

--- a/apps/core/components/sharing-links/index.tsx
+++ b/apps/core/components/sharing-links/index.tsx
@@ -24,7 +24,7 @@ export const SharingLinks = ({
     <div className="mb-10 flex items-center [&>*:not(:last-child)]:me-2.5">
       <h3 className="text-xl font-bold lg:text-2xl">Share</h3>
       <a
-        className="hover:text-primary focus:outline-none focus:ring-4 focus:ring-primary/20"
+        className="hover:text-primary focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20"
         href={`https://facebook.com/sharer/sharer.php?u=${encodedUrl}`}
         rel="noopener noreferrer"
         target="_blank"
@@ -32,7 +32,7 @@ export const SharingLinks = ({
         <SiFacebook size={24} title="Facebook" />
       </a>
       <a
-        className="hover:text-primary focus:outline-none focus:ring-4 focus:ring-primary/20"
+        className="hover:text-primary focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20"
         href={`mailto:?subject=${encodedTitle}&body=${encodedUrl}`}
         rel="noopener noreferrer"
         target="_self"
@@ -42,7 +42,7 @@ export const SharingLinks = ({
         </Mail>
       </a>
       <button
-        className="hover:text-primary focus:outline-none focus:ring-4 focus:ring-primary/20"
+        className="hover:text-primary focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20"
         onClick={() => {
           window.print();
 
@@ -55,7 +55,7 @@ export const SharingLinks = ({
         </Printer>
       </button>
       <a
-        className="hover:text-primary focus:outline-none focus:ring-4 focus:ring-primary/20"
+        className="hover:text-primary focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20"
         href={`https://twitter.com/intent/tweet/?text=${encodedTitle}&url=${encodedUrl}`}
         rel="noopener noreferrer"
         target="_blank"
@@ -63,7 +63,7 @@ export const SharingLinks = ({
         <SiX size={24} title="X" />
       </a>
       <a
-        className="hover:text-primary focus:outline-none focus:ring-4 focus:ring-primary/20"
+        className="hover:text-primary focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20"
         href={`https://www.linkedin.com/shareArticle?mini=true&url=${encodedUrl}&title=${encodedTitle}&summary=${encodedTitle}&source=${encodedUrl}`}
         rel="noopener noreferrer"
         target="_blank"
@@ -71,7 +71,7 @@ export const SharingLinks = ({
         <SiLinkedin size={24} title="LinkedIn" />
       </a>
       <a
-        className="hover:text-primary focus:outline-none focus:ring-4 focus:ring-primary/20"
+        className="hover:text-primary focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20"
         href={`https://pinterest.com/pin/create/button/?url=${encodedUrl}&media=${blogPostImageUrl}&description=${encodedTitle}`}
         rel="noopener noreferrer"
         target="_blank"

--- a/apps/docs/stories/blog-post-card.stories.tsx
+++ b/apps/docs/stories/blog-post-card.stories.tsx
@@ -25,7 +25,7 @@ export const BlogPostCardWithImage: Story = {
         <div>
           <BlogPostImage>
             <a
-              className="block w-full focus:outline-none focus:ring-4 focus:ring-primary/20"
+              className="block w-full focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20"
               href="/"
             >
               <div className="flex h-full w-full items-center justify-center bg-gray-200 text-2xl font-bold lg:text-3xl">
@@ -34,7 +34,10 @@ export const BlogPostCardWithImage: Story = {
             </a>
           </BlogPostImage>
           <BlogPostTitle>
-            <a className="focus:outline-none focus:ring-4 focus:ring-primary/20" href="/">
+            <a
+              className="focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20"
+              href="/"
+            >
               Blog Post Title
             </a>
           </BlogPostTitle>
@@ -63,7 +66,10 @@ export const BlogPostCardWithoutImage: Story = {
             </BlogPostDate>
           </BlogPostBanner>
           <BlogPostTitle>
-            <a className="focus:outline-none focus:ring-4 focus:ring-primary/20" href="/">
+            <a
+              className="focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20"
+              href="/"
+            >
               Blog Post Title
             </a>
           </BlogPostTitle>

--- a/packages/components/src/components/accordion/accordion.tsx
+++ b/packages/components/src/components/accordion/accordion.tsx
@@ -22,7 +22,7 @@ const AccordionTrigger = React.forwardRef<
   <AccordionPrimitive.Header className="flex">
     <AccordionPrimitive.Trigger
       className={cn(
-        'flex flex-1 items-center justify-between py-[9.5px] text-lg font-bold outline-none transition-all hover:text-secondary focus:text-secondary [&[data-state=open]>svg]:rotate-180',
+        'flex flex-1 items-center justify-between py-[9.5px] text-lg font-bold outline-none transition-all hover:text-secondary focus-visible:text-secondary [&[data-state=open]>svg]:rotate-180',
         className,
       )}
       ref={ref}

--- a/packages/components/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/components/src/components/breadcrumbs/breadcrumbs.tsx
@@ -31,7 +31,7 @@ const BreadcrumbItem = forwardRef<ElementRef<'li'>, BreadcrumbItemProps>(
         <Comp
           aria-current={isActive ? `page` : undefined}
           className={cn(
-            'p-1 font-semibold hover:text-primary focus:outline-none focus:ring-4 focus:ring-primary/20',
+            'p-1 font-semibold hover:text-primary focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20',
             isActive && 'cursor-default font-extrabold hover:text-black',
             className,
           )}

--- a/packages/components/src/components/button/button.tsx
+++ b/packages/components/src/components/button/button.tsx
@@ -5,7 +5,7 @@ import { ComponentPropsWithRef, ElementRef, forwardRef } from 'react';
 import { cn } from '~/lib/utils';
 
 export const buttonVariants = cva(
-  'inline-flex w-full justify-center items-center border-2 py-2.5 px-[30px] text-base leading-6 font-semibold border-primary disabled:border-gray-400 focus:outline-none focus:ring-4 focus:ring-primary/20',
+  'inline-flex w-full justify-center items-center border-2 py-2.5 px-[30px] text-base leading-6 font-semibold border-primary disabled:border-gray-400 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20',
   {
     variants: {
       variant: {

--- a/packages/components/src/components/calendar/calendar.tsx
+++ b/packages/components/src/components/calendar/calendar.tsx
@@ -32,7 +32,7 @@ export const Calendar = ({
           'relative flex h-10 w-10 items-center justify-center p-0 text-center text-xs font-normal focus-within:relative focus-within:z-20 focus-within:rounded focus-within:border focus-within:border-primary/20',
         ),
         day: cn(
-          'h-8 w-8 p-0 text-base hover:bg-secondary/10 focus:outline-none aria-selected:bg-primary aria-selected:text-white aria-selected:hover:bg-primary aria-selected:hover:text-white',
+          'h-8 w-8 p-0 text-base hover:bg-secondary/10 focus-visible:outline-none aria-selected:bg-primary aria-selected:text-white aria-selected:hover:bg-primary aria-selected:hover:text-white',
         ),
         day_today: 'bg-secondary/10',
         day_disabled: 'text-gray-400 aria-selected:bg-gray-100 aria-selected:text-white',

--- a/packages/components/src/components/checkbox/checkbox.tsx
+++ b/packages/components/src/components/checkbox/checkbox.tsx
@@ -8,12 +8,12 @@ import { cn } from '~/lib/utils';
 type CheckboxType = typeof CheckboxPrimitive.Root;
 
 const checkboxVariants = cva(
-  'block h-6 w-6 border-2 border-gray-200 hover:border-secondary focus:border-primary focus:outline-none focus:ring-4 focus:ring-primary/20 focus:hover:border-secondary radix-state-checked:border-primary radix-state-checked:bg-primary radix-state-checked:hover:border-secondary radix-state-checked:hover:bg-secondary disabled:pointer-events-none disabled:bg-gray-100 radix-state-checked:disabled:border-gray-400 radix-state-checked:disabled:bg-gray-400',
+  'block h-6 w-6 border-2 border-gray-200 hover:border-secondary focus-visible:border-primary focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20 focus-visible:hover:border-secondary radix-state-checked:border-primary radix-state-checked:bg-primary radix-state-checked:hover:border-secondary radix-state-checked:hover:bg-secondary disabled:pointer-events-none disabled:bg-gray-100 radix-state-checked:disabled:border-gray-400 radix-state-checked:disabled:bg-gray-400',
   {
     variants: {
       variant: {
         error:
-          'border-error-secondary focus:border-error-secondary focus:ring-error-secondary/20 hover:border-error focus:hover:border-error disabled:border-gray-200 radix-state-checked:border-error-secondary radix-state-checked:bg-error-secondary radix-state-checked:hover:border-error radix-state-checked:hover:bg-error',
+          'border-error-secondary focus-visible:border-error-secondary focus-visible:ring-error-secondary/20 hover:border-error focus-visible:hover:border-error disabled:border-gray-200 radix-state-checked:border-error-secondary radix-state-checked:bg-error-secondary radix-state-checked:hover:border-error radix-state-checked:hover:bg-error',
       },
     },
   },

--- a/packages/components/src/components/counter/counter.tsx
+++ b/packages/components/src/components/counter/counter.tsx
@@ -5,14 +5,14 @@ import { ComponentPropsWithRef, ElementRef, forwardRef, useRef, useState } from 
 import { cn } from '~/lib/utils';
 
 const inputVariants = cva(
-  'peer/input w-full border-2 border-gray-200 px-12 py-2.5 text-center text-base placeholder:text-gray-500 hover:border-primary focus:border-primary focus:outline-none focus:ring-4 focus:ring-primary/20 disabled:bg-gray-100 disabled:hover:border-gray-200 peer-hover/down:border-primary peer-hover/up:border-primary peer-hover/down:disabled:border-gray-200 peer-hover/up:disabled:border-gray-200 [&::-webkit-inner-spin-button]:appearance-none',
+  'peer/input w-full border-2 border-gray-200 px-12 py-2.5 text-center text-base placeholder:text-gray-500 hover:border-primary focus-visible:border-primary focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20 disabled:bg-gray-100 disabled:hover:border-gray-200 peer-hover/down:border-primary peer-hover/up:border-primary peer-hover/down:disabled:border-gray-200 peer-hover/up:disabled:border-gray-200 [&::-webkit-inner-spin-button]:appearance-none',
   {
     variants: {
       variant: {
         success:
-          'border-success-secondary focus:border-success-secondary focus:ring-success-secondary/20 disabled:border-gray-200 hover:border-success peer-hover/down:border-success peer-hover/up:border-success peer-hover/down:disabled:border-gray-200 peer-hover/up:disabled:border-gray-200',
+          'border-success-secondary focus-visible:border-success-secondary focus-visible:ring-success-secondary/20 disabled:border-gray-200 hover:border-success peer-hover/down:border-success peer-hover/up:border-success peer-hover/down:disabled:border-gray-200 peer-hover/up:disabled:border-gray-200',
         error:
-          'border-error-secondary focus:border-error-secondary focus:ring-error-secondary/20 disabled:border-gray-200 hover:border-error peer-hover/down:border-error peer-hover/up:border-error peer-hover/down:disabled:border-gray-200 peer-hover/up:disabled:border-gray-200',
+          'border-error-secondary focus-visible:border-error-secondary focus-visible:ring-error-secondary/20 disabled:border-gray-200 hover:border-error peer-hover/down:border-error peer-hover/up:border-error peer-hover/down:disabled:border-gray-200 peer-hover/up:disabled:border-gray-200',
       },
     },
   },
@@ -108,7 +108,7 @@ export const Counter = forwardRef<ElementRef<'div'>, CounterProps>(
           aria-hidden="true"
           aria-label="Decrease count"
           className={cn(
-            'peer/down absolute start-0 top-0 flex h-full w-12 items-center justify-center focus:outline-none disabled:text-gray-200',
+            'peer/down absolute start-0 top-0 flex h-full w-12 items-center justify-center focus-visible:outline-none disabled:text-gray-200',
           )}
           disabled={!canDecrement()}
           onClick={() => {
@@ -126,7 +126,7 @@ export const Counter = forwardRef<ElementRef<'div'>, CounterProps>(
           aria-hidden="true"
           aria-label="Increase count"
           className={cn(
-            'peer/up absolute end-0 top-0 flex h-full w-12 items-center justify-center focus:outline-none disabled:text-gray-200',
+            'peer/up absolute end-0 top-0 flex h-full w-12 items-center justify-center focus-visible:outline-none disabled:text-gray-200',
           )}
           disabled={!canIncrement()}
           onClick={() => {

--- a/packages/components/src/components/gallery/gallery.tsx
+++ b/packages/components/src/components/gallery/gallery.tsx
@@ -41,7 +41,10 @@ const GalleryPreviousIndicator = forwardRef<ElementRef<'button'>, ComponentProps
     return (
       <button
         aria-label="Previous product image"
-        className={cn('focus:outline-none focus:ring-4 focus:ring-primary/20', className)}
+        className={cn(
+          'focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20',
+          className,
+        )}
         onClick={(e) => {
           setSelectedImageIndex(previousIndex);
 
@@ -68,7 +71,10 @@ const GalleryNextIndicator = forwardRef<ElementRef<'button'>, ComponentPropsWith
     return (
       <button
         aria-label="Next product image"
-        className={cn('focus:outline-none focus:ring-4 focus:ring-primary/20', className)}
+        className={cn(
+          'focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20',
+          className,
+        )}
         onClick={(e) => {
           setSelectedImageIndex(nextIndex);
 
@@ -198,7 +204,7 @@ const GalleryThumbnailItem = forwardRef<ElementRef<'button'>, GalleryThumbnailIt
         aria-label="Enlarge product image"
         aria-pressed={isActive}
         className={cn(
-          'inline-block h-12 w-12 flex-shrink-0 flex-grow-0 focus:outline-none focus:ring-4 focus:ring-primary/20 md:h-24 md:w-24',
+          'inline-block h-12 w-12 flex-shrink-0 flex-grow-0 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20 md:h-24 md:w-24',
           className,
         )}
         onClick={(e) => {

--- a/packages/components/src/components/input/input.tsx
+++ b/packages/components/src/components/input/input.tsx
@@ -5,14 +5,14 @@ import { ComponentPropsWithRef, createContext, ElementRef, forwardRef, useContex
 import { cn } from '~/lib/utils';
 
 const inputVariants = cva(
-  'peer focus:ring-primary/20 w-full border-2 border-gray-200 py-2.5 px-4 text-base placeholder:text-gray-500 focus:border-primary focus:outline-none focus:ring-4 hover:border-primary disabled:bg-gray-100 disabled:hover:border-gray-200',
+  'peer focus-visible:ring-primary/20 w-full border-2 border-gray-200 py-2.5 px-4 text-base placeholder:text-gray-500 focus-visible:border-primary focus-visible:outline-none focus-visible:ring-4 hover:border-primary disabled:bg-gray-100 disabled:hover:border-gray-200',
   {
     variants: {
       variant: {
         success:
-          'pe-12 border-success-secondary focus:border-success-secondary focus:ring-success-secondary/20 disabled:border-gray-200 hover:border-success',
+          'pe-12 border-success-secondary focus-visible:border-success-secondary focus-visible:ring-success-secondary/20 disabled:border-gray-200 hover:border-success',
         error:
-          'pe-12 border-error-secondary focus:border-error-secondary focus:ring-error-secondary/20 disabled:border-gray-200 hover:border-error',
+          'pe-12 border-error-secondary focus-visible:border-error-secondary focus-visible:ring-error-secondary/20 disabled:border-gray-200 hover:border-error',
       },
     },
   },

--- a/packages/components/src/components/navigation-menu/navigation-menu.tsx
+++ b/packages/components/src/components/navigation-menu/navigation-menu.tsx
@@ -98,7 +98,7 @@ const NavigationMenuTrigger = forwardRef<
 >(({ className, children, ...props }, ref) => (
   <NavigationMenuPrimitive.Trigger
     className={cn(
-      'group/button flex w-full items-center justify-between gap-1 p-3 font-semibold hover:text-primary focus:outline-none focus:ring-4 focus:ring-primary/20',
+      'group/button flex w-full items-center justify-between gap-1 p-3 font-semibold hover:text-primary focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20',
       className,
     )}
     ref={ref}
@@ -144,7 +144,7 @@ const NavigationMenuLink = forwardRef<
   return (
     <NavigationMenuPrimitive.Link
       className={cn(
-        'flex justify-between p-3 font-semibold hover:text-primary focus:outline-none focus:ring-4 focus:ring-primary/20',
+        'flex justify-between p-3 font-semibold hover:text-primary focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20',
         className,
       )}
       onClick={() => setIsExpanded(false)}
@@ -168,7 +168,7 @@ const NavigationMenuToggle = forwardRef<ElementRef<'button'>, ComponentPropsWith
         aria-expanded={isExpanded}
         aria-label="Toggle navigation"
         className={cn(
-          'group p-3 hover:text-primary focus:outline-none focus:ring-4 focus:ring-primary/20',
+          'group p-3 hover:text-primary focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20',
           className,
         )}
         onClick={(e) => {

--- a/packages/components/src/components/pick-list/pick-list.tsx
+++ b/packages/components/src/components/pick-list/pick-list.tsx
@@ -31,8 +31,8 @@ const PickListItem = forwardRef<ElementRef<RadioItemType>, ComponentPropsWithRef
         className={cn(
           'flex h-6 w-6 shrink-0 items-center justify-center rounded-full border-2 border-gray-200',
           'hover:border-secondary',
-          'focus:border-primary focus:outline-none focus:ring-4 focus:ring-primary/20',
-          'focus:hover:border-secondary',
+          'focus-visible:border-primary focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20',
+          'focus-visible:hover:border-secondary',
           'radix-state-checked:border-primary radix-state-checked:bg-primary',
           'radix-state-checked:hover:border-secondary radix-state-checked:hover:bg-secondary',
           'disabled:pointer-events-none disabled:bg-gray-100',

--- a/packages/components/src/components/radio-group/radio-group.tsx
+++ b/packages/components/src/components/radio-group/radio-group.tsx
@@ -7,12 +7,12 @@ import { cn } from '~/lib/utils';
 type RadioIndicatorType = typeof RadioGroupPrimitive.Indicator;
 
 const radioGroupVariants = cva(
-  'flex h-6 w-6 items-center justify-center rounded-full border-2 border-gray-200 hover:border-secondary focus:border-primary focus:outline-none focus:ring-4 focus:ring-primary/20 focus:hover:border-secondary radix-state-checked:border-primary radix-state-checked:bg-primary radix-state-checked:hover:border-secondary radix-state-checked:hover:bg-secondary disabled:pointer-events-none disabled:bg-gray-100 radix-state-checked:disabled:border-gray-400 radix-state-checked:disabled:bg-gray-400',
+  'flex h-6 w-6 items-center justify-center rounded-full border-2 border-gray-200 hover:border-secondary focus-visible:border-primary focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20 focus-visible:hover:border-secondary radix-state-checked:border-primary radix-state-checked:bg-primary radix-state-checked:hover:border-secondary radix-state-checked:hover:bg-secondary disabled:pointer-events-none disabled:bg-gray-100 radix-state-checked:disabled:border-gray-400 radix-state-checked:disabled:bg-gray-400',
   {
     variants: {
       variant: {
         error:
-          'border-error-secondary focus:border-error-secondary focus:ring-error-secondary/20 hover:border-error focus:hover:border-error disabled:border-gray-200 radix-state-checked:border-error-secondary radix-state-checked:bg-error-secondary radix-state-checked:hover:border-error radix-state-checked:hover:bg-error',
+          'border-error-secondary focus-visible:border-error-secondary focus-visible:ring-error-secondary/20 hover:border-error focus-visible:hover:border-error disabled:border-gray-200 radix-state-checked:border-error-secondary radix-state-checked:bg-error-secondary radix-state-checked:hover:border-error radix-state-checked:hover:bg-error',
       },
     },
   },

--- a/packages/components/src/components/rectangle-list/rectangle-list.tsx
+++ b/packages/components/src/components/rectangle-list/rectangle-list.tsx
@@ -25,7 +25,7 @@ const RectangleListItem = forwardRef<
 >(({ className, children, ...props }, ref) => (
   <RadioGroupPrimitive.Item
     className={cn(
-      'border-2 px-6 py-2.5 font-semibold text-black hover:border-primary focus:outline-none focus:ring-4 focus:ring-primary/20 disabled:border-gray-100 disabled:text-gray-400 disabled:hover:border-gray-100',
+      'border-2 px-6 py-2.5 font-semibold text-black hover:border-primary focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20 disabled:border-gray-100 disabled:text-gray-400 disabled:hover:border-gray-100',
       'data-[state=checked]:border-primary',
       className,
     )}

--- a/packages/components/src/components/select/select.tsx
+++ b/packages/components/src/components/select/select.tsx
@@ -6,14 +6,14 @@ import { ComponentPropsWithRef, ElementRef, forwardRef } from 'react';
 import { cn } from '~/lib/utils';
 
 const selectVariants = cva(
-  'focus:ring-primary/20 group flex h-12 w-full items-center justify-between border-2 border-gray-200 px-4 py-3 text-base text-black hover:border-primary focus:border-primary focus:outline-none focus:ring-4 disabled:bg-gray-100 disabled:hover:border-gray-200 data-[placeholder]:text-gray-500',
+  'focus-visible:ring-primary/20 group flex h-12 w-full items-center justify-between border-2 border-gray-200 px-4 py-3 text-base text-black hover:border-primary focus-visible:border-primary focus-visible:outline-none focus-visible:ring-4 disabled:bg-gray-100 disabled:hover:border-gray-200 data-[placeholder]:text-gray-500',
   {
     variants: {
       variant: {
         success:
-          'border-success-secondary focus:border-success-secondary focus:ring-success-secondary/20 disabled:border-gray-200 hover:border-success',
+          'border-success-secondary focus-visible:border-success-secondary focus-visible:ring-success-secondary/20 disabled:border-gray-200 hover:border-success',
         error:
-          'border-error-secondary focus:border-error-secondary focus:ring-error-secondary/20 disabled:border-gray-200 hover:border-error',
+          'border-error-secondary focus-visible:border-error-secondary focus-visible:ring-error-secondary/20 disabled:border-gray-200 hover:border-error',
       },
     },
   },
@@ -42,7 +42,7 @@ const Select = forwardRef<ElementRef<SelectTriggerType>, SelectProps>(
           <SelectPrimitive.Value placeholder={placeholder} />
           {/* TODO: For the sake of moving fast we are leaving this in, but in the future we need to figure out how enable custom icons */}
           <SelectPrimitive.Icon>
-            <ChevronDown className="inline group-focus:text-primary group-enabled:group-hover:text-primary" />
+            <ChevronDown className="inline group-focus-visible:text-primary group-enabled:group-hover:text-primary" />
           </SelectPrimitive.Icon>
         </SelectPrimitive.Trigger>
 
@@ -89,7 +89,7 @@ const SelectItem = forwardRef<ElementRef<SelectItemType>, ComponentPropsWithRef<
       <SelectPrimitive.Item
         {...props}
         className={cn(
-          'relative flex w-full cursor-pointer select-none items-center justify-between overflow-visible px-4 py-2 outline-none hover:bg-secondary/10 hover:text-primary focus:bg-secondary/10 data-[disabled]:pointer-events-none data-[state="checked"]:bg-secondary/10 data-[state="checked"]:text-primary data-[disabled]:opacity-50',
+          'relative flex w-full cursor-pointer select-none items-center justify-between overflow-visible px-4 py-2 outline-none hover:bg-secondary/10 hover:text-primary focus-visible:bg-secondary/10 data-[disabled]:pointer-events-none data-[state="checked"]:bg-secondary/10 data-[state="checked"]:text-primary data-[disabled]:opacity-50',
           className,
         )}
         ref={ref}

--- a/packages/components/src/components/sheet/sheet.tsx
+++ b/packages/components/src/components/sheet/sheet.tsx
@@ -14,7 +14,10 @@ type SheetCloseProps = ComponentPropsWithoutRef<typeof SheetPrimitive.Close>;
 const SheetClose = forwardRef<ElementRef<typeof SheetPrimitive.Close>, SheetCloseProps>(
   ({ children, className, ...props }, ref) => (
     <SheetPrimitive.Close
-      className={cn('focus:outline-none focus:ring-4 focus:ring-primary/20', className)}
+      className={cn(
+        'focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20',
+        className,
+      )}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/components/slideshow/slideshow.tsx
+++ b/packages/components/src/components/slideshow/slideshow.tsx
@@ -197,7 +197,7 @@ const SlideshowAutoplayControl = forwardRef<ElementRef<'button'>, SlideshowAutop
       <button
         aria-label={isPaused ? 'Play slideshow' : 'Pause slideshow'}
         className={cn(
-          'inline-flex h-12 w-12 items-center justify-center focus:outline-none focus:ring-4 focus:ring-primary/20',
+          'inline-flex h-12 w-12 items-center justify-center focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20',
           className,
         )}
         onClick={(e) => {
@@ -232,7 +232,7 @@ const SlideshowNextIndicator = forwardRef<ElementRef<'button'>, ComponentPropsWi
         aria-controls="slideshow-slides"
         aria-label="Next slide"
         className={cn(
-          'inline-flex h-12 w-12 items-center justify-center focus:outline-none focus:ring-4 focus:ring-primary/20',
+          'inline-flex h-12 w-12 items-center justify-center focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20',
           className,
         )}
         onClick={scrollNext}
@@ -263,7 +263,7 @@ const SlideshowPreviousIndicator = forwardRef<
       aria-controls="slideshow-slides"
       aria-label="Previous slide"
       className={cn(
-        'inline-flex h-12 w-12 items-center justify-center focus:outline-none focus:ring-4 focus:ring-primary/20',
+        'inline-flex h-12 w-12 items-center justify-center focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20',
         className,
       )}
       onClick={scrollPrev}

--- a/packages/components/src/components/swatch/swatch.tsx
+++ b/packages/components/src/components/swatch/swatch.tsx
@@ -29,7 +29,7 @@ const SwatchItem = forwardRef<ElementRef<typeof RadioGroupPrimitive.Item>, Swatc
   ({ children, className, disabled, variantColor, ...props }, ref) => (
     <RadioGroupPrimitive.Item
       className={cn(
-        'group h-12 w-12 border-2 bg-white p-1 hover:border-primary focus:outline-none focus:ring-4 focus:ring-primary/20 disabled:border-gray-100 disabled:hover:border-gray-100',
+        'group h-12 w-12 border-2 bg-white p-1 hover:border-primary focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary/20 disabled:border-gray-100 disabled:hover:border-gray-100',
         'data-[state=checked]:border-primary',
         className,
       )}

--- a/packages/components/src/components/tag/tag.tsx
+++ b/packages/components/src/components/tag/tag.tsx
@@ -39,7 +39,7 @@ const TagAction = forwardRef<ElementRef<'button'>, TagActionProps>(
     return (
       <button
         className={cn(
-          'box-content inline-flex h-8 w-8 items-center justify-center p-1 hover:bg-primary/10 focus:outline-none focus:ring-4 focus:ring-inset focus:ring-primary/20',
+          'box-content inline-flex h-8 w-8 items-center justify-center p-1 hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-inset focus-visible:ring-primary/20',
         )}
         ref={ref}
         type="button"

--- a/packages/components/src/components/text-area/text-area.tsx
+++ b/packages/components/src/components/text-area/text-area.tsx
@@ -4,14 +4,14 @@ import { ComponentPropsWithRef, ElementRef, forwardRef } from 'react';
 import { cn } from '~/lib/utils';
 
 const textAreaVariants = cva(
-  'focus:ring-primary/20 h-[64px] w-full border-2 border-gray-200 py-2.5 px-4 hover:border-primary focus:border-primary focus:outline-none focus:ring-4',
+  'focus-visible:ring-primary/20 h-[64px] w-full border-2 border-gray-200 py-2.5 px-4 hover:border-primary focus-visible:border-primary focus-visible:outline-none focus-visible:ring-4',
   {
     variants: {
       variant: {
         success:
-          'pe-12 border-success-secondary focus:border-success-secondary focus:ring-success-secondary/20 disabled:border-gray-200 hover:border-success',
+          'pe-12 border-success-secondary focus-visible:border-success-secondary focus-visible:ring-success-secondary/20 disabled:border-gray-200 hover:border-success',
         error:
-          'ring-error-secondary/20 focus:ring-error-secondary/20 !border-error-secondary pe-12 hover:border-error-secondary focus:border-error-secondary  disabled:border-gray-200',
+          'ring-error-secondary/20 focus-visible:ring-error-secondary/20 !border-error-secondary pe-12 hover:border-error-secondary focus-visible:border-error-secondary  disabled:border-gray-200',
       },
     },
   },


### PR DESCRIPTION
## What/Why?
Use `focus-visible` instead of `focus`, so that we retain our focus styles for accessibility purposes, but do not style elements when focused via actions like click or touch events.

## Testing
Ensured no focus styling is visible when using click or touch events, but remains when navigating via keyboard.