### PR TITLE
fix(deps): bump zod-validation-error to fix import error

### DIFF
--- a/.changeset/silent-horses-beam.md
+++ b/.changeset/silent-horses-beam.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": patch
+---
+
+Bump `zod-validation-error` in `@bigcommerce/create-catalyst` to `^3.0.3`. This fixes a recently discovered bug that was caused by `zod-validation-error@3.0.2`.

--- a/packages/create-catalyst/package.json
+++ b/packages/create-catalyst/package.json
@@ -30,7 +30,7 @@
     "ora": "^8.0.1",
     "semver": "^7.6.0",
     "zod": "^3.22.4",
-    "zod-validation-error": "^3.0.0"
+    "zod-validation-error": "^3.0.3"
   },
   "devDependencies": {
     "@bigcommerce/eslint-config": "^2.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -448,8 +448,8 @@ importers:
         specifier: ^3.22.4
         version: 3.22.4
       zod-validation-error:
-        specifier: ^3.0.0
-        version: 3.0.2(zod@3.22.4)
+        specifier: ^3.0.3
+        version: 3.0.3(zod@3.22.4)
     devDependencies:
       '@bigcommerce/eslint-config':
         specifier: ^2.7.0
@@ -15652,8 +15652,8 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  /zod-validation-error@3.0.2(zod@3.22.4):
-    resolution: {integrity: sha512-21xGaDmnU7lJZ4J63n5GXWqi+rTzGy3gDHbuZ1jP6xrK/DEQGyOqs/xW7eH96tIfCOYm+ecCuT0bfajBRKEVUw==}
+  /zod-validation-error@3.0.3(zod@3.22.4):
+    resolution: {integrity: sha512-cETTrcMq3Ze58vhdR0zD37uJm/694I6mAxcf/ei5bl89cC++fBNxrC2z8lkFze/8hVMPwrbtrwXHR2LB50fpHw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.18.0


### PR DESCRIPTION
## What/Why?
Bump `zod-validation-error` for the `create-catalyst` CLI to `^3.0.3`. This fixes a recently discovered bug that was caused by `zod-validation-error@3.0.2`.

Bug report:
<img width="920" alt="Screenshot 2024-03-12 at 5 26 26 PM" src="https://github.com/bigcommerce/catalyst/assets/28374851/642aaa40-d42f-4015-933b-b14c6e1d73a8">

## Testing
`pnpm create catalyst-storefront@latest`