### PR TITLE
chore: remove @bigcommerce/docs references from changesets

### DIFF
--- a/.changeset/itchy-buttons-join.md
+++ b/.changeset/itchy-buttons-join.md
@@ -1,7 +1,6 @@
 ---
 "@bigcommerce/components": patch
 "@bigcommerce/catalyst-core": patch
-"@bigcommerce/docs": patch
 ---
 
 Update `tailwindFunctions` to use the correct className utility function `cn`.

--- a/.changeset/thin-pumpkins-search.md
+++ b/.changeset/thin-pumpkins-search.md
@@ -1,6 +1,5 @@
 ---
 "@bigcommerce/components": minor
-"@bigcommerce/docs": minor
 ---
 
 Add dialog component


### PR DESCRIPTION
## What/Why?
Our CI is erroring out: https://github.com/bigcommerce/catalyst/actions/runs/8901051590/job/24443995639
This removes the reference to the docs package which was removed in #835 

## Testing
See CI.