### PR TITLE
refactor(core): related products query

### DIFF
--- a/apps/core/app/[locale]/(default)/product/[slug]/_components/related-products.tsx
+++ b/apps/core/app/[locale]/(default)/product/[slug]/_components/related-products.tsx
@@ -2,19 +2,26 @@ import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
 import { NextIntlClientProvider } from 'next-intl';
 import { getLocale, getMessages, getTranslations } from 'next-intl/server';
 
-import { graphql, ResultOf } from '~/client/graphql';
+import { getSessionCustomerId } from '~/auth';
+import { client } from '~/client';
+import { graphql } from '~/client/graphql';
+import { revalidate } from '~/client/revalidate-target';
 import {
   ProductCardCarousel,
   ProductCardCarouselFragment,
 } from '~/components/product-card-carousel';
 
-export const RelatedProductsFragment = graphql(
+export const RelatedProductsQuery = graphql(
   `
-    fragment RelatedProductsFragment on Product {
-      relatedProducts(first: 12) {
-        edges {
-          node {
-            ...ProductCardCarouselFragment
+    query RelatedProductsQuery($entityId: Int!) {
+      site {
+        product(entityId: $entityId) {
+          relatedProducts(first: 12) {
+            edges {
+              node {
+                ...ProductCardCarouselFragment
+              }
+            }
           }
         }
       }
@@ -24,15 +31,30 @@ export const RelatedProductsFragment = graphql(
 );
 
 interface Props {
-  data: ResultOf<typeof RelatedProductsFragment>;
+  productId: number;
 }
 
-export const RelatedProducts = async ({ data }: Props) => {
+export const RelatedProducts = async ({ productId }: Props) => {
+  const customerId = await getSessionCustomerId();
+
   const t = await getTranslations('Product');
   const locale = await getLocale();
   const messages = await getMessages({ locale });
 
-  const relatedProducts = removeEdgesAndNodes(data.relatedProducts);
+  const { data } = await client.fetch({
+    document: RelatedProductsQuery,
+    variables: { entityId: productId },
+    customerId,
+    fetchOptions: customerId ? { cache: 'no-store' } : { next: { revalidate } },
+  });
+
+  const product = data.site.product;
+
+  if (!product) {
+    return null;
+  }
+
+  const relatedProducts = removeEdgesAndNodes(product.relatedProducts);
 
   return (
     <NextIntlClientProvider locale={locale} messages={{ Product: messages.Product ?? {} }}>

--- a/apps/core/app/[locale]/(default)/product/[slug]/page.tsx
+++ b/apps/core/app/[locale]/(default)/product/[slug]/page.tsx
@@ -17,7 +17,7 @@ import { Description, DescriptionFragment } from './_components/description';
 import { Details, DetailsFragment } from './_components/details';
 import { Gallery } from './_components/gallery';
 import { GalleryFragment } from './_components/gallery/fragment';
-import { RelatedProducts, RelatedProductsFragment } from './_components/related-products';
+import { RelatedProducts } from './_components/related-products';
 import { Reviews } from './_components/reviews';
 import { Warranty, WarrantyFragment } from './_components/warranty';
 
@@ -60,7 +60,6 @@ const ProductPageQuery = graphql(
       site {
         product(entityId: $entityId, optionValueIds: $optionValueIds) {
           ...GalleryFragment
-          ...RelatedProductsFragment
           ...DetailsFragment
           ...DescriptionFragment
           ...WarrantyFragment
@@ -76,14 +75,7 @@ const ProductPageQuery = graphql(
       }
     }
   `,
-  [
-    RelatedProductsFragment,
-    BreadcrumbsFragment,
-    GalleryFragment,
-    DetailsFragment,
-    DescriptionFragment,
-    WarrantyFragment,
-  ],
+  [BreadcrumbsFragment, GalleryFragment, DetailsFragment, DescriptionFragment, WarrantyFragment],
 );
 
 export default async function Product({ params, searchParams }: ProductPageProps) {
@@ -142,7 +134,7 @@ export default async function Product({ params, searchParams }: ProductPageProps
       </div>
 
       <Suspense fallback={t('loading')}>
-        <RelatedProducts data={product} />
+        <RelatedProducts productId={product.entityId} />
       </Suspense>
     </>
   );


### PR DESCRIPTION
## What/Why?
The `RelatedProducts` component is wrapped in `<Suspense>`. I converted it to a fragment instead of a query in a previous PR by mistake.