### PR TITLE
feat(core): hide handling cost if no cost associated

### DIFF
--- a/.changeset/wet-students-fry.md
+++ b/.changeset/wet-students-fry.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Hide handling cost in shipping estimate if there is no cost associated.

--- a/apps/core/app/[locale]/(default)/cart/_components/shipping-estimator.tsx
+++ b/apps/core/app/[locale]/(default)/cart/_components/shipping-estimator.tsx
@@ -55,12 +55,14 @@ export const ShippingEstimator = ({
           key={shippingCosts.selectedShippingOption}
         />
       </div>
-      <div className="inline-flex justify-between border-t border-t-gray-200 pt-4">
-        <span className="text-base font-semibold">{t('handlingCost')}</span>
-        <span className="text-base">
-          {currencyFormatter.format(shippingCosts.handlingCostTotal)}
-        </span>
-      </div>
+      {Boolean(shippingCosts.handlingCostTotal) && (
+        <div className="inline-flex justify-between border-t border-t-gray-200 pt-4">
+          <span className="text-base font-semibold">{t('handlingCost')}</span>
+          <span className="text-base">
+            {currencyFormatter.format(shippingCosts.handlingCostTotal)}
+          </span>
+        </div>
+      )}
     </div>
   ) : (
     <div className="flex flex-col justify-between gap-4 border-t border-t-gray-200 py-4">


### PR DESCRIPTION
## What/Why?
No need to display if the cost is $0.

Handling cost shown below:
![image](https://github.com/bigcommerce/catalyst/assets/196129/b59060ec-83e9-4177-aea3-96cd46c60361)

## Testing
Locally.