### PR TITLE
feat(core): use LRU cache for DevKvAdapter

### DIFF
--- a/.changeset/empty-carrots-poke.md
+++ b/.changeset/empty-carrots-poke.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+use LRU cache for DevKvAdapter

--- a/apps/core/lib/kv/adapters/dev.ts
+++ b/apps/core/lib/kv/adapters/dev.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/require-await */
+import { LRUCache } from 'lru-cache';
+
 import { KvAdapter } from '../types';
 
 interface CacheEntry {
@@ -7,7 +9,9 @@ interface CacheEntry {
 }
 
 export class DevKvAdapter implements KvAdapter {
-  private kv = new Map<string, CacheEntry>();
+  private kv = new LRUCache<string, CacheEntry>({
+    max: 500,
+  });
 
   constructor() {
     // eslint-disable-next-line no-console

--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -23,6 +23,7 @@
     "gql.tada": "^1.4.3",
     "graphql": "^16.8.1",
     "lodash.debounce": "^4.0.8",
+    "lru-cache": "^10.2.0",
     "lucide-react": "^0.365.0",
     "next": "14.1.4",
     "next-auth": "5.0.0-beta.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       lodash.debounce:
         specifier: ^4.0.8
         version: 4.0.8
+      lru-cache:
+        specifier: ^10.2.0
+        version: 10.2.0
       lucide-react:
         specifier: ^0.365.0
         version: 0.365.0(react@18.2.0)


### PR DESCRIPTION
## What/Why?
Use an LRU cache for our dev kv adapter. This should work closer to how KV works in prod.

We will be dogfooding this for a bit, and potentially promote it to a non-dev adapter as it may benefit self-hosters.