### PR TITLE
feat(client): add channelId as an optional param

### DIFF
--- a/.changeset/selfish-hairs-sit.md
+++ b/.changeset/selfish-hairs-sit.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-client": patch
+---
+
+Add channelId param to client to allow fetching from multiple channels with the same client.

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -155,15 +155,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
   }
 
   private getEndpoint(channelId?: string) {
-    if (channelId && channelId !== '1') {
-      return `https://store-${this.config.storeHash}-${channelId}.${graphqlApiDomain}/graphql`;
-    }
-
-    if (!this.config.channelId || this.config.channelId === '1' || channelId === '1') {
-      return `https://store-${this.config.storeHash}.${graphqlApiDomain}/graphql`;
-    }
-
-    return `https://store-${this.config.storeHash}-${this.config.channelId}.${graphqlApiDomain}/graphql`;
+    return `https://store-${this.config.storeHash}-${channelId ?? this.config.channelId}.${graphqlApiDomain}/graphql`;
   }
 
   private requestLogger(document: string) {

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -155,6 +155,10 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
   }
 
   private getEndpoint(channelId?: string) {
+    if (!channelId && !this.config.channelId) {
+      throw new Error('Missing channelId');
+    }
+
     return `https://store-${this.config.storeHash}-${channelId ?? this.config.channelId}.${graphqlApiDomain}/graphql`;
   }
 


### PR DESCRIPTION
## What/Why?

- Add optional channelId param to client to allow fetching from multiple channels with the same client.
- Remove non channel-aware endpoint.
- Enforce channelId being used.

## Testing
TBD