### PR TITLE
chore(ci): bump dependabot pr limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'monday'
+    open-pull-requests-limit: 10
     ignore:
       - dependency-name: '*storybook*'
         update-types: ['version-update:semver-major']


### PR DESCRIPTION
## What/Why?
Bump dependabot's PR limit from `5 (default)` ->  `10`