### PR TITLE
fix(core): overflow issue with account dropdown in header

### DIFF
--- a/.changeset/small-ducks-wink.md
+++ b/.changeset/small-ducks-wink.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Fix issue with account dropdown in header.

--- a/core/components/ui/navigation-menu/navigation-menu.tsx
+++ b/core/components/ui/navigation-menu/navigation-menu.tsx
@@ -51,7 +51,7 @@ const NavigationMenu = forwardRef<
           <div className="relative">
             <div
               className={cn(
-                'group flex min-h-[92px] items-center justify-between gap-1 overflow-x-hidden bg-white px-4 2xl:container sm:px-10 lg:gap-8 lg:px-12 2xl:mx-auto 2xl:px-0',
+                'group flex min-h-[92px] items-center justify-between gap-1 overflow-y-visible bg-white px-4 2xl:container sm:px-10 lg:gap-8 lg:px-12 2xl:mx-auto 2xl:px-0',
                 className,
               )}
             >

--- a/core/tests/ui/desktop/e2e/account.spec.ts
+++ b/core/tests/ui/desktop/e2e/account.spec.ts
@@ -47,3 +47,18 @@ test('My Account tabs are displayed and clickable', async ({ page }) => {
   await expect(page).toHaveURL('account/settings/');
   await expect(page.getByRole('heading', { name: 'Account settings' })).toBeVisible();
 });
+
+test('Account dropdown is visible in header', async ({ page }) => {
+  await page.goto('/login/');
+  await page.getByLabel('Login').click();
+  await page.getByLabel('Email').fill(process.env.TEST_ACCOUNT_EMAIL || '');
+  await page.getByLabel('Password').fill(process.env.TEST_ACCOUNT_PASSWORD || '');
+  await page.getByRole('button', { name: 'Log in' }).click();
+  await page.getByRole('heading', { name: 'My Account' }).waitFor();
+
+  await page.goto('/');
+
+  await page.getByRole('link', { name: 'Account' }).hover();
+
+  await expect(page.getByText('Log out')).toBeInViewport();
+});


### PR DESCRIPTION
## What/Why?
Account dropdown menu is not visible with current classes, fixed this by making overflow-y visible.

## Testing
![Screenshot 2024-05-16 at 3 46 45 PM](https://github.com/bigcommerce/catalyst/assets/196129/118e72e5-ea2e-4c97-900c-4f522ba7c49f)
