### PR TITLE
fix(cli): adjust order of package.json properties

### DIFF
--- a/.changeset/big-stingrays-collect.md
+++ b/.changeset/big-stingrays-collect.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": patch
+---
+
+Adjust order of `package.json` properties created by the CLI

--- a/packages/create-catalyst/src/utils/clone-catalyst.ts
+++ b/packages/create-catalyst/src/utils/clone-catalyst.ts
@@ -45,6 +45,10 @@ export const cloneCatalyst = async ({
 
   const packageJson = z
     .object({
+      name: z.string(),
+      description: z.string(),
+      version: z.string(),
+      scripts: z.object({}).passthrough().optional(),
       private: z.boolean().optional(),
       exports: z.object({}).passthrough().optional(),
       sideEffects: z.boolean().optional(),


### PR DESCRIPTION
## What/Why?
Explicitly define `name`, `description`, `version`, and `scripts` in `zod` schema because defined properties are always placed above properties parsed by the `zod.passthrough` method.

## Testing
Note how `name`, `description`, `version`, and `scripts` are all placed above other defined properties - when the CLI deletes properties such as `private`, `exports`, etc., they will still be at the top:
![Screenshot 2024-03-20 at 10 52 50 AM](https://github.com/bigcommerce/catalyst/assets/28374851/60c7c582-01ba-4c1f-99e9-59f79215bf15)
