### PR TITLE
feat(cli): copy vscode ts settings

### DIFF
--- a/.changeset/clean-jokes-sneeze.md
+++ b/.changeset/clean-jokes-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": minor
+---
+
+Adds the `.vscode/settings.json` file pointing to the correct typescript sdk for gql-tada support.

--- a/packages/create-catalyst/src/commands/create.ts
+++ b/packages/create-catalyst/src/commands/create.ts
@@ -20,7 +20,7 @@ import { writeEnv } from '../utils/write-env';
 const exec = promisify(execCallback);
 
 export const create = async (options: CreateCommandOptions) => {
-  const { packageManager } = options;
+  const { packageManager, codeEditor } = options;
 
   const URLSchema = z.string().url();
   const sampleDataApiUrl = parse(options.sampleDataApiUrl, URLSchema);
@@ -97,7 +97,7 @@ export const create = async (options: CreateCommandOptions) => {
   if (!storeHash || !accessToken) {
     console.log(`\nCreating '${projectName}' at '${projectDir}'\n`);
 
-    await cloneCatalyst({ projectDir, projectName, ghRef });
+    await cloneCatalyst({ projectDir, projectName, ghRef, codeEditor });
 
     console.log(`\nUsing ${chalk.bold(packageManager)}\n`);
 
@@ -193,7 +193,7 @@ export const create = async (options: CreateCommandOptions) => {
 
   console.log(`\nCreating '${projectName}' at '${projectDir}'\n`);
 
-  await cloneCatalyst({ projectDir, projectName, ghRef });
+  await cloneCatalyst({ projectDir, projectName, ghRef, codeEditor });
 
   writeEnv(projectDir, {
     channelId: channelId.toString(),

--- a/packages/create-catalyst/src/index.ts
+++ b/packages/create-catalyst/src/index.ts
@@ -65,6 +65,12 @@ const createCommand = program
       .default(getPackageManager())
       .hideHelp(),
   )
+  .addOption(
+    new Option('--code-editor <editor>', 'Your preferred code editor')
+      .choices(['vscode'])
+      .default('vscode')
+      .hideHelp(),
+  )
   .action((opts) => create(opts));
 
 export type CreateCommandOptions = Options<typeof createCommand>[0];

--- a/packages/create-catalyst/src/utils/clone-catalyst.ts
+++ b/packages/create-catalyst/src/utils/clone-catalyst.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { copySync, readJsonSync, removeSync, writeJsonSync } from 'fs-extra/esm';
+import { copySync, ensureDir, readJsonSync, removeSync, writeJsonSync } from 'fs-extra/esm';
 import { downloadTemplate } from 'giget';
 import merge from 'lodash.merge';
 import { join } from 'path';
@@ -8,10 +8,12 @@ import * as z from 'zod';
 import { spinner } from './spinner';
 
 export const cloneCatalyst = async ({
+  codeEditor,
   projectDir,
   projectName,
   ghRef = 'main',
 }: {
+  codeEditor: string;
   projectDir: string;
   projectName: string;
   ghRef?: string;
@@ -42,6 +44,21 @@ export const cloneCatalyst = async ({
 
   copySync(join(projectDir, 'tmp/src/components'), join(projectDir, 'components', 'ui'));
   copySync(join(projectDir, 'tmp/tailwind.config.js'), join(projectDir, 'tailwind.config.js'));
+
+  switch (codeEditor) {
+    case 'vscode':
+      await ensureDir(join(projectDir, '.vscode'));
+
+      writeJsonSync(
+        join(projectDir, '.vscode/settings.json'),
+        { 'typescript.tsdk': 'node_modules/typescript/lib' },
+        { spaces: 2 },
+      );
+      break;
+
+    default:
+      break;
+  }
 
   const packageJson = z
     .object({


### PR DESCRIPTION
## What/Why?
Creates the `.vscode/settings.json` file pointing to the Typescript SDK. This will help with new repos getting better TS support for gql-tada locally.

## Testing
![Screenshot 2024-04-17 at 14 33 50](https://github.com/bigcommerce/catalyst/assets/10539418/9baa7350-5d30-4465-859a-68f5963354be)
