### PR TITLE
feat(core): add customer & address form fields queries

### DIFF
--- a/.changeset/poor-pens-matter.md
+++ b/.changeset/poor-pens-matter.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+add customer & address form fields queries

--- a/apps/core/client/fragments/form-fields.ts
+++ b/apps/core/client/fragments/form-fields.ts
@@ -1,0 +1,54 @@
+import { graphql } from '../graphql';
+
+export const FORM_FIELDS_FRAGMENT = graphql(`
+  fragment FormFields on FormField {
+    entityId
+    label
+    sortOrder
+    isBuiltIn
+    isRequired
+    __typename
+    ... on CheckboxesFormField {
+      options {
+        entityId
+        label
+      }
+    }
+    ... on DateFormField {
+      defaultDate
+      minDate
+      maxDate
+    }
+    ... on MultilineTextFormField {
+      defaultText
+      rows
+    }
+    ... on NumberFormField {
+      defaultNumber
+      maxLength
+      minNumber
+      maxNumber
+    }
+    ... on PasswordFormField {
+      defaultText
+      maxLength
+    }
+    ... on PicklistFormField {
+      choosePrefix
+      options {
+        entityId
+        label
+      }
+    }
+    ... on RadioButtonsFormField {
+      options {
+        entityId
+        label
+      }
+    }
+    ... on TextFormField {
+      defaultText
+      maxLength
+    }
+  }
+`);

--- a/apps/core/client/queries/get-address-form-fields.ts
+++ b/apps/core/client/queries/get-address-form-fields.ts
@@ -1,0 +1,46 @@
+import { cache } from 'react';
+
+import { client } from '..';
+import { FORM_FIELDS_FRAGMENT } from '../fragments/form-fields';
+import { graphql, VariablesOf } from '../graphql';
+import { revalidate } from '../revalidate-target';
+
+const GET_ADDRESS_FORM_FIELDS = graphql(
+  `
+    query getAddressFormFields($filters: FormFieldFiltersInput, $sortBy: FormFieldSortInput) {
+      site {
+        settings {
+          formFields {
+            shippingAddress(filters: $filters, sortBy: $sortBy) {
+              ...FormFields
+            }
+          }
+        }
+      }
+    }
+  `,
+  [FORM_FIELDS_FRAGMENT],
+);
+
+type Variables = VariablesOf<typeof GET_ADDRESS_FORM_FIELDS>;
+
+interface AddressFormFields {
+  filters?: Variables['filters'];
+  sortBy?: Variables['sortBy'];
+}
+
+export const getAddressFormFields = cache(async ({ filters, sortBy }: AddressFormFields) => {
+  const response = await client.fetch({
+    document: GET_ADDRESS_FORM_FIELDS,
+    variables: { filters, sortBy },
+    fetchOptions: { next: { revalidate } },
+  });
+
+  const { settings } = response.data.site;
+
+  if (!settings) {
+    return null;
+  }
+
+  return settings.formFields.shippingAddress;
+});

--- a/apps/core/client/queries/get-customer-form-fields.ts
+++ b/apps/core/client/queries/get-customer-form-fields.ts
@@ -1,0 +1,46 @@
+import { cache } from 'react';
+
+import { client } from '..';
+import { FORM_FIELDS_FRAGMENT } from '../fragments/form-fields';
+import { graphql, VariablesOf } from '../graphql';
+import { revalidate } from '../revalidate-target';
+
+const GET_CUSTOMER_FORM_FIELDS = graphql(
+  `
+    query getCustomerFormFields($filters: FormFieldFiltersInput, $sortBy: FormFieldSortInput) {
+      site {
+        settings {
+          formFields {
+            customer(filters: $filters, sortBy: $sortBy) {
+              ...FormFields
+            }
+          }
+        }
+      }
+    }
+  `,
+  [FORM_FIELDS_FRAGMENT],
+);
+
+type Variables = VariablesOf<typeof GET_CUSTOMER_FORM_FIELDS>;
+
+interface CustomerFormFields {
+  filters?: Variables['filters'];
+  sortBy?: Variables['sortBy'];
+}
+
+export const getCustomerFormFields = cache(async ({ filters, sortBy }: CustomerFormFields) => {
+  const response = await client.fetch({
+    document: GET_CUSTOMER_FORM_FIELDS,
+    variables: { filters, sortBy },
+    fetchOptions: { next: { revalidate } },
+  });
+
+  const { settings } = response.data.site;
+
+  if (!settings) {
+    return null;
+  }
+
+  return settings.formFields.customer;
+});


### PR DESCRIPTION
## What/Why?
This pr adds

- `getAddressFormFields` query
- `getCustomerFormFields` query
- `FormFields` fragment used in those queries


## Testing
Locally