### PR TITLE
fix(core): preselect first state when country is selected

### DIFF
--- a/.changeset/mean-meals-appear.md
+++ b/.changeset/mean-meals-appear.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Preselect first state when country is selected for Shipping Info

--- a/apps/core/app/[locale]/(default)/cart/_components/shipping-info.tsx
+++ b/apps/core/app/[locale]/(default)/cart/_components/shipping-info.tsx
@@ -106,6 +106,12 @@ export const ShippingInfo = ({
     }
   }, [formValues.country, t]);
 
+  useEffect(() => {
+    if (formValues.states && !formValues.state) {
+      setFormValues({ state: formValues.states[0]?.state || '' });
+    }
+  }, [formValues.state, formValues.states]);
+
   const onSubmit = async (formData: FormData) => {
     const { status } = await submitShippingInfo(formData, {
       checkoutId: checkout.entityId,

--- a/apps/core/app/[locale]/(default)/cart/_components/shipping-info.tsx
+++ b/apps/core/app/[locale]/(default)/cart/_components/shipping-info.tsx
@@ -86,6 +86,7 @@ export const ShippingInfo = ({
     },
   );
 
+  // Fetch states when country changes
   useEffect(() => {
     if (formValues.country) {
       const countryId = formValues.country.split('-')[1];
@@ -106,6 +107,7 @@ export const ShippingInfo = ({
     }
   }, [formValues.country, t]);
 
+  // Preselect first state when states array changes and state is empty
   useEffect(() => {
     if (formValues.states && !formValues.state) {
       setFormValues({ state: formValues.states[0]?.state || '' });
@@ -130,19 +132,6 @@ export const ShippingInfo = ({
     }
   };
 
-  const resetFormFieldsOnCountryChange = () => {
-    if (formValues.country) {
-      setFormValues({
-        states: [],
-        state: '',
-        city: '',
-        postcode: '',
-      });
-
-      hideShippingOptions();
-    }
-  };
-
   return (
     <Form
       action={onSubmit}
@@ -158,12 +147,12 @@ export const ShippingInfo = ({
                 const countryId = value.split('-')[1];
 
                 if (countryId) {
-                  setFormValues({ country: value });
+                  setFormValues({ country: value, states: [], state: '', city: '', postcode: '' });
                 } else {
-                  setFormValues({ country: '' });
+                  setFormValues({ country: '', states: [], state: '', city: '', postcode: '' });
                 }
 
-                resetFormFieldsOnCountryChange();
+                hideShippingOptions();
               }}
               placeholder={t('countryPlaceholder')}
               value={formValues.country}

--- a/packages/components/src/components/form/form.tsx
+++ b/packages/components/src/components/form/form.tsx
@@ -68,7 +68,7 @@ const FieldLabel = forwardRef<ElementRef<typeof Label>, FieldLabelProps>(
       {...props}
     >
       <span>{children}</span>
-      {isRequired && <span className="text-xs font-normal  text-gray-500">Required</span>}
+      {isRequired && <span className="text-xs font-normal text-gray-500">Required</span>}
     </Label>
   ),
 );

--- a/packages/components/src/components/form/form.tsx
+++ b/packages/components/src/components/form/form.tsx
@@ -68,9 +68,7 @@ const FieldLabel = forwardRef<ElementRef<typeof Label>, FieldLabelProps>(
       {...props}
     >
       <span>{children}</span>
-      {isRequired && (
-        <span className="text-xs font-normal font-normal text-gray-500">Required</span>
-      )}
+      {isRequired && <span className="text-xs font-normal  text-gray-500">Required</span>}
     </Label>
   ),
 );


### PR DESCRIPTION
## What/Why?
To match the expected behavior, this change will preselect first state (if country has states array) so that it visibly demonstrate state selection that is currently being preselected when form submits.

![Screenshot 2024-04-02 at 1 31 57 PM](https://github.com/bigcommerce/catalyst/assets/196129/8172fb9f-c5ee-4ef3-8bde-480cf668dc55)

## Testing
Locally.