### PR TITLE
don't show featured products section if none exist (on not-found template)

### DIFF
--- a/.changeset/perfect-seas-breathe.md
+++ b/.changeset/perfect-seas-breathe.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Conditionally show featuredProducts on 404 page.

--- a/apps/core/app/[locale]/not-found.tsx
+++ b/apps/core/app/[locale]/not-found.tsx
@@ -66,7 +66,7 @@ export default async function NotFound() {
         <NextIntlClientProvider locale={locale} messages={{ NotFound: messages.NotFound ?? {} }}>
           <SearchForm />
         </NextIntlClientProvider>
-        {featuredProducts?.length ? (
+        {featuredProducts.length ? (
           <section>
             <h3 className="mb-8 text-3xl font-black lg:text-4xl">{t('featuredProducts')}</h3>
             <div className="grid grid-cols-2 gap-x-8 gap-y-8 md:grid-cols-4">

--- a/apps/core/app/[locale]/not-found.tsx
+++ b/apps/core/app/[locale]/not-found.tsx
@@ -66,25 +66,27 @@ export default async function NotFound() {
         <NextIntlClientProvider locale={locale} messages={{ NotFound: messages.NotFound ?? {} }}>
           <SearchForm />
         </NextIntlClientProvider>
-        <section>
-          <h3 className="mb-8 text-3xl font-black lg:text-4xl">{t('featuredProducts')}</h3>
-          <div className="grid grid-cols-2 gap-x-8 gap-y-8 md:grid-cols-4">
-            {featuredProducts.map((product) => (
-              <NextIntlClientProvider
-                key={product.entityId}
-                locale={locale}
-                messages={{ Product: messages.Product ?? {} }}
-              >
-                <ProductCard
-                  product={product}
-                  showCart={false}
-                  showCompare={false}
-                  showReviews={false}
-                />
-              </NextIntlClientProvider>
-            ))}
-          </div>
-        </section>
+        {featuredProducts?.length ? (
+          <section>
+            <h3 className="mb-8 text-3xl font-black lg:text-4xl">{t('featuredProducts')}</h3>
+            <div className="grid grid-cols-2 gap-x-8 gap-y-8 md:grid-cols-4">
+              {featuredProducts.map((product) => (
+                <NextIntlClientProvider
+                  key={product.entityId}
+                  locale={locale}
+                  messages={{ Product: messages.Product ?? {} }}
+                >
+                  <ProductCard
+                    product={product}
+                    showCart={false}
+                    showCompare={false}
+                    showReviews={false}
+                  />
+                </NextIntlClientProvider>
+              ))}
+            </div>
+          </section>
+        ) : null}
       </main>
 
       <Footer data={data.site} />


### PR DESCRIPTION
## What/Why?
The not found template doesn't account for stores that do not have any featured products, which is a dev error. 

If featured products do not exist, not-found template still shows the section and the h3 headline. this commit fixes that with a length check / fallback of return null.

The git file changes may show a big block replacement, but the only changes are the if statement above the section open and else condition below the section close.

<!--- 
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
--->

## Testing

I tested by running two different Catalyst stores in dev & build, one on a store with no featured products, and one with featured products. I also had tested using a single store with featured products toggled on/off too.

<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->