### PR TITLE
refactor(core): use gql.tada on get web pages queries

### DIFF
--- a/apps/core/client/fragments/web-page.ts
+++ b/apps/core/client/fragments/web-page.ts
@@ -1,9 +1,0 @@
-export const WEB_PAGE_FRAGMENT = /* GraphQL */ `
-  fragment WebPage on WebPage {
-    __typename
-    entityId
-    parentEntityId
-    name
-    isVisibleInNavigation
-  }
-`;

--- a/apps/core/client/queries/get-web-page.ts
+++ b/apps/core/client/queries/get-web-page.ts
@@ -1,65 +1,52 @@
 import { cache } from 'react';
 
 import { client } from '..';
-import { graphql } from '../generated';
+import { graphql } from '../graphql';
 import { revalidate } from '../revalidate-target';
 
-export const GET_WEB_PAGE_QUERY = /* GraphQL */ `
-  query getWebPage($path: String!, $characterLimit: Int = 120) {
-    site {
-      route(path: $path) {
-        node {
-          ... on ContactPage {
-            contactFields
-            path
-            htmlBody
-            plainTextSummary(characterLimit: $characterLimit)
-            renderedRegions {
-              regions {
-                name
-                html
-              }
-            }
-            seo {
-              pageTitle
-              metaKeywords
-              metaDescription
-            }
+const WEB_PAGE_FRAGMENT = graphql(`
+  fragment WebPage on WebPage {
+    __typename
+    entityId
+    name
+    seo {
+      pageTitle
+      metaKeywords
+      metaDescription
+    }
+  }
+`);
+
+const GET_WEB_PAGE_QUERY = graphql(
+  `
+    query getWebPage($path: String!) {
+      site {
+        route(path: $path) {
+          node {
             ...WebPage
-          }
-          ... on NormalPage {
-            htmlBody
-            plainTextSummary(characterLimit: $characterLimit)
-            renderedRegions {
-              regions {
-                name
-                html
-              }
+            ... on ContactPage {
+              contactFields
+              htmlBody
             }
-            seo {
-              pageTitle
-              metaKeywords
-              metaDescription
+            ... on NormalPage {
+              htmlBody
             }
-            ...WebPage
           }
         }
       }
     }
-  }
-`;
+  `,
+  [WEB_PAGE_FRAGMENT],
+);
 
 export interface Options {
   path: string;
-  characterLimit?: number;
 }
 
-export const getWebPage = cache(async ({ path, characterLimit = 120 }: Options) => {
-  const query = graphql(GET_WEB_PAGE_QUERY);
-
+export const getWebPage = cache(async ({ path }: Options) => {
   const response = await client.fetch({
-    document: query,
-    variables: { path, characterLimit },
+    document: GET_WEB_PAGE_QUERY,
+    variables: { path },
     fetchOptions: { next: { revalidate } },
   });
 

--- a/apps/core/client/queries/get-web-pages.ts
+++ b/apps/core/client/queries/get-web-pages.ts
@@ -2,20 +2,21 @@ import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
 import { cache } from 'react';
 
 import { client } from '..';
-import { graphql } from '../generated';
+import { graphql } from '../graphql';
 import { revalidate } from '../revalidate-target';
 import { ExistingResultType } from '../util';
 
 export type AvailableWebPages = ExistingResultType<typeof getWebPages>;
 
-export const GET_WEB_PAGES_QUERY = /* GraphQL */ `
+const GET_WEB_PAGES_QUERY = graphql(`
   query getWebPages {
     site {
       content {
         pages(filters: { isVisibleInNavigation: true }) {
           edges {
             node {
-              ...WebPage
+              __typename
+              name
               ... on RawHtmlPage {
                 path
               }
@@ -37,13 +38,11 @@ export const GET_WEB_PAGES_QUERY = /* GraphQL */ `
       }
     }
   }
-`;
+`);
 
 export const getWebPages = cache(async () => {
-  const query = graphql(GET_WEB_PAGES_QUERY);
-
   const response = await client.fetch({
-    document: query,
+    document: GET_WEB_PAGES_QUERY,
     fetchOptions: { next: { revalidate } },
   });
 


### PR DESCRIPTION
## What/Why?
Refactor `getWebPage` and `getWebPages` queries to use `gql.tada`.

Removed the shared fragment and some unused properties.