### PR TITLE
Add support for checking out as a logged-in customer

### DIFF
--- a/.changeset/neat-masks-travel.md
+++ b/.changeset/neat-masks-travel.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Add support for logged-in customer checkout using Customer Login API

--- a/apps/core/app/[locale]/(default)/cart/page.tsx
+++ b/apps/core/app/[locale]/(default)/cart/page.tsx
@@ -5,10 +5,10 @@ import { NextIntlClientProvider, useTranslations } from 'next-intl';
 import { getMessages, getTranslations } from 'next-intl/server';
 import { Suspense } from 'react';
 
-import { getCheckoutUrl } from '~/client/management/get-checkout-url';
 import { getCart } from '~/client/queries/get-cart';
 import { BcImage } from '~/components/bc-image';
 import { LocaleType } from '~/i18n';
+import { redirectToCheckout } from '~/lib/checkout-action';
 
 import { getShippingCountries } from './_actions/get-shipping-countries';
 import { removeProduct } from './_actions/remove-products';
@@ -33,13 +33,13 @@ const EmptyCart = () => {
   );
 };
 
-const CheckoutButton = async ({ cartId, label }: { cartId: string; label: string }) => {
-  const checkoutUrl = await getCheckoutUrl(cartId);
-
+const CheckoutButton = ({ label }: { label: string }) => {
   return (
-    <Button asChild className="mt-6">
-      <a href={checkoutUrl}>{label}</a>
-    </Button>
+    <form action={redirectToCheckout}>
+      <Button className="mt-6" type="submit">
+        {label}
+      </Button>
+    </form>
   );
 };
 
@@ -196,7 +196,7 @@ export default async function CartPage({ params: { locale } }: Props) {
           </NextIntlClientProvider>
 
           <Suspense fallback={t('loading')}>
-            <CheckoutButton cartId={cartId} label={t('proceedToCheckout')} />
+            <CheckoutButton label={t('proceedToCheckout')} />
           </Suspense>
         </div>
       </div>

--- a/apps/core/client/management/get-checkout-url.ts
+++ b/apps/core/client/management/get-checkout-url.ts
@@ -1,6 +1,12 @@
+import * as jose from 'jose';
 import { z } from 'zod';
 
 import { client } from '..';
+
+const clientSecret = process.env.BIGCOMMERCE_CLIENT_SECRET;
+const clientId = process.env.BIGCOMMERCE_CLIENT_ID;
+const channelId = process.env.BIGCOMMERCE_CHANNEL_ID ?? Number(process.env.BIGCOMMERCE_CHANNEL_ID);
+const storeHash = process.env.BIGCOMMERCE_STORE_HASH;
 
 const RedirectUrlsSchema = z.object({
   data: z.object({
@@ -10,13 +16,65 @@ const RedirectUrlsSchema = z.object({
   }),
 });
 
+/*
+ * Use the Customer Login API to ensure the customer is logged into the hosted checkout during the checkout redirect
+ * process. This is a temporary solution to support logged-in customer checkout until the GraphQL API supports this redirect functionality.
+ *
+ * https://developer.bigcommerce.com/docs/store-operations/customers#customer-login-api
+ *
+ * @param checkoutUrl - The checkout URL to redirect to, from V3 Cart API
+ * @param customerId - The customer ID to log in as, from the session
+ * @returns The Customer Login API URL, with the redirect URL encoded in the JWT
+ */
+const wrapInCustomerLoginJwt = async (checkoutUrl: string, customerId: number) => {
+  if (!clientSecret || !clientId) {
+    // eslint-disable-next-line no-console
+    console.error(
+      'Missing BIGCOMMERCE_CLIENT_SECRET and/or BIGCOMMERCE_CLIENT_ID, unable to redirect to checkout while preserving login state',
+    );
+
+    return checkoutUrl;
+  }
+
+  const urlObj = new URL(checkoutUrl);
+  const origin = urlObj.origin;
+  const relativeUrl = urlObj.pathname + urlObj.search;
+
+  const secret = new TextEncoder().encode(clientSecret);
+  const alg = 'HS256';
+
+  const jwt = await new jose.SignJWT({
+    operation: 'customer_login',
+    store_hash: storeHash,
+    customer_id: customerId,
+    channel_id: channelId,
+    jti: crypto.randomUUID(),
+    redirect_to: relativeUrl,
+  })
+    .setProtectedHeader({ alg, typ: 'JWT' })
+    .setIssuer(clientId)
+    // accommodate minor clock skew, ensures the token is not created
+    // in the future from the BigCommerce server's perspective
+    .setIssuedAt(Date.now() / 1000 - 5)
+    .setExpirationTime('24h')
+    .sign(secret);
+
+  return `${origin}/login/token/${jwt}`;
+};
+
 // Url used to redirect the user to the checkout page
-export const getCheckoutUrl = async (cartId: string) => {
+export const getCheckoutUrl = async (cartId: string, customerId?: number) => {
   const response = await client.fetchCartRedirectUrls(cartId);
   const parsedResponse = RedirectUrlsSchema.safeParse(response);
 
   if (parsedResponse.success) {
-    return parsedResponse.data.data.checkout_url;
+    const checkoutUrl = parsedResponse.data.data.checkout_url;
+
+    if (customerId) {
+      return wrapInCustomerLoginJwt(checkoutUrl, customerId);
+    }
+
+    return checkoutUrl;
   }
 
   throw new Error('Unable to get checkout URL: Invalid response');

--- a/apps/core/lib/checkout-action.ts
+++ b/apps/core/lib/checkout-action.ts
@@ -1,0 +1,20 @@
+'use server';
+
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+import { getSessionCustomerId } from '~/auth';
+import { getCheckoutUrl } from '~/client/management/get-checkout-url';
+
+export async function redirectToCheckout() {
+  const cartId = cookies().get('cartId')?.value;
+  const customerId = await getSessionCustomerId();
+
+  if (!cartId) {
+    redirect('/cart');
+  }
+
+  const checkoutUrl = await getCheckoutUrl(cartId, customerId);
+
+  redirect(checkoutUrl);
+}

--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -22,6 +22,7 @@
     "clsx": "^2.0.0",
     "gql.tada": "^1.4.0",
     "graphql": "^16.8.1",
+    "jose": "5.2.3",
     "lodash.debounce": "^4.0.8",
     "lucide-react": "^0.294.0",
     "next": "^14.1.0",

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -59,11 +59,11 @@ The call to the carts feature of the Management API generates checkout redirect 
 
 #### Customer Login
 
-If you want to support checkout for signed-in customers, add the Customers Login scope so you can generate valid Customer Login JWTs to pass to the [Customer Login API](https://developer.bigcommerce.com/docs/start/authentication/customer-login). To learn more, see [BIGCOMMERCE_CLIENT_SECRET](#bigcommerce_client_secret).
+If you want to support checkout for signed-in customers, add the Customers Login scope so you can generate valid Customer Login JWTs to pass to the [Customer Login API](https://developer.bigcommerce.com/docs/start/authentication/customer-login). To learn more, see [BIGCOMMERCE_CLIENT_SECRET](#bigcommerce_client_secret) and [BIGCOMMERCE_CLIENT_ID](#bigcommerce_client_id). We will remove this dependency in a future version of Catalyst.
 
 #### Information and Settings
 
-As of this writing, Catalyst requires the Information & Settings read-only scopes to estimate shipping costs using the Management API.
+As of this writing, Catalyst requires the Information & Settings read-only scopes to estimate shipping costs using the Management API. We will remove this dependency in a future version of Catalyst.
 
 ### BIGCOMMERCE_CUSTOMER_IMPERSONATION_TOKEN
 
@@ -173,6 +173,18 @@ To learn more, see any of the following docs:
 * [Customer Login](#customer-login) in this reference
 * Guide to the [Customer Login API](https://developer.bigcommerce.com/docs/start/authentication/customer-login), which describes how to make the necessary JWT
 * Reference for the endpoint to [Log a customer in](https://developer.bigcommerce.com/docs/rest-authentication/customer-login), which describes how to send the JWT to BigCommerce
+
+### BIGCOMMERCE_CLIENT_ID
+
+| Attribute | Value |
+|:----------|:------|
+| Type | string |
+| Default | no value |
+| Required | false |
+| CLI-configurable | false |
+| Recommended | true |
+
+If you create a dedicated API Account to support logged-in customer checkout, you should populate the `BIGCOMMERCE_CLIENT_ID` variable with the client ID corresponding to the `BIGCOMMERCE_CLIENT_SECRET`. Both of these values are necessary to sign Customer Login JWTs.
 
 ## Optional
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       graphql:
         specifier: ^16.8.1
         version: 16.8.1
+      jose:
+        specifier: 5.2.3
+        version: 5.2.3
       lodash.debounce:
         specifier: ^4.0.8
         version: 4.0.8
@@ -599,7 +602,7 @@ packages:
     dependencies:
       '@panva/hkdf': 1.1.1
       cookie: 0.6.0
-      jose: 5.1.3
+      jose: 5.2.3
       oauth4webapi: 2.4.0
       preact: 10.11.3
       preact-render-to-string: 5.2.3(preact@10.11.3)
@@ -10308,8 +10311,8 @@ packages:
     hasBin: true
     dev: true
 
-  /jose@5.1.3:
-    resolution: {integrity: sha512-GPExOkcMsCLBTi1YetY2LmkoY559fss0+0KVa6kOfb2YFe84nAM7Nm/XzuZozah4iHgmBGrCOHL5/cy670SBRw==}
+  /jose@5.2.3:
+    resolution: {integrity: sha512-KUXdbctm1uHVL8BYhnyHkgp3zDX5KW8ZhAKVFEfUbU2P8Alpzjb+48hHvjOdQIyPshoblhzsuqOwEEAbtHVirA==}
     dev: false
 
   /joycon@3.1.1:


### PR DESCRIPTION
## What/Why?
Adds the existing methodology for maintaining login state while checking out as a logged-in customer.

This approach uses the [Customer Login API](https://developer.bigcommerce.com/docs/start/authentication/customer-login), which requires that the Catalyst app have a Client ID and Client Secret from a Store API Account in order to sign login JWTs. This approach works for now, but we'd like to replace it in the future by supporting this checkout redirect directly in the GraphQL Storefront API - so this will be removed & replaced in the future, and that will remove the dependency on these additional credentials as well.

## Testing
Tested locally:
- Checking out as guest
- Checking out as customer with correct credentials
- Checking out as customer with no client ID/secret (falls back gracefully to guest checkout + logs error)