### PR TITLE
fix(cli): install latest versions of catalyst dependencies

### DIFF
--- a/.changeset/little-flowers-invite.md
+++ b/.changeset/little-flowers-invite.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": patch
+---
+
+Install latest versions of all Catalyst workspace dependencies during project creation

--- a/packages/create-catalyst/src/utils/clone-catalyst.ts
+++ b/packages/create-catalyst/src/utils/clone-catalyst.ts
@@ -49,23 +49,12 @@ export const cloneCatalyst = async ({
       description: z.string(),
       version: z.string(),
       scripts: z.object({}).passthrough().optional(),
+      dependencies: z.object({}).passthrough(),
+      devDependencies: z.object({}).passthrough(),
       private: z.boolean().optional(),
       exports: z.object({}).passthrough().optional(),
       sideEffects: z.boolean().optional(),
       peerDependencies: z.object({}).passthrough().optional(),
-      dependencies: z
-        .object({
-          '@bigcommerce/components': z.string().optional(),
-          '@bigcommerce/catalyst-client': z.string().optional(),
-        })
-        .passthrough(),
-      devDependencies: z
-        .object({
-          react: z.string().optional(),
-          'react-dom': z.string().optional(),
-          '@bigcommerce/eslint-config-catalyst': z.string().optional(),
-        })
-        .passthrough(),
     })
     .passthrough()
     .parse(
@@ -82,11 +71,10 @@ export const cloneCatalyst = async ({
   delete packageJson.sideEffects;
   delete packageJson.peerDependencies; // will go away
   delete packageJson.dependencies['@bigcommerce/components']; // will go away
+  delete packageJson.dependencies['@bigcommerce/catalyst-client'];
   delete packageJson.devDependencies.react; // will go away
   delete packageJson.devDependencies['react-dom']; // will go away
-
-  packageJson.dependencies['@bigcommerce/catalyst-client'] = `^0.1.1`;
-  packageJson.devDependencies['@bigcommerce/eslint-config-catalyst'] = `^0.1.0`;
+  delete packageJson.devDependencies['@bigcommerce/eslint-config-catalyst'];
 
   writeJsonSync(join(projectDir, 'package.json'), packageJson, { spaces: 2 });
 

--- a/packages/create-catalyst/src/utils/install-dependencies.ts
+++ b/packages/create-catalyst/src/utils/install-dependencies.ts
@@ -1,11 +1,25 @@
 import chalk from 'chalk';
-import { installDependencies as installDeps } from 'nypm';
+import { addDependency, addDevDependency, installDependencies as installDeps } from 'nypm';
 
 import { type PackageManager } from './pm';
 import { spinner } from './spinner';
 
+const installAllDeps = async (projectDir: string, packageManager: PackageManager) => {
+  await installDeps({ cwd: projectDir, silent: true, packageManager });
+  await addDependency('@bigcommerce/catalyst-client', {
+    cwd: projectDir,
+    silent: true,
+    packageManager,
+  });
+  await addDevDependency('@bigcommerce/eslint-config-catalyst', {
+    cwd: projectDir,
+    silent: true,
+    packageManager,
+  });
+};
+
 export const installDependencies = async (projectDir: string, packageManager: PackageManager) =>
-  spinner(installDeps({ cwd: projectDir, silent: true, packageManager }), {
+  spinner(installAllDeps(projectDir, packageManager), {
     text: `Installing dependencies. This could take a minute...`,
     successText: `Dependencies installed successfully`,
     failText: (err) => chalk.red(`Failed to install dependencies: ${err.message}`),


### PR DESCRIPTION
## What/Why?
Rather than writing a hardcoded version specifier to `package.json` during project creation, we will instead delete the `package.json` entries for workspace dependencies such as `@bigcommerce/catalyst-client` and simply install them manually during the "Installing dependencies" phase of project creation.

## Testing

https://github.com/bigcommerce/catalyst/assets/28374851/bce4c76c-9c04-46c7-a4bb-ccbc0dd11a9a

