### PR TITLE
Add new helper functions for serving store assets

### DIFF
--- a/apps/core/lib/store-assets.ts
+++ b/apps/core/lib/store-assets.ts
@@ -1,0 +1,54 @@
+const cdnHostname = process.env.BIGCOMMERCE_CDN_HOSTNAME ?? 'cdn11.bigcommerce.com';
+const storeHash = process.env.BIGCOMMERCE_STORE_HASH ?? '';
+const commitSha = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA;
+
+/**
+ * Build the CDN image URL.
+ * A query parameter containing the commit SHA is appended to the URL to ensure
+ * that the asset is invalidated when the storefront app is deployed.
+ *
+ * @param {string} sizeSegment - The size segment of the URL. Can be of the form `{:size}` (to make it a urlTemplate) or `original` or `123w` or `123x123`.
+ * @param {string} source - The source of the image. Can be either `content` or `image-manager`.
+ * @param {string} path - The path of the image relative to the source.
+ * @returns {string} The CDN image URL.
+ */
+const cdnImageUrlBuilder = (sizeSegment: string, source: string, path: string): string => {
+  return `https://${cdnHostname}/s-${storeHash}/images/stencil/${sizeSegment}/${source}/${path}${commitSha ? `?v=${commitSha}` : ''}`;
+};
+
+/**
+ * Given a path, return the full URL to the content asset.
+ * These assets are accessible via the /content folder in WebDAV on the store.
+ * A query parameter containing the commit SHA is appended to the URL to ensure
+ * that the asset is invalidated when the storefront app is deployed.
+ *
+ * @param {string} path - The path of the content asset.
+ * @returns {string} The full URL to the content asset.
+ */
+export const contentAssetUrl = (path: string): string => {
+  return `https://${cdnHostname}/s-${storeHash}/content/${path}${commitSha ? `?v=${commitSha}` : ''}`;
+};
+
+/**
+ * Build a URL or resizable URL template for an image in the /content folder in WebDAV.
+ *
+ * @param {string} path - The path of the image relative to the /content folder.
+ * @param {string} sizeParam - The optional size parameter. Can be of the form `{:size}` (to make it a urlTemplate) or `original` or `123w` or `123x123`. If omitted, will return the templated string containing `{:size}`.
+ * @returns {string} The resizeable URL template for the image, which can be used with `<BcImage>`.
+ */
+export const contentImageUrl = (path: string, sizeParam?: string): string => {
+  // return a urlTemplate that can be used with the <BcImage> component
+  return cdnImageUrlBuilder(`${sizeParam || '{:size}'}`, 'content', path);
+};
+
+/**
+ * Build a URL or resizable URL template for an image in the Image Manager.
+ *
+ * @param {string} filename - The filename of the image managed by the image manager.
+ * @param {string} sizeParam - The optional size parameter. Can be of the form `{:size}` (to make it a urlTemplate) or `original` or `123w` or `123x123`. If omitted, will return the templated string containing `{:size}`.
+ * @returns {string} The resizeable URL template for the image, which can be used with `<BcImage>`.
+ */
+export const imageManagerImageUrl = (filename: string, sizeParam?: string): string => {
+  // return a urlTemplate that can be used with the <BcImage> component
+  return cdnImageUrlBuilder(`${sizeParam || '{:size}'}`, 'image-manager', filename);
+};

--- a/docs/cdn-and-images.md
+++ b/docs/cdn-and-images.md
@@ -1,6 +1,68 @@
 **Overview**
-# `<BcImage />` and `bcCdnImageLoader`
+
+Catalyst takes full advantage of the BigCommerce CDN to provide globally-distributed asset hosting and on-the-fly image resizing. This functionality is included with all BigCommerce plans and is agnostic to the hosting provider you use to host your Catalyst storefront.
+
+## `<BcImage />` and `bcCdnImageLoader`
 
 For loading images from the BigCommerce platform, Catalyst provides [`<BcImage />`](https://github.com/bigcommerce/catalyst/blob/main/apps/core/components/bc-image/index.tsx) as a wrapper for Next's `<Image />` component to allow you to use the BigCommerce CDN directly to reduce load on the Next.js application and hosting costs.
 
 This component expects to receive the `urlTemplate` field from GraphQL Storefront API which contains a `{:size}` placeholder which the custom [`bcCdnImageLoader` image loader](https://github.com/bigcommerce/catalyst/blob/main/apps/core/lib/cdn-image-loader.ts) will replace with the desired image dimensions. Width is required and height is optional. You may also optionally supply a `lossy` parameter to indicate if you would like images to be compressed lossily; the default is `true`. If you supply `false`, lossless compression will be used.
+
+## Using store assets uploaded via WebDAV
+
+Two helper functions are provided in [lib/store-assets](https://github.com/bigcommerce/catalyst/blob/main/apps/core/lib/store-assets.ts) to help build URLs for assets living in your store's object storage.
+
+`contentAssetUrl()` can be used to generate a URL to an arbitrary file asset in the `/content/` folder in WebDAV on your store.
+
+Usage:
+
+```javascript
+<Link href={contentAssetUrl('pdfs/user-manual.pdf')} >
+   User Manual
+</Link>
+```
+
+For image assets uploaded to `/content`, you may use `contentImageUrl()` to build a resizeable image URL that can be used with `<BcImage>`.
+
+Usage:
+
+```javascript
+<BcImage
+    alt="an assortment of brandless products against a blank background"
+    src={contentImageUrl('newsletter-images/april.png')}
+/>
+```
+
+You may optionally request a specific size for the image, using a size parameter of the form `123w`, `123x123`, or `original`.
+
+Usage:
+
+```javascript
+<Image
+    src={contentImageUrl('newsletter-images/april.png', '1000w')}
+/>
+```
+
+
+## Using Images uploaded to the Image Manager
+
+Use the `imageManagerImageUrl()` function to build a CDN URL for an image asset that has been uploaded to the Image Manager. This returns a resizeable URL template that can be used with `<BcImage>`.
+
+Usage:
+
+```javascript
+<BcImage
+    alt="an assortment of brandless products against a blank background"
+    src={imageManagerImageUrl('slideshow-bg-01.jpg')}
+/>
+```
+
+You may optionally request a specific size for the image, using a size parameter of the form `123w`, `123x123`, or `original`.
+
+Usage:
+
+```javascript
+<Image
+    src={imageManagerImageUrl('slideshow-bg-01.jpg', '1000w')}
+/>
+```


### PR DESCRIPTION
## What/Why?
Adds new helper functions + docs for using store assets in `/content` or Image Manager as part of a Catalyst storefront.

## Testing
Tested each function in isolation to load the carousel image and a link to a PDF.