### PR TITLE
fix(core): use correct font styles for Grand Total

### DIFF
--- a/.changeset/polite-items-burn.md
+++ b/.changeset/polite-items-burn.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Use correct font weight and size for Grand Total in Cart Summary

--- a/apps/core/app/[locale]/(default)/cart/_components/checkout-summary.tsx
+++ b/apps/core/app/[locale]/(default)/cart/_components/checkout-summary.tsx
@@ -131,9 +131,9 @@ export const CheckoutSummary = ({
         </span>
       </div>
 
-      <div className="flex justify-between border-t border-t-gray-200 py-4">
-        <span className="text-h5">{t('grandTotal')}</span>
-        <span className="text-h5">
+      <div className="flex justify-between border-t border-t-gray-200 py-4 text-xl font-bold lg:text-2xl">
+        {t('grandTotal')}
+        <span>
           {currencyFormatter.format(
             checkoutSummary.amount.value +
               checkoutSummary.shippingCostTotal.value +


### PR DESCRIPTION
## What/Why?
Seems like we lost the classes in the Internationalization PR. Adding them back.

![Screenshot 2024-03-18 at 12 55 31 PM](https://github.com/bigcommerce/catalyst/assets/196129/e9c2e2eb-fa37-4354-b927-5b046bf122d0)

## Testing
Locally.