### PR TITLE
fix(core): respect isVisibleInNavigation for blog pages

### DIFF
--- a/.changeset/early-bananas-wonder.md
+++ b/.changeset/early-bananas-wonder.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Respect isVisibleInNavigation for blog pages

--- a/apps/core/app/[locale]/(default)/blog/[blogId]/page-data.ts
+++ b/apps/core/app/[locale]/(default)/blog/[blogId]/page-data.ts
@@ -12,7 +12,6 @@ const PageQuery = graphql(
       site {
         content {
           blog {
-            isVisibleInNavigation
             post(entityId: $entityId) {
               author
               htmlBody

--- a/apps/core/app/[locale]/(default)/blog/[blogId]/page.tsx
+++ b/apps/core/app/[locale]/(default)/blog/[blogId]/page.tsx
@@ -40,9 +40,8 @@ export default async function BlogPostPage({ params: { blogId, locale } }: Props
 
   const data = await getPageData({ entityId: Number(blogId) });
   const blogPost = data?.content.blog?.post;
-  const isVisibleInNavigation = data?.content.blog?.isVisibleInNavigation;
 
-  if (!blogPost || !isVisibleInNavigation) {
+  if (!blogPost) {
     return notFound();
   }
 

--- a/apps/core/app/[locale]/(default)/blog/page-data.ts
+++ b/apps/core/app/[locale]/(default)/blog/page-data.ts
@@ -28,7 +28,6 @@ const BlogPostsPageQuery = graphql(
       site {
         content {
           blog {
-            isVisibleInNavigation
             name
             posts(first: $first, after: $after, last: $last, before: $before, filters: $filters) {
               edges {

--- a/apps/core/app/[locale]/(default)/blog/page.tsx
+++ b/apps/core/app/[locale]/(default)/blog/page.tsx
@@ -28,7 +28,7 @@ export default async function BlogPostPage({ params: { locale }, searchParams }:
   const blogPosts = await getBlogPosts(searchParams);
   const t = await getTranslations({ locale, namespace: 'Pagination' });
 
-  if (!blogPosts || !blogPosts.isVisibleInNavigation) {
+  if (!blogPosts) {
     return notFound();
   }
 

--- a/apps/core/app/[locale]/(default)/blog/tag/[tagId]/page.tsx
+++ b/apps/core/app/[locale]/(default)/blog/tag/[tagId]/page.tsx
@@ -19,7 +19,7 @@ export default async function BlogPostPage({ params: { tagId, locale }, searchPa
   const blogPosts = await getBlogPosts({ tagId, ...searchParams });
   const t = await getTranslations({ locale, namespace: 'Pagination' });
 
-  if (!blogPosts || !blogPosts.isVisibleInNavigation) {
+  if (!blogPosts) {
     return notFound();
   }
 


### PR DESCRIPTION
Fixes: #853

## What/Why?
Doesn't return 404 if the blog is disabled from navigation. This is to preserve functionality from Stencil -> Catalyst.

## Testing
![Screenshot 2024-05-06 at 11 10 33](https://github.com/bigcommerce/catalyst/assets/10539418/375ef9b7-6acc-40cb-bcdf-3ebb8e0d3160)
