### PR TITLE
fix(core): add missing Cart.spinnerText translation

### DIFF
--- a/.changeset/smooth-ties-explain.md
+++ b/.changeset/smooth-ties-explain.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Add missing `Cart.spinnerText` translation.

--- a/apps/core/messages/en.json
+++ b/apps/core/messages/en.json
@@ -105,6 +105,7 @@
     "removeFromCart": "Remove product from cart",
     "proceedToCheckout": "Proceed to checkout",
     "loading": "Loading...",
+    "spinnerText": "Updating...",
     "CheckoutSummary": {
       "subTotal": "Subtotal",
       "discounts": "Discounts",


### PR DESCRIPTION
## What/Why?
Adds the missing `Cart.spinnerText` translation.