### PR TITLE
refactor(core): use gql.tada on mutations

### DIFF
--- a/.changeset/swift-cougars-wait.md
+++ b/.changeset/swift-cougars-wait.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+use gql.tada on all mutations

--- a/apps/core/client/mutations/add-cart-line-item.ts
+++ b/apps/core/client/mutations/add-cart-line-item.ts
@@ -1,10 +1,10 @@
 import { getSessionCustomerId } from '~/auth';
 
 import { client } from '..';
-import { graphql } from '../generated';
 import { AddCartLineItemsDataInput } from '../generated/graphql';
+import { graphql } from '../graphql';
 
-export const ADD_TO_CART_LINE_ITEM_MUTATION = /* GraphQL */ `
+const ADD_TO_CART_LINE_ITEM_MUTATION = graphql(`
   mutation AddCartLineItem($input: AddCartLineItemsInput!) {
     cart {
       addCartLineItems(input: $input) {
@@ -14,14 +14,13 @@ export const ADD_TO_CART_LINE_ITEM_MUTATION = /* GraphQL */ `
       }
     }
   }
-`;
+`);
 
 export const addCartLineItem = async (cartEntityId: string, data: AddCartLineItemsDataInput) => {
-  const mutation = graphql(ADD_TO_CART_LINE_ITEM_MUTATION);
   const customerId = await getSessionCustomerId();
 
   const response = await client.fetch({
-    document: mutation,
+    document: ADD_TO_CART_LINE_ITEM_MUTATION,
     variables: { input: { cartEntityId, data } },
     customerId,
     fetchOptions: { cache: 'no-store' },

--- a/apps/core/client/mutations/add-checkout-shipping-info.ts
+++ b/apps/core/client/mutations/add-checkout-shipping-info.ts
@@ -1,8 +1,8 @@
 import { client } from '..';
-import { graphql } from '../generated';
 import { CheckoutAddressInput } from '../generated/graphql';
+import { graphql } from '../graphql';
 
-export const ADD_CHECKOUT_SHIPPING_INFO_MUTATION = /* GraphQL */ `
+const ADD_CHECKOUT_SHIPPING_INFO_MUTATION = graphql(`
   mutation AddCheckoutShippingInfo($input: AddCheckoutShippingConsignmentsInput!) {
     checkout {
       addCheckoutShippingConsignments(input: $input) {
@@ -41,7 +41,7 @@ export const ADD_CHECKOUT_SHIPPING_INFO_MUTATION = /* GraphQL */ `
       }
     }
   }
-`;
+`);
 
 interface AddCheckoutShippingInfoProps {
   cartId: string;
@@ -62,10 +62,8 @@ export const addCheckoutShippingInfo = async ({
   cartItems,
   shouldSaveAddress = false,
 }: AddCheckoutShippingInfoProps) => {
-  const mutation = graphql(ADD_CHECKOUT_SHIPPING_INFO_MUTATION);
-
   const response = await client.fetch({
-    document: mutation,
+    document: ADD_CHECKOUT_SHIPPING_INFO_MUTATION,
     variables: {
       input: {
         checkoutEntityId: cartId,

--- a/apps/core/client/mutations/assign-cart-to-customer.ts
+++ b/apps/core/client/mutations/assign-cart-to-customer.ts
@@ -1,8 +1,8 @@
 import { client } from '..';
-import { graphql } from '../generated';
 import { AssignCartToCustomerInput } from '../generated/graphql';
+import { graphql } from '../graphql';
 
-export const ASSIGN_CART_TO_CUSTOMER_MUTATION = /* GraphQL */ `
+const ASSIGN_CART_TO_CUSTOMER_MUTATION = graphql(`
   mutation AssignCartToCustomer($assignCartToCustomerInput: AssignCartToCustomerInput!) {
     cart {
       assignCartToCustomer(input: $assignCartToCustomerInput) {
@@ -12,16 +12,14 @@ export const ASSIGN_CART_TO_CUSTOMER_MUTATION = /* GraphQL */ `
       }
     }
   }
-`;
+`);
 
 export const assignCartToCustomer = async (
   customerId: string,
   cartEntityId: AssignCartToCustomerInput['cartEntityId'],
 ) => {
-  const mutation = graphql(ASSIGN_CART_TO_CUSTOMER_MUTATION);
-
   const response = await client.fetch({
-    document: mutation,
+    document: ASSIGN_CART_TO_CUSTOMER_MUTATION,
     variables: {
       assignCartToCustomerInput: {
         cartEntityId,

--- a/apps/core/client/mutations/create-cart.ts
+++ b/apps/core/client/mutations/create-cart.ts
@@ -1,10 +1,10 @@
 import { getSessionCustomerId } from '~/auth';
 
 import { client } from '..';
-import { graphql } from '../generated';
 import { CreateCartInput } from '../generated/graphql';
+import { graphql } from '../graphql';
 
-export const CREATE_CART_MUTATION = /* GraphQL */ `
+const CREATE_CART_MUTATION = graphql(`
   mutation CreateCart($createCartInput: CreateCartInput!) {
     cart {
       createCart(input: $createCartInput) {
@@ -14,14 +14,13 @@ export const CREATE_CART_MUTATION = /* GraphQL */ `
       }
     }
   }
-`;
+`);
 
 export const createCart = async (cartItems: CreateCartInput['lineItems']) => {
-  const mutation = graphql(CREATE_CART_MUTATION);
   const customerId = await getSessionCustomerId();
 
   const response = await client.fetch({
-    document: mutation,
+    document: CREATE_CART_MUTATION,
     variables: {
       createCartInput: {
         lineItems: cartItems,

--- a/apps/core/client/mutations/delete-cart-line-item.ts
+++ b/apps/core/client/mutations/delete-cart-line-item.ts
@@ -1,9 +1,9 @@
 import { getSessionCustomerId } from '~/auth';
 
 import { client } from '..';
-import { graphql } from '../generated';
+import { graphql } from '../graphql';
 
-export const DELETE_CART_LINE_ITEM = /* GraphQL */ `
+const DELETE_CART_LINE_ITEM = graphql(`
   mutation DeleteCartLineItem($input: DeleteCartLineItemInput!) {
     cart {
       deleteCartLineItem(input: $input) {
@@ -13,14 +13,13 @@ export const DELETE_CART_LINE_ITEM = /* GraphQL */ `
       }
     }
   }
-`;
+`);
 
 export const deleteCartLineItem = async (cartEntityId: string, lineItemEntityId: string) => {
-  const mutation = graphql(DELETE_CART_LINE_ITEM);
   const customerId = await getSessionCustomerId();
 
   const response = await client.fetch({
-    document: mutation,
+    document: DELETE_CART_LINE_ITEM,
     variables: {
       input: {
         cartEntityId,

--- a/apps/core/client/mutations/login.ts
+++ b/apps/core/client/mutations/login.ts
@@ -1,7 +1,7 @@
 import { client } from '..';
-import { graphql } from '../generated';
+import { graphql } from '../graphql';
 
-export const LOGIN_MUTATION = /* GraphQL */ `
+const LOGIN_MUTATION = graphql(`
   mutation Login($email: String!, $password: String!) {
     login(email: $email, password: $password) {
       customer {
@@ -9,13 +9,11 @@ export const LOGIN_MUTATION = /* GraphQL */ `
       }
     }
   }
-`;
+`);
 
 export const login = async (email: string, password: string) => {
-  const mutation = graphql(LOGIN_MUTATION);
-
   const response = await client.fetch({
-    document: mutation,
+    document: LOGIN_MUTATION,
     variables: { email, password },
   });
 

--- a/apps/core/client/mutations/select-checkout-shipping-option.ts
+++ b/apps/core/client/mutations/select-checkout-shipping-option.ts
@@ -1,7 +1,7 @@
 import { client } from '..';
-import { graphql } from '../generated';
+import { graphql } from '../graphql';
 
-export const SELECT_CHECKOUT_SHIPPING_OPTION_MUTATION = /* GraphQL */ `
+const SELECT_CHECKOUT_SHIPPING_OPTION_MUTATION = graphql(`
   mutation SelectCheckoutShippingOption($input: SelectCheckoutShippingOptionInput!) {
     checkout {
       selectCheckoutShippingOption(input: $input) {
@@ -31,7 +31,7 @@ export const SELECT_CHECKOUT_SHIPPING_OPTION_MUTATION = /* GraphQL */ `
       }
     }
   }
-`;
+`);
 
 export const selectCheckoutShippingOption = async ({
   checkoutEntityId,
@@ -42,10 +42,8 @@ export const selectCheckoutShippingOption = async ({
   consignmentEntityId: string;
   shippingOptionEntityId: string;
 }) => {
-  const mutation = graphql(SELECT_CHECKOUT_SHIPPING_OPTION_MUTATION);
-
   const response = await client.fetch({
-    document: mutation,
+    document: SELECT_CHECKOUT_SHIPPING_OPTION_MUTATION,
     variables: {
       input: {
         checkoutEntityId,

--- a/apps/core/client/mutations/submit-change-password.ts
+++ b/apps/core/client/mutations/submit-change-password.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 import { client } from '..';
-import { graphql } from '../generated';
+import { graphql } from '../graphql';
 
 export const ChangePasswordSchema = z.object({
   newPassword: z.string(),
@@ -14,7 +14,7 @@ interface SubmitChangePassword {
   customerEntityId: number;
 }
 
-const SUBMIT_CHANGE_PASSWORD_MUTATION = /* GraphQL */ `
+const SUBMIT_CHANGE_PASSWORD_MUTATION = graphql(`
   mutation ChangePassword($input: ResetPasswordInput!) {
     customer {
       resetPassword(input: $input) {
@@ -28,15 +28,13 @@ const SUBMIT_CHANGE_PASSWORD_MUTATION = /* GraphQL */ `
       }
     }
   }
-`;
+`);
 
 export const submitChangePassword = async ({
   newPassword,
   token,
   customerEntityId,
 }: SubmitChangePassword) => {
-  const mutation = graphql(SUBMIT_CHANGE_PASSWORD_MUTATION);
-
   const variables = {
     input: {
       token,
@@ -46,7 +44,7 @@ export const submitChangePassword = async ({
   };
 
   const response = await client.fetch({
-    document: mutation,
+    document: SUBMIT_CHANGE_PASSWORD_MUTATION,
     variables,
   });
 

--- a/apps/core/client/mutations/submit-contact-form.ts
+++ b/apps/core/client/mutations/submit-contact-form.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 import { client } from '..';
-import { graphql } from '../generated';
+import { graphql } from '../graphql';
 
 export const ContactUsSchema = z.object({
   companyName: z.string().optional(),
@@ -19,7 +19,7 @@ interface SubmitContactForm {
   reCaptchaToken?: string;
 }
 
-const SUBMIT_CONTACT_FORM_MUTATION = /* GraphQL */ `
+const SUBMIT_CONTACT_FORM_MUTATION = graphql(`
   mutation submitContactUs($input: SubmitContactUsInput!, $reCaptchaV2: ReCaptchaV2Input) {
     submitContactUs(input: $input, reCaptchaV2: $reCaptchaV2) {
       __typename
@@ -31,15 +31,13 @@ const SUBMIT_CONTACT_FORM_MUTATION = /* GraphQL */ `
       }
     }
   }
-`;
+`);
 
 export const submitContactForm = async ({
   formFields,
   pageEntityId,
   reCaptchaToken,
 }: SubmitContactForm) => {
-  const mutation = graphql(SUBMIT_CONTACT_FORM_MUTATION);
-
   const variables = {
     input: {
       pageEntityId,
@@ -49,7 +47,7 @@ export const submitContactForm = async ({
   };
 
   const response = await client.fetch({
-    document: mutation,
+    document: SUBMIT_CONTACT_FORM_MUTATION,
     variables,
   });
 

--- a/apps/core/client/mutations/submit-reset-password.ts
+++ b/apps/core/client/mutations/submit-reset-password.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 import { client } from '..';
-import { graphql } from '../generated';
+import { graphql } from '../graphql';
 
 export const ResetPasswordSchema = z.object({
   email: z.string().email(),
@@ -11,7 +11,7 @@ type SubmitResetPassword = z.infer<typeof ResetPasswordSchema> & {
   reCaptchaToken?: string;
 };
 
-const SUBMIT_RESET_PASSWORD_MUTATION = /* GraphQL */ `
+const SUBMIT_RESET_PASSWORD_MUTATION = graphql(`
   mutation ResetPassword($input: RequestResetPasswordInput!, $reCaptcha: ReCaptchaV2Input) {
     customer {
       requestResetPassword(input: $input, reCaptchaV2: $reCaptcha) {
@@ -25,11 +25,9 @@ const SUBMIT_RESET_PASSWORD_MUTATION = /* GraphQL */ `
       }
     }
   }
-`;
+`);
 
 export const submitResetPassword = async ({ email, reCaptchaToken }: SubmitResetPassword) => {
-  const mutation = graphql(SUBMIT_RESET_PASSWORD_MUTATION);
-
   const variables = {
     input: {
       email,
@@ -38,7 +36,7 @@ export const submitResetPassword = async ({ email, reCaptchaToken }: SubmitReset
   };
 
   const response = await client.fetch({
-    document: mutation,
+    document: SUBMIT_RESET_PASSWORD_MUTATION,
     variables,
   });
 

--- a/apps/core/client/mutations/unassign-cart-from-customer.ts
+++ b/apps/core/client/mutations/unassign-cart-from-customer.ts
@@ -1,10 +1,10 @@
 import { getSessionCustomerId } from '~/auth';
 
 import { client } from '..';
-import { graphql } from '../generated';
 import { UnassignCartFromCustomerInput } from '../generated/graphql';
+import { graphql } from '../graphql';
 
-export const UNASSIGN_CART_FROM_CUSTOMER_MUTATION = /* GraphQL */ `
+const UNASSIGN_CART_FROM_CUSTOMER_MUTATION = graphql(`
   mutation UnassignCartFromCustomer(
     $unassignCartFromCustomerInput: UnassignCartFromCustomerInput!
   ) {
@@ -16,16 +16,15 @@ export const UNASSIGN_CART_FROM_CUSTOMER_MUTATION = /* GraphQL */ `
       }
     }
   }
-`;
+`);
 
 export const unassignCartFromCustomer = async (
   cartEntityId: UnassignCartFromCustomerInput['cartEntityId'],
 ) => {
-  const mutation = graphql(UNASSIGN_CART_FROM_CUSTOMER_MUTATION);
   const customerId = await getSessionCustomerId();
 
   const response = await client.fetch({
-    document: mutation,
+    document: UNASSIGN_CART_FROM_CUSTOMER_MUTATION,
     variables: {
       unassignCartFromCustomerInput: {
         cartEntityId,

--- a/apps/core/client/mutations/update-cart-line-item.ts
+++ b/apps/core/client/mutations/update-cart-line-item.ts
@@ -1,10 +1,10 @@
 import { getSessionCustomerId } from '~/auth';
 
 import { client } from '..';
-import { graphql } from '../generated';
 import { UpdateCartLineItemDataInput } from '../generated/graphql';
+import { graphql } from '../graphql';
 
-export const UPDATE_CART_LINE_ITEM_MUTATION = /* GraphQL */ `
+const UPDATE_CART_LINE_ITEM_MUTATION = graphql(`
   mutation UpdateCartLineItem($input: UpdateCartLineItemInput!) {
     cart {
       updateCartLineItem(input: $input) {
@@ -14,18 +14,17 @@ export const UPDATE_CART_LINE_ITEM_MUTATION = /* GraphQL */ `
       }
     }
   }
-`;
+`);
 
 export const updateCartLineItem = async (
   cartEntityId: string,
   lineItemEntityId: string,
   data: UpdateCartLineItemDataInput,
 ) => {
-  const mutation = graphql(UPDATE_CART_LINE_ITEM_MUTATION);
   const customerId = await getSessionCustomerId();
 
   const response = await client.fetch({
-    document: mutation,
+    document: UPDATE_CART_LINE_ITEM_MUTATION,
     variables: {
       input: {
         cartEntityId,

--- a/apps/core/client/mutations/update-checkout-shipping-info.ts
+++ b/apps/core/client/mutations/update-checkout-shipping-info.ts
@@ -1,8 +1,8 @@
 import { client } from '..';
-import { graphql } from '../generated';
 import { CheckoutAddressInput } from '../generated/graphql';
+import { graphql } from '../graphql';
 
-export const UPDATE_CHECKOUT_SHIPPING_INFO_MUTATION = /* GraphQL */ `
+const UPDATE_CHECKOUT_SHIPPING_INFO_MUTATION = graphql(`
   mutation UpdateCheckoutShippingInfo($input: UpdateCheckoutShippingConsignmentInput!) {
     checkout {
       updateCheckoutShippingConsignment(input: $input) {
@@ -41,7 +41,7 @@ export const UPDATE_CHECKOUT_SHIPPING_INFO_MUTATION = /* GraphQL */ `
       }
     }
   }
-`;
+`);
 
 interface UpdateCheckoutShippingInfoProps {
   cartId: string;
@@ -64,10 +64,8 @@ export const updateCheckoutShippingInfo = async ({
   cartItems,
   shouldSaveAddress = false,
 }: UpdateCheckoutShippingInfoProps) => {
-  const mutation = graphql(UPDATE_CHECKOUT_SHIPPING_INFO_MUTATION);
-
   const response = await client.fetch({
-    document: mutation,
+    document: UPDATE_CHECKOUT_SHIPPING_INFO_MUTATION,
     variables: {
       input: {
         checkoutEntityId: cartId,


### PR DESCRIPTION
## What/Why?
Refactor all mutations to use `gql.tada`