### PR TITLE
fix(cli): use prefix flag to set cwd for schema generation

### DIFF
--- a/.changeset/gentle-countries-bake.md
+++ b/.changeset/gentle-countries-bake.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": patch
+---
+
+use `--prefix` npm flag to set `cwd` for GraphQL schema generation insead of `exec`'s `cwd` option

--- a/packages/create-catalyst/src/commands/create.ts
+++ b/packages/create-catalyst/src/commands/create.ts
@@ -198,7 +198,7 @@ export const create = async (options: CreateCommandOptions) => {
 
   await installDependencies(projectDir, packageManager);
 
-  await spinner(exec(`${packageManager} run generate`, { cwd: projectDir }), {
+  await spinner(exec(`${packageManager} run --prefix ${projectDir} generate`), {
     text: 'Creating GraphQL schema...',
     successText: 'Created GraphQL schema',
     failText: (err) => chalk.red(`Failed to create GraphQL schema: ${err.message}`),


### PR DESCRIPTION
## What/Why?
`exec` option for `cwd` isn't working properly, and results in the following error when running the CLI:
![GyNFvsqP](https://github.com/bigcommerce/catalyst/assets/28374851/35b8e673-302e-40db-a764-132ed3caafaa)

Using `--prefix` flag fixes this issue

## Testing
Verdaccio, locally:
![Screenshot 2024-03-18 at 2 06 14 PM](https://github.com/bigcommerce/catalyst/assets/28374851/93f93ad7-e089-4726-88c3-b3c6c1518c71)
