### PR TITLE
feat: use streaming + cache for cart [experimental]

### DIFF
--- a/apps/core/app/[locale]/(default)/cart/_actions/update-product-quantity.ts
+++ b/apps/core/app/[locale]/(default)/cart/_actions/update-product-quantity.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { revalidatePath } from 'next/cache';
+import { revalidatePath, revalidateTag } from 'next/cache';
 import { cookies } from 'next/headers';
 
 import { graphql } from '~/client/graphql';
@@ -44,5 +44,6 @@ export async function updateProductQuantity({
     throw new Error('Failed to change product quantity in Cart');
   }
 
+  revalidateTag('cart');
   revalidatePath('/cart');
 }

--- a/apps/core/app/[locale]/(default)/layout.tsx
+++ b/apps/core/app/[locale]/(default)/layout.tsx
@@ -8,7 +8,6 @@ import { graphql } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
 import { Footer, FooterFragment } from '~/components/footer/footer';
 import { Header, HeaderFragment } from '~/components/header';
-import { Cart } from '~/components/header/cart';
 import { ProductSheet } from '~/components/product-sheet';
 import { LocaleType } from '~/i18n';
 
@@ -42,7 +41,7 @@ export default async function DefaultLayout({ children, params: { locale } }: Pr
 
   return (
     <>
-      <Header cart={<Cart />} data={data.site} />
+      <Header data={data.site} />
 
       <main className="flex-1 px-6 2xl:container sm:px-10 lg:px-12 2xl:mx-auto 2xl:px-0">
         {children}

--- a/apps/core/app/[locale]/not-found.tsx
+++ b/apps/core/app/[locale]/not-found.tsx
@@ -1,5 +1,4 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
-import { ShoppingCart } from 'lucide-react';
 import { NextIntlClientProvider } from 'next-intl';
 import { getLocale, getMessages, getTranslations } from 'next-intl/server';
 
@@ -9,7 +8,6 @@ import { graphql } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
 import { Footer, FooterFragment } from '~/components/footer/footer';
 import { Header, HeaderFragment } from '~/components/header';
-import { CartLink } from '~/components/header/cart';
 import { ProductCard } from '~/components/product-card';
 import { SearchForm } from '~/components/search-form';
 
@@ -55,14 +53,7 @@ export default async function NotFound() {
 
   return (
     <>
-      <Header
-        cart={
-          <CartLink>
-            <ShoppingCart aria-label="cart" />
-          </CartLink>
-        }
-        data={data.site}
-      />
+      <Header data={data.site} />
 
       <main className="mx-auto mb-10 max-w-[835px] space-y-8 px-6 sm:px-10 lg:px-0">
         <div className="flex flex-col gap-8 px-0 py-16">

--- a/apps/core/client/queries/get-cart.ts
+++ b/apps/core/client/queries/get-cart.ts
@@ -128,7 +128,6 @@ export const getCart = cache(async (cartId?: string) => {
     variables: { cartId },
     customerId,
     fetchOptions: {
-      cache: 'no-store',
       next: {
         tags: ['cart'],
       },

--- a/apps/core/components/header/cart.tsx
+++ b/apps/core/components/header/cart.tsx
@@ -7,7 +7,7 @@ import { ReactNode } from 'react';
 import { getCart } from '~/client/queries/get-cart';
 import { Link } from '~/components/link';
 
-export const CartLink = ({ children }: { children: ReactNode }) => (
+const CartLink = ({ children }: { children: ReactNode }) => (
   <NavigationMenuLink asChild>
     <Link className="relative" href="/cart">
       {children}
@@ -15,15 +15,17 @@ export const CartLink = ({ children }: { children: ReactNode }) => (
   </NavigationMenuLink>
 );
 
+export const EmptyCart = () => (
+  <CartLink>
+    <ShoppingCart aria-label="cart" />
+  </CartLink>
+);
+
 export const Cart = async () => {
   const cartId = cookies().get('cartId')?.value;
 
   if (!cartId) {
-    return (
-      <CartLink>
-        <ShoppingCart aria-label="cart" />
-      </CartLink>
-    );
+    return <EmptyCart />;
   }
 
   const cart = await getCart(cartId);

--- a/apps/core/components/header/index.tsx
+++ b/apps/core/components/header/index.tsx
@@ -7,8 +7,8 @@ import {
   NavigationMenuList,
   NavigationMenuToggle,
 } from '@bigcommerce/components/navigation-menu';
-import { ShoppingCart, User } from 'lucide-react';
-import { ReactNode, Suspense } from 'react';
+import { User } from 'lucide-react';
+import { Suspense } from 'react';
 
 import { getSessionCustomerId } from '~/auth';
 import { FragmentOf, graphql } from '~/client/graphql';
@@ -19,7 +19,7 @@ import { StoreLogo, StoreLogoFragment } from '../store-logo';
 
 import { HeaderNav, HeaderNavFragment } from './_actions/header-nav';
 import { logout } from './_actions/logout';
-import { CartLink } from './cart';
+import { Cart, EmptyCart } from './cart';
 
 export const HeaderFragment = graphql(
   `
@@ -34,11 +34,10 @@ export const HeaderFragment = graphql(
 );
 
 interface Props {
-  cart: ReactNode;
   data: FragmentOf<typeof HeaderFragment>;
 }
 
-export const Header = async ({ cart, data }: Props) => {
+export const Header = async ({ data }: Props) => {
   const customerId = await getSessionCustomerId();
 
   return (
@@ -156,14 +155,8 @@ export const Header = async ({ cart, data }: Props) => {
             </NavigationMenuItem>
             <NavigationMenuItem>
               <p role="status">
-                <Suspense
-                  fallback={
-                    <CartLink>
-                      <ShoppingCart aria-label="cart" />
-                    </CartLink>
-                  }
-                >
-                  {cart}
+                <Suspense fallback={<EmptyCart />}>
+                  <Cart />
                 </Suspense>
               </p>
             </NavigationMenuItem>


### PR DESCRIPTION
## What/Why?
After doing some research from @christensenep's PR #724, we are not caching our cart request. We also discussed this a bit in #647. I am proposing to add this PR into main for a bit to see from Vercel's side what Data Cache implications are if we cached this request. We are mostly curious to see if our cache will be evicted more heavily now that we are caching user-specific requests.

## Testing
Doing some testing, most requests seemed to be sub-400ms with an item added to the cart. I want to measure for a week if that is the case in prod + identifying the Data Cache implications.