### PR TITLE
feat: quality of life improvements for graphql file generation

### DIFF
--- a/.changeset/lovely-adults-learn.md
+++ b/.changeset/lovely-adults-learn.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Introduces more consistent naming convention for files related to GraphQL, changes opinions around when it is appropriate to track GraphQL files in version control, fixes an issue where the `generate.cjs` script was swallowing helpful error messaging

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ dist
 test-results/
 playwright-report/
 playwright/.cache/
-graphql-env.d.ts
+bigcommerce.graphql
+bigcommerce-graphql.d.ts
 .DS_Store

--- a/core/.gitignore
+++ b/core/.gitignore
@@ -40,7 +40,6 @@ next-env.d.ts
 
 # generated
 client/generated
-schema.graphql
 
 # secrets
 .catalyst

--- a/core/client/graphql.ts
+++ b/core/client/graphql.ts
@@ -1,6 +1,6 @@
 import { initGraphQLTada } from 'gql.tada';
 
-import type { introspection } from '~/graphql-env';
+import type { introspection } from '~/bigcommerce-graphql';
 
 export const graphql = initGraphQLTada<{
   introspection: introspection;

--- a/core/scripts/generate.cjs
+++ b/core/scripts/generate.cjs
@@ -44,18 +44,24 @@ const getEndpoint = () => {
 };
 
 const generate = async () => {
-  await generateSchema({
-    input: getEndpoint(),
-    headers: { Authorization: `Bearer ${getToken()}` },
-    output: join(__dirname, '../schema.graphql'),
-    tsconfig: undefined,
-  });
+  try {
+    await generateSchema({
+      input: getEndpoint(),
+      headers: { Authorization: `Bearer ${getToken()}` },
+      output: join(__dirname, '../bigcommerce.graphql'),
+      tsconfig: undefined,
+    });
 
-  await generateOutput({
-    disablePreprocessing: false,
-    output: join(__dirname, '../graphql-env.d.ts'),
-    tsconfig: undefined,
-  });
+    await generateOutput({
+      disablePreprocessing: false,
+      output: undefined,
+      tsconfig: undefined,
+    });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(error);
+    process.exit(1);
+  }
 };
 
 generate();

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -25,10 +25,15 @@
       },
       {
         "name": "@0no-co/graphqlsp",
-        "schema": "./schema.graphql",
-        "tadaOutputLocation": "./graphql-env.d.ts",
         "trackFieldUsage": false,
-        "shouldCheckForColocatedFragments": false
+        "shouldCheckForColocatedFragments": false,
+        "schemas": [
+          {
+            "name": "bigcommerce",
+            "schema": "./bigcommerce.graphql",
+            "tadaOutputLocation": "./bigcommerce-graphql.d.ts"
+          }
+        ]
       }
     ],
     "baseUrl": ".",


### PR DESCRIPTION
## What/Why?
This PR introduces changes that address the following concerns:
- Tracking GraphQL schemas in version control
- Consistent naming conventions for files related to GraphQL
- More helpful error messaging when generating GraphQL introspection files

A common pattern I'm seeing when integrating Catalyst with various third party services is that some third party services may have their own GraphQL API's that Catalyst needs to interface with; in these cases, I've been leveraging the [Multi-schema mode feature](https://gql-tada.0no.co/guides/multiple-schemas) of `gql.tada`. 

The moment that a second schema is added to a Catalyst project, the `schema.graphql` and `graphql-env.d.ts` file naming conventions become less useful, as the file names do not easily describe the provider from which the files were created. Changing the naming convention of the default BigCommerce GraphQL files to include `bigcommerce` in the name makes it much easier to identify which GraphQL API the files are generated from, especially when you have multiple GraphQL schema files in a single project. 

Additionally, I want to propose a change to our opinions of which files should live in version control for both the Catalyst monorepository, and separately, scaffolded Catalyst projects. In the context of working within the monorepository, it makes sense to `.gitignore` these files; we don't want any single test store's schema to be tracked in `/core`, as this would cause those files to be copied into scaffolded Catalyst projects. However, this opinion changes in the context of scaffolded projects. Scaffolded projects _should_ have their GraphQL schema/introspection files tracked so that developers who are all collaborating on a single storefront build can track changes introduced to GraphQL schemas in pull requests. 

Finally, this PR also slightly modifies `core/scripts/generate.cjs` to prevent errors from being swallowed by the script instead of being logged to the console. Since `generate` is asynchronous, Node throws an `unhandledRejection` event instead of actually throwing the error in the console. The change introduced catches any errors thrown, and manually logs them to the console.

> [!TIP]
> If this PR is merged, be sure to run `pnpm generate` locally to create required GraphQL files, and then delete the now-untracked `schema.graphql` and `graphql-env.d.ts` files to help prevent accidentally committing them. 

## Testing
> Ensure you have a `.env.local` file inside of `/core` with required environment variables

1. Run `pnpm generate`
2. See that GraphQL files are generated with BigCommerce-specific naming conventions
3. If you remove any required environment variables from `.env.local` (such as store hash) and run `pnpm generate` again, you'll see the more helpful error messages logged by `generate.cjs`. 