### PR TITLE
chore(core): bump react simple icons

### DIFF
--- a/.changeset/slow-pens-change.md
+++ b/.changeset/slow-pens-change.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+fix social icons type errors with latest @types/react

--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@bigcommerce/catalyst-client": "workspace:^",
     "@bigcommerce/components": "workspace:^",
-    "@icons-pack/react-simple-icons": "^9.4.0",
+    "@icons-pack/react-simple-icons": "^9.4.1",
     "@vercel/analytics": "^1.2.2",
     "@vercel/kv": "^1.0.1",
     "@vercel/speed-insights": "^1.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/components
       '@icons-pack/react-simple-icons':
-        specifier: ^9.4.0
-        version: 9.4.0(react@18.2.0)
+        specifier: ^9.4.1
+        version: 9.4.1(react@18.2.0)
       '@vercel/analytics':
         specifier: ^1.2.2
         version: 1.2.2(next@14.1.4)(react@18.2.0)
@@ -2992,8 +2992,8 @@ packages:
   /@humanwhocodes/object-schema@2.0.3:
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
 
-  /@icons-pack/react-simple-icons@9.4.0(react@18.2.0):
-    resolution: {integrity: sha512-fZtC4Zv53hE+IQE2dJlFt3EB6UOifwTrUNMuEu4hSXemtqMahd05Dpvj2K0j2ewVc+j/ibavud3xjfaMB2Nj7g==}
+  /@icons-pack/react-simple-icons@9.4.1(react@18.2.0):
+    resolution: {integrity: sha512-oDX8iE/AOyRIY0ys56+eybKSsyZODHQIPZ5mAGVxx3TszkA5l8lIxKl8HI9F801Y1CJxcySBjIk1XibrnFF0Hw==}
     peerDependencies:
       react: ^16.13 || ^17 || ^18
     dependencies:


### PR DESCRIPTION
## What/Why?
`@icons-pack/react-simple-icons` released a new patch version addressing the typing issues with latest `@types/react`.

This change should fix the errors in https://github.com/bigcommerce/catalyst/pull/738 

## Testing
CI 👀 