### PR TITLE
fix(core): on hover bg for buttons in shipping estimator

### DIFF
--- a/.changeset/tall-crabs-leave.md
+++ b/.changeset/tall-crabs-leave.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Fix on hover style for buttons in Shipping Estimator

--- a/apps/core/app/[locale]/(default)/cart/_components/shipping-estimator.tsx
+++ b/apps/core/app/[locale]/(default)/cart/_components/shipping-estimator.tsx
@@ -42,7 +42,7 @@ export const ShippingEstimator = ({
         <p className="inline-flex gap-2">
           <span className="text-base">{shippingCosts.selectedShippingOption}</span>
           <Button
-            className="w-fit p-0 text-base text-primary"
+            className="w-fit p-0 text-base text-primary hover:bg-transparent"
             onClick={() => setIsOpened((open) => !open)}
             variant="subtle"
           >
@@ -68,7 +68,7 @@ export const ShippingEstimator = ({
         <div className="inline-flex items-center justify-between">
           <span className="text-base font-semibold">{t('shippingCost')}</span>
           <Button
-            className="w-fit p-0 text-base text-primary"
+            className="w-fit p-0 text-base text-primary hover:bg-transparent"
             onClick={() => setIsOpened((open) => !open)}
             variant="subtle"
           >


### PR DESCRIPTION
## What/Why?
Button styles were being applied but this button is very subtle and needs no bg on hover (Cancel button in image).

![Screenshot 2024-03-18 at 12 23 30 PM](https://github.com/bigcommerce/catalyst/assets/196129/279690f4-ee23-4d9d-b295-7efdc7b4e8aa)

## Testing
Locally