### PR TITLE
feat(functional): Add test for shipping estimation recalculation

### DIFF
--- a/core/tests/ui/desktop/e2e/checkout.spec.ts
+++ b/core/tests/ui/desktop/e2e/checkout.spec.ts
@@ -70,9 +70,6 @@ test('Complete checkout as a logged in shopper', async ({ page }) => {
   await page.getByRole('heading', { level: 1, name: 'Your cart' }).click();
   await page.getByRole('button', { name: 'Proceed to checkout' }).click();
 
-  await page.getByLabel('Email').fill(faker.internet.email());
-  await page.getByRole('button', { name: 'Continue' }).click();
-
   await enterShopperDetails(page);
 
   await page.getByRole('button', { name: 'Continue' }).click();

--- a/core/tests/ui/desktop/e2e/shipping.spec.ts
+++ b/core/tests/ui/desktop/e2e/shipping.spec.ts
@@ -62,3 +62,31 @@ test('Add shipping estimates for Canada', async ({ page }) => {
   await addEstimatedShippingCosts(page, 'Canada', 'British Columbia', 'Vancouver', '98617');
   await expect(page.getByRole('button', { name: 'Change' })).toBeVisible();
 });
+
+/**
+ * @description When the item in cart is modified after shipping estimation is calculated, shipping estimation
+ * is reset but shipping information is persisted.
+ */
+test('Updating cart items should reset shipping costs but retain shipping information', async ({
+  page,
+}) => {
+  await expect(page.getByText('Shipping cost')).toBeVisible();
+  await page.getByRole('button', { name: 'Add' }).first().click();
+
+  await addEstimatedShippingCosts(page, 'United States', 'Texas', 'Austin', '76267');
+  await page.getByRole('button', { name: 'Change' }).waitFor();
+
+  await page.getByRole('button', { name: 'Increase count' }).click();
+  await page.getByRole('link', { name: 'Cart Items 2' }).waitFor();
+
+  await page.getByRole('button', { name: 'Add' }).first().click();
+
+  await expect(
+    page.getByRole('combobox', { name: 'Country' }).filter({ hasText: 'United States' }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('combobox', { name: 'State/province' }).filter({ hasText: 'Texas' }),
+  ).toBeVisible();
+  await expect(page.getByPlaceholder('City')).toHaveValue('Austin');
+  await expect(page.getByPlaceholder('Postal code')).toHaveValue('76267');
+});


### PR DESCRIPTION
## What/Why?
Add a test to verify that shipping information is persisted when cart items are modified but shipping estimates need to be recalculated.

## Testing
Verified the test locally. CI runs with the new test.