### PR TITLE
Move Homepage Carousel Data/Queries to page-data.ts file

### DIFF
--- a/core/app/[locale]/(default)/page-data.ts
+++ b/core/app/[locale]/(default)/page-data.ts
@@ -1,0 +1,45 @@
+import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
+import { getSessionCustomerId } from '~/auth';
+import { client } from '~/client';
+import { graphql } from '~/client/graphql';
+import { revalidate } from '~/client/revalidate-target';
+import { ProductCardCarouselFragment } from '~/components/product-card-carousel';
+
+const HomePageQuery = graphql(
+  `
+    query HomePageQuery {
+      site {
+        newestProducts(first: 12) {
+          edges {
+            node {
+              ...ProductCardCarouselFragment
+            }
+          }
+        }
+        featuredProducts(first: 12) {
+          edges {
+            node {
+              ...ProductCardCarouselFragment
+            }
+          }
+        }
+      }
+    }
+  `,
+  [ProductCardCarouselFragment],
+);
+
+export const getPageData = async () => {
+  const customerId = await getSessionCustomerId();
+
+  const { data } = await client.fetch({
+    document: HomePageQuery,
+    customerId,
+    fetchOptions: customerId ? { cache: 'no-store' } : { next: { revalidate } },
+  });
+
+  return {
+    featuredProducts: removeEdgesAndNodes(data.site.featuredProducts),
+    newestProducts: removeEdgesAndNodes(data.site.newestProducts),
+  };
+};

--- a/core/app/[locale]/(default)/page.tsx
+++ b/core/app/[locale]/(default)/page.tsx
@@ -1,16 +1,8 @@
-import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages, getTranslations, unstable_setRequestLocale } from 'next-intl/server';
-
-import { getSessionCustomerId } from '~/auth';
-import { client } from '~/client';
-import { graphql } from '~/client/graphql';
-import { revalidate } from '~/client/revalidate-target';
+import { getPageData } from './page-data';
 import { Hero } from '~/components/hero';
-import {
-  ProductCardCarousel,
-  ProductCardCarouselFragment,
-} from '~/components/product-card-carousel';
+import { ProductCardCarousel } from '~/components/product-card-carousel';
 import { LocaleType } from '~/i18n';
 
 interface Props {
@@ -19,46 +11,17 @@ interface Props {
   };
 }
 
-const HomePageQuery = graphql(
-  `
-    query HomePageQuery {
-      site {
-        newestProducts(first: 12) {
-          edges {
-            node {
-              ...ProductCardCarouselFragment
-            }
-          }
-        }
-        featuredProducts(first: 12) {
-          edges {
-            node {
-              ...ProductCardCarouselFragment
-            }
-          }
-        }
-      }
-    }
-  `,
-  [ProductCardCarouselFragment],
-);
-
 export default async function Home({ params: { locale } }: Props) {
-  const customerId = await getSessionCustomerId();
-
   unstable_setRequestLocale(locale);
 
   const t = await getTranslations({ locale, namespace: 'Home' });
   const messages = await getMessages({ locale });
 
-  const { data } = await client.fetch({
-    document: HomePageQuery,
-    customerId,
-    fetchOptions: customerId ? { cache: 'no-store' } : { next: { revalidate } },
-  });
+  const pageData = await getPageData();
+  const featuredProducts = pageData.featuredProducts;
+  const newestProducts = pageData.newestProducts;
 
-  const featuredProducts = removeEdgesAndNodes(data.site.featuredProducts);
-  const newestProducts = removeEdgesAndNodes(data.site.newestProducts);
+  console.log(pageData, ' is page data');
 
   return (
     <>


### PR DESCRIPTION
## What/Why?
I recommended that pages be normalized, either all using page-data.ts files, or none using them, for consistency. This seemed to be pretty agreeable so I've made a pull request that starts the process of using a page-data.ts file for home. 

## Testing
Frontend was not changed for the outcome / client display so existing component/UI tests will work the same. The only difference is that the query logic for the carousel's newest & featured products now lives in an imported page-data.ts file instead of within the main page.tsx file for the default locale's home "/" route.