### PR TITLE
fix: apply the edge runtime to missing routes

### DIFF
--- a/.changeset/angry-nails-help.md
+++ b/.changeset/angry-nails-help.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Apply the edge runtime to missing routes.

--- a/apps/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/apps/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -130,3 +130,5 @@ export default async function Category({ params: { locale, slug }, searchParams 
     </div>
   );
 }
+
+export const runtime = 'edge';

--- a/apps/core/app/[locale]/(default)/account/page.tsx
+++ b/apps/core/app/[locale]/(default)/account/page.tsx
@@ -63,3 +63,5 @@ export default async function AccountPage({ params: { locale } }: Props) {
     </div>
   );
 }
+
+export const runtime = 'edge';

--- a/apps/core/app/api/auth/[...nextauth]/route.ts
+++ b/apps/core/app/api/auth/[...nextauth]/route.ts
@@ -1,3 +1,4 @@
 import { handlers } from '~/auth';
 
 export const { GET, POST } = handlers;
+export const runtime = 'edge';


### PR DESCRIPTION
## What/Why?
Apply the edge runtime to missing routes.

## Testing
### Before
![Screenshot 2024-04-17 at 16 03 20](https://github.com/bigcommerce/catalyst/assets/10539418/be85731e-ff76-439e-ae1e-0ca1ba88ccbd)

### After
![Screenshot 2024-04-17 at 16 03 26](https://github.com/bigcommerce/catalyst/assets/10539418/2659ea5f-0804-4891-91d5-12bc979333ba)
