### PR TITLE
chore(ci): exclude next from dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,4 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: 'eslint'
         update-types: ['version-update:semver-major']
+      - dependency-name: '*next*'


### PR DESCRIPTION
## What/Why?
Ignore `next` and sibling packages (eslint next config, etc). We are planning on manually bumping those.