### PR TITLE
feat: respect logger=false in environment variables

### DIFF
--- a/.changeset/rude-dodos-collect.md
+++ b/.changeset/rude-dodos-collect.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Respects when `CLIENT_LOGGER="false"` or `KV_LOGGER="false"` is set in .env.local regardless of environment.

--- a/apps/core/client/index.ts
+++ b/apps/core/client/index.ts
@@ -8,5 +8,7 @@ export const client = createClient({
   storeHash: process.env.BIGCOMMERCE_STORE_HASH ?? '',
   channelId: process.env.BIGCOMMERCE_CHANNEL_ID,
   backendUserAgentExtensions: backendUserAgent,
-  logger: process.env.NODE_ENV !== 'production' || process.env.CLIENT_LOGGER === 'true',
+  logger:
+    (process.env.NODE_ENV !== 'production' && process.env.CLIENT_LOGGER !== 'false') ||
+    process.env.CLIENT_LOGGER === 'true',
 });

--- a/apps/core/lib/kv/index.ts
+++ b/apps/core/lib/kv/index.ts
@@ -83,7 +83,9 @@ async function createKVAdapter() {
 }
 
 const adapterInstance = new KV(createKVAdapter, {
-  logger: process.env.NODE_ENV !== 'production' || process.env.KV_LOGGER === 'true',
+  logger:
+    (process.env.NODE_ENV !== 'production' && process.env.KV_LOGGER !== 'false') ||
+    process.env.KV_LOGGER === 'true',
 });
 
 export { adapterInstance as kv };


### PR DESCRIPTION
## What/Why?
Respects when `CLIENT_LOGGER="false"` or `KV_LOGGER="false"` is set in `.env.local` regardless of environment. This make it a little more configurable when doing local development.

## Testing

#### All false
![Screenshot 2024-04-30 at 17 03 25](https://github.com/bigcommerce/catalyst/assets/10539418/7bc0c0fd-48cd-435a-aa9f-aa59dcecd3a3)

#### Client true
![Screenshot 2024-04-30 at 17 05 50](https://github.com/bigcommerce/catalyst/assets/10539418/e0895e12-3b50-4eac-a893-a0aa949c0dd1)

#### KV true
![Screenshot 2024-04-30 at 17 06 20](https://github.com/bigcommerce/catalyst/assets/10539418/be03f503-8894-4ef8-a47b-237db1702079)
