### PR TITLE
feat(core): add tax total in checkout summary

### DIFF
--- a/.changeset/tiny-balloons-learn.md
+++ b/.changeset/tiny-balloons-learn.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Add tax total in checkout summary

--- a/apps/core/app/[locale]/(default)/cart/_components/checkout-summary.tsx
+++ b/apps/core/app/[locale]/(default)/cart/_components/checkout-summary.tsx
@@ -47,6 +47,11 @@ export const CheckoutSummary = async ({ cartId, locale }: { cartId: string; loca
         <span>-{currencyFormatter.format(checkout.cart?.discountedAmount.value || 0)}</span>
       </div>
 
+      <div className="flex justify-between border-t border-t-gray-200 py-4">
+        <span className="font-semibold">{t('tax')}</span>
+        <span>{currencyFormatter.format(checkout.taxTotal?.value || 0)}</span>
+      </div>
+
       <div className="flex justify-between border-t border-t-gray-200 py-4 text-xl font-bold lg:text-2xl">
         {t('grandTotal')}
         <span>{currencyFormatter.format(checkout.grandTotal?.value || 0)}</span>

--- a/apps/core/app/[locale]/(default)/cart/_components/checkout-summary.tsx
+++ b/apps/core/app/[locale]/(default)/cart/_components/checkout-summary.tsx
@@ -47,10 +47,12 @@ export const CheckoutSummary = async ({ cartId, locale }: { cartId: string; loca
         <span>-{currencyFormatter.format(checkout.cart?.discountedAmount.value || 0)}</span>
       </div>
 
-      <div className="flex justify-between border-t border-t-gray-200 py-4">
-        <span className="font-semibold">{t('tax')}</span>
-        <span>{currencyFormatter.format(checkout.taxTotal?.value || 0)}</span>
-      </div>
+      {checkout.taxTotal && (
+        <div className="flex justify-between border-t border-t-gray-200 py-4">
+          <span className="font-semibold">{t('tax')}</span>
+          <span>{currencyFormatter.format(checkout.taxTotal.value)}</span>
+        </div>
+      )}
 
       <div className="flex justify-between border-t border-t-gray-200 py-4 text-xl font-bold lg:text-2xl">
         {t('grandTotal')}

--- a/apps/core/messages/en.json
+++ b/apps/core/messages/en.json
@@ -108,6 +108,7 @@
     "CheckoutSummary": {
       "subTotal": "Subtotal",
       "discounts": "Discounts",
+      "tax": "Tax",
       "grandTotal": "Grand total",
       "shipping": "Shipping",
       "shippingCost": "Shipping Cost",


### PR DESCRIPTION
## What/Why?
Add total tax from checkout.

![Screenshot 2024-04-04 at 10 25 20 AM](https://github.com/bigcommerce/catalyst/assets/196129/b22125d4-df39-4e29-ad30-ffa10874d1be)

## Testing
Locally.