### PR TITLE
Prefetch the cart link immediately after add-to-cart

### DIFF
--- a/.changeset/fresh-lemons-lick.md
+++ b/.changeset/fresh-lemons-lick.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Prefetch high-intent cart link immediately after add to cart action

--- a/apps/core/app/[locale]/(default)/compare/_components/add-to-cart-form.tsx
+++ b/apps/core/app/[locale]/(default)/compare/_components/add-to-cart-form.tsx
@@ -40,7 +40,12 @@ export const AddToCartForm = ({
                 {t.rich('addedProductQuantity', {
                   cartItems: quantity,
                   cartLink: (chunks) => (
-                    <Link className="font-semibold text-primary" href="/cart">
+                    <Link
+                      className="font-semibold text-primary"
+                      href="/cart"
+                      prefetch="viewport"
+                      prefetchKind="full"
+                    >
                       {chunks}
                     </Link>
                   ),

--- a/apps/core/components/product-card/cart.tsx
+++ b/apps/core/components/product-card/cart.tsx
@@ -56,7 +56,12 @@ export const Cart = ({ product }: { product: Partial<Product> }) => {
                 {t.rich('addedProductQuantity', {
                   cartItems: quantity,
                   cartLink: (chunks) => (
-                    <Link className="font-semibold text-primary" href="/cart">
+                    <Link
+                      className="font-semibold text-primary"
+                      href="/cart"
+                      prefetch="viewport"
+                      prefetchKind="full"
+                    >
                       {chunks}
                     </Link>
                   ),

--- a/apps/core/components/product-form/index.tsx
+++ b/apps/core/components/product-form/index.tsx
@@ -48,7 +48,12 @@ export const ProductForm = ({ product }: { product: Product }) => {
             {t.rich('addedProductQuantity', {
               cartItems: quantity,
               cartLink: (chunks) => (
-                <Link className="font-semibold text-primary hover:text-secondary" href="/cart">
+                <Link
+                  className="font-semibold text-primary hover:text-secondary"
+                  href="/cart"
+                  prefetch="viewport"
+                  prefetchKind="full"
+                >
                   {chunks}
                 </Link>
               ),


### PR DESCRIPTION
## What/Why?
Add opportunistic `prefetch` to the cart link a shopper sees immediately after add-to-cart, since they are very likely to click on it after adding to cart.

This is a low-traffic, high-value deployment of prefetch which significantly improves the experience.

## Testing
Added to cart on PDP, PLP, and compare page and compared load performance of the cart link to main.

Try it yourself on the preview deployment.