### PR TITLE
fix(core): use categoryEntityId filter on category PLP

### DIFF
--- a/.changeset/violet-swans-suffer.md
+++ b/.changeset/violet-swans-suffer.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Category pages now use the `categoryEntityId` filter

--- a/core/app/[locale]/(default)/(faceted)/_components/facets.tsx
+++ b/core/app/[locale]/(default)/(faceted)/_components/facets.tsx
@@ -151,7 +151,7 @@ export const Facets = ({ facets, pageType }: Props) => {
                           aria-labelledby={labelId}
                           defaultChecked={category.isSelected}
                           id={id}
-                          name="category"
+                          name="categoryIn"
                           onCheckedChange={submitForm}
                           value={category.entityId}
                         />

--- a/core/app/[locale]/(default)/(faceted)/_components/refine-by.tsx
+++ b/core/app/[locale]/(default)/(faceted)/_components/refine-by.tsx
@@ -43,7 +43,7 @@ const mapFacetsToRefinements = ({ facets, pageType }: Props) =>
           return facet.categories
             .filter((category) => category.isSelected)
             .map<FacetProps<PublicParamKeys>>(({ name, entityId }) => ({
-              key: 'category',
+              key: 'categoryIn',
               display_name: name,
               value: String(entityId),
             }));

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -46,7 +46,7 @@ export default async function Category({ params: { locale, slug }, searchParams 
   const messages = await getMessages({ locale });
 
   const categoryId = Number(slug);
-  const search = await fetchFacetedSearch({ ...searchParams, category: [slug] });
+  const search = await fetchFacetedSearch({ ...searchParams, category: categoryId });
 
   const data = await getCategoryPageData({
     categoryId,

--- a/core/app/[locale]/(default)/(faceted)/fetch-faceted-search.ts
+++ b/core/app/[locale]/(default)/(faceted)/fetch-faceted-search.ts
@@ -78,7 +78,8 @@ export const PublicSearchParamsSchema = z.object({
   after: z.string().optional(),
   before: z.string().optional(),
   brand: SearchParamToArray.transform((value) => value?.map(Number)),
-  category: SearchParamToArray.transform((value) => value?.map(Number)),
+  category: z.coerce.number().optional(),
+  categoryIn: SearchParamToArray.transform((value) => value?.map(Number)),
   isFeatured: z.coerce.boolean().optional(),
   limit: z.coerce.number().optional(),
   minPrice: z.coerce.number().optional(),
@@ -108,6 +109,7 @@ export const PublicToPrivateParams = PublicSearchParamsSchema.catchall(SearchPar
     const {
       brand,
       category,
+      categoryIn,
       isFeatured,
       minPrice,
       maxPrice,
@@ -137,7 +139,8 @@ export const PublicToPrivateParams = PublicSearchParamsSchema.catchall(SearchPar
       sort,
       filters: {
         brandEntityIds: brand,
-        categoryEntityIds: category,
+        categoryEntityId: category,
+        categoryEntityIds: categoryIn,
         hideOutOfStock: stock?.includes('in_stock'),
         isFreeShipping: shipping?.includes('free_shipping'),
         isFeatured,


### PR DESCRIPTION
## What/Why?
According to our gql schema, category pages should use `categoryEntityId` filter instead of `categoryEntityIds`.

Introduced a new `categoryIn` filter for non-category pages and `category` now accepts a single category.