### PR TITLE
fix: eslint config resolution in core

### DIFF
--- a/core/.eslintrc.cjs
+++ b/core/.eslintrc.cjs
@@ -1,5 +1,8 @@
 // @ts-check
 
+// eslint-disable-next-line import/no-extraneous-dependencies
+require('@bigcommerce/eslint-config/patch');
+
 /** @type {import('eslint').Linter.Config} */
 const config = {
   root: true,


### PR DESCRIPTION
## What/Why?
Fixes ESLint resolution error in scaffolded projects. Note, the eslint-disable-next-line is needed for scaffolded projects.

## Testing
Locally:
<img width="1089" alt="Screenshot 2024-05-17 at 1 49 56 PM" src="https://github.com/bigcommerce/catalyst/assets/28374851/6b303d8d-b8b4-499d-8640-6abbc2340c3f">
