### PR TITLE
chore(functional): remove erroneous playwright projects

### DIFF
--- a/packages/functional/playwright.config.js
+++ b/packages/functional/playwright.config.js
@@ -25,20 +25,5 @@ export default defineConfig({
       name: 'tests-chromium',
       use: { ...devices['Desktop Chrome'] },
     },
-
-    {
-      name: 'tests-firefox',
-      use: { ...devices['Desktop Firefox'] },
-    },
-
-    {
-      name: 'tests-webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
-
-    {
-      name: 'tests-ios',
-      use: { ...devices['iPhone 13'] },
-    },
   ],
 });


### PR DESCRIPTION
## What/Why?
This cleans up unused playwright projects that weren't being referenced or used.

## Testing
https://github.com/bigcommerce/catalyst/actions/runs/8821597392
