### PR TITLE
refactor(core): use gql.tada on store status query

### DIFF
--- a/apps/core/client/queries/get-store-status.ts
+++ b/apps/core/client/queries/get-store-status.ts
@@ -1,7 +1,7 @@
 import { client } from '..';
-import { graphql } from '../generated';
+import { graphql } from '../graphql';
 
-export const GET_STORE_STATUS_QUERY = /* GraphQL */ `
+const GET_STORE_STATUS_QUERY = graphql(`
   query getStoreStatus {
     site {
       settings {
@@ -9,12 +9,11 @@ export const GET_STORE_STATUS_QUERY = /* GraphQL */ `
       }
     }
   }
-`;
+`);
 
 export const getStoreStatus = async () => {
-  const query = graphql(GET_STORE_STATUS_QUERY);
   const { data } = await client.fetch({
-    document: query,
+    document: GET_STORE_STATUS_QUERY,
     fetchOptions: { next: { revalidate: 300 } },
   });
 

--- a/apps/core/middlewares/with-routes.ts
+++ b/apps/core/middlewares/with-routes.ts
@@ -4,7 +4,7 @@ import createMiddleware from 'next-intl/middleware';
 import { z } from 'zod';
 
 import { getSessionCustomerId } from '~/auth';
-import { StorefrontStatusType } from '~/client/generated/graphql';
+import { graphql } from '~/client/graphql';
 import { getRawWebPageContent } from '~/client/queries/get-raw-web-page-content';
 import { getRoute } from '~/client/queries/get-route';
 import { getStoreStatus } from '~/client/queries/get-store-status';
@@ -16,6 +16,7 @@ import { kv } from '../lib/kv';
 import { type MiddlewareFactory } from './compose-middlewares';
 
 type Route = Awaited<ReturnType<typeof getRoute>>;
+type StorefrontStatusType = ReturnType<typeof graphql.scalar<'StorefrontStatusType'>>;
 
 interface RouteCache {
   route: Route;
@@ -28,7 +29,12 @@ interface StorefrontStatusCache {
 }
 
 const StorefrontStatusCacheSchema = z.object({
-  status: z.nativeEnum(StorefrontStatusType),
+  status: z.union([
+    z.literal('HIBERNATION'),
+    z.literal('LAUNCHED'),
+    z.literal('MAINTENANCE'),
+    z.literal('PRE_LAUNCH'),
+  ]),
   expiryTime: z.number(),
 });
 


### PR DESCRIPTION
## What/Why?
Refactor `getStoreStatus` to use gql.tada

Note: `gql.tada` doesn't generate `enums` like codegen, added a few manual types.