### PR TITLE
fix(core): custom 404 page not rendering

### DIFF
--- a/.changeset/rare-bees-beg.md
+++ b/.changeset/rare-bees-beg.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+fix custom 404 page not being used

--- a/core/app/[locale]/(default)/[...rest]/page.tsx
+++ b/core/app/[locale]/(default)/[...rest]/page.tsx
@@ -1,0 +1,5 @@
+import { notFound } from 'next/navigation';
+
+export default function CatchAllPage() {
+  notFound();
+}

--- a/core/tests/ui/desktop/e2e/404.spec.ts
+++ b/core/tests/ui/desktop/e2e/404.spec.ts
@@ -1,0 +1,7 @@
+import { expect, test } from '@playwright/test';
+
+test('404 page', async ({ page }) => {
+  await page.goto('/unknown-url');
+
+  await expect(page.getByRole('heading', { name: "We couldn't find that page!" })).toBeVisible();
+});


### PR DESCRIPTION
## What/Why?
Fixes an issue with our custom 404 page not being used.

## Testing
CI

Closes: https://github.com/bigcommerce/catalyst/issues/956