### PR TITLE
feat(core): Support SSG when the cart is non-empty

### DIFF
--- a/.changeset/yellow-clouds-grab.md
+++ b/.changeset/yellow-clouds-grab.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Support serving static pages when the cart is not empty

--- a/apps/core/app/api/cart-quantity/route.ts
+++ b/apps/core/app/api/cart-quantity/route.ts
@@ -1,0 +1,18 @@
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+
+import { getCart } from '~/client/queries/get-cart';
+
+export const GET = async () => {
+  const cartId = cookies().get('cartId')?.value;
+
+  if (cartId) {
+    const cart = await getCart(cartId);
+
+    return NextResponse.json({ count: cart?.lineItems.totalQuantity ?? 0 });
+  }
+
+  return NextResponse.json({ count: 0 });
+};
+
+export const runtime = 'edge';

--- a/apps/core/components/header/cart-icon.tsx
+++ b/apps/core/components/header/cart-icon.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { Badge } from '@bigcommerce/components/badge';
+import { ShoppingCart } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { z } from 'zod';
+
+export const CartQuantityResponseSchema = z.object({
+  count: z.number(),
+});
+
+interface CartIconProps {
+  count?: number;
+}
+
+export const CartIcon = ({ count }: CartIconProps) => {
+  const [fetchedCount, setFetchedCount] = useState<number | null>();
+  const computedCount = count ?? fetchedCount;
+
+  useEffect(() => {
+    async function fetchCartQuantity() {
+      const response = await fetch(`/api/cart-quantity/`);
+      const parsedData = CartQuantityResponseSchema.parse(await response.json());
+
+      setFetchedCount(parsedData.count);
+    }
+
+    // When a page is rendered statically via the 'force-static' route config option, cookies().get() always returns undefined,
+    // which ultimately means that the `count` prop here will always be undefined on initial render, even if there actually is
+    // a populated cart. Thus, we perform a client-side check in this case.
+    if (count === undefined) {
+      void fetchCartQuantity();
+    }
+  }, [count]);
+
+  if (!computedCount) {
+    return <ShoppingCart aria-label="cart" />;
+  }
+
+  return (
+    <>
+      <span className="sr-only">Cart Items</span>
+      <ShoppingCart aria-hidden="true" />
+      <Badge> {computedCount}</Badge>
+    </>
+  );
+};

--- a/apps/core/components/header/cart.tsx
+++ b/apps/core/components/header/cart.tsx
@@ -1,11 +1,11 @@
-import { Badge } from '@bigcommerce/components/badge';
 import { NavigationMenuLink } from '@bigcommerce/components/navigation-menu';
-import { ShoppingCart } from 'lucide-react';
 import { cookies } from 'next/headers';
 import { ReactNode } from 'react';
 
 import { getCart } from '~/client/queries/get-cart';
 import { Link } from '~/components/link';
+
+import { CartIcon } from './cart-icon';
 
 export const CartLink = ({ children }: { children: ReactNode }) => (
   <NavigationMenuLink asChild>
@@ -21,20 +21,18 @@ export const Cart = async () => {
   if (!cartId) {
     return (
       <CartLink>
-        <ShoppingCart aria-label="cart" />
+        <CartIcon />
       </CartLink>
     );
   }
 
   const cart = await getCart(cartId);
 
-  const count = cart?.lineItems.totalQuantity;
+  const count = cart?.lineItems.totalQuantity ?? 0;
 
   return (
     <CartLink>
-      <span className="sr-only">Cart Items</span>
-      <ShoppingCart aria-hidden="true" />
-      {Boolean(count) && <Badge> {count}</Badge>}
+      <CartIcon count={count} />
     </CartLink>
   );
 };

--- a/apps/core/middlewares/with-routes.ts
+++ b/apps/core/middlewares/with-routes.ts
@@ -205,10 +205,9 @@ export const withRoutes: MiddlewareFactory = () => {
     }
 
     const customerId = await getSessionCustomerId();
-    const cartId = cookies().get('cartId');
     let postfix = '';
 
-    if (!request.nextUrl.search && !customerId && !cartId && request.method === 'GET') {
+    if (!request.nextUrl.search && !customerId && request.method === 'GET') {
       postfix = '/static';
     }
 


### PR DESCRIPTION
## What/Why?
Move the cart badge icon (indicating the number of items in the cart) to a client component, allowing us to drop the requirement that the user must not have a cart yet in order to support static routes. Now, the static pages are generated with empty carts, and when the client `CartBadge` component is initially rendered, it fetches the cart quantity from a new API endpoint. Revalidation of data still works as it did previously.

## Testing
Tested locally and in a vercel preview build, verifying that the transition from empty cart -> populated cart works correctly, as well as subsequent additions to the cart.