### PR TITLE
refactor: better node version check

### DIFF
--- a/.changeset/breezy-beers-listen.md
+++ b/.changeset/breezy-beers-listen.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": minor
+---
+
+Adds more helpful error messaging when using older versions of Node (<12) with the CLI

--- a/packages/create-catalyst/bin/index.cjs
+++ b/packages/create-catalyst/bin/index.cjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+const semver = require('semver');
+
+const catalystRequiredNodeVersion = '>=20';
+const userNodeVersion = process.version;
+
+if (!semver.satisfies(userNodeVersion, catalystRequiredNodeVersion)) {
+  console.error(`\n\x1b[31mYou are using Node.js version: ${userNodeVersion}.`);
+  console.error(`Catalyst requires Node.js version: ${catalystRequiredNodeVersion}.\x1b[0m\n`);
+  process.exit(1);
+}
+
+// eslint-disable-next-line import/dynamic-import-chunkname, import/extensions
+import('../dist/index.js').catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/create-catalyst/package.json
+++ b/packages/create-catalyst/package.json
@@ -2,8 +2,9 @@
   "name": "@bigcommerce/create-catalyst",
   "version": "0.7.0",
   "type": "module",
-  "bin": "dist/index.js",
+  "bin": "bin/index.cjs",
   "files": [
+    "bin",
     "dist"
   ],
   "scripts": {

--- a/packages/create-catalyst/src/index.ts
+++ b/packages/create-catalyst/src/index.ts
@@ -2,26 +2,11 @@
 
 import { program } from '@commander-js/extra-typings';
 import chalk from 'chalk';
-import { satisfies } from 'semver';
 
 import PACKAGE_INFO from '../package.json';
 
 import { create } from './commands/create';
 import { init } from './commands/init';
-
-if (!satisfies(process.version, PACKAGE_INFO.engines.node)) {
-  console.error(
-    chalk.red(
-      `\nYou are using Node.js ${process.version}. Catalyst requires ${PACKAGE_INFO.engines.node}. Please upgrade your Node.js version to continue.\n`,
-    ),
-  );
-  console.log(
-    chalk.yellow(
-      'Tip: If you use nvm, you can run `nvm install 18` to install a compatible node version.\n',
-    ),
-  );
-  process.exit(1);
-}
 
 console.log(chalk.cyanBright(`\n◢ ${PACKAGE_INFO.name} v${PACKAGE_INFO.version}\n`));
 


### PR DESCRIPTION
## What/Why?
> [!NOTE]
> ~This PR stacks on #935~ ✅ **Merged**

There were some reports of users not receiving a helpful error message when attempting to run the CLI with a Node version <12. While <12 versions of Node became EOL back in 2021 and earlier, there is still a chance that someone is accidentally using an early version of Node when trying to run the CLI, and we should help guide them. 

The error thrown looked like:
```
$ node packages/create-catalyst/dist/index.js

/Users/matt.volk/code/catalyst/packages/create-catalyst/dist/index.js:55
import { program } from "@commander-js/extra-typings";
       ^

SyntaxError: Unexpected token {
    at Module._compile (internal/modules/cjs/loader.js:723:23)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:831:12)
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:623:3)
```

The ESM syntax could not be interpreted by early versions of Node. This PR adds a `bin/index.cjs` file that serves as the new entry point of the CLI, which performs a Node version check, and if successful, uses a dynamic import to run the original entry point. 

This also cleans up the original `index.ts` entry point file, building on top of #935 

## Testing

In order to test this as closely as possible to how users will execute the binary in production, I followed the steps below:

> *Be sure to checkout this branch and run `pnpm i`, then `pnpm -F @bigcommerce/create-catalyst build` before proceeding*

1. Change directory into `catalyst/packages/create-catalyst`
2. Ensure you're using Node v20+ and pnpm v8+
3. Run `pnpm pack` which should create a tarball: `bigcommerce-create-catalyst-0.7.0.tgz`
4. Switch Node versions to <12: `nvm use lts/dubnium` for v10
5. Install local tarball: `npm install -g ./bigcommerce-create-catalyst-0.7.0.tgz` (Note: you'll get a number of `npm WARN notsup` logs due to installing packages with an old Node version)
6. Run `npm list -g --depth=0` to ensure the package was installed globally successfully
7. Run `npm init @bigcommerce/catalyst` to execute the local, global `create-catalyst` binary. You should see:

```bash
npm init @bigcommerce/catalyst                        

You are using Node.js version: v10.24.1.
Catalyst requires Node.js version: >=20.
```

8. Uninstall the tarball to clean up your local Node environment: `npm uninstall -g @bigcommerce/create-catalyst`
9. Ensure it is removed: `npm list -g --depth=0`
10. Switch to a supported Node version: `nvm use 20`
11. Install the local tarball on your new Node version: `npm install -g ./bigcommerce-create-catalyst-0.7.0.tgz`
12. Ensure it is installed: `npm list -g --depth=0`
13. Execute: `npm init @bigcommerce/catalyst`. You should see:

```bash
npm init @bigcommerce/catalyst                        

◢ @bigcommerce/create-catalyst v0.7.0

? What is the name of your project? (my-catalyst-app)
```

14. Uninstall to clean local env: `npm uninstall -g @bigcommerce/create-catalyst`
15. Ensure it is removed: `npm list -g --depth=0`
