### PR TITLE
fix(core): check for auth on account pages

### DIFF
--- a/.changeset/silver-bulldogs-hammer.md
+++ b/.changeset/silver-bulldogs-hammer.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+check for auth on /account pages

--- a/apps/core/app/[locale]/(default)/account/layout.tsx
+++ b/apps/core/app/[locale]/(default)/account/layout.tsx
@@ -1,0 +1,14 @@
+import { redirect } from 'next/navigation';
+import { PropsWithChildren } from 'react';
+
+import { auth } from '~/auth';
+
+export default async function AccountLayout({ children }: PropsWithChildren) {
+  const session = await auth();
+
+  if (!session) {
+    redirect('/login');
+  }
+
+  return children;
+}

--- a/apps/core/app/[locale]/(default)/account/page.tsx
+++ b/apps/core/app/[locale]/(default)/account/page.tsx
@@ -1,9 +1,7 @@
 import { BookUser, Eye, Gift, Mail, Package, Settings } from 'lucide-react';
-import { redirect } from 'next/navigation';
 import { getTranslations } from 'next-intl/server';
 import { ReactNode } from 'react';
 
-import { auth } from '~/auth';
 import { Link } from '~/components/link';
 import { LocaleType } from '~/i18n';
 
@@ -36,16 +34,11 @@ interface Props {
 }
 
 export default async function AccountPage({ params: { locale } }: Props) {
-  const session = await auth();
   const t = await getTranslations({ locale, namespace: 'Account.Home' });
-
-  if (!session) {
-    redirect('/login');
-  }
 
   return (
     <div className="mx-auto">
-      <h1 className="my-6 my-8 text-4xl font-black lg:my-8 lg:text-5xl">{t('heading')}</h1>
+      <h1 className="my-8 text-4xl font-black lg:my-8 lg:text-5xl">{t('heading')}</h1>
 
       <div className="mb-14 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
         <AccountItem href="/account/orders" title={t('orders')}>


### PR DESCRIPTION
## What/Why?
Check for auth in all child pages of `/account`. Currently accessing `/account/settings` without being logged in will still render the page.

## Testing
Navigating to `/account/settings` redirects to `/login` when not logged in.