### PR TITLE
feat(core): add numbers-only field & utils for account form fields

### DIFF
--- a/.changeset/afraid-experts-fold.md
+++ b/.changeset/afraid-experts-fold.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+add numbers-only field & utils for account form fields

--- a/core/app/[locale]/(default)/account/[tab]/_actions/add-address.ts
+++ b/core/app/[locale]/(default)/account/[tab]/_actions/add-address.ts
@@ -7,6 +7,8 @@ import {
   AddCustomerAddressInput,
 } from '~/client/mutations/add-customer-address';
 
+import { parseAccountFormData } from '../../../login/register-customer/_components/register-customer-form/fields/parse-fields';
+
 const isAddCustomerAddressInput = (data: unknown): data is AddCustomerAddressInput => {
   if (typeof data === 'object' && data !== null && 'address1' in data) {
     return true;
@@ -23,22 +25,7 @@ export const addAddress = async ({
   reCaptchaToken?: string;
 }) => {
   try {
-    const parsed: unknown = [...formData.entries()].reduce<
-      Record<string, FormDataEntryValue | Record<string, FormDataEntryValue>>
-    >((parsedData, [name, value]) => {
-      const key = name.split('-').at(-1) ?? '';
-      const sections = name.split('-').slice(0, -1);
-
-      if (sections.includes('customer')) {
-        parsedData[key] = value;
-      }
-
-      if (sections.includes('address')) {
-        parsedData[key] = value;
-      }
-
-      return parsedData;
-    }, {});
+    const parsed = parseAccountFormData(formData);
 
     if (!isAddCustomerAddressInput(parsed)) {
       return {

--- a/core/app/[locale]/(default)/account/[tab]/_actions/update-address.ts
+++ b/core/app/[locale]/(default)/account/[tab]/_actions/update-address.ts
@@ -7,6 +7,8 @@ import {
   UpdateCustomerAddressInput,
 } from '~/client/mutations/update-customer-address';
 
+import { parseAccountFormData } from '../../../login/register-customer/_components/register-customer-form/fields/parse-fields';
+
 const isUpdateCustomerAddressInput = (
   data: unknown,
 ): data is UpdateCustomerAddressInput['data'] => {
@@ -27,22 +29,7 @@ export const updateAddress = async ({
   reCaptchaToken?: string;
 }) => {
   try {
-    const parsed: unknown = [...formData.entries()].reduce<
-      Record<string, FormDataEntryValue | Record<string, FormDataEntryValue>>
-    >((parsedData, [name, value]) => {
-      const key = name.split('-').at(-1) ?? '';
-      const sections = name.split('-').slice(0, -1);
-
-      if (sections.includes('customer')) {
-        parsedData[key] = value;
-      }
-
-      if (sections.includes('address')) {
-        parsedData[key] = value;
-      }
-
-      return parsedData;
-    }, {});
+    const parsed = parseAccountFormData(formData);
 
     if (!isUpdateCustomerAddressInput(parsed)) {
       return {

--- a/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/add-address.tsx
+++ b/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/add-address.tsx
@@ -10,6 +10,7 @@ import {
   createFieldName,
   FieldNameToFieldId,
   FieldWrapper,
+  NumbersOnly,
   Picklist,
   PicklistOrText,
   Text,
@@ -23,6 +24,7 @@ import { addAddress } from '../../_actions/add-address';
 
 import {
   createCountryChangeHandler,
+  createNumbersInputValidationHandler,
   createTextInputValidationHandler,
 } from './address-field-handlers';
 import { NewAddressQueryResponseType } from './customer-new-address';
@@ -92,6 +94,7 @@ export const AddAddress = ({
   const [isReCaptchaValid, setReCaptchaValid] = useState(true);
 
   const [textInputValid, setTextInputValid] = useState<Record<string, boolean>>({});
+  const [numbersInputValid, setNumbersInputValid] = useState<Record<string, boolean>>({});
   const [countryStates, setCountryStates] = useState(defaultCountry.states);
 
   const handleTextInputValidation = createTextInputValidationHandler(
@@ -99,6 +102,10 @@ export const AddAddress = ({
     textInputValid,
   );
   const handleCountryChange = createCountryChangeHandler(setCountryStates, countries);
+  const handleNumbersInputValidation = createNumbersInputValidationHandler(
+    setNumbersInputValid,
+    numbersInputValid,
+  );
 
   const onReCaptchaChange = (token: string | null) => {
     if (!token) {
@@ -113,6 +120,8 @@ export const AddAddress = ({
   const onSubmit = async (formData: FormData) => {
     if (reCaptchaSettings?.isEnabledOnStorefront && !reCaptchaToken) {
       setReCaptchaValid(false);
+
+      return;
     }
 
     setReCaptchaValid(true);
@@ -158,8 +167,21 @@ export const AddAddress = ({
                     <Text
                       field={field}
                       isValid={textInputValid[field.entityId]}
-                      name={createFieldName('address', field.entityId)}
+                      name={createFieldName(field, 'address')}
                       onChange={handleTextInputValidation}
+                    />
+                  </FieldWrapper>
+                );
+              }
+
+              case 'NumberFormField': {
+                return (
+                  <FieldWrapper fieldId={field.entityId} key={field.entityId}>
+                    <NumbersOnly
+                      field={field}
+                      isValid={numbersInputValid[field.entityId]}
+                      name={createFieldName(field, 'address')}
+                      onChange={handleNumbersInputValidation}
                     />
                   </FieldWrapper>
                 );
@@ -175,7 +197,7 @@ export const AddAddress = ({
                           : undefined
                       }
                       field={field}
-                      name={createFieldName('address', field.entityId)}
+                      name={createFieldName(field, 'address')}
                       onChange={
                         field.entityId === FieldNameToFieldId.countryCode
                           ? handleCountryChange
@@ -198,7 +220,7 @@ export const AddAddress = ({
                           : undefined
                       }
                       field={field}
-                      name={createFieldName('address', field.entityId)}
+                      name={createFieldName(field, 'address')}
                       options={countryStates.map(({ name }) => {
                         return { entityId: name, label: name };
                       })}

--- a/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/customer-edit-address.tsx
+++ b/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/customer-edit-address.tsx
@@ -86,8 +86,8 @@ export async function CustomerEditAddress({
       <EditAddressForm
         address={address}
         addressFields={addressFields}
-        canBeDeleted={isAddressRemovable}
         countries={countries || []}
+        isAddressRemovable={isAddressRemovable}
         reCaptchaSettings={reCaptchaSettings}
       />
     </NextIntlClientProvider>

--- a/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/edit-address.tsx
+++ b/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/edit-address.tsx
@@ -10,6 +10,7 @@ import {
   createFieldName,
   FieldNameToFieldId,
   FieldWrapper,
+  NumbersOnly,
   Picklist,
   PicklistOrText,
   Text,
@@ -27,6 +28,7 @@ import { Modal } from '../modal';
 import { AddressFields, Countries } from './add-address';
 import {
   createCountryChangeHandler,
+  createNumbersInputValidationHandler,
   createTextInputValidationHandler,
 } from './address-field-handlers';
 import { Address } from './customer-edit-address';
@@ -75,8 +77,8 @@ const SubmitButton = ({ messages }: SumbitMessages) => {
 interface EditAddressProps {
   address: Address;
   addressFields: AddressFields;
-  canBeDeleted: boolean;
   countries: Countries;
+  isAddressRemovable: boolean;
   reCaptchaSettings?: {
     isEnabledOnStorefront: boolean;
     siteKey: string;
@@ -86,13 +88,12 @@ interface EditAddressProps {
 export const EditAddress = ({
   address,
   addressFields,
-  canBeDeleted,
   countries,
+  isAddressRemovable,
   reCaptchaSettings,
 }: EditAddressProps) => {
   const form = useRef<HTMLFormElement>(null);
   const [formStatus, setFormStatus] = useState<FormStatus | null>(null);
-
   const t = useTranslations('Account.EditAddress');
 
   const reCaptchaRef = useRef<ReCaptcha>(null);
@@ -102,6 +103,7 @@ export const EditAddress = ({
   const { setAccountState } = useAccountStatusContext();
 
   const [textInputValid, setTextInputValid] = useState<Record<string, boolean>>({});
+  const [numbersInputValid, setNumbersInputValid] = useState<Record<string, boolean>>({});
 
   const defaultStates = countries
     .filter((country) => country.code === address.countryCode)
@@ -111,6 +113,10 @@ export const EditAddress = ({
   const handleTextInputValidation = createTextInputValidationHandler(
     setTextInputValid,
     textInputValid,
+  );
+  const handleNumbersInputValidation = createNumbersInputValidationHandler(
+    setNumbersInputValid,
+    numbersInputValid,
   );
   const handleCountryChange = createCountryChangeHandler(setCountryStates, countries);
 
@@ -137,7 +143,6 @@ export const EditAddress = ({
     const submit = await updateAddress({ addressId: address.entityId, formData });
 
     if (submit.status === 'success') {
-      form.current?.reset();
       setFormStatus({
         status: 'success',
         message: t('successMessage'),
@@ -168,14 +173,7 @@ export const EditAddress = ({
       setAccountState({ status, message });
     }
 
-    window.scrollTo({
-      top: 0,
-      behavior: 'smooth',
-    });
-
-    setTimeout(() => {
-      router.replace('/account/addresses');
-    }, 500);
+    router.replace('/account/addresses');
   };
 
   return (
@@ -188,24 +186,53 @@ export const EditAddress = ({
       <Form action={onSubmit} ref={form}>
         <div className="grid grid-cols-1 gap-y-6 lg:grid-cols-2 lg:gap-x-6 lg:gap-y-2">
           {addressFields.map((field) => {
-            const key = FieldNameToFieldId[field.entityId];
+            const fieldId = field.entityId;
+            const key = FieldNameToFieldId[fieldId];
+            let defaultValue;
+            let defaultCustomField;
 
-            if (!isExistedField(key)) {
-              return null;
+            if (isExistedField(key)) {
+              defaultValue = address[key] ?? undefined;
+            } else {
+              defaultCustomField = address.formFields.filter(
+                ({ entityId }) => entityId === fieldId,
+              )[0];
             }
-
-            const defaultValue = address[key] || undefined;
 
             switch (field.__typename) {
               case 'TextFormField': {
+                const defaultText =
+                  defaultCustomField?.__typename === `TextFormFieldValue`
+                    ? defaultCustomField.text
+                    : undefined;
+
                 return (
-                  <FieldWrapper fieldId={field.entityId} key={field.entityId}>
+                  <FieldWrapper fieldId={fieldId} key={fieldId}>
                     <Text
-                      defaultValue={defaultValue}
+                      defaultValue={defaultValue ?? defaultText}
                       field={field}
-                      isValid={textInputValid[field.entityId]}
-                      name={createFieldName('address', field.entityId)}
+                      isValid={textInputValid[fieldId]}
+                      name={createFieldName(field, 'address')}
                       onChange={handleTextInputValidation}
+                    />
+                  </FieldWrapper>
+                );
+              }
+
+              case 'NumberFormField': {
+                const defaultNumber =
+                  defaultCustomField?.__typename === `NumberFormFieldValue`
+                    ? defaultCustomField.number
+                    : undefined;
+
+                return (
+                  <FieldWrapper fieldId={fieldId} key={fieldId}>
+                    <NumbersOnly
+                      defaultValue={defaultNumber}
+                      field={field}
+                      isValid={numbersInputValid[fieldId]}
+                      name={createFieldName(field, 'address')}
+                      onChange={handleNumbersInputValidation}
                     />
                   </FieldWrapper>
                 );
@@ -213,17 +240,15 @@ export const EditAddress = ({
 
               case 'PicklistFormField':
                 return (
-                  <FieldWrapper fieldId={field.entityId} key={field.entityId}>
+                  <FieldWrapper fieldId={fieldId} key={fieldId}>
                     <Picklist
                       defaultValue={
-                        field.entityId === FieldNameToFieldId.countryCode ? defaultValue : undefined
+                        fieldId === FieldNameToFieldId.countryCode ? defaultValue : undefined
                       }
                       field={field}
-                      name={createFieldName('address', field.entityId)}
+                      name={createFieldName(field, 'address')}
                       onChange={
-                        field.entityId === FieldNameToFieldId.countryCode
-                          ? handleCountryChange
-                          : undefined
+                        fieldId === FieldNameToFieldId.countryCode ? handleCountryChange : undefined
                       }
                       options={countries.map(({ name, code }) => {
                         return { label: name, entityId: code };
@@ -234,16 +259,14 @@ export const EditAddress = ({
 
               case 'PicklistOrTextFormField': {
                 return (
-                  <FieldWrapper fieldId={field.entityId} key={field.entityId}>
+                  <FieldWrapper fieldId={fieldId} key={fieldId}>
                     <PicklistOrText
                       defaultValue={
-                        field.entityId === FieldNameToFieldId.stateOrProvince
-                          ? defaultValue
-                          : undefined
+                        fieldId === FieldNameToFieldId.stateOrProvince ? defaultValue : undefined
                       }
                       field={field}
                       key={countryStates.length}
-                      name={createFieldName('address', field.entityId)}
+                      name={createFieldName(field, 'address')}
                       options={countryStates.map(({ name }) => {
                         return { entityId: name, label: name };
                       })}
@@ -287,7 +310,7 @@ export const EditAddress = ({
           >
             <Button
               className="ms-auto items-center px-8 md:w-fit"
-              disabled={!canBeDeleted}
+              disabled={!isAddressRemovable}
               variant="subtle"
             >
               {t('deleteButton')}

--- a/core/app/[locale]/(default)/login/register-customer/_components/register-customer-form/fields/index.ts
+++ b/core/app/[locale]/(default)/login/register-customer/_components/register-customer-form/fields/index.ts
@@ -1,5 +1,6 @@
 export * from './password';
 export * from './text';
+export * from './numbers-only';
 export * from './picklist';
 export * from './picklist-or-text';
 export * from './shared/field-wrapper';

--- a/core/app/[locale]/(default)/login/register-customer/_components/register-customer-form/fields/numbers-only.tsx
+++ b/core/app/[locale]/(default)/login/register-customer/_components/register-customer-form/fields/numbers-only.tsx
@@ -1,0 +1,76 @@
+import { useTranslations } from 'next-intl';
+import { ChangeEvent } from 'react';
+
+import { Field, FieldControl, FieldLabel, FieldMessage } from '~/components/ui/form';
+import { Input } from '~/components/ui/input';
+
+import { CustomerFields } from '..';
+
+type NumbersOnlyType = Extract<
+  NonNullable<CustomerFields>[number],
+  { __typename: 'NumberFormField' }
+>;
+
+interface NumbersOnlyProps {
+  field: NumbersOnlyType;
+  name: string;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  isValid?: boolean;
+  defaultValue?: number;
+}
+
+export const NumbersOnly = ({ defaultValue, field, isValid, name, onChange }: NumbersOnlyProps) => {
+  const t = useTranslations('Account.Register.validationMessages');
+
+  return (
+    <Field className="relative space-y-2 pb-7" name={name}>
+      <FieldLabel htmlFor={`field-${field.entityId}`} isRequired={field.isRequired}>
+        {field.label}
+      </FieldLabel>
+      <FieldControl asChild>
+        <Input
+          defaultValue={field.defaultNumber ?? defaultValue}
+          id={`field-${field.entityId}`}
+          max={field.maxNumber ?? undefined}
+          min={field.minNumber ?? undefined}
+          minLength={field.minNumber ?? undefined}
+          onChange={field.isRequired ? onChange : undefined}
+          onInvalid={field.isRequired ? onChange : undefined}
+          required={field.isRequired}
+          type="number"
+          variant={isValid === false ? 'error' : undefined}
+        />
+      </FieldControl>
+      {field.isRequired && (
+        <FieldMessage
+          className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-error-secondary"
+          match="valueMissing"
+        >
+          {t('empty')}
+        </FieldMessage>
+      )}
+      <FieldMessage
+        className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-error-secondary"
+        match="typeMismatch"
+      >
+        {t('numbersOnly')}
+      </FieldMessage>
+      {Boolean(field.minNumber) && (
+        <FieldMessage
+          className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-error-secondary"
+          match="rangeUnderflow"
+        >
+          {t('numbersUnderflow', { min: field.minNumber })}
+        </FieldMessage>
+      )}
+      {Boolean(field.maxNumber) && (
+        <FieldMessage
+          className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-error-secondary"
+          match="rangeOverflow"
+        >
+          {t('numbersOverflow', { max: field.maxNumber })}
+        </FieldMessage>
+      )}
+    </Field>
+  );
+};

--- a/core/app/[locale]/(default)/login/register-customer/_components/register-customer-form/fields/parse-fields.ts
+++ b/core/app/[locale]/(default)/login/register-customer/_components/register-customer-form/fields/parse-fields.ts
@@ -1,0 +1,165 @@
+import { UpdateCustomerAddressInput } from '~/client/mutations/update-customer-address';
+
+type FormFieldsType = UpdateCustomerAddressInput['data']['formFields'];
+type ReturnedFormData = Record<string, unknown>;
+
+const updateFormFields = ({
+  formFields,
+  fieldType,
+  fieldEntityId,
+  fieldValue,
+}: {
+  formFields: FormFieldsType;
+  fieldType: string;
+  fieldEntityId: number;
+  fieldValue: string;
+}) => {
+  const customFormFields = formFields ?? {};
+
+  if (fieldValue.length === 0) {
+    return customFormFields;
+  }
+
+  switch (fieldType) {
+    case 'texts': {
+      const customTexts = customFormFields[fieldType];
+
+      const fieldData = {
+        text: fieldValue,
+        fieldEntityId,
+      };
+
+      customFormFields[fieldType] = customTexts ? [...customTexts, fieldData] : [fieldData];
+
+      break;
+    }
+
+    case 'passwords': {
+      const customPasswords = customFormFields[fieldType];
+
+      const fieldData = {
+        password: fieldValue,
+        fieldEntityId,
+      };
+
+      customFormFields[fieldType] = customPasswords ? [...customPasswords, fieldData] : [fieldData];
+
+      break;
+    }
+
+    case 'checkboxes': {
+      const customCheckboxes = customFormFields[fieldType];
+
+      const fieldData = {
+        fieldValueEntityIds: [Number(fieldValue)],
+        fieldEntityId,
+      };
+
+      customFormFields[fieldType] = customCheckboxes
+        ? [...customCheckboxes, fieldData]
+        : [fieldData];
+
+      break;
+    }
+
+    case 'multipleChoices': {
+      const customMultipleChoices = customFormFields[fieldType];
+
+      const fieldData = {
+        fieldValueEntityId: Number(fieldValue),
+        fieldEntityId,
+      };
+
+      customFormFields[fieldType] = customMultipleChoices
+        ? [...customMultipleChoices, fieldData]
+        : [fieldData];
+
+      break;
+    }
+
+    case 'numbers': {
+      const customNumbers = customFormFields[fieldType];
+
+      const fieldData = {
+        number: Number(fieldValue),
+        fieldEntityId,
+      };
+
+      customFormFields[fieldType] = customNumbers ? [...customNumbers, fieldData] : [fieldData];
+
+      break;
+    }
+
+    case 'dates': {
+      const customDates = customFormFields[fieldType];
+
+      const [day, mm, year] = fieldValue.split('/');
+      const month = Number(mm) - 1;
+      const date = new Date(Date.UTC(Number(year), month, Number(day))).toISOString();
+      const fieldData = {
+        date,
+        fieldEntityId,
+      };
+
+      customFormFields[fieldType] = customDates ? [...customDates, fieldData] : [fieldData];
+
+      break;
+    }
+  }
+
+  return customFormFields;
+};
+
+const isFormFieldsType = (data: unknown): data is FormFieldsType => {
+  if (
+    typeof data === 'object' &&
+    data !== null &&
+    ('texts' in data ||
+      'checkboxes' in data ||
+      'multipleChoices' in data ||
+      'numbers' in data ||
+      'dates' in data ||
+      'passwords' in data)
+  ) {
+    return true;
+  }
+
+  return false;
+};
+
+export const parseAccountFormData = (accountFormData: FormData): unknown =>
+  [...accountFormData.entries()].reduce<ReturnedFormData>((parsedData, [name, value]) => {
+    // files are not supported in Form Fields
+    if (typeof value !== 'string') {
+      return parsedData;
+    }
+
+    const key = name.split('-').at(-1) ?? '';
+    const sections = name.split('-').slice(0, -1);
+
+    if (sections.includes('customer')) {
+      parsedData[key] = value;
+
+      return parsedData;
+    }
+
+    if (sections.includes('address')) {
+      parsedData[key] = value;
+
+      return parsedData;
+    }
+
+    // merchant defined Form Fields
+    if (sections.every((section) => section.startsWith('custom_'))) {
+      const customFieldType = sections[0]?.split('_').at(-1) ?? '';
+
+      parsedData.formFields = updateFormFields({
+        formFields: isFormFieldsType(parsedData.formFields) ? parsedData.formFields : null,
+        fieldType: customFieldType,
+        fieldEntityId: Number(key),
+        fieldValue: value,
+      });
+    }
+
+    return parsedData;
+  }, {});

--- a/core/app/[locale]/(default)/login/register-customer/_components/register-customer-form/fields/utils.ts
+++ b/core/app/[locale]/(default)/login/register-customer/_components/register-customer-form/fields/utils.ts
@@ -1,3 +1,5 @@
+import { AddressOrAccountFormField } from '..';
+
 /* This mapping needed for aligning built-in fields names to their ids
  for creating valid register customer request object
  that will be sent in mutation */
@@ -19,6 +21,19 @@ export enum FieldNameToFieldId {
   exclusiveOffers = 25,
 }
 
+export enum FieldTypeToFieldInput {
+  'CheckboxesFormField' = 'checkboxes',
+  'DateFormField' = 'dates',
+  'NumberFormField' = 'numbers',
+  'PasswordFormField' = 'passwords',
+  'TextFormField' = 'texts',
+  'RadioButtonsFormField' = 'multipleChoices',
+  'MultilineTextFormField' = 'multilineTexts',
+  // TODO: add them later
+  'PicklistFormField' = 'mocked_PicklistFormField',
+  'PicklistOrTextFormField' = 'mocked_PicklistOrTextFormField',
+}
+
 export const CUSTOMER_FIELDS_TO_EXCLUDE = [
   FieldNameToFieldId.currentPassword,
   FieldNameToFieldId.exclusiveOffers,
@@ -31,8 +46,25 @@ export const BOTH_CUSTOMER_ADDRESS_FIELDS = [
   FieldNameToFieldId.phone,
 ];
 
-export const createFieldName = (fieldType: 'customer' | 'address', fieldId: number) => {
-  const secondFieldType = fieldType === 'customer' ? 'address' : 'customer';
+export const createFieldName = (
+  field: AddressOrAccountFormField,
+  fieldOrigin: 'customer' | 'address',
+) => {
+  const { isBuiltIn, entityId: fieldId, __typename: fieldType } = field;
+  const isCustomField = !isBuiltIn;
+  let secondFieldType = fieldOrigin;
 
-  return `${fieldType}-${BOTH_CUSTOMER_ADDRESS_FIELDS.includes(fieldId) ? `${secondFieldType}-` : ''}${FieldNameToFieldId[fieldId] || fieldId}`;
+  if (isCustomField) {
+    return `custom_${FieldTypeToFieldInput[fieldType]}-${fieldId}`;
+  }
+
+  if (fieldOrigin === 'address') {
+    secondFieldType = 'customer';
+  }
+
+  if (fieldOrigin === 'customer') {
+    secondFieldType = 'address';
+  }
+
+  return `${fieldOrigin}-${BOTH_CUSTOMER_ADDRESS_FIELDS.includes(fieldId) ? `${secondFieldType}-` : ''}${FieldNameToFieldId[fieldId] || fieldId}`;
 };

--- a/core/client/fragments/form-fields-values.ts
+++ b/core/client/fragments/form-fields-values.ts
@@ -1,0 +1,31 @@
+import { graphql } from '../graphql';
+
+export const FORM_FIELDS_VALUES_FRAGMENT = graphql(`
+  fragment FormFieldsValues on CustomerFormFieldValue {
+    entityId
+    __typename
+    name
+    ... on CheckboxesFormFieldValue {
+      valueEntityIds
+      values
+    }
+    ... on DateFormFieldValue {
+      date {
+        utc
+      }
+    }
+    ... on MultipleChoiceFormFieldValue {
+      valueEntityId
+      value
+    }
+    ... on NumberFormFieldValue {
+      number
+    }
+    ... on PasswordFormFieldValue {
+      password
+    }
+    ... on TextFormFieldValue {
+      text
+    }
+  }
+`);

--- a/core/client/queries/get-customer-addresses.ts
+++ b/core/client/queries/get-customer-addresses.ts
@@ -4,41 +4,48 @@ import { cache } from 'react';
 import { getSessionCustomerId } from '~/auth';
 
 import { client } from '..';
+import { FORM_FIELDS_VALUES_FRAGMENT } from '../fragments/form-fields-values';
 import { graphql } from '../graphql';
 
-const GET_CUSTOMER_ADDRESSES_QUERY = graphql(`
-  query getCustomerAddresses($after: String, $before: String, $first: Int, $last: Int) {
-    customer {
-      entityId
-      addresses(before: $before, after: $after, first: $first, last: $last) {
-        pageInfo {
-          hasNextPage
-          hasPreviousPage
-          startCursor
-          endCursor
-        }
-        collectionInfo {
-          totalItems
-        }
-        edges {
-          node {
-            entityId
-            firstName
-            lastName
-            address1
-            address2
-            city
-            stateOrProvince
-            countryCode
-            phone
-            postalCode
-            company
+const GET_CUSTOMER_ADDRESSES_QUERY = graphql(
+  `
+    query getCustomerAddresses($after: String, $before: String, $first: Int, $last: Int) {
+      customer {
+        entityId
+        addresses(before: $before, after: $after, first: $first, last: $last) {
+          pageInfo {
+            hasNextPage
+            hasPreviousPage
+            startCursor
+            endCursor
+          }
+          collectionInfo {
+            totalItems
+          }
+          edges {
+            node {
+              entityId
+              firstName
+              lastName
+              address1
+              address2
+              city
+              stateOrProvince
+              countryCode
+              phone
+              postalCode
+              company
+              formFields {
+                ...FormFieldsValues
+              }
+            }
           }
         }
       }
     }
-  }
-`);
+  `,
+  [FORM_FIELDS_VALUES_FRAGMENT],
+);
 
 export interface CustomerAddressesArgs {
   after?: string;

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -266,6 +266,9 @@
         "validationMessages": {
             "email": "Enter a valid email such as name@domain.com",
             "empty": "This field can not be empty",
+            "numbersOverflow": "Entered value exceeds max range of {max}",
+            "numbersUnderflow": "Entered value falls short of min range of {min}",
+            "numbersOnly": "Enter numbers only",
             "firstName": "Enter your first name",
             "lastName": "Enter your last name",
             "password": "Enter a password",

--- a/core/tests/ui/desktop/core/components/accordion.spec.ts
+++ b/core/tests/ui/desktop/core/components/accordion.spec.ts
@@ -25,15 +25,7 @@ test('Verify accordion behavior on header', async ({ page }) => {
 });
 
 test('Verify accordion behavior on desktop filter', async ({ page }) => {
-  await page.goto('/');
-  await expect(
-    page.getByRole('navigation', { name: 'Main' }).getByRole('link', { name: 'Kitchen' }),
-  ).toBeVisible();
-
-  await page
-    .getByRole('navigation', { name: 'Main' })
-    .getByRole('link', { name: 'Kitchen' })
-    .click();
+  await page.goto('/kitchen/');
 
   await expect(page.getByRole('button', { name: 'Color' })).toBeVisible();
   await expect(page.getByText('Black1 products')).toBeVisible();

--- a/core/tests/ui/desktop/e2e/checkout.spec.ts
+++ b/core/tests/ui/desktop/e2e/checkout.spec.ts
@@ -65,7 +65,10 @@ test.describe(() => {
     ).toBeVisible();
   });
 
-  test('Complete checkout as a logged in shopper', async ({ page }) => {
+  test('Complete checkout as a logged in shopper', async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
     await page.goto('/login/');
     await page.getByLabel('Login').click();
     await page.getByLabel('Email').fill(process.env.TEST_ACCOUNT_EMAIL || '');


### PR DESCRIPTION
## What/Why?
This PR adds brings first of custom fields to `Account` forms - `NumberFormField`

## Testing
locally
![Screenshot 2024-05-27 at 18 11 01](https://github.com/bigcommerce/catalyst/assets/67792608/83e64d64-74d6-4812-b92e-7ad8fd89a78d)
<img width="1224" alt="Screenshot 2024-05-27 at 18 10 27" src="https://github.com/bigcommerce/catalyst/assets/67792608/fe9153da-746f-4756-a8fb-d37beaeff6bd">
<img width="1220" alt="Screenshot 2024-05-27 at 18 09 55" src="https://github.com/bigcommerce/catalyst/assets/67792608/d233a93c-11dc-4055-9044-a106ca49ad61">
