### PR TITLE
feat(core): Verify account access is restricted

### DIFF
--- a/packages/functional/tests/ui/desktop/e2e/account.spec.ts
+++ b/packages/functional/tests/ui/desktop/e2e/account.spec.ts
@@ -1,0 +1,8 @@
+import { expect, test } from '@playwright/test';
+
+test('Account access is restricted for guest users', async ({ page }) => {
+  await page.goto('/account/settings');
+
+  await expect(page.getByRole('heading', { name: 'My Account' })).toBeVisible({ visible: false });
+  await expect(page.getByRole('heading', { name: 'Log in' })).toBeVisible();
+});


### PR DESCRIPTION
## What/Why?
Test to verify that a guest user cannot access account settings unless they login.

## Testing
Tested against a deployment locally.