### PR TITLE
fix(tests): accommodate recent category changes

### DIFF
--- a/core/tests/ui/desktop/core/components/radio-group.spec.ts
+++ b/core/tests/ui/desktop/core/components/radio-group.spec.ts
@@ -5,12 +5,9 @@ test('Changing selection on radio button options should update query parameters'
 }) => {
   await page.goto('/');
 
-  await page
-    .getByRole('navigation', { name: 'Main' })
-    .getByRole('link', { name: 'Shop All' })
-    .click();
+  await page.getByRole('navigation', { name: 'Main' }).getByRole('link', { name: 'Bath' }).click();
 
-  await expect(page).toHaveURL('shop-all/');
+  await expect(page).toHaveURL('bath/');
 
   await page.getByRole('link', { name: 'Quick add' }).first().click();
 
@@ -18,15 +15,15 @@ test('Changing selection on radio button options should update query parameters'
 
   await page.getByLabel('Radio').getByText('1').click();
 
-  await expect(page).toHaveURL('shop-all/?showQuickAdd=77&134=139');
+  await expect(page).toHaveURL('bath/?showQuickAdd=77&134=139');
 
   await expect(page.getByRole('dialog', { name: 'Choose options' })).toBeVisible();
 
   await page.getByLabel('Radio').getByText('2').click();
 
-  await expect(page).toHaveURL('shop-all/?showQuickAdd=77&134=140');
+  await expect(page).toHaveURL('bath/?showQuickAdd=77&134=140');
 
   await page.getByLabel('Radio').getByText('3').click();
 
-  await expect(page).toHaveURL('shop-all/?showQuickAdd=77&134=141');
+  await expect(page).toHaveURL('bath/?showQuickAdd=77&134=141');
 });

--- a/core/tests/ui/desktop/core/components/swatch.spec.ts
+++ b/core/tests/ui/desktop/core/components/swatch.spec.ts
@@ -5,12 +5,9 @@ test('Selecting various options on color panel should update query parameters', 
 }) => {
   await page.goto('/');
 
-  await page
-    .getByRole('navigation', { name: 'Main' })
-    .getByRole('link', { name: 'Shop All' })
-    .click();
+  await page.getByRole('navigation', { name: 'Main' }).getByRole('link', { name: 'Bath' }).click();
 
-  await expect(page).toHaveURL('shop-all/');
+  await expect(page).toHaveURL('bath/');
 
   await page.getByRole('link', { name: 'Quick add' }).first().click();
 
@@ -18,15 +15,15 @@ test('Selecting various options on color panel should update query parameters', 
 
   await page.getByRole('radio', { name: 'Color Silver' }).click();
 
-  await expect(page).toHaveURL('shop-all/?showQuickAdd=77&109=103');
+  await expect(page).toHaveURL('bath/?showQuickAdd=77&109=103');
 
   await expect(page.getByRole('dialog', { name: 'Choose options' })).toBeVisible();
 
   await page.getByRole('radio', { name: 'Color Purple' }).click();
 
-  await expect(page).toHaveURL('shop-all/?showQuickAdd=77&109=105');
+  await expect(page).toHaveURL('bath/?showQuickAdd=77&109=105');
 
   await page.getByRole('radio', { name: 'Color Orange' }).click();
 
-  await expect(page).toHaveURL('shop-all/?showQuickAdd=77&109=109');
+  await expect(page).toHaveURL('bath/?showQuickAdd=77&109=109');
 });

--- a/core/tests/ui/desktop/e2e/product.spec.ts
+++ b/core/tests/ui/desktop/e2e/product.spec.ts
@@ -28,19 +28,19 @@ test('Validate product page', async ({ page }) => {
 });
 
 test('Compare products', async ({ page }) => {
-  await selectProductForComparison(page, 'Orbit Terrarium - Large');
-  await selectProductForComparison(page, 'Orbit Terrarium - Small');
-  await selectProductForComparison(page, 'Able Brewing System');
+  await selectProductForComparison(page, 'Smith Journal 13');
+  await selectProductForComparison(page, 'Utility Caddy');
+  await selectProductForComparison(page, 'Laundry Detergent');
 
   await expect(page.getByRole('link', { name: 'Compare (3)' })).toBeVisible();
   await expect(
-    page.getByRole('button', { name: 'Remove [Sample] Orbit Terrarium - Large from compare list' }),
+    page.getByRole('button', { name: 'Remove [Sample] Smith Journal 13 from compare list' }),
   ).toBeAttached();
   await expect(
-    page.getByRole('button', { name: 'Remove [Sample] Orbit Terrarium - Small from compare list' }),
+    page.getByRole('button', { name: 'Remove [Sample] Utility Caddy from compare list' }),
   ).toBeAttached();
   await expect(
-    page.getByRole('button', { name: 'Remove [Sample] Able Brewing System from compare list' }),
+    page.getByRole('button', { name: 'Remove [Sample] Laundry Detergent from compare list' }),
   ).toBeAttached();
 
   await page.getByRole('link', { name: 'Compare (3)' }).click();
@@ -48,32 +48,23 @@ test('Compare products', async ({ page }) => {
 });
 
 test('Add and remove products to compare', async ({ page }) => {
-  await selectProductForComparison(page, 'Orbit Terrarium - Large');
-  await selectProductForComparison(page, 'Orbit Terrarium - Small');
-  await selectProductForComparison(page, 'Able Brewing System');
-  await selectProductForComparison(page, 'Fog Linen Chambray Towel');
+  await selectProductForComparison(page, 'Smith Journal 13');
+  await selectProductForComparison(page, 'Utility Caddy');
+  await selectProductForComparison(page, 'Laundry Detergent');
 
-  await expect(page.getByRole('link', { name: 'Compare (4)' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Compare (3)' })).toBeVisible();
   await expect(
-    page.getByRole('button', { name: 'Remove [Sample] Orbit Terrarium - Large from compare list' }),
+    page.getByRole('button', { name: 'Remove [Sample] Smith Journal 13 from compare list' }),
   ).toBeAttached();
   await expect(
-    page.getByRole('button', { name: 'Remove [Sample] Orbit Terrarium - Small from compare list' }),
+    page.getByRole('button', { name: 'Remove [Sample] Utility Caddy from compare list' }),
   ).toBeAttached();
   await expect(
-    page.getByRole('button', { name: 'Remove [Sample] Able Brewing System from compare list' }),
-  ).toBeAttached();
-  await expect(
-    page.getByRole('button', {
-      name: 'Remove [Sample] Fog Linen Chambray Towel - Beige Stripe from compare list',
-    }),
+    page.getByRole('button', { name: 'Remove [Sample] Laundry Detergent from compare list' }),
   ).toBeAttached();
 
   await page
-    .getByRole('button', { name: `Remove [Sample] Orbit Terrarium - Large from compare list` })
-    .click();
-  await page
-    .getByRole('button', { name: `Remove [Sample] Orbit Terrarium - Small from compare list` })
+    .getByRole('button', { name: `Remove [Sample] Smith Journal 13 from compare list` })
     .click();
   await expect(page.getByRole('link', { name: 'Compare (2)' })).toBeVisible();
 });

--- a/core/tests/ui/mobile/checkout-experience.spec.ts
+++ b/core/tests/ui/mobile/checkout-experience.spec.ts
@@ -9,10 +9,10 @@ test('Checkout experience on ios mobile', async ({ page }) => {
   await page.goto('/');
   await page.getByLabel('Toggle navigation').click();
   await page.getByLabel('Main').getByRole('link', { name: 'Shop All' }).click();
-  await page.getByRole('link', { name: '[Sample] Able Brewing System' }).click();
+  await page.getByRole('link', { name: '[Sample] Laundry Detergent' }).click();
 
   await expect(
-    page.getByRole('heading', { level: 1, name: '[Sample] Able Brewing System' }),
+    page.getByRole('heading', { level: 1, name: '[Sample] Laundry Detergent' }),
   ).toBeVisible();
 
   await page.getByRole('button', { name: 'Add to Cart' }).first().click();


### PR DESCRIPTION
## What/Why?
A few tests broke after https://github.com/bigcommerce/catalyst/pull/880

