### PR TITLE
chore: update tailwindFunctions to use correct utility name

### DIFF
--- a/.changeset/itchy-buttons-join.md
+++ b/.changeset/itchy-buttons-join.md
@@ -1,0 +1,7 @@
+---
+"@bigcommerce/components": patch
+"@bigcommerce/catalyst-core": patch
+"@bigcommerce/docs": patch
+---
+
+Update `tailwindFunctions` to use the correct className utility function `cn`.

--- a/apps/core/prettier.config.js
+++ b/apps/core/prettier.config.js
@@ -6,7 +6,7 @@ const config = {
   singleQuote: true,
   trailingComma: 'all',
   plugins: ['prettier-plugin-tailwindcss'],
-  tailwindFunctions: ['cs'],
+  tailwindFunctions: ['cn'],
 };
 
 module.exports = config;

--- a/apps/docs/prettier.config.js
+++ b/apps/docs/prettier.config.js
@@ -6,7 +6,7 @@ const config = {
   singleQuote: true,
   trailingComma: 'all',
   plugins: ['prettier-plugin-tailwindcss'],
-  tailwindFunctions: ['cs'],
+  tailwindFunctions: ['cn'],
 };
 
 module.exports = config;

--- a/packages/components/prettier.config.js
+++ b/packages/components/prettier.config.js
@@ -6,7 +6,7 @@ const config = {
   singleQuote: true,
   trailingComma: 'all',
   plugins: ['prettier-plugin-tailwindcss'],
-  tailwindFunctions: ['cs'],
+  tailwindFunctions: ['cn'],
 };
 
 module.exports = config;


### PR DESCRIPTION
## What/Why?
Remaps the `tailwindFunctions` class name utility from `cs` (old) to `cn` (new). Looks like it was missed in https://github.com/bigcommerce/catalyst/pull/457

## Testing
See the lint task