### PR TITLE
refactor(core): use gql.tada on remaining queries

### DIFF
--- a/apps/core/client/fragments/page-details.ts
+++ b/apps/core/client/fragments/page-details.ts
@@ -1,8 +1,10 @@
-export const PAGE_DETAILS_FRAGMENT = /* GraphQL */ `
+import { graphql } from '../graphql';
+
+export const PAGE_DETAILS_FRAGMENT = graphql(`
   fragment PageDetails on PageInfo {
     hasNextPage
     hasPreviousPage
     startCursor
     endCursor
   }
-`;
+`);

--- a/apps/core/client/fragments/product-details.ts
+++ b/apps/core/client/fragments/product-details.ts
@@ -1,44 +1,51 @@
-export const PRODUCT_DETAILS_FRAGMENT = /* GraphQL */ `
-  fragment ProductDetails on Product {
-    entityId
-    name
-    description
-    path
-    ...Prices
-    brand {
+import { graphql } from '../graphql';
+
+import { PRICES_FRAGMENT } from './prices';
+
+export const PRODUCT_DETAILS_FRAGMENT = graphql(
+  `
+    fragment ProductDetails on Product {
+      entityId
       name
+      description
       path
-    }
-    defaultImage {
-      url(width: $imageWidth, height: $imageHeight)
-      altText
-    }
-    availabilityV2 {
-      status
-    }
-    inventory {
-      aggregated {
-        availableToSell
+      ...Prices
+      brand {
+        name
+        path
       }
-    }
-    reviewSummary {
-      averageRating
-      numberOfReviews
-    }
-    categories {
-      edges {
-        node {
-          name
-          path
+      defaultImage {
+        url(width: $imageWidth, height: $imageHeight)
+        altText
+      }
+      availabilityV2 {
+        status
+      }
+      inventory {
+        aggregated {
+          availableToSell
+        }
+      }
+      reviewSummary {
+        averageRating
+        numberOfReviews
+      }
+      categories {
+        edges {
+          node {
+            name
+            path
+          }
+        }
+      }
+      productOptions(first: 3) {
+        edges {
+          node {
+            entityId
+          }
         }
       }
     }
-    productOptions(first: 3) {
-      edges {
-        node {
-          entityId
-        }
-      }
-    }
-  }
-`;
+  `,
+  [PRICES_FRAGMENT],
+);

--- a/apps/core/client/queries/get-featured-products.ts
+++ b/apps/core/client/queries/get-featured-products.ts
@@ -4,22 +4,26 @@ import { cache } from 'react';
 import { getSessionCustomerId } from '~/auth';
 
 import { client } from '..';
-import { graphql } from '../generated';
+import { PRODUCT_DETAILS_FRAGMENT } from '../fragments/product-details';
+import { graphql } from '../graphql';
 import { revalidate } from '../revalidate-target';
 
-export const GET_FEATURED_PRODUCTS_QUERY = /* GraphQL */ `
-  query getFeaturedProducts($first: Int, $imageHeight: Int!, $imageWidth: Int!) {
-    site {
-      featuredProducts(first: $first) {
-        edges {
-          node {
-            ...ProductDetails
+const GET_FEATURED_PRODUCTS_QUERY = graphql(
+  `
+    query getFeaturedProducts($first: Int, $imageHeight: Int!, $imageWidth: Int!) {
+      site {
+        featuredProducts(first: $first) {
+          edges {
+            node {
+              ...ProductDetails
+            }
           }
         }
       }
     }
-  }
-`;
+  `,
+  [PRODUCT_DETAILS_FRAGMENT],
+);
 
 interface Options {
   first?: number;
@@ -29,11 +33,10 @@ interface Options {
 
 export const getFeaturedProducts = cache(
   async ({ first = 12, imageHeight = 300, imageWidth = 300 }: Options = {}) => {
-    const query = graphql(GET_FEATURED_PRODUCTS_QUERY);
     const customerId = await getSessionCustomerId();
 
     const response = await client.fetch({
-      document: query,
+      document: GET_FEATURED_PRODUCTS_QUERY,
       variables: { first, imageWidth, imageHeight },
       customerId,
       fetchOptions: customerId ? { cache: 'no-store' } : { next: { revalidate } },

--- a/apps/core/client/queries/get-newest-products.ts
+++ b/apps/core/client/queries/get-newest-products.ts
@@ -4,22 +4,26 @@ import { cache } from 'react';
 import { getSessionCustomerId } from '~/auth';
 
 import { client } from '..';
-import { graphql } from '../generated';
+import { PRODUCT_DETAILS_FRAGMENT } from '../fragments/product-details';
+import { graphql } from '../graphql';
 import { revalidate } from '../revalidate-target';
 
-export const GET_NEWEST_PRODUCTS_QUERY = /* GraphQL */ `
-  query getNewestProducts($first: Int, $imageHeight: Int!, $imageWidth: Int!) {
-    site {
-      newestProducts(first: $first) {
-        edges {
-          node {
-            ...ProductDetails
+const GET_NEWEST_PRODUCTS_QUERY = graphql(
+  `
+    query getNewestProducts($first: Int, $imageHeight: Int!, $imageWidth: Int!) {
+      site {
+        newestProducts(first: $first) {
+          edges {
+            node {
+              ...ProductDetails
+            }
           }
         }
       }
     }
-  }
-`;
+  `,
+  [PRODUCT_DETAILS_FRAGMENT],
+);
 
 interface Options {
   first?: number;
@@ -29,11 +33,10 @@ interface Options {
 
 export const getNewestProducts = cache(
   async ({ first = 12, imageHeight = 300, imageWidth = 300 }: Options = {}) => {
-    const query = graphql(GET_NEWEST_PRODUCTS_QUERY);
     const customerId = await getSessionCustomerId();
 
     const response = await client.fetch({
-      document: query,
+      document: GET_NEWEST_PRODUCTS_QUERY,
       variables: { first, imageWidth, imageHeight },
       customerId,
       fetchOptions: customerId ? { cache: 'no-store' } : { next: { revalidate } },

--- a/apps/core/client/queries/get-related-products.ts
+++ b/apps/core/client/queries/get-related-products.ts
@@ -4,32 +4,36 @@ import { cache } from 'react';
 import { getSessionCustomerId } from '~/auth';
 
 import { client } from '..';
-import { graphql } from '../generated';
+import { PRODUCT_DETAILS_FRAGMENT } from '../fragments/product-details';
+import { graphql } from '../graphql';
 import { revalidate } from '../revalidate-target';
 
 import { GetProductOptions } from './get-product';
 
-export const GET_RELATED_PRODUCTS = /* GraphQL */ `
-  query getRelatedProducts(
-    $entityId: Int!
-    $optionValueIds: [OptionValueId!]
-    $first: Int!
-    $imageHeight: Int!
-    $imageWidth: Int!
-  ) {
-    site {
-      product(entityId: $entityId, optionValueIds: $optionValueIds) {
-        relatedProducts(first: $first) {
-          edges {
-            node {
-              ...ProductDetails
+const GET_RELATED_PRODUCTS = graphql(
+  `
+    query getRelatedProducts(
+      $entityId: Int!
+      $optionValueIds: [OptionValueId!]
+      $first: Int!
+      $imageHeight: Int!
+      $imageWidth: Int!
+    ) {
+      site {
+        product(entityId: $entityId, optionValueIds: $optionValueIds) {
+          relatedProducts(first: $first) {
+            edges {
+              node {
+                ...ProductDetails
+              }
             }
           }
         }
       }
     }
-  }
-`;
+  `,
+  [PRODUCT_DETAILS_FRAGMENT],
+);
 
 export const getRelatedProducts = cache(
   async (
@@ -41,11 +45,10 @@ export const getRelatedProducts = cache(
   ) => {
     const { productId, optionValueIds, first = 12, imageWidth = 300, imageHeight = 300 } = options;
 
-    const query = graphql(GET_RELATED_PRODUCTS);
     const customerId = await getSessionCustomerId();
 
     const response = await client.fetch({
-      document: query,
+      document: GET_RELATED_PRODUCTS,
       variables: { entityId: productId, optionValueIds, first, imageWidth, imageHeight },
       fetchOptions: customerId ? { cache: 'no-store' } : { next: { revalidate } },
     });


### PR DESCRIPTION
[Hide whitespaces on this one](https://github.com/bigcommerce/catalyst/pull/688/files?diff=unified&w=1)

## What/Why?
Port remaining queries to `gql.tada`, had to do all these together because of the shared `ProductDetails` fragment.

