### PR TITLE
refactor(core): product gallery fragment colocation

### DIFF
--- a/apps/core/app/[locale]/(default)/product/[slug]/_components/gallery/fragment.ts
+++ b/apps/core/app/[locale]/(default)/product/[slug]/_components/gallery/fragment.ts
@@ -1,0 +1,19 @@
+import { graphql } from '~/client/graphql';
+
+export const GalleryFragment = graphql(`
+  fragment GalleryFragment on Product {
+    images {
+      edges {
+        node {
+          altText
+          url: urlTemplate
+          isDefault
+        }
+      }
+    }
+    defaultImage {
+      altText
+      url: urlTemplate
+    }
+  }
+`);

--- a/apps/core/app/[locale]/(default)/product/[slug]/_components/gallery/index.tsx
+++ b/apps/core/app/[locale]/(default)/product/[slug]/_components/gallery/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
 import {
   Gallery as ComponentsGallery,
   GalleryContent,
@@ -10,25 +11,23 @@ import {
   GalleryThumbnailList,
 } from '@bigcommerce/components/gallery';
 
-import { getProduct } from '~/client/queries/get-product';
+import { FragmentOf } from '~/client/graphql';
 import { BcImage } from '~/components/bc-image';
 
-type Product = Awaited<ReturnType<typeof getProduct>>;
+import { GalleryFragment } from './fragment';
 
-export const Gallery = ({
-  product,
-  noImageText,
-}: {
-  product: NonNullable<Product>;
+interface Props {
+  product: FragmentOf<typeof GalleryFragment>;
   noImageText?: string;
-}) => {
-  // Make a copy of product.images
-  const images = product.images;
+}
 
-  // Pick the top-level default image out of the `Image` response
-  const topLevelDefaultImg = product.images.find((image) => image.isDefault);
+export const Gallery = ({ product, noImageText }: Props) => {
+  const images = removeEdgesAndNodes(product.images);
 
-  // If product.defaultImage exists, and product.defaultImage.url is not equal to the url of the isDefault image in the Image response,
+  // Pick the top-level default image
+  const topLevelDefaultImg = images.find((image) => image.isDefault);
+
+  // If product.defaultImage exists, and product.defaultImage.url is not equal to the url of the isDefault image in images,
   // mark the existing isDefault image to "isDefault = false" and append the correct default image to images
   if (product.defaultImage && topLevelDefaultImg?.url !== product.defaultImage.url) {
     images.forEach((image) => {

--- a/apps/core/app/[locale]/(default)/product/[slug]/page.tsx
+++ b/apps/core/app/[locale]/(default)/product/[slug]/page.tsx
@@ -16,6 +16,7 @@ import { Breadcrumbs, BreadcrumbsFragment } from './_components/breadcrumbs';
 import { Description } from './_components/description';
 import { Details } from './_components/details';
 import { Gallery } from './_components/gallery';
+import { GalleryFragment } from './_components/gallery/fragment';
 import { RelatedProducts, RelatedProductsFragment } from './_components/related-products';
 import { Reviews } from './_components/reviews';
 import { Warranty } from './_components/warranty';
@@ -58,6 +59,7 @@ const ProductPageQuery = graphql(
     query ProductPageQuery($entityId: Int!, $optionValueIds: [OptionValueId!]) {
       site {
         product(entityId: $entityId, optionValueIds: $optionValueIds) {
+          ...GalleryFragment
           ...RelatedProductsFragment
           categories(first: 1) {
             edges {
@@ -70,7 +72,7 @@ const ProductPageQuery = graphql(
       }
     }
   `,
-  [RelatedProductsFragment, BreadcrumbsFragment],
+  [RelatedProductsFragment, BreadcrumbsFragment, GalleryFragment],
 );
 
 export default async function Product({ params, searchParams }: ProductPageProps) {
@@ -124,7 +126,7 @@ export default async function Product({ params, searchParams }: ProductPageProps
 
       <div className="mb-12 mt-4 lg:grid lg:grid-cols-2 lg:gap-8">
         <NextIntlClientProvider locale={locale} messages={{ Product: messages.Product ?? {} }}>
-          <Gallery noImageText={t('noGalleryText')} product={product} />
+          <Gallery noImageText={t('noGalleryText')} product={data.site.product} />
           <Details product={product} />
           <div className="lg:col-span-2">
             <Description product={product} />


### PR DESCRIPTION
~⚠️  Builds on top of https://github.com/bigcommerce/catalyst/pull/833~

## What/Why?
Product gallery now defines its own gql fragment.