### PR TITLE
chore(ci): dependabot ignore eslint major

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,5 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: '@types/node'
         update-types: ['version-update:semver-major']
+      - dependency-name: 'eslint'
+        update-types: ['version-update:semver-major']


### PR DESCRIPTION
## What/Why?
`eslint` major will take us a bit, need to update BC's config first