### PR TITLE
Pass customer ID when requesting checkout URL

### DIFF
--- a/core/app/[locale]/(default)/cart/_actions/redirect-to-checkout.ts
+++ b/core/app/[locale]/(default)/cart/_actions/redirect-to-checkout.ts
@@ -3,6 +3,7 @@
 import { redirect } from 'next/navigation';
 import { z } from 'zod';
 
+import { getSessionCustomerId } from '~/auth';
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
 
@@ -20,11 +21,13 @@ const CheckoutRedirectMutation = graphql(`
 
 export const redirectToCheckout = async (formData: FormData) => {
   const cartId = z.string().parse(formData.get('cartId'));
+  const customerId = await getSessionCustomerId();
 
   const { data } = await client.fetch({
     document: CheckoutRedirectMutation,
     variables: { cartId },
     fetchOptions: { cache: 'no-store' },
+    customerId,
   });
 
   const url = data.cart.createCartRedirectUrls.redirectUrls?.redirectedCheckoutUrl;


### PR DESCRIPTION
## What/Why?
Customer ID was not being passed to the request to get a checkout URL. As a result, there was a server error when checking out while logged in. This fixes that.

In the future, this request will return a customer-specific checkout URL, but for now it returns a guest checkout URL. This approach should automatically work in the future when the underlying URL is updated.

## Testing
Locally tested both logged-in checkout and guest checkout.