### PR TITLE
feat(core): vercel kv adapter cache

### DIFF
--- a/.changeset/four-candles-share.md
+++ b/.changeset/four-candles-share.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+best-effort in memory cache for vercel kv adapter


### PR DESCRIPTION
## What/Why?
Adds a best-effort cache for Vercel KV reads. This cache will be hit while a worker isolate is being reused.