### PR TITLE
fix(cli): remove forward slash from regex

### DIFF
--- a/packages/create-catalyst/src/utils/clone-catalyst.ts
+++ b/packages/create-catalyst/src/utils/clone-catalyst.ts
@@ -142,8 +142,8 @@ export const cloneCatalyst = async ({
 
   if (!includeFunctionalTests) {
     const eslint = (await readFile(join(projectDir, '.eslintrc.cjs'), { encoding: 'utf-8' }))
-      .replace(/['"]\/playwright-report\/\*\*['"],?/, '')
-      .replace(/['"]\/test-results\/\*\*['"],?/, '');
+      .replace(/['"]playwright-report\/\*\*['"],?/, '')
+      .replace(/['"]test-results\/\*\*['"],?/, '');
 
     await writeFile(join(projectDir, '.eslintrc.cjs'), eslint);
 


### PR DESCRIPTION
## What/Why?
Removes the forward slash in front of the playwright strings as the eslint file doesn't contain them.

```js
{
  // ...
  ignorePatterns: ['client/generated/**/*.ts', 'playwright-report/**', 'test-results/**'],
}
```

## Testing
Ran a symlinked version of the CLI locally, using the latest github ref:
```bash
cd $(mktemp -d) && catalyst --gh-ref=ba0b205866891184bbe224e5a45783db6a44e032
```