### PR TITLE
fix(core): hover text when remove product button is loading

### DIFF
--- a/.changeset/hip-hornets-jump.md
+++ b/.changeset/hip-hornets-jump.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Show correct color of remove button when in loading state.

--- a/core/app/[locale]/(default)/cart/_components/remove-from-cart-button.tsx
+++ b/core/app/[locale]/(default)/cart/_components/remove-from-cart-button.tsx
@@ -11,7 +11,7 @@ export const RemoveFromCartButton = () => {
 
   return (
     <Button
-      className="w-auto items-center p-0 text-primary hover:bg-transparent disabled:text-primary"
+      className="w-auto items-center p-0 text-primary hover:bg-transparent disabled:text-primary disabled:hover:text-primary"
       loading={pending}
       loadingText={t('spinnerText')}
       type="submit"


### PR DESCRIPTION
## What/Why?
Hover state wasn't being overriden with the desired color.

## Testing
Locally.

![Screenshot 2024-06-03 at 1 25 25 PM](https://github.com/bigcommerce/catalyst/assets/196129/58ea4290-4179-4eb0-a173-1f183990531a)

