### PR TITLE
refactor(core): use gql.tada on get cart query

### DIFF
--- a/apps/core/client/fragments/money-fields.ts
+++ b/apps/core/client/fragments/money-fields.ts
@@ -1,6 +1,0 @@
-export const MONEY_FIELDS_FRAGMENT = /* GraphQL */ `
-  fragment MoneyFields on Money {
-    currencyCode
-    value
-  }
-`;


### PR DESCRIPTION
[Hide whitespace for this one
](https://github.com/bigcommerce/catalyst/pull/673/files?w=1)
## What/Why?
`getCart` now uses `gql.tada`.

`MoneyFields` fragment was only used in `getCart`.