### PR TITLE
fix(core): remove extra colon on PDP sales price

### DIFF
--- a/apps/core/app/[locale]/(default)/product/[slug]/_components/details.tsx
+++ b/apps/core/app/[locale]/(default)/product/[slug]/_components/details.tsx
@@ -133,7 +133,7 @@ export const Details = ({ product }: Props) => {
                   </span>
                   <br />
                   <span>
-                    {t('Prices.now')}{' '}
+                    {t('Prices.now')}:{' '}
                     {format.number(product.prices.salePrice.value, {
                       style: 'currency',
                       currency: product.prices.price.currencyCode,

--- a/apps/core/components/product-sheet/product-sheet-content.tsx
+++ b/apps/core/components/product-sheet/product-sheet-content.tsx
@@ -162,7 +162,7 @@ export const ProductSheetContent = () => {
                   product.prices.basePrice?.value !== undefined ? (
                     <>
                       <span>
-                        {t('was')}{' '}
+                        {t('was')}:{' '}
                         <span className="line-through">
                           {format.number(product.prices.basePrice.value, {
                             style: 'currency',
@@ -172,7 +172,7 @@ export const ProductSheetContent = () => {
                       </span>
                       <br />
                       <span>
-                        {t('now')}{' '}
+                        {t('now')}:{' '}
                         {format.number(product.prices.salePrice.value, {
                           style: 'currency',
                           currency: product.prices.price.currencyCode,

--- a/apps/core/messages/en.json
+++ b/apps/core/messages/en.json
@@ -56,8 +56,8 @@
       },
       "Prices": {
         "msrp": "MSRP",
-        "was": "Was:",
-        "now": "Now:"
+        "was": "Was",
+        "now": "Now"
       }
     },
     "Form": {
@@ -75,8 +75,8 @@
       "numberReviews": "Number of reviews:",
       "productRating": "<rating>Rating:</rating> {currentRating} <stars> out of 5 stars.</stars>",
       "msrp": "MSRP",
-      "was": "Was:",
-      "now": "Now:",
+      "was": "Was",
+      "now": "Now",
       "quickAdd": "Quick add",
       "addedProductQuantity": "{cartItems, plural, =1 {1 Item} other {# Items}} added to <cartLink> your cart</cartLink>",
       "processing": "Processing...",


### PR DESCRIPTION
## What/Why?
Removes extra `:` on PDP page:

![5sueQy5Z](https://github.com/bigcommerce/catalyst/assets/2752665/db8357f4-315f-4cda-8f23-f5411ad6c641)
