### PR TITLE
feat(core): add sample rate for Vercel analytics and speed insights

### DIFF
--- a/.changeset/six-birds-accept.md
+++ b/.changeset/six-birds-accept.md
@@ -1,0 +1,9 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Added a default sample rate of 25% for both Vercel Speed Insights and Vercel Analytics. This provides a good jumping off point for merchants to tweak their sample rates if they choose to.
+
+In order to tweak the sample rate, you can add the following environment variables to your Vercel project:
+- `NEXT_PUBLIC_ANALYTICS_SAMPLE_RATE` for Vercel Analytics
+- `NEXT_PUBLIC_SPEED_INSIGHTS_SAMPLE_RATE` for Vercel Speed Insights

--- a/apps/core/app/[locale]/layout.tsx
+++ b/apps/core/app/[locale]/layout.tsx
@@ -1,5 +1,3 @@
-import { Analytics } from '@vercel/analytics/react';
-import { SpeedInsights } from '@vercel/speed-insights/next';
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import { NextIntlClientProvider, useMessages } from 'next-intl';
@@ -72,8 +70,6 @@ export default function RootLayout({ children, params: { locale } }: RootLayoutP
         <NextIntlClientProvider locale={locale} messages={{ Providers: messages.Providers ?? {} }}>
           <Providers>{children}</Providers>
         </NextIntlClientProvider>
-        <Analytics />
-        <SpeedInsights />
       </body>
     </html>
   );

--- a/apps/core/app/providers.tsx
+++ b/apps/core/app/providers.tsx
@@ -1,9 +1,47 @@
 'use client';
 
+import { Analytics } from '@vercel/analytics/react';
+import { SpeedInsights } from '@vercel/speed-insights/next';
 import { PropsWithChildren } from 'react';
 
 import { CompareProductsProvider } from '~/app/contexts/compare-products-context';
 
+const ANALYTICS_SESSION_STORAGE_KEY = 'analyticsEnabled';
+
+const ANALYTICS_SAMPLE_RATE = process.env.NEXT_PUBLIC_ANALYTICS_SAMPLE_RATE
+  ? Number.parseFloat(process.env.NEXT_PUBLIC_ANALYTICS_SAMPLE_RATE)
+  : 0.25;
+
+const SPEED_INSIGHTS_SAMPLE_RATE = process.env.NEXT_PUBLIC_SPEED_INSIGHTS_SAMPLE_RATE
+  ? Number.parseFloat(process.env.NEXT_PUBLIC_SPEED_INSIGHTS_SAMPLE_RATE)
+  : 0.25;
+
+function isAnalyticsEnabled() {
+  try {
+    let analyticsEnabled = sessionStorage.getItem(ANALYTICS_SESSION_STORAGE_KEY);
+
+    if (analyticsEnabled === null) {
+      if (Math.random() <= ANALYTICS_SAMPLE_RATE) {
+        analyticsEnabled = '1';
+      } else {
+        analyticsEnabled = '0';
+      }
+
+      sessionStorage.setItem(ANALYTICS_SESSION_STORAGE_KEY, analyticsEnabled);
+    }
+
+    return analyticsEnabled === '1';
+  } catch {
+    return false;
+  }
+}
+
 export function Providers({ children }: PropsWithChildren) {
-  return <CompareProductsProvider>{children}</CompareProductsProvider>;
+  return (
+    <>
+      <CompareProductsProvider>{children}</CompareProductsProvider>
+      <Analytics beforeSend={(event) => (isAnalyticsEnabled() ? event : null)} />
+      <SpeedInsights sampleRate={SPEED_INSIGHTS_SAMPLE_RATE} />
+    </>
+  );
 }


### PR DESCRIPTION
## What/Why?
Adds an opinionated default on the sample rates for both Vercel Speed Insights and Vercel Analytics. Most of the time you don't need to capture 100%, especially on a heavily trafficked site.

For Vercel Analytics, there was a little lifting that was needed to be done. We don't necessarily want to send events 25% of the time, but rather 25% of the users get analytics tracked per session.

## Testing
![Screenshot 2024-05-06 at 15 56 04](https://github.com/bigcommerce/catalyst/assets/10539418/3c7432bc-0a9e-4d79-b64a-b20a053d7664)
![Screenshot 2024-05-06 at 15 56 16](https://github.com/bigcommerce/catalyst/assets/10539418/9effb024-a66e-4cf3-883f-f1a51ee42920)
