### PR TITLE
fix(core): use amount and discounts fields for cart summary

### DIFF
--- a/.changeset/perfect-spies-cheat.md
+++ b/.changeset/perfect-spies-cheat.md
@@ -2,4 +2,4 @@
 "@bigcommerce/catalyst-core": patch
 ---
 
-Use total discount value for cart
+Use amount and discount values for cart summary in Cart page

--- a/.changeset/perfect-spies-cheat.md
+++ b/.changeset/perfect-spies-cheat.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Use total discount value for cart

--- a/apps/core/app/[locale]/(default)/cart/_components/checkout-summary.tsx
+++ b/apps/core/app/[locale]/(default)/cart/_components/checkout-summary.tsx
@@ -127,7 +127,7 @@ export const CheckoutSummary = ({
       <div className="flex justify-between border-t border-t-gray-200 py-4">
         <span className="text-base font-semibold">{t('discounts')}</span>
         <span className="text-base">
-          {currencyFormatter.format(checkoutSummary.totalDiscountedAmount.value)}
+          {currencyFormatter.format(checkoutSummary.discountedAmount.value)}
         </span>
       </div>
 

--- a/apps/core/app/[locale]/(default)/cart/_components/checkout-summary.tsx
+++ b/apps/core/app/[locale]/(default)/cart/_components/checkout-summary.tsx
@@ -127,7 +127,7 @@ export const CheckoutSummary = ({
       <div className="flex justify-between border-t border-t-gray-200 py-4">
         <span className="text-base font-semibold">{t('discounts')}</span>
         <span className="text-base">
-          {currencyFormatter.format(checkoutSummary.discountedAmount.value)}
+          -{currencyFormatter.format(checkoutSummary.discountedAmount.value)}
         </span>
       </div>
 

--- a/apps/core/app/[locale]/(default)/cart/_components/checkout-summary.tsx
+++ b/apps/core/app/[locale]/(default)/cart/_components/checkout-summary.tsx
@@ -135,7 +135,7 @@ export const CheckoutSummary = ({
         <span className="text-h5">{t('grandTotal')}</span>
         <span className="text-h5">
           {currencyFormatter.format(
-            checkoutSummary.totalExtendedSalePrice.value +
+            checkoutSummary.amount.value +
               checkoutSummary.shippingCostTotal.value +
               checkoutSummary.handlingCostTotal.value,
           )}

--- a/apps/core/app/[locale]/(default)/cart/page.tsx
+++ b/apps/core/app/[locale]/(default)/cart/page.tsx
@@ -184,7 +184,6 @@ export default async function CartPage({ params: { locale } }: Props) {
           <NextIntlClientProvider locale={locale} messages={{ Cart: messages.Cart ?? {} }}>
             <CheckoutSummary
               cart={cart}
-              key={cart.totalExtendedListPrice.value}
               shippingCosts={shippingCosts}
               shippingCountries={shippingCountries}
             />

--- a/apps/core/app/[locale]/(default)/cart/page.tsx
+++ b/apps/core/app/[locale]/(default)/cart/page.tsx
@@ -184,6 +184,7 @@ export default async function CartPage({ params: { locale } }: Props) {
           <NextIntlClientProvider locale={locale} messages={{ Cart: messages.Cart ?? {} }}>
             <CheckoutSummary
               cart={cart}
+              key={cart.totalExtendedListPrice.value}
               shippingCosts={shippingCosts}
               shippingCountries={shippingCountries}
             />

--- a/apps/core/client/queries/get-cart.ts
+++ b/apps/core/client/queries/get-cart.ts
@@ -28,9 +28,6 @@ export const GET_CART_QUERY = /* GraphQL */ `
             extendedSalePrice {
               ...MoneyFields
             }
-            discountedAmount {
-              ...MoneyFields
-            }
             selectedOptions {
               __typename
               entityId
@@ -59,6 +56,9 @@ export const GET_CART_QUERY = /* GraphQL */ `
               }
             }
           }
+        }
+        discountedAmount {
+          ...MoneyFields
         }
       }
     }
@@ -91,10 +91,6 @@ export const getCart = cache(async (cartId?: string) => {
     return acc + item.extendedListPrice.value;
   }, 0);
 
-  const totalDiscountedAmount = cart.lineItems.physicalItems.reduce((acc, item) => {
-    return acc + item.discountedAmount.value;
-  }, 0);
-
   const totalExtendedSalePrice = cart.lineItems.physicalItems.reduce((acc, item) => {
     return acc + item.extendedSalePrice.value;
   }, 0);
@@ -104,10 +100,6 @@ export const getCart = cache(async (cartId?: string) => {
     totalExtendedListPrice: {
       currencyCode: cart.currencyCode,
       value: totalExtendedListPrice,
-    },
-    totalDiscountedAmount: {
-      currencyCode: cart.currencyCode,
-      value: totalDiscountedAmount,
     },
     totalExtendedSalePrice: {
       currencyCode: cart.currencyCode,

--- a/apps/core/client/queries/get-cart.ts
+++ b/apps/core/client/queries/get-cart.ts
@@ -57,6 +57,9 @@ export const GET_CART_QUERY = /* GraphQL */ `
             }
           }
         }
+        amount {
+          ...MoneyFields
+        }
         discountedAmount {
           ...MoneyFields
         }
@@ -91,19 +94,11 @@ export const getCart = cache(async (cartId?: string) => {
     return acc + item.extendedListPrice.value;
   }, 0);
 
-  const totalExtendedSalePrice = cart.lineItems.physicalItems.reduce((acc, item) => {
-    return acc + item.extendedSalePrice.value;
-  }, 0);
-
   return {
     ...cart,
     totalExtendedListPrice: {
       currencyCode: cart.currencyCode,
       value: totalExtendedListPrice,
-    },
-    totalExtendedSalePrice: {
-      currencyCode: cart.currencyCode,
-      value: totalExtendedSalePrice,
     },
   };
 });


### PR DESCRIPTION
## What/Why?
Discount was not showing in cart for a marketing promotion. Noticed we were using the `discountedAmount` for each specific line item instead of the global discounted amount value. 

![Screenshot 2024-03-14 at 2 59 56 PM](https://github.com/bigcommerce/catalyst/assets/196129/92bdbf35-3879-4fab-8a51-5c44350e1497)

![Screenshot 2024-03-14 at 6 55 10 PM](https://github.com/bigcommerce/catalyst/assets/196129/5c7e7d31-ca7a-498e-abf7-a2eb73aa8350)

## Testing
Locally