### PR TITLE
fix(core): Fix breadcrumb links on PDP

### DIFF
--- a/.changeset/sweet-frogs-compete.md
+++ b/.changeset/sweet-frogs-compete.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Fix breadcrumbs on PDP to have correct links

--- a/apps/core/app/[locale]/(default)/product/[slug]/_components/breadcrumbs.tsx
+++ b/apps/core/app/[locale]/(default)/product/[slug]/_components/breadcrumbs.tsx
@@ -17,7 +17,7 @@ export const BreadCrumbs = async ({ productId }: Props) => {
   return (
     <nav>
       <ul className="m-0 flex flex-wrap items-center p-0 md:container md:mx-auto ">
-        {category.breadcrumbs.map((breadcrumb, i, arr) => {
+        {category.breadcrumbs.map(({ name, path }, i, arr) => {
           const isLast = arr.length - 1 === i;
 
           return (
@@ -26,9 +26,9 @@ export const BreadCrumbs = async ({ productId }: Props) => {
                 'font-semibold': !isLast,
                 'font-extrabold': isLast,
               })}
-              key={breadcrumb.name}
+              key={name}
             >
-              <Link href="#">{breadcrumb.name}</Link>
+              <Link href={path ?? '#'}>{name}</Link>
               {!isLast && <span className="mx-2">/</span>}
             </li>
           );

--- a/apps/core/client/queries/get-product.ts
+++ b/apps/core/client/queries/get-product.ts
@@ -175,6 +175,7 @@ const PRODUCT_FRAGMENT = graphql(
               edges {
                 node {
                   name
+                  path
                 }
               }
             }


### PR DESCRIPTION
## What/Why?
The breadcrumb links on the PDP were all pointing to `#`. I've added the `path` field to the getProduct query so that we have the path of each category available to populate the link with.

## Testing
Verified that the breadcrumb links on the PDP now link to the correct page.