### PR TITLE
chore(cli): remove cloning logic for components

### DIFF
--- a/.changeset/perfect-roses-cheer.md
+++ b/.changeset/perfect-roses-cheer.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": patch
+---
+
+Remove cloning logic for components. 

--- a/packages/create-catalyst/src/utils/clone-catalyst.ts
+++ b/packages/create-catalyst/src/utils/clone-catalyst.ts
@@ -65,9 +65,6 @@ export const cloneCatalyst = async ({
       }),
     );
 
-  delete packageJson.private;
-  delete packageJson.exports;
-  delete packageJson.sideEffects;
   delete packageJson.dependencies['@bigcommerce/catalyst-client'];
   delete packageJson.devDependencies['@bigcommerce/eslint-config-catalyst'];
 
@@ -81,19 +78,10 @@ export const cloneCatalyst = async ({
   if (!includeFunctionalTests) {
     const tsConfigJson = z
       .object({
-        compilerOptions: z
-          .object({
-            declaration: z.boolean().optional(),
-            declarationMap: z.boolean().optional(),
-          })
-          .passthrough(),
         include: z.array(z.string()).optional(),
       })
       .passthrough()
-      .parse(merge({}, readJsonSync(join(projectDir, 'tsconfig.json'))));
-
-    delete tsConfigJson.compilerOptions.declaration;
-    delete tsConfigJson.compilerOptions.declarationMap;
+      .parse(readJsonSync(join(projectDir, 'tsconfig.json')));
 
     tsConfigJson.include = tsConfigJson.include?.filter(
       (include) => !['tests/**/*', 'playwright.config.ts'].includes(include),

--- a/packages/create-catalyst/src/utils/clone-catalyst.ts
+++ b/packages/create-catalyst/src/utils/clone-catalyst.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { readFile, writeFile } from 'fs/promises';
-import { copySync, ensureDir, readJsonSync, removeSync, writeJsonSync } from 'fs-extra/esm';
+import { ensureDir, readJsonSync, removeSync, writeJsonSync } from 'fs-extra/esm';
 import { downloadTemplate } from 'giget';
 import merge from 'lodash.merge';
 import { join } from 'path';
@@ -33,21 +33,6 @@ export const cloneCatalyst = async ({
     },
   );
 
-  await spinner(
-    downloadTemplate(`github:bigcommerce/catalyst/packages/components#${ghRef}`, {
-      dir: join(projectDir, 'tmp'),
-      offline: false,
-    }),
-    {
-      text: 'Cloning Catalyst components...',
-      successText: 'Catalyst components cloned successfully',
-      failText: (err) => chalk.red(`Failed to clone Catalyst components: ${err.message}`),
-    },
-  );
-
-  copySync(join(projectDir, 'tmp/src/components'), join(projectDir, 'components', 'ui'));
-  copySync(join(projectDir, 'tmp/tailwind.config.js'), join(projectDir, 'tailwind.config.js'));
-
   switch (codeEditor) {
     case 'vscode':
       await ensureDir(join(projectDir, '.vscode'));
@@ -71,29 +56,19 @@ export const cloneCatalyst = async ({
       scripts: z.object({}).passthrough().optional(),
       dependencies: z.object({}).passthrough(),
       devDependencies: z.object({}).passthrough(),
-      private: z.boolean().optional(),
-      exports: z.object({}).passthrough().optional(),
-      sideEffects: z.boolean().optional(),
-      peerDependencies: z.object({}).passthrough().optional(),
     })
     .passthrough()
     .parse(
-      merge(
-        {},
-        readJsonSync(join(projectDir, 'tmp/package.json')),
-        readJsonSync(join(projectDir, 'package.json')),
-        { name: projectName, description: '' },
-      ),
+      merge({}, readJsonSync(join(projectDir, 'package.json')), {
+        name: projectName,
+        description: '',
+      }),
     );
 
   delete packageJson.private;
   delete packageJson.exports;
   delete packageJson.sideEffects;
-  delete packageJson.peerDependencies; // will go away
-  delete packageJson.dependencies['@bigcommerce/components']; // will go away
   delete packageJson.dependencies['@bigcommerce/catalyst-client'];
-  delete packageJson.devDependencies.react; // will go away
-  delete packageJson.devDependencies['react-dom']; // will go away
   delete packageJson.devDependencies['@bigcommerce/eslint-config-catalyst'];
 
   if (!includeFunctionalTests) {
@@ -103,42 +78,29 @@ export const cloneCatalyst = async ({
 
   writeJsonSync(join(projectDir, 'package.json'), packageJson, { spaces: 2 });
 
-  const tsConfigJson = z
-    .object({
-      compilerOptions: z
-        .object({
-          declaration: z.boolean().optional(),
-          declarationMap: z.boolean().optional(),
-          paths: z
-            .object({
-              '@bigcommerce/components/*': z.string().array().optional(),
-            })
-            .passthrough(),
-        })
-        .passthrough(),
-      include: z.array(z.string()).optional(),
-    })
-    .passthrough()
-    .parse(
-      merge(
-        {},
-        readJsonSync(join(projectDir, 'tmp/tsconfig.json')),
-        readJsonSync(join(projectDir, 'tsconfig.json')),
-      ),
-    );
-
-  delete tsConfigJson.compilerOptions.declaration;
-  delete tsConfigJson.compilerOptions.declarationMap;
-
-  tsConfigJson.compilerOptions.paths['@bigcommerce/components/*'] = ['./components/ui/*'];
-
   if (!includeFunctionalTests) {
+    const tsConfigJson = z
+      .object({
+        compilerOptions: z
+          .object({
+            declaration: z.boolean().optional(),
+            declarationMap: z.boolean().optional(),
+          })
+          .passthrough(),
+        include: z.array(z.string()).optional(),
+      })
+      .passthrough()
+      .parse(merge({}, readJsonSync(join(projectDir, 'tsconfig.json'))));
+
+    delete tsConfigJson.compilerOptions.declaration;
+    delete tsConfigJson.compilerOptions.declarationMap;
+
     tsConfigJson.include = tsConfigJson.include?.filter(
       (include) => !['tests/**/*', 'playwright.config.ts'].includes(include),
     );
-  }
 
-  writeJsonSync(join(projectDir, 'tsconfig.json'), tsConfigJson, { spaces: 2 });
+    writeJsonSync(join(projectDir, 'tsconfig.json'), tsConfigJson, { spaces: 2 });
+  }
 
   if (!includeFunctionalTests) {
     const eslint = (await readFile(join(projectDir, '.eslintrc.cjs'), { encoding: 'utf-8' }))
@@ -150,6 +112,4 @@ export const cloneCatalyst = async ({
     removeSync(join(projectDir, 'tests'));
     removeSync(join(projectDir, 'playwright.config.ts'));
   }
-
-  removeSync(join(projectDir, 'tmp'));
 };


### PR DESCRIPTION
## What/Why?
Since we no longer have `/packages/components`, we don't need to clone it.

## Testing
TBD