### PR TITLE
fix(core): remove --turbo from dev script

### DIFF
--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -4,7 +4,7 @@
   "version": "0.6.0",
   "private": true,
   "scripts": {
-    "dev": "npm run generate && next dev --turbo",
+    "dev": "npm run generate && next dev",
     "generate": "dotenv -e .env.local -- node ./scripts/generate.cjs",
     "build": "npm run generate && next build",
     "start": "next start",


### PR DESCRIPTION
## What/Why?
This causes an issue with the hero image we import in the homepage. This is fixed in Next 14.2, we can add it back when we upgrade next.