### PR TITLE
fix(core): broken Slot functionality in Button

### DIFF
--- a/.changeset/small-eagles-switch.md
+++ b/.changeset/small-eagles-switch.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Fix broken Slot functionality in Button

--- a/core/components/ui/button/button.tsx
+++ b/core/components/ui/button/button.tsx
@@ -45,13 +45,17 @@ export const Button = forwardRef<ElementRef<'button'>, ButtonProps>(
         ref={ref}
         {...props}
       >
-        {loading && (
-          <span className="absolute z-10 flex h-full w-full items-center justify-center">
-            <Spinner aria-hidden="true" className="animate-spin" />
-            <span className="sr-only">{loadingText}</span>
-          </span>
+        {loading ? (
+          <>
+            <span className="absolute z-10 flex h-full w-full items-center justify-center">
+              <Spinner aria-hidden="true" className="animate-spin" />
+              <span className="sr-only">{loadingText}</span>
+            </span>
+            <span className={cn('invisible flex items-center')}>{children}</span>
+          </>
+        ) : (
+          children
         )}
-        <span className={cn('flex items-center', loading && 'invisible')}>{children}</span>
       </Comp>
     );
   },


### PR DESCRIPTION
## What/Why?
Change in #916 broke Slot because Slot needs a single React child, plus it was Slotting in the span instead of the Children as expected.

This fixes specifically the scenario of a Link slotting as a Button.

## Testing
Locally.