### PR TITLE
fix(core): show correct base price when sale is active in Cart

### DIFF
--- a/.changeset/curvy-items-cheat.md
+++ b/.changeset/curvy-items-cheat.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Fix incorrect sale price showing when no sale was active in Cart

--- a/core/app/[locale]/(default)/cart/_components/cart-item.tsx
+++ b/core/app/[locale]/(default)/cart/_components/cart-item.tsx
@@ -28,6 +28,10 @@ const PhysicalItemFragment = graphql(`
       currencyCode
       value
     }
+    listPrice {
+      currencyCode
+      value
+    }
     selectedOptions {
       __typename
       entityId
@@ -76,6 +80,10 @@ const DigitalItemFragment = graphql(`
       value
     }
     originalPrice {
+      currencyCode
+      value
+    }
+    listPrice {
       currencyCode
       value
     }
@@ -222,9 +230,9 @@ export const CartItem = async ({ currencyCode, product }: Props) => {
             <div className="flex flex-col gap-2 md:items-end">
               <div>
                 {product.originalPrice.value &&
-                product.originalPrice.value !== product.extendedSalePrice.value ? (
+                product.originalPrice.value !== product.listPrice.value ? (
                   <p className="text-lg font-bold line-through">
-                    {format.number(product.originalPrice.value, {
+                    {format.number(product.originalPrice.value * product.quantity, {
                       style: 'currency',
                       currency: currencyCode,
                     })}


### PR DESCRIPTION
## What/Why?
Fixes issue of showing an item as on sale when quantity was 2 or above.

`extendedListPrice` and `extendedSalePrice` account for quantity, but `originalPrice` doesn't. With this change I compare `originalPrice` to `listPrice`, and multiple original Price accordingly.

Before:
![Screenshot 2024-05-17 at 1 55 58 PM](https://github.com/bigcommerce/catalyst/assets/196129/4aa223db-48a5-47aa-ae6a-fdfe7a538f1b)

After:
![Screenshot 2024-05-17 at 1 55 37 PM](https://github.com/bigcommerce/catalyst/assets/196129/615ba86a-7b0f-417f-932e-c71c955e210d)

## Testing
Locally.