### PR TITLE
feat(cli): create channel menus for new catalyst channels

### DIFF
--- a/.changeset/nervous-dancers-kick.md
+++ b/.changeset/nervous-dancers-kick.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": minor
+---
+
+The `create-catalyst` CLI will now create channel menus for new Catalyst channels

--- a/packages/create-catalyst/src/commands/create.ts
+++ b/packages/create-catalyst/src/commands/create.ts
@@ -149,6 +149,8 @@ export const create = async (options: CreateCommandOptions) => {
         data: { id: createdChannelId, storefront_api_token: storefrontApiToken },
       } = await sampleDataApi.createChannel(newChannelName);
 
+      await bc.createChannelMenus(createdChannelId);
+
       channelId = createdChannelId;
       customerImpersonationToken = storefrontApiToken;
 

--- a/packages/create-catalyst/src/utils/https.ts
+++ b/packages/create-catalyst/src/utils/https.ts
@@ -204,6 +204,30 @@ export class Https {
     return parse(await res.json(), BigCommerceChannelsV3ResponseSchema);
   }
 
+  async createChannelMenus(channelId: number) {
+    const res = await this.api(`/v3/channels/${channelId}/channel-menus`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        bigcommerce_protected_app_sections: [
+          'storefront_settings',
+          'currencies',
+          'domains',
+          'notifications',
+          'social',
+        ],
+      }),
+    });
+
+    if (!res.ok) {
+      console.warn(
+        chalk.yellow(
+          `\nFailed to create channel menus: ${res.status} ${res.statusText}. You may want to create these later: https://developer.bigcommerce.com/docs/rest-management/channels/menus#create-channel-menus\n`,
+        ),
+      );
+    }
+  }
+
   async customerImpersonationToken(channelId: number) {
     const res = await this.api('/v3/storefront/api-token-customer-impersonation', {
       method: 'POST',


### PR DESCRIPTION
## What/Why?
Adds a default set of Channel Menus to the newly created storefront channel.

Currently, no channel menus are created by the CLI when it creates a new Catalyst channel, which leads to a lower quality experience for BigCommerce merchants unfamiliar with the ability to create channel menus. If we create channel menus for them, they'll be able to configure settings, notifications, etc. for their new storefront channel.

> [!NOTE]
> The `social` channel menu is included in the POST request, but it will not show up in Channel Manager unless the merchant has MSF enabled on their store

## Testing
Locally built and ran the CLI, opted to create a new channel, checked created channel in Channel Manager:

<img width="1154" alt="Screenshot 2024-05-07 at 4 11 01 PM" src="https://github.com/bigcommerce/catalyst/assets/28374851/1a353dc5-b29c-4607-986f-25cd8fb4ea9a">
