### PR TITLE
feat(core): add a min width to body

### DIFF
--- a/.changeset/quiet-carrots-yell.md
+++ b/.changeset/quiet-carrots-yell.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Set a min width to body.

--- a/core/app/[locale]/layout.tsx
+++ b/core/app/[locale]/layout.tsx
@@ -67,7 +67,7 @@ export default function RootLayout({ children, params: { locale } }: RootLayoutP
 
   return (
     <html className={`${inter.variable} font-sans`} lang={locale}>
-      <body className="flex h-screen flex-col">
+      <body className="flex h-screen min-w-[375px] flex-col">
         <Notifications />
         <NextIntlClientProvider locale={locale} messages={{ Providers: messages.Providers ?? {} }}>
           <Providers>{children}</Providers>


### PR DESCRIPTION
## What/Why?
Sets a min width to body to prevent shrinking content to breaking widths.

![Screenshot 2024-05-07 at 3 38 04 PM](https://github.com/bigcommerce/catalyst/assets/196129/c4b938f9-827e-4e7b-801f-d614ee07303a)

## Testing
Locally.