### PR TITLE
fix(core): Add translation provider to No Search Results

### DIFF
--- a/.changeset/breezy-spies-sleep.md
+++ b/.changeset/breezy-spies-sleep.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Add intl provider to No Search Results page

--- a/apps/core/app/[locale]/(default)/(faceted)/search/page.tsx
+++ b/apps/core/app/[locale]/(default)/(faceted)/search/page.tsx
@@ -31,7 +31,9 @@ export default async function Search({ params: { locale }, searchParams }: Props
     return (
       <>
         <h1 className="mb-3 text-4xl font-black lg:text-5xl">{t('heading')}</h1>
-        <SearchForm />
+        <NextIntlClientProvider locale={locale} messages={{ NotFound: messages.NotFound ?? {} }}>
+          <SearchForm />
+        </NextIntlClientProvider>
       </>
     );
   }
@@ -45,9 +47,9 @@ export default async function Search({ params: { locale }, searchParams }: Props
     return (
       <div>
         <h1 className="mb-3 text-4xl font-black lg:text-5xl">{t('heading')}</h1>
-
-        <SearchForm initialTerm={searchTerm} />
-
+        <NextIntlClientProvider locale={locale} messages={{ NotFound: messages.NotFound ?? {} }}>
+          <SearchForm initialTerm={searchTerm} />
+        </NextIntlClientProvider>
         <p className="pv-6">
           <em>{t('noResults')}</em>
         </p>


### PR DESCRIPTION
## What/Why?
The No Search Results form was missing a translation provider. This fixes that.

## Testing
Verified that the "No Search Results" form now shows translated strings rather than e.g. `NotFound.searchProducts`