### PR TITLE
refactor(core): remove cogen usages v3

### DIFF
--- a/apps/core/app/[locale]/(default)/(faceted)/fetch-faceted-search.ts
+++ b/apps/core/app/[locale]/(default)/(faceted)/fetch-faceted-search.ts
@@ -1,8 +1,11 @@
 import { cache } from 'react';
 import { z } from 'zod';
 
-import { SearchProductsFiltersInput, SearchProductsSortInput } from '~/client/generated/graphql';
+import { graphql } from '~/client/graphql';
 import { getProductSearchResults } from '~/client/queries/get-product-search-results';
+
+type SearchProductsFiltersInput = ReturnType<typeof graphql.scalar<'SearchProductsFiltersInput'>>;
+type SearchProductsSortInput = ReturnType<typeof graphql.scalar<'SearchProductsSortInput'>>;
 
 const SearchParamSchema = z.union([z.string(), z.array(z.string()), z.undefined()]);
 
@@ -18,7 +21,17 @@ const SearchParamToArray = SearchParamSchema.transform((value) => {
   return undefined;
 });
 
-const PrivateSortParam = z.nativeEnum(SearchProductsSortInput);
+const PrivateSortParam = z.union([
+  z.literal('A_TO_Z'),
+  z.literal('BEST_REVIEWED'),
+  z.literal('BEST_SELLING'),
+  z.literal('FEATURED'),
+  z.literal('HIGHEST_PRICE'),
+  z.literal('LOWEST_PRICE'),
+  z.literal('NEWEST'),
+  z.literal('RELEVANCE'),
+  z.literal('Z_TO_A'),
+]) satisfies z.ZodType<SearchProductsSortInput>;
 
 const PublicSortParam = z.string().toUpperCase().pipe(PrivateSortParam);
 

--- a/apps/core/app/[locale]/(default)/cart/_actions/update-product-quantity.ts
+++ b/apps/core/app/[locale]/(default)/cart/_actions/update-product-quantity.ts
@@ -3,8 +3,11 @@
 import { revalidatePath } from 'next/cache';
 import { cookies } from 'next/headers';
 
-import { CartLineItemInput, UpdateCartLineItemInput } from '~/client/generated/graphql';
+import { graphql } from '~/client/graphql';
 import { updateCartLineItem } from '~/client/mutations/update-cart-line-item';
+
+type CartLineItemInput = ReturnType<typeof graphql.scalar<'CartLineItemInput'>>;
+type UpdateCartLineItemInput = ReturnType<typeof graphql.scalar<'UpdateCartLineItemInput'>>;
 
 interface UpdateProductQuantityParams extends CartLineItemInput {
   lineItemEntityId: UpdateCartLineItemInput['lineItemEntityId'];

--- a/apps/core/app/[locale]/(default)/cart/_components/cart-item-counter.tsx
+++ b/apps/core/app/[locale]/(default)/cart/_components/cart-item-counter.tsx
@@ -3,15 +3,14 @@
 import { Counter } from '@bigcommerce/components/counter';
 import { useState } from 'react';
 
-import {
-  CartLineItemInput,
-  CartPhysicalItem,
-  CartSelectedOptionsInput,
-  UpdateCartLineItemInput,
-} from '~/client/generated/graphql';
+import { graphql } from '~/client/graphql';
 import { getCart } from '~/client/queries/get-cart';
 
 import { updateProductQuantity } from '../_actions/update-product-quantity';
+
+type CartLineItemInput = ReturnType<typeof graphql.scalar<'CartLineItemInput'>>;
+type CartSelectedOptionsInput = ReturnType<typeof graphql.scalar<'CartSelectedOptionsInput'>>;
+type UpdateCartLineItemInput = ReturnType<typeof graphql.scalar<'UpdateCartLineItemInput'>>;
 
 type Cart = NonNullable<Awaited<ReturnType<typeof getCart>>>;
 
@@ -19,7 +18,7 @@ type CartItemData = Pick<
   Cart['lineItems']['physicalItems'][number],
   'quantity' | 'productEntityId' | 'variantEntityId' | 'selectedOptions'
 > & {
-  lineItemEntityId: CartPhysicalItem['entityId'];
+  lineItemEntityId: string;
 };
 
 interface UpdateProductQuantityData extends CartLineItemInput {

--- a/apps/core/client/queries/get-product-search-results.ts
+++ b/apps/core/client/queries/get-product-search-results.ts
@@ -6,19 +6,8 @@ import { getSessionCustomerId } from '~/auth';
 import { client } from '..';
 import { PAGE_DETAILS_FRAGMENT } from '../fragments/page-details';
 import { PRODUCT_DETAILS_FRAGMENT } from '../fragments/product-details';
-import { SearchProductsFiltersInput, SearchProductsSortInput } from '../generated/graphql';
-import { graphql } from '../graphql';
+import { graphql, VariablesOf } from '../graphql';
 import { revalidate } from '../revalidate-target';
-
-interface ProductSearch {
-  limit?: number;
-  before?: string;
-  after?: string;
-  sort?: SearchProductsSortInput;
-  filters: SearchProductsFiltersInput;
-  imageWidth?: number;
-  imageHeight?: number;
-}
 
 const GET_PRODUCT_SEARCH_RESULTS_QUERY = graphql(
   `
@@ -165,6 +154,20 @@ const GET_PRODUCT_SEARCH_RESULTS_QUERY = graphql(
   `,
   [PAGE_DETAILS_FRAGMENT, PRODUCT_DETAILS_FRAGMENT],
 );
+
+type Variables = VariablesOf<typeof GET_PRODUCT_SEARCH_RESULTS_QUERY>;
+type SearchProductsSortInput = Variables['sort'];
+type SearchProductsFiltersInput = Variables['filters'];
+
+interface ProductSearch {
+  limit?: number;
+  before?: string;
+  after?: string;
+  sort?: SearchProductsSortInput;
+  filters: SearchProductsFiltersInput;
+  imageWidth?: number;
+  imageHeight?: number;
+}
 
 export const getProductSearchResults = cache(
   async ({

--- a/apps/core/components/product-form/_actions/add-to-cart.ts
+++ b/apps/core/components/product-form/_actions/add-to-cart.ts
@@ -3,13 +3,15 @@
 import { revalidateTag } from 'next/cache';
 import { cookies } from 'next/headers';
 
-import { CartSelectedOptionsInput } from '~/client/generated/graphql';
+import { graphql } from '~/client/graphql';
 import { addCartLineItem } from '~/client/mutations/add-cart-line-item';
 import { createCart } from '~/client/mutations/create-cart';
 import { getCart } from '~/client/queries/get-cart';
 import { getProduct } from '~/client/queries/get-product';
 
 import { ProductFormData } from '../use-product-form';
+
+type CartSelectedOptionsInput = ReturnType<typeof graphql.scalar<'CartSelectedOptionsInput'>>;
 
 export async function handleAddToCart(data: ProductFormData) {
   const productEntityId = Number(data.product_id);


### PR DESCRIPTION
## What/Why?
Continuation of https://github.com/bigcommerce/catalyst/pull/690

Removes remaining usages of codegen. Will open a follow-up PR removing the codegen setup.