### PR TITLE
fix(docs): Re-add internal md links

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,7 +17,7 @@
 
 To create a new Catalyst project, use the Catalyst CLI, which will create a new directory that contains your Catalyst project. You don't need to clone the [Catalyst GitHub repository](https://github.com/bigcommerce/catalyst) monorepo to use the CLI.
 
-When the CLI connects your project to the BigCommerce store you intend to use, you will be asked to sign in to the subject store using the browser and enter a code provided by the CLI. This step registers your Catalyst project and generates the access tokens the storefront needs to use our APIs. For a more in-depth explanation of authentication mechanisms in Catalyst, see [Environment variables](/environment-variables) in the Catalyst docs and [Authenticating Customers](https://developer.bigcommerce.com/docs/start/authentication/customer-login) on the BigCommerce Dev Center.
+When the CLI connects your project to the BigCommerce store you intend to use, you will be asked to sign in to the subject store using the browser and enter a code provided by the CLI. This step registers your Catalyst project and generates the access tokens the storefront needs to use our APIs. For a more in-depth explanation of authentication mechanisms in Catalyst, see [Environment variables](/docs/environment-variables.md) in the Catalyst docs and [Authenticating Customers](https://developer.bigcommerce.com/docs/start/authentication/customer-login) on the BigCommerce Dev Center.
 
 We recommend creating a new channel for the Catalyst storefront. For more about channel configuration, see BigCommerce's [channels docs](https://developer.bigcommerce.com/docs/storefront/headless/channels).
 
@@ -84,4 +84,4 @@ If you want to link your Catalyst project to a different BigCommerce store, repe
 npx create-catalyst-storefront@latest init
 ```
 
-If you prefer more control over Catalyst's configuration, you can manually set Catalyst's [environment variables](/environment-variables). For more information, see [Advanced config](/monorepo).
+If you prefer more control over Catalyst's configuration, you can manually set Catalyst's [environment variables](/docs/environment-variables.md). For more information, see [Advanced config](/docs/monorepo.md).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -3,7 +3,7 @@
 
 > [!NOTE]
 > **Before you start**
-> This guide assumes you have created a Catalyst storefront using [the CLI](/cli) or the [Advanced configuration guide](/monorepo). Your project directory should contain only a Next.js application rather than the monorepo in the [Catalyst GitHub repository](https://github.com/bigcommerce/catalyst). If you want to develop using the monorepo, you must modify these instructions. For more information, see [Monorepo](/monorepo).
+> This guide assumes you have created a Catalyst storefront using [the CLI](/docs/getting_started.md) or the [Advanced configuration guide](/docs/monorepo.md). Your project directory should contain only a Next.js application rather than the monorepo in the [Catalyst GitHub repository](https://github.com/bigcommerce/catalyst). If you want to develop using the monorepo, you must modify these instructions. For more information, see [Monorepo](/docs/monorepo.md).
 
 ## Deploy to Vercel from vercel.com
 
@@ -17,7 +17,7 @@ On the **Let's build something new** page, point Vercel to a GitHub, GitLab, or 
 
 ![Vercel project page](https://storage.googleapis.com/bigcommerce-production-dev-center/images/catalyst/deployment-vercel-project-page.jpg)
 
-Add the required [environment variables](/environment-variables). In addition to the required variables, add a value for `TURBO_REMOTE_CACHE_SIGNATURE_KEY` for optimal build performance on Vercel. After you add the environment variables, click **Deploy**. 
+Add the required [environment variables](/docs/environment-variables.md). In addition to the required variables, add a value for `TURBO_REMOTE_CACHE_SIGNATURE_KEY` for optimal build performance on Vercel. After you add the environment variables, click **Deploy**.
 
 ![Vercel environment variables](https://storage.googleapis.com/bigcommerce-production-dev-center/images/catalyst/deployment-vercel-environment-variables.jpg)
 
@@ -27,7 +27,7 @@ To learn more about deploying to Vercel, consult the [Vercel deployments overvie
 
 To deploy using the [Vercel CLI](https://vercel.com/docs/cli), install it by running `npm i -g vercel` or `pnpm i -g vercel`.
 
-Next, add the required [environment variables](/environment-variables) to your `.env.local` file. For optimal build performance on Vercel, add a value for `TURBO_REMOTE_CACHE_SIGNATURE_KEY` in addition to the required variables.
+Next, add the required [environment variables](/docs/environment-variables.md) to your `.env.local` file. For optimal build performance on Vercel, add a value for `TURBO_REMOTE_CACHE_SIGNATURE_KEY` in addition to the required variables.
 
 Next, open a terminal session and `cd` into the local directory that contains your Catalyst storefront's code. Install or update the project dependencies with `npm i` or `pnpm i`, then run `npm run dev` or `pnpm run dev` and make sure the storefront functions correctly.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,9 +55,9 @@ Out-of-the-box, Catalyst has the following capabilities you can use to further b
 
 We expect you will prioritize some of these features over others as you make Catalyst your own. We recommend exploring the following configurations as you build:
 
-* **A caching backend**. For example, using Vercel KV may improve the performance of our [with-routes middleware](/catalyst-middleware).
+* **A caching backend**. For example, using Vercel KV may improve the performance of our [with-routes middleware](/docs/catalyst-middleware.md).
 * **Using microservices**. Externally hosted databases and third-party APIs can expand the feature set and data persistence available to Catalyst storefronts.
-* **Evaluating middleware**. Assess the costs and benefits of the [default Catalyst middleware](/catalyst-middleware). You may tailor the middleware for your use case or remove it altogether.
+* **Evaluating middleware**. Assess the costs and benefits of the [default Catalyst middleware](/docs/catalyst-middleware.md). You may tailor the middleware for your use case or remove it altogether.
 * **Additional catalog optimization**. You can tune Catalyst's performance based on your store's catalog size, complexity, and update frequency. For example, a catalog with a small number of products and infrequent updates may be able to take advantage of static generation, whereas a large catalog with frequent changes may lean into an aggressive caching strategy that relies on webhooks.
 
 ## Future releases


### PR DESCRIPTION
## What/Why?
Our [catalyst.dev/docs](https://catalyst.dev/docs) site now has support for rendering internal links in the `.md` files correctly. Previously it was converting them to e.g. `/docs/docs/cli` rather than `/docs/cli`. This behavior has been fixed, so we can once again use internal links to other markdown files.

## Testing
Tested against a preview build of the catalyst.dev/docs site pointing to this branch.