### PR TITLE
Add account tabs tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ dist
 .idea
 .vercel
 .catalyst
-.env
+.env.local
 .env*.local
 test-results/
 playwright-report/

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ dist
 .idea
 .vercel
 .catalyst
-.env.local
+.env
 .env*.local
 test-results/
 playwright-report/

--- a/packages/functional/pages/login-page.ts
+++ b/packages/functional/pages/login-page.ts
@@ -1,0 +1,14 @@
+import { Page } from '@playwright/test';
+
+export const testAccountEmail = process.env.TEST_ACCOUNT_EMAIL || '';
+export const testAccountPassword = process.env.TEST_ACCOUNT_PASSWORD || '';
+
+export async function loginAsShopper(page: Page) {
+    await page.goto('/login/');
+    await page.getByLabel('Login').click();
+    await page.getByLabel('Email').fill(testAccountEmail);
+    await page.getByLabel('Password').fill(testAccountPassword);
+    await page.getByRole('button', { name: 'Log in' }).click();
+}
+
+export * as LoginPage from './login-page';

--- a/packages/functional/pages/login-page.ts
+++ b/packages/functional/pages/login-page.ts
@@ -9,6 +9,7 @@ export async function loginAsShopper(page: Page) {
     await page.getByLabel('Email').fill(testAccountEmail);
     await page.getByLabel('Password').fill(testAccountPassword);
     await page.getByRole('button', { name: 'Log in' }).click();
+    await page.getByRole('heading', { name: 'My Account' }).waitFor();
 }
 
 export * as LoginPage from './login-page';

--- a/packages/functional/tests/ui/desktop/e2e/account.spec.ts
+++ b/packages/functional/tests/ui/desktop/e2e/account.spec.ts
@@ -10,7 +10,14 @@ test('Account access is restricted for guest users', async ({ page }) => {
 
 test('My Account tabs are displayed and clickable', async ({ page }) => {
   await LoginPage.loginAsShopper(page);
-  await expect(page.getByRole('heading', { name: 'My Account' })).toBeVisible();
+  await page.getByRole('heading', { name: 'My Account' }).waitFor();
 
+  await expect(page).toHaveURL('/.*account');
+  await expect(page.getByRole('heading', { name: 'Orders' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Messages' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Addresses' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Wish lists' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Recently viewed' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Account settings' })).toBeVisible();
 
 })

--- a/packages/functional/tests/ui/desktop/e2e/account.spec.ts
+++ b/packages/functional/tests/ui/desktop/e2e/account.spec.ts
@@ -11,7 +11,7 @@ test('Account access is restricted for guest users', async ({ page }) => {
 test('My Account tabs are displayed and clickable', async ({ page }) => {
   await LoginPage.loginAsShopper(page);
 
-  await expect(page).toHaveURL('/.*account/');
+  await expect(page).toHaveURL('/account/');
   await expect(page.getByRole('heading', { name: 'Orders' })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'Messages' })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'Addresses' })).toBeVisible();
@@ -20,26 +20,26 @@ test('My Account tabs are displayed and clickable', async ({ page }) => {
   await expect(page.getByRole('heading', { name: 'Account settings' })).toBeVisible();
 
   await page.getByRole('heading', { name: 'Orders' }).click();
-  await expect(page).toHaveURL('/.*orders/');
+  await expect(page).toHaveURL('account/orders/');
   await expect(page.getByRole('heading', { name: 'Orders' })).toBeVisible();
 
   await page.getByRole('tab', { name: 'Messages' }).click();
-  await expect(page).toHaveURL('/.*messages/');
+  await expect(page).toHaveURL('account/messages/');
   await expect(page.getByRole('heading', { name: 'Messages' })).toBeVisible();
 
   await page.getByRole('tab', { name: 'Addresses' }).click();
-  await expect(page).toHaveURL('/.*addresses/');
+  await expect(page).toHaveURL('account/addresses/');
   await expect(page.getByRole('heading', { name: 'Addresses' })).toBeVisible();
 
   await page.getByRole('tab', { name: 'Wish lists' }).click();
-  await expect(page).toHaveURL('/.*wishlists/');
+  await expect(page).toHaveURL('account/wishlists/');
   await expect(page.getByRole('heading', { name: 'Wish lists' })).toBeVisible();
 
   await page.getByRole('tab', { name: 'Recently viewed' }).click();
-  await expect(page).toHaveURL('/.*recently-viewed/');
+  await expect(page).toHaveURL('account/recently-viewed/');
   await expect(page.getByRole('heading', { name: 'Recently viewed' })).toBeVisible();
 
   await page.getByRole('tab', { name: 'Account settings' }).click();
-  await expect(page).toHaveURL('/.*settings/');
+  await expect(page).toHaveURL('account/settings/');
   await expect(page.getByRole('heading', { name: 'Account settings' })).toBeVisible();
 })

--- a/packages/functional/tests/ui/desktop/e2e/account.spec.ts
+++ b/packages/functional/tests/ui/desktop/e2e/account.spec.ts
@@ -6,3 +6,12 @@ test('Account access is restricted for guest users', async ({ page }) => {
   await expect(page.getByRole('heading', { name: 'My Account' })).toBeVisible({ visible: false });
   await expect(page.getByRole('heading', { name: 'Log in' })).toBeVisible();
 });
+
+test('Create user Account', async ({ page }) => {
+  await page.goto('/login/');
+  // click "Create Account" button
+  // Fill out required fields
+  // Click "Submit" button
+  // Verify success message
+  // Make sure user is able to login
+})

--- a/packages/functional/tests/ui/desktop/e2e/account.spec.ts
+++ b/packages/functional/tests/ui/desktop/e2e/account.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { LoginPage } from '../../../../pages/login-page';
 
 test('Account access is restricted for guest users', async ({ page }) => {
   await page.goto('/account/settings');
@@ -7,11 +8,9 @@ test('Account access is restricted for guest users', async ({ page }) => {
   await expect(page.getByRole('heading', { name: 'Log in' })).toBeVisible();
 });
 
-test('Create user Account', async ({ page }) => {
-  await page.goto('/login/');
-  // click "Create Account" button
-  // Fill out required fields
-  // Click "Submit" button
-  // Verify success message
-  // Make sure user is able to login
+test('My Account tabs are displayed and clickable', async ({ page }) => {
+  await LoginPage.loginAsShopper(page);
+  await expect(page.getByRole('heading', { name: 'My Account' })).toBeVisible();
+
+
 })

--- a/packages/functional/tests/ui/desktop/e2e/account.spec.ts
+++ b/packages/functional/tests/ui/desktop/e2e/account.spec.ts
@@ -10,9 +10,8 @@ test('Account access is restricted for guest users', async ({ page }) => {
 
 test('My Account tabs are displayed and clickable', async ({ page }) => {
   await LoginPage.loginAsShopper(page);
-  await page.getByRole('heading', { name: 'My Account' }).waitFor();
 
-  await expect(page).toHaveURL('/.*account');
+  await expect(page).toHaveURL('/.*account/');
   await expect(page.getByRole('heading', { name: 'Orders' })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'Messages' })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'Addresses' })).toBeVisible();
@@ -20,4 +19,27 @@ test('My Account tabs are displayed and clickable', async ({ page }) => {
   await expect(page.getByRole('heading', { name: 'Recently viewed' })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'Account settings' })).toBeVisible();
 
+  await page.getByRole('heading', { name: 'Orders' }).click();
+  await expect(page).toHaveURL('/.*orders/');
+  await expect(page.getByRole('heading', { name: 'Orders' })).toBeVisible();
+
+  await page.getByRole('tab', { name: 'Messages' }).click();
+  await expect(page).toHaveURL('/.*messages/');
+  await expect(page.getByRole('heading', { name: 'Messages' })).toBeVisible();
+
+  await page.getByRole('tab', { name: 'Addresses' }).click();
+  await expect(page).toHaveURL('/.*addresses/');
+  await expect(page.getByRole('heading', { name: 'Addresses' })).toBeVisible();
+
+  await page.getByRole('tab', { name: 'Wish lists' }).click();
+  await expect(page).toHaveURL('/.*wishlists/');
+  await expect(page.getByRole('heading', { name: 'Wish lists' })).toBeVisible();
+
+  await page.getByRole('tab', { name: 'Recently viewed' }).click();
+  await expect(page).toHaveURL('/.*recently-viewed/');
+  await expect(page.getByRole('heading', { name: 'Recently viewed' })).toBeVisible();
+
+  await page.getByRole('tab', { name: 'Account settings' }).click();
+  await expect(page).toHaveURL('/.*settings/');
+  await expect(page.getByRole('heading', { name: 'Account settings' })).toBeVisible();
 })

--- a/packages/functional/tests/ui/desktop/e2e/login.spec.ts
+++ b/packages/functional/tests/ui/desktop/e2e/login.spec.ts
@@ -1,7 +1,5 @@
 import { expect, test } from '@playwright/test';
-
-const testAccountEmail = process.env.TEST_ACCOUNT_EMAIL || '';
-const testAccountPassword = process.env.TEST_ACCOUNT_PASSWORD || '';
+import { LoginPage } from '../../../../pages/login-page';
 
 test('Account login and logout', async ({ page }) => {
   await page.goto('/');
@@ -9,8 +7,8 @@ test('Account login and logout', async ({ page }) => {
   await page.getByLabel('Login').click();
   await expect(page.getByLabel('Email')).toBeVisible();
 
-  await page.getByLabel('Email').fill(testAccountEmail);
-  await page.getByLabel('Password').fill(testAccountPassword);
+  await page.getByLabel('Email').fill(LoginPage.testAccountEmail);
+  await page.getByLabel('Password').fill(LoginPage.testAccountPassword);
   await page.getByRole('button', { name: 'Log in' }).click();
   await expect(page.getByRole('heading', { name: 'My Account' })).toBeVisible();
 


### PR DESCRIPTION
## What/Why?
- Add Account tabs tests to verify they are present and clickable
- Add `loginAsShopper()` helper method and `login-page.ts` as it surely will be used in next Account related tests to achieve logged in state

## Testing
<img width="1207" alt="Screenshot 2024-04-25 at 19 41 33" src="https://github.com/bigcommerce/catalyst/assets/81637332/9dc0b230-9814-455a-9682-186d4840a353">
