### PR TITLE
Add custom image loader for BigCommerce CDN

### DIFF
--- a/apps/core/app/[locale]/(default)/(faceted)/fetch-faceted-search.ts
+++ b/apps/core/app/[locale]/(default)/(faceted)/fetch-faceted-search.ts
@@ -173,8 +173,6 @@ export const fetchFacetedSearch = cache(
       limit,
       sort,
       filters,
-      imageHeight: 500,
-      imageWidth: 500,
     });
   },
 );

--- a/apps/core/app/[locale]/(default)/blog/[blogId]/page.tsx
+++ b/apps/core/app/[locale]/(default)/blog/[blogId]/page.tsx
@@ -7,10 +7,10 @@ import {
 } from '@bigcommerce/components/blog-post-card';
 import { Tag, TagContent } from '@bigcommerce/components/tag';
 import type { Metadata } from 'next';
-import Image from 'next/image';
 import { notFound } from 'next/navigation';
 
 import { getBlogPost } from '~/client/queries/get-blog-post';
+import { BcImage } from '~/components/bc-image';
 import { Link } from '~/components/link';
 import { SharingLinks } from '~/components/sharing-links';
 import { LocaleType } from '~/i18n';
@@ -52,7 +52,7 @@ export default async function BlogPostPage({ params: { blogId } }: Props) {
 
       {blogPost.thumbnailImage ? (
         <BlogPostImage className="mb-6 h-40 sm:h-80 lg:h-96">
-          <Image
+          <BcImage
             alt={blogPost.thumbnailImage.altText}
             className="h-full w-full object-cover object-center"
             height={900}

--- a/apps/core/app/[locale]/(default)/cart/page.tsx
+++ b/apps/core/app/[locale]/(default)/cart/page.tsx
@@ -1,13 +1,13 @@
 import { Button } from '@bigcommerce/components/button';
 import { Trash2 as Trash } from 'lucide-react';
 import { cookies } from 'next/headers';
-import Image from 'next/image';
 import { NextIntlClientProvider, useTranslations } from 'next-intl';
 import { getMessages, getTranslations } from 'next-intl/server';
 import { Suspense } from 'react';
 
 import { getCheckoutUrl } from '~/client/management/get-checkout-url';
 import { getCart } from '~/client/queries/get-cart';
+import { BcImage } from '~/components/bc-image';
 import { LocaleType } from '~/i18n';
 
 import { getShippingCountries } from './_actions/get-shipping-countries';
@@ -93,7 +93,12 @@ export default async function CartPage({ params: { locale } }: Props) {
             <li key={product.entityId}>
               <div className="flex items-center gap-6 border-t border-t-gray-200 py-4">
                 <div>
-                  <Image alt={product.name} height={104} src={product.imageUrl ?? ''} width={104} />
+                  <BcImage
+                    alt={product.name}
+                    height={104}
+                    src={product.imageUrl ?? ''}
+                    width={104}
+                  />
                 </div>
 
                 <div className="flex-1">

--- a/apps/core/app/[locale]/(default)/compare/page.tsx
+++ b/apps/core/app/[locale]/(default)/compare/page.tsx
@@ -1,11 +1,11 @@
 import { Button } from '@bigcommerce/components/button';
 import { Rating } from '@bigcommerce/components/rating';
-import Image from 'next/image';
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages, getTranslations } from 'next-intl/server';
 import * as z from 'zod';
 
 import { getProducts } from '~/client/queries/get-products';
+import { BcImage } from '~/components/bc-image';
 import { Link } from '~/components/link';
 import { Pricing } from '~/components/pricing';
 import { SearchForm } from '~/components/search-form';
@@ -96,7 +96,7 @@ export default async function Compare({
                   return (
                     <td className="px-4" key={product.entityId}>
                       <Link aria-label={product.name} href={product.path}>
-                        <Image
+                        <BcImage
                           alt={product.defaultImage.altText}
                           height={300}
                           src={product.defaultImage.url}

--- a/apps/core/app/[locale]/(default)/page.tsx
+++ b/apps/core/app/[locale]/(default)/page.tsx
@@ -19,8 +19,8 @@ export default async function Home({ params: { locale } }: Props) {
   const t = await getTranslations({ locale, namespace: 'Home' });
   const messages = await getMessages({ locale });
   const [newestProducts, featuredProducts] = await Promise.all([
-    getNewestProducts({ imageWidth: 500, imageHeight: 500 }),
-    getFeaturedProducts({ imageWidth: 500, imageHeight: 500 }),
+    getNewestProducts(),
+    getFeaturedProducts(),
   ]);
 
   return (

--- a/apps/core/app/[locale]/(default)/product/[slug]/_components/gallery.tsx
+++ b/apps/core/app/[locale]/(default)/product/[slug]/_components/gallery.tsx
@@ -9,9 +9,9 @@ import {
   GalleryThumbnailItem,
   GalleryThumbnailList,
 } from '@bigcommerce/components/gallery';
-import Image from 'next/image';
 
 import { getProduct } from '~/client/queries/get-product';
+import { BcImage } from '~/components/bc-image';
 
 type Product = Awaited<ReturnType<typeof getProduct>>;
 
@@ -52,7 +52,7 @@ export const Gallery = ({
             <GalleryImage>
               {({ selectedImage }) =>
                 selectedImage ? (
-                  <Image
+                  <BcImage
                     alt={selectedImage.altText}
                     className="h-full w-full object-contain"
                     fill
@@ -76,7 +76,7 @@ export const Gallery = ({
               return (
                 <GalleryThumbnailItem imageIndex={index} key={image.url}>
                   <GalleryThumbnail asChild>
-                    <Image alt={image.altText} priority={true} src={image.url} />
+                    <BcImage alt={image.altText} priority={true} src={image.url} />
                   </GalleryThumbnail>
                 </GalleryThumbnailItem>
               );

--- a/apps/core/app/[locale]/(default)/product/[slug]/_components/related-products.tsx
+++ b/apps/core/app/[locale]/(default)/product/[slug]/_components/related-products.tsx
@@ -11,8 +11,6 @@ export const RelatedProducts = async ({ productId }: { productId: number }) => {
 
   const relatedProducts = await getRelatedProducts({
     productId,
-    imageWidth: 500,
-    imageHeight: 500,
   });
 
   return (

--- a/apps/core/app/[locale]/not-found.tsx
+++ b/apps/core/app/[locale]/not-found.tsx
@@ -19,8 +19,6 @@ export default async function NotFound() {
   const messages = await getMessages({ locale });
 
   const featuredProducts = await getFeaturedProducts({
-    imageHeight: 500,
-    imageWidth: 500,
     first: 4,
   });
 

--- a/apps/core/client/fragments/product-details.ts
+++ b/apps/core/client/fragments/product-details.ts
@@ -15,7 +15,7 @@ export const PRODUCT_DETAILS_FRAGMENT = graphql(
         path
       }
       defaultImage {
-        url(width: $imageWidth, height: $imageHeight)
+        url: urlTemplate
         altText
       }
       availabilityV2 {

--- a/apps/core/client/queries/get-blog-post.ts
+++ b/apps/core/client/queries/get-blog-post.ts
@@ -21,7 +21,7 @@ const GET_BLOG_POST_QUERY = graphql(`
             tags
             thumbnailImage {
               altText
-              url(width: 900)
+              url: urlTemplate
             }
             seo {
               metaKeywords

--- a/apps/core/client/queries/get-blog-posts.ts
+++ b/apps/core/client/queries/get-blog-posts.ts
@@ -46,7 +46,7 @@ const GET_BLOG_POSTS_QUERY = graphql(`
                   utc
                 }
                 thumbnailImage {
-                  url(width: 300)
+                  url: urlTemplate
                   altText
                 }
               }

--- a/apps/core/client/queries/get-category.ts
+++ b/apps/core/client/queries/get-category.ts
@@ -40,7 +40,7 @@ const GET_CATEGORY_QUERY = graphql(`
                 }
               }
               defaultImage {
-                url(width: 300)
+                url: urlTemplate
                 altText
               }
             }

--- a/apps/core/client/queries/get-featured-products.ts
+++ b/apps/core/client/queries/get-featured-products.ts
@@ -10,7 +10,7 @@ import { revalidate } from '../revalidate-target';
 
 const GET_FEATURED_PRODUCTS_QUERY = graphql(
   `
-    query getFeaturedProducts($first: Int, $imageHeight: Int!, $imageWidth: Int!) {
+    query getFeaturedProducts($first: Int) {
       site {
         featuredProducts(first: $first) {
           edges {
@@ -27,26 +27,22 @@ const GET_FEATURED_PRODUCTS_QUERY = graphql(
 
 interface Options {
   first?: number;
-  imageWidth?: number;
-  imageHeight?: number;
 }
 
-export const getFeaturedProducts = cache(
-  async ({ first = 12, imageHeight = 300, imageWidth = 300 }: Options = {}) => {
-    const customerId = await getSessionCustomerId();
+export const getFeaturedProducts = cache(async ({ first = 12 }: Options = {}) => {
+  const customerId = await getSessionCustomerId();
 
-    const response = await client.fetch({
-      document: GET_FEATURED_PRODUCTS_QUERY,
-      variables: { first, imageWidth, imageHeight },
-      customerId,
-      fetchOptions: customerId ? { cache: 'no-store' } : { next: { revalidate } },
-    });
+  const response = await client.fetch({
+    document: GET_FEATURED_PRODUCTS_QUERY,
+    variables: { first },
+    customerId,
+    fetchOptions: customerId ? { cache: 'no-store' } : { next: { revalidate } },
+  });
 
-    const { site } = response.data;
+  const { site } = response.data;
 
-    return removeEdgesAndNodes(site.featuredProducts).map((featuredProduct) => ({
-      ...featuredProduct,
-      productOptions: removeEdgesAndNodes(featuredProduct.productOptions),
-    }));
-  },
-);
+  return removeEdgesAndNodes(site.featuredProducts).map((featuredProduct) => ({
+    ...featuredProduct,
+    productOptions: removeEdgesAndNodes(featuredProduct.productOptions),
+  }));
+});

--- a/apps/core/client/queries/get-newest-products.ts
+++ b/apps/core/client/queries/get-newest-products.ts
@@ -10,7 +10,7 @@ import { revalidate } from '../revalidate-target';
 
 const GET_NEWEST_PRODUCTS_QUERY = graphql(
   `
-    query getNewestProducts($first: Int, $imageHeight: Int!, $imageWidth: Int!) {
+    query getNewestProducts($first: Int) {
       site {
         newestProducts(first: $first) {
           edges {
@@ -27,26 +27,22 @@ const GET_NEWEST_PRODUCTS_QUERY = graphql(
 
 interface Options {
   first?: number;
-  imageWidth?: number;
-  imageHeight?: number;
 }
 
-export const getNewestProducts = cache(
-  async ({ first = 12, imageHeight = 300, imageWidth = 300 }: Options = {}) => {
-    const customerId = await getSessionCustomerId();
+export const getNewestProducts = cache(async ({ first = 12 }: Options = {}) => {
+  const customerId = await getSessionCustomerId();
 
-    const response = await client.fetch({
-      document: GET_NEWEST_PRODUCTS_QUERY,
-      variables: { first, imageWidth, imageHeight },
-      customerId,
-      fetchOptions: customerId ? { cache: 'no-store' } : { next: { revalidate } },
-    });
+  const response = await client.fetch({
+    document: GET_NEWEST_PRODUCTS_QUERY,
+    variables: { first },
+    customerId,
+    fetchOptions: customerId ? { cache: 'no-store' } : { next: { revalidate } },
+  });
 
-    const { site } = response.data;
+  const { site } = response.data;
 
-    return removeEdgesAndNodes(site.newestProducts).map((product) => ({
-      ...product,
-      productOptions: removeEdgesAndNodes(product.productOptions),
-    }));
-  },
-);
+  return removeEdgesAndNodes(site.newestProducts).map((product) => ({
+    ...product,
+    productOptions: removeEdgesAndNodes(product.productOptions),
+  }));
+});

--- a/apps/core/client/queries/get-product-search-results.ts
+++ b/apps/core/client/queries/get-product-search-results.ts
@@ -18,8 +18,6 @@ const GET_PRODUCT_SEARCH_RESULTS_QUERY = graphql(
       $before: String
       $filters: SearchProductsFiltersInput!
       $sort: SearchProductsSortInput
-      $imageHeight: Int!
-      $imageWidth: Int!
     ) {
       site {
         search {
@@ -165,22 +163,12 @@ interface ProductSearch {
   after?: string;
   sort?: SearchProductsSortInput;
   filters: SearchProductsFiltersInput;
-  imageWidth?: number;
-  imageHeight?: number;
 }
 
 export const getProductSearchResults = cache(
-  async ({
-    limit = 9,
-    after,
-    before,
-    sort,
-    filters,
-    imageHeight = 300,
-    imageWidth = 300,
-  }: ProductSearch) => {
+  async ({ limit = 9, after, before, sort, filters }: ProductSearch) => {
     const customerId = await getSessionCustomerId();
-    const filterArgs = { filters, sort, imageHeight, imageWidth };
+    const filterArgs = { filters, sort };
     const paginationArgs = before ? { last: limit, before } : { first: limit, after };
 
     const response = await client.fetch({

--- a/apps/core/client/queries/get-product.ts
+++ b/apps/core/client/queries/get-product.ts
@@ -65,7 +65,7 @@ const PRODUCT_OPTIONS_FRAGMENT = graphql(`
                     __typename
                     defaultImage {
                       altText
-                      url(width: 48)
+                      url: urlTemplate
                     }
                     productId
                   }
@@ -124,13 +124,13 @@ const PRODUCT_FRAGMENT = graphql(
       plainTextDescription(characterLimit: 2000)
       defaultImage {
         altText
-        url(width: 600)
+        url: urlTemplate
       }
       images {
         edges {
           node {
             altText
-            url(width: 600)
+            url: urlTemplate
             isDefault
           }
         }

--- a/apps/core/client/queries/get-products.ts
+++ b/apps/core/client/queries/get-products.ts
@@ -11,13 +11,11 @@ import { revalidate } from '../revalidate-target';
 export interface GetProductsArguments {
   productIds: number[];
   first: number;
-  imageWidth?: number;
-  imageHeight?: number;
 }
 
 const GET_PRODUCTS_QUERY = graphql(
   `
-    query getProducts($entityIds: [Int!], $first: Int, $imageHeight: Int!, $imageWidth: Int!) {
+    query getProducts($entityIds: [Int!], $first: Int) {
       site {
         products(entityIds: $entityIds, first: $first) {
           edges {
@@ -32,22 +30,20 @@ const GET_PRODUCTS_QUERY = graphql(
   [PRODUCT_DETAILS_FRAGMENT],
 );
 
-export const getProducts = cache(
-  async ({ productIds, first, imageWidth = 300, imageHeight = 300 }: GetProductsArguments) => {
-    const customerId = await getSessionCustomerId();
+export const getProducts = cache(async ({ productIds, first }: GetProductsArguments) => {
+  const customerId = await getSessionCustomerId();
 
-    const response = await client.fetch({
-      document: GET_PRODUCTS_QUERY,
-      variables: { entityIds: productIds, first, imageWidth, imageHeight },
-      customerId,
-      fetchOptions: customerId ? { cache: 'no-store' } : { next: { revalidate } },
-    });
+  const response = await client.fetch({
+    document: GET_PRODUCTS_QUERY,
+    variables: { entityIds: productIds, first },
+    customerId,
+    fetchOptions: customerId ? { cache: 'no-store' } : { next: { revalidate } },
+  });
 
-    const products = removeEdgesAndNodes(response.data.site.products);
+  const products = removeEdgesAndNodes(response.data.site.products);
 
-    return products.map((product) => ({
-      ...product,
-      productOptions: removeEdgesAndNodes(product.productOptions),
-    }));
-  },
-);
+  return products.map((product) => ({
+    ...product,
+    productOptions: removeEdgesAndNodes(product.productOptions),
+  }));
+});

--- a/apps/core/client/queries/get-quick-search-results.ts
+++ b/apps/core/client/queries/get-quick-search-results.ts
@@ -10,17 +10,11 @@ import { revalidate } from '../revalidate-target';
 
 interface QuickSearch {
   searchTerm: string;
-  imageWidth?: number;
-  imageHeight?: number;
 }
 
 const GET_QUICK_SEARCH_RESULTS_QUERY = graphql(
   `
-    query getQuickSearchResults(
-      $filters: SearchProductsFiltersInput!
-      $imageHeight: Int!
-      $imageWidth: Int!
-    ) {
+    query getQuickSearchResults($filters: SearchProductsFiltersInput!) {
       site {
         search {
           searchProducts(filters: $filters) {
@@ -39,21 +33,19 @@ const GET_QUICK_SEARCH_RESULTS_QUERY = graphql(
   [PRODUCT_DETAILS_FRAGMENT],
 );
 
-export const getQuickSearchResults = cache(
-  async ({ searchTerm, imageHeight = 300, imageWidth = 300 }: QuickSearch) => {
-    const customerId = await getSessionCustomerId();
+export const getQuickSearchResults = cache(async ({ searchTerm }: QuickSearch) => {
+  const customerId = await getSessionCustomerId();
 
-    const response = await client.fetch({
-      document: GET_QUICK_SEARCH_RESULTS_QUERY,
-      variables: { filters: { searchTerm }, imageHeight, imageWidth },
-      customerId,
-      fetchOptions: customerId ? { cache: 'no-store' } : { next: { revalidate } },
-    });
+  const response = await client.fetch({
+    document: GET_QUICK_SEARCH_RESULTS_QUERY,
+    variables: { filters: { searchTerm } },
+    customerId,
+    fetchOptions: customerId ? { cache: 'no-store' } : { next: { revalidate } },
+  });
 
-    const { products } = response.data.site.search.searchProducts;
+  const { products } = response.data.site.search.searchProducts;
 
-    return {
-      products: removeEdgesAndNodes(products),
-    };
-  },
-);
+  return {
+    products: removeEdgesAndNodes(products),
+  };
+});

--- a/apps/core/client/queries/get-related-products.ts
+++ b/apps/core/client/queries/get-related-products.ts
@@ -12,13 +12,7 @@ import { GetProductOptions } from './get-product';
 
 const GET_RELATED_PRODUCTS = graphql(
   `
-    query getRelatedProducts(
-      $entityId: Int!
-      $optionValueIds: [OptionValueId!]
-      $first: Int!
-      $imageHeight: Int!
-      $imageWidth: Int!
-    ) {
+    query getRelatedProducts($entityId: Int!, $optionValueIds: [OptionValueId!], $first: Int!) {
       site {
         product(entityId: $entityId, optionValueIds: $optionValueIds) {
           relatedProducts(first: $first) {
@@ -39,17 +33,15 @@ export const getRelatedProducts = cache(
   async (
     options: GetProductOptions & {
       first?: number;
-      imageWidth?: number;
-      imageHeight?: number;
     },
   ) => {
-    const { productId, optionValueIds, first = 12, imageWidth = 300, imageHeight = 300 } = options;
+    const { productId, optionValueIds, first = 12 } = options;
 
     const customerId = await getSessionCustomerId();
 
     const response = await client.fetch({
       document: GET_RELATED_PRODUCTS,
-      variables: { entityId: productId, optionValueIds, first, imageWidth, imageHeight },
+      variables: { entityId: productId, optionValueIds, first },
       fetchOptions: customerId ? { cache: 'no-store' } : { next: { revalidate } },
     });
 

--- a/apps/core/client/queries/get-store-settings.ts
+++ b/apps/core/client/queries/get-store-settings.ts
@@ -16,7 +16,7 @@ const GET_STORE_SETTINGS_QUERY = graphql(`
           }
           ... on StoreImageLogo {
             image {
-              url(width: 155)
+              url: urlTemplate
               altText
             }
           }

--- a/apps/core/components/bc-image/index.tsx
+++ b/apps/core/components/bc-image/index.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import Image from 'next/image';
+import { ComponentPropsWithRef } from 'react';
+
+import bcCdnImageLoader from '~/lib/cdn-image-loader';
+
+type NextImageProps = Omit<ComponentPropsWithRef<typeof Image>, 'quality'>;
+
+interface BcImageOptions {
+  lossy?: boolean;
+}
+
+type Props = NextImageProps & BcImageOptions;
+
+export const BcImage = ({ ...props }: Props) => {
+  return <Image loader={bcCdnImageLoader} {...props} />;
+};

--- a/apps/core/components/blog-post-card/index.tsx
+++ b/apps/core/components/blog-post-card/index.tsx
@@ -7,11 +7,12 @@ import {
   BlogPostTitle,
   BlogPostCard as ComponentsBlogPostCard,
 } from '@bigcommerce/components/blog-post-card';
-import Image from 'next/image';
 
 import { getBlogPosts } from '~/client/queries/get-blog-posts';
 import { ExistingResultType } from '~/client/util';
 import { Link } from '~/components/link';
+
+import { BcImage } from '../bc-image';
 
 interface BlogPostCardProps {
   blogPost: ExistingResultType<typeof getBlogPosts>['posts']['items'][number];
@@ -22,7 +23,7 @@ export const BlogPostCard = ({ blogPost }: BlogPostCardProps) => (
     {blogPost.thumbnailImage ? (
       <BlogPostImage>
         <Link className="block w-full" href={`/blog/${blogPost.entityId}`}>
-          <Image
+          <BcImage
             alt={blogPost.thumbnailImage.altText}
             className="h-full w-full object-cover object-center"
             height={300}

--- a/apps/core/components/compare-drawer/index.tsx
+++ b/apps/core/components/compare-drawer/index.tsx
@@ -8,12 +8,13 @@ import {
 } from '@bigcommerce/components/accordion';
 import { Button } from '@bigcommerce/components/button';
 import { X } from 'lucide-react';
-import Image from 'next/image';
 import { usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 
 import { CheckedProduct, useCompareProductsContext } from '~/app/contexts/compare-products-context';
 import { Link } from '~/components/link';
+
+import { BcImage } from '../bc-image';
 
 const CompareLink = ({ products }: { products: CheckedProduct[] }) => {
   const t = useTranslations('Providers.Compare');
@@ -45,7 +46,7 @@ const CompareItem = ({
       key={product.id}
     >
       {product.image ? (
-        <Image
+        <BcImage
           alt={product.image.altText ?? product.name}
           className="object-contain"
           height={48}

--- a/apps/core/components/forbidden/index.tsx
+++ b/apps/core/components/forbidden/index.tsx
@@ -3,7 +3,7 @@ import { ProductCard } from '~/components/product-card';
 import { SearchForm } from '~/components/search-form';
 
 const FeaturedProducts = async () => {
-  const featuredProducts = await getFeaturedProducts({ imageHeight: 500, imageWidth: 500 });
+  const featuredProducts = await getFeaturedProducts();
 
   return (
     <section className="w-full">

--- a/apps/core/components/product-card/index.tsx
+++ b/apps/core/components/product-card/index.tsx
@@ -7,13 +7,13 @@ import {
   ProductCardInfoProductName,
 } from '@bigcommerce/components/product-card';
 import { Rating } from '@bigcommerce/components/rating';
-import Image from 'next/image';
 import { useTranslations } from 'next-intl';
 import { useId } from 'react';
 
 import { Link } from '~/components/link';
 import { cn } from '~/lib/utils';
 
+import { BcImage } from '../bc-image';
 import { Pricing } from '../pricing';
 
 import { Cart } from './cart';
@@ -103,7 +103,7 @@ export const ProductCard = ({
           })}
         >
           {product.defaultImage ? (
-            <Image
+            <BcImage
               alt={product.defaultImage.altText ?? product.name ?? ''}
               className="object-contain"
               fill

--- a/apps/core/components/product-form/fields/multiple-choice-field.tsx
+++ b/apps/core/components/product-form/fields/multiple-choice-field.tsx
@@ -4,11 +4,11 @@ import { RadioGroup, RadioItem } from '@bigcommerce/components/radio-group';
 import { RectangleList, RectangleListItem } from '@bigcommerce/components/rectangle-list';
 import { Select, SelectContent, SelectItem } from '@bigcommerce/components/select';
 import { Swatch, SwatchItem } from '@bigcommerce/components/swatch';
-import Image from 'next/image';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
 import { getProduct } from '~/client/queries/get-product';
 import { ExistingResultType, Unpacked } from '~/client/util';
+import { BcImage } from '~/components/bc-image';
 
 import { useProductFieldController } from '../use-product-form';
 
@@ -213,7 +213,7 @@ export const MultipleChoiceField = ({ option }: { option: MultipleChoiceOption }
                 return (
                   <div className="flex items-center p-4" key={value.entityId}>
                     {Boolean(value.defaultImage) && (
-                      <Image
+                      <BcImage
                         alt={value.defaultImage?.altText || ''}
                         className="me-6"
                         height={48}

--- a/apps/core/components/product-sheet/product-sheet-content.tsx
+++ b/apps/core/components/product-sheet/product-sheet-content.tsx
@@ -2,7 +2,6 @@
 
 import { Rating } from '@bigcommerce/components/rating';
 import { Loader2 as Spinner } from 'lucide-react';
-import Image from 'next/image';
 import { useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { useEffect, useId, useState } from 'react';
@@ -10,6 +9,8 @@ import { useEffect, useId, useState } from 'react';
 import { getProduct } from '~/client/queries/get-product';
 import { ProductForm } from '~/components/product-form';
 import { cn } from '~/lib/utils';
+
+import { BcImage } from '../bc-image';
 
 export const ProductSheetContent = () => {
   const summaryId = useId();
@@ -73,7 +74,7 @@ export const ProductSheetContent = () => {
         <div className="flex">
           <div className="square relative h-[144px] w-[144px] shrink-0 grow-0">
             {product.defaultImage ? (
-              <Image
+              <BcImage
                 alt={product.defaultImage.altText}
                 className="object-contain"
                 fill

--- a/apps/core/components/quick-search/_actions/get-search-results.ts
+++ b/apps/core/components/quick-search/_actions/get-search-results.ts
@@ -5,8 +5,6 @@ import { getQuickSearchResults } from '~/client/queries/get-quick-search-results
 export async function getSearchResults(searchTerm: string) {
   const searchResults = await getQuickSearchResults({
     searchTerm,
-    imageHeight: 150,
-    imageWidth: 150,
   });
 
   return searchResults;

--- a/apps/core/components/quick-search/index.tsx
+++ b/apps/core/components/quick-search/index.tsx
@@ -13,13 +13,13 @@ import {
 } from '@bigcommerce/components/sheet';
 import debounce from 'lodash.debounce';
 import { Search, Loader2 as Spinner, X } from 'lucide-react';
-import Image from 'next/image';
 import { PropsWithChildren, useEffect, useRef, useState } from 'react';
 
 import { getQuickSearchResults } from '~/client/queries/get-quick-search-results';
 import { ExistingResultType } from '~/client/util';
 import { cn } from '~/lib/utils';
 
+import { BcImage } from '../bc-image';
 import { Pricing } from '../pricing';
 
 import { getSearchResults } from './_actions/get-search-results';
@@ -196,7 +196,7 @@ export const QuickSearch = ({ children, initialTerm = '' }: SearchProps) => {
                           href={product.path}
                         >
                           {product.defaultImage ? (
-                            <Image
+                            <BcImage
                               alt={product.defaultImage.altText}
                               className="self-start object-contain"
                               height={80}

--- a/apps/core/components/store-logo/index.tsx
+++ b/apps/core/components/store-logo/index.tsx
@@ -1,6 +1,6 @@
-import Image from 'next/image';
-
 import { getStoreSettings } from '~/client/queries/get-store-settings';
+
+import { BcImage } from '../bc-image';
 
 export const StoreLogo = async () => {
   const settings = await getStoreSettings();
@@ -16,7 +16,7 @@ export const StoreLogo = async () => {
   }
 
   return (
-    <Image
+    <BcImage
       alt={logo.image.altText ? logo.image.altText : storeName}
       className="max-h-16 object-contain"
       height={32}

--- a/apps/core/lib/cdn-image-loader.ts
+++ b/apps/core/lib/cdn-image-loader.ts
@@ -1,0 +1,35 @@
+'use client';
+
+export const addCompressionParam = (url: string, lossy: boolean): string => {
+  const urlObj = new URL(url);
+
+  const paramValue = lossy ? 'lossy' : 'lossless';
+
+  urlObj.searchParams.set('compression', paramValue);
+
+  return urlObj.toString();
+};
+
+export default function bcCdnImageLoader({
+  src,
+  width,
+  height,
+  lossy = true,
+}: {
+  src: string;
+  width: number;
+  height?: number;
+  lossy?: boolean;
+}): string {
+  let url;
+
+  if (height) {
+    url = src.replace('{:size}', `${width}x${height}`);
+  }
+
+  url = src.replace('{:size}', `${width}w`);
+
+  url = addCompressionParam(url, lossy);
+
+  return url;
+}


### PR DESCRIPTION
## What/Why?
Adds a custom image loader to use images directly from the BigCommerce CDN.

This allows for more optimal image loading and is a more generic solution that should work across hosts, and prevent wasteful double-processing of images by stacking CDNs.

In order to make sure the default Next.js image loader is still available, I've added a new `<BcImage>` component to wrap next `<Image>` and enforce the use of our loader, instead of changing the default loader. I was unable to find a way to [build a new loader which falls back to the default loader](https://stackoverflow.com/questions/77752851/next-image-loaderfile-but-fallback-to-default-optimized-loader), so this is a compromise that prioritizes an unpolluted dev experience for any additional images added to the app that don't come from BigCommerce.

I've updated the GraphQL queries to request the `urlTemplate` for each image we get from BC GQL, which has a size parameter which must be replaced with the desired size; this gives the Next.js app control over image sizing without additional network requests.

## Testing
Ensured images are coming from BC CDN where relevant, and other URLs are not interfered with: