### PR TITLE
chore: fix vscode settings pattern

### DIFF
--- a/.vscode/settings.example.json
+++ b/.vscode/settings.example.json
@@ -2,7 +2,7 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "eslint.workingDirectories": [
-    { "pattern": "apps/*/" },
+    { "pattern": "core/*/" },
     { "pattern": "packages/*/" }
   ]
 }


### PR DESCRIPTION
## What/Why?
Missed this change whenever we moved the `apps/core` folder in #870 