### PR TITLE
fix(build): add exclude property to fix ts conflict errors

### DIFF
--- a/packages/create-catalyst/tsconfig.json
+++ b/packages/create-catalyst/tsconfig.json
@@ -10,5 +10,6 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
-  }
+  },
+  "exclude": ["node_modules", "dist", "jest.config.cjs", "prettier.config.cjs"]
 }


### PR DESCRIPTION
## What/Why?
Fixes the following error in `packages/create-catalyst`:

![Screenshot 2024-03-19 at 1 58 19 PM](https://github.com/bigcommerce/catalyst/assets/28374851/529a8c24-c8e9-48f0-b151-a7521b23a847)


## Testing
N/A