### PR TITLE
Make Width Required for BcImage Component

### DIFF
--- a/apps/core/components/bc-image/index.tsx
+++ b/apps/core/components/bc-image/index.tsx
@@ -9,6 +9,7 @@ type NextImageProps = Omit<ComponentPropsWithRef<typeof Image>, 'quality'>;
 
 interface BcImageOptions {
   lossy?: boolean;
+  width: number;
 }
 
 type Props = NextImageProps & BcImageOptions;


### PR DESCRIPTION
## What/Why?

When I Use BCImage Without width props. next js gave me 
`Error: Image with src ["https://cdn11.bigcommerce.com/s-wjib9vtsnm/images/stencil/{:size}/image-manager/led-office-lighting.jpg"](http://localhost:3000/%22https://cdn11.bigcommerce.com/s-xxxxxxxx/images/stencil/%7B:size%7D/image-manager/led-office-lighting.jpg%22) is missing required "width" property.`

`
 <BcImage src={imageManagerImageUrl('led-office-lighting.jpg')} alt="Led Office Lightning" />
`

 In `bcCdnImageLoader` function width is required so In BcImage Component width should be required

___ edit screenshot ___

<img width="1015" alt="Screenshot 2024-03-26 at 14 07 37" src="https://github.com/bigcommerce/catalyst/assets/16627430/0c9fbfaa-7a76-43ca-8570-a1f5249793a1">





## Testing

Use BcImage component without width prop