### PR TITLE
Remove remotePatterns from next.config.js

### DIFF
--- a/apps/core/next.config.js
+++ b/apps/core/next.config.js
@@ -12,13 +12,6 @@ const cspHeader = `
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  images: {
-    remotePatterns: [
-      {
-        hostname: process.env.BIGCOMMERCE_CDN_HOSTNAME ?? '*.bigcommerce.com',
-      },
-    ],
-  },
   experimental: {
     optimizePackageImports: ['@icons-pack/react-simple-icons'],
   },


### PR DESCRIPTION
## What/Why?
Now that we've added a custom image loader in https://github.com/bigcommerce/catalyst/pull/701, we no longer need to specify these remotePatterns.

## Testing
https://catalyst-ksjmb4x1t-bigcommerce-platform.vercel.app/
