### PR TITLE
refactor(core): use gql.tada on get product

### DIFF
--- a/apps/core/client/fragments/prices.ts
+++ b/apps/core/client/fragments/prices.ts
@@ -1,0 +1,34 @@
+import { graphql } from '../graphql';
+
+export const PRICES_FRAGMENT = graphql(`
+  fragment Prices on Product {
+    prices {
+      basePrice {
+        currencyCode
+        value
+      }
+      price {
+        currencyCode
+        value
+      }
+      retailPrice {
+        currencyCode
+        value
+      }
+      salePrice {
+        currencyCode
+        value
+      }
+      priceRange {
+        min {
+          value
+          currencyCode
+        }
+        max {
+          value
+          currencyCode
+        }
+      }
+    }
+  }
+`);


### PR DESCRIPTION
## What/Why?
Move `getProduct` query to use `gql.tada`.