### PR TITLE
fix(core): update icons on the account page

### DIFF
--- a/.changeset/stupid-hairs-clean.md
+++ b/.changeset/stupid-hairs-clean.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+update icons on the account page

--- a/core/app/[locale]/(default)/account/page.tsx
+++ b/core/app/[locale]/(default)/account/page.tsx
@@ -42,22 +42,22 @@ export default async function AccountPage({ params: { locale } }: Props) {
 
       <div className="mb-14 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
         <AccountItem href="/account/orders" title={t('orders')}>
-          <Package className="me-8" height={48} width={48} />
+          <Package className="me-8" size={48} strokeWidth={1.5} />
         </AccountItem>
         <AccountItem href="/account/messages" title={t('messages')}>
-          <Mail className="me-8" height={48} width={48} />
+          <Mail className="me-8" size={48} strokeWidth={1.5} />
         </AccountItem>
         <AccountItem href="/account/addresses" title={t('addresses')}>
-          <BookUser className="me-8" height={48} width={48} />
+          <BookUser className="me-8" size={48} strokeWidth={1.5} />
         </AccountItem>
         <AccountItem href="/account/wishlists" title={t('wishlists')}>
-          <Gift className="me-8" height={48} width={48} />
+          <Gift className="me-8" size={48} strokeWidth={1.5} />
         </AccountItem>
         <AccountItem href="/account/recently-viewed" title={t('recentlyViewed')}>
-          <Eye className="me-8" height={48} width={48} />
+          <Eye className="me-8" size={48} strokeWidth={1.5} />
         </AccountItem>
         <AccountItem href="/account/settings" title={t('settings')}>
-          <Settings className="me-8" height={48} width={48} />
+          <Settings className="me-8" size={48} strokeWidth={1.5} />
         </AccountItem>
       </div>
     </div>


### PR DESCRIPTION
## What/Why?
This PR fixes icons border width on the Account Page

## Testing
locally

before:
<img width="1656" alt="1846_bug" src="https://github.com/bigcommerce/catalyst/assets/82589781/3671bd7e-5c74-4023-ad35-39b8198498e8">

after:
<img width="1662" alt="1846_fix" src="https://github.com/bigcommerce/catalyst/assets/82589781/6b0c4d8b-5d02-4af8-aa72-5019d4efb35c">


[BCTHEME-1846]: https://bigcommercecloud.atlassian.net/browse/BCTHEME-1846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ