### PR TITLE
feat(cli): add option to include functional test suite

### DIFF
--- a/.changeset/lovely-camels-raise.md
+++ b/.changeset/lovely-camels-raise.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": minor
+---
+
+Adds an option to include the functional test suite as part of the create command. Defaults to false.

--- a/packages/create-catalyst/src/commands/create.ts
+++ b/packages/create-catalyst/src/commands/create.ts
@@ -20,7 +20,7 @@ import { writeEnv } from '../utils/write-env';
 const exec = promisify(execCallback);
 
 export const create = async (options: CreateCommandOptions) => {
-  const { packageManager, codeEditor } = options;
+  const { packageManager, codeEditor, includeFunctionalTests } = options;
 
   const URLSchema = z.string().url();
   const sampleDataApiUrl = parse(options.sampleDataApiUrl, URLSchema);
@@ -97,7 +97,7 @@ export const create = async (options: CreateCommandOptions) => {
   if (!storeHash || !accessToken) {
     console.log(`\nCreating '${projectName}' at '${projectDir}'\n`);
 
-    await cloneCatalyst({ projectDir, projectName, ghRef, codeEditor });
+    await cloneCatalyst({ projectDir, projectName, ghRef, codeEditor, includeFunctionalTests });
 
     console.log(`\nUsing ${chalk.bold(packageManager)}\n`);
 
@@ -193,7 +193,7 @@ export const create = async (options: CreateCommandOptions) => {
 
   console.log(`\nCreating '${projectName}' at '${projectDir}'\n`);
 
-  await cloneCatalyst({ projectDir, projectName, ghRef, codeEditor });
+  await cloneCatalyst({ projectDir, projectName, ghRef, codeEditor, includeFunctionalTests });
 
   writeEnv(projectDir, {
     channelId: channelId.toString(),

--- a/packages/create-catalyst/src/index.ts
+++ b/packages/create-catalyst/src/index.ts
@@ -71,6 +71,11 @@ const createCommand = program
       .default('vscode')
       .hideHelp(),
   )
+  .addOption(
+    new Option('--include-functional-tests', 'Include the functional test suite')
+      .default(false)
+      .hideHelp(),
+  )
   .action((opts) => create(opts));
 
 export type CreateCommandOptions = Options<typeof createCommand>[0];


### PR DESCRIPTION
## What/Why?
Adds the ability to include the functional test suite when creating a Catalyst repo from the CLI. We are about to migrate the tests over to the core app which this PR adds some preparation for it from the CLI perspective.

> [!WARNING]
> Just note that the functional test suite won't actually be included until we port it over. This is prep work for it actually being added.

## Testing
![Screenshot 2024-04-23 at 11 27 26](https://github.com/bigcommerce/catalyst/assets/10539418/4c2b7a4d-520e-45e1-836f-8c2cbb0949d4)
