### PR TITLE
fix(docs): Fix additional broken link

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -3,7 +3,7 @@
 
 > [!NOTE]
 > **Before you start**
-> This guide assumes you have created a Catalyst storefront using [the CLI](/docs/getting_started.md) or the [Advanced configuration guide](/docs/monorepo.md). Your project directory should contain only a Next.js application rather than the monorepo in the [Catalyst GitHub repository](https://github.com/bigcommerce/catalyst). If you want to develop using the monorepo, you must modify these instructions. For more information, see [Monorepo](/docs/monorepo.md).
+> This guide assumes you have created a Catalyst storefront using [the CLI](/docs/cli.md) or the [Advanced configuration guide](/docs/environment-variables.md). Your project directory should contain only a Next.js application rather than the monorepo in the [Catalyst GitHub repository](https://github.com/bigcommerce/catalyst). If you want to develop using the monorepo, you must modify these instructions. For more information, see [Monorepo](/docs/monorepo.md).
 
 ## Deploy to Vercel from vercel.com
 


### PR DESCRIPTION
## What/Why?
Missed one broken link in my prior PR that did not get changed when `cli.md` was renamed from `getting_started.md`. Also fixed a link that was going to the wrong destination.

## Testing
Documentation change.