### PR TITLE
fix(core): pass customer id to shipping mutations

### DIFF
--- a/.changeset/smart-turtles-raise.md
+++ b/.changeset/smart-turtles-raise.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Pass customer id to shipping mutation that were missing.

--- a/apps/core/app/[locale]/(default)/cart/_components/shipping-info.tsx
+++ b/apps/core/app/[locale]/(default)/cart/_components/shipping-info.tsx
@@ -125,7 +125,7 @@ export const ShippingInfo = ({
       shippingId: shippingConsignment?.entityId ?? '',
     });
 
-    if (status === 'error') {
+    if (status === 'failed') {
       toast.error(t('errorMessage'), {
         icon: <AlertCircle className="text-error-secondary" />,
       });

--- a/apps/core/app/[locale]/(default)/cart/_components/shipping-options.tsx
+++ b/apps/core/app/[locale]/(default)/cart/_components/shipping-options.tsx
@@ -68,8 +68,8 @@ export const ShippingOptions = ({
   const onSubmit = async (formData: FormData) => {
     const { status } = await submitShippingCosts(formData, checkout.entityId, consignmentEntityId);
 
-    if (status === 'error') {
-      toast.error(t('errorMessage2'), {
+    if (status === 'failed') {
+      toast.error(t('errorMessage'), {
         icon: <AlertCircle className="text-error-secondary" />,
       });
     }

--- a/apps/core/client/mutations/add-checkout-shipping-consignments.ts
+++ b/apps/core/client/mutations/add-checkout-shipping-consignments.ts
@@ -1,3 +1,5 @@
+import { getSessionCustomerId } from '~/auth';
+
 import { client } from '..';
 import { graphql, VariablesOf } from '../graphql';
 
@@ -38,6 +40,8 @@ export const addCheckoutShippingConsignments = async ({
   lineItems,
   shouldSaveAddress = false,
 }: AddCheckoutShippingConsignmentsProps) => {
+  const customerId = await getSessionCustomerId();
+
   const response = await client.fetch({
     document: ADD_CHECKOUT_SHIPPING_CONSIGNMENTS_MUTATION,
     variables: {
@@ -59,6 +63,8 @@ export const addCheckoutShippingConsignments = async ({
         },
       },
     },
+    customerId,
+    fetchOptions: { cache: 'no-store' },
   });
 
   const checkout = response.data.checkout.addCheckoutShippingConsignments?.checkout;

--- a/apps/core/client/mutations/select-checkout-shipping-option.ts
+++ b/apps/core/client/mutations/select-checkout-shipping-option.ts
@@ -1,3 +1,5 @@
+import { getSessionCustomerId } from '~/auth';
+
 import { client } from '..';
 import { graphql } from '../graphql';
 
@@ -22,6 +24,8 @@ export const selectCheckoutShippingOption = async ({
   consignmentEntityId: string;
   shippingOptionEntityId: string;
 }) => {
+  const customerId = await getSessionCustomerId();
+
   const response = await client.fetch({
     document: SELECT_CHECKOUT_SHIPPING_OPTION_MUTATION,
     variables: {
@@ -33,6 +37,8 @@ export const selectCheckoutShippingOption = async ({
         },
       },
     },
+    customerId,
+    fetchOptions: { cache: 'no-store' },
   });
 
   const shippingCosts = response.data.checkout.selectCheckoutShippingOption?.checkout;

--- a/apps/core/client/mutations/update-checkout-shipping-consigment.ts
+++ b/apps/core/client/mutations/update-checkout-shipping-consigment.ts
@@ -1,3 +1,5 @@
+import { getSessionCustomerId } from '~/auth';
+
 import { client } from '..';
 import { graphql, VariablesOf } from '../graphql';
 
@@ -40,6 +42,8 @@ export const updateCheckoutShippingConsignment = async ({
   lineItems,
   shouldSaveAddress = false,
 }: UpdateCheckoutShippingConsignmentProps) => {
+  const customerId = await getSessionCustomerId();
+
   const response = await client.fetch({
     document: UPDATE_CHECKOUT_SHIPPING_CONSIGNMENT,
     variables: {
@@ -60,6 +64,8 @@ export const updateCheckoutShippingConsignment = async ({
         },
       },
     },
+    customerId,
+    fetchOptions: { cache: 'no-store' },
   });
 
   const checkout = response.data.checkout.updateCheckoutShippingConsignment?.checkout;


### PR DESCRIPTION
## What/Why?
Because we were not passing in customer id, logged in users couldn't update shipping info.

## Testing
Locally.