### PR TITLE
refactor: remove unnecessary lint command from cli

### DIFF
--- a/.changeset/hot-starfishes-join.md
+++ b/.changeset/hot-starfishes-join.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": minor
+---
+
+Removes unnecessary lint task from create command

--- a/packages/create-catalyst/src/commands/create.ts
+++ b/packages/create-catalyst/src/commands/create.ts
@@ -214,12 +214,6 @@ export const create = async (options: CreateCommandOptions) => {
     failText: (err) => chalk.red(`Failed to create GraphQL schema: ${err.message}`),
   });
 
-  await spinner(exec(`${packageManager} run lint -- --fix`, { cwd: projectDir }), {
-    text: 'Linting to validate generated types...',
-    successText: 'GraphQL types validated successfully',
-    failText: (err) => chalk.red(`Failed to validate GraphQL types: ${err.message}`),
-  });
-
   console.log(
     `\n${chalk.green('Success!')} Created '${projectName}' at '${projectDir}'\n`,
     '\nNext steps:\n',


### PR DESCRIPTION
## What/Why?
Since the `core` folder is running with the same ESLint config as scaffolded projects, we no longer need to run the `lint` task as part of the `create-catalyst` `create` command

## Testing
Remove lint step in CLI locally and test against `--gh-ref=main`