### PR TITLE
Add blurDataURL to default carousel image

### DIFF
--- a/core/components/hero/index.tsx
+++ b/core/components/hero/index.tsx
@@ -14,6 +14,9 @@ import {
 
 import SlideshowBG from './slideshow-bg-01.jpg';
 
+const SlideshowBlurDataURL =
+  'data:image/jpeg;base64,/9j/4QC8RXhpZgAASUkqAAgAAAAGABIBAwABAAAAAQAAABoBBQABAAAAVgAAABsBBQABAAAAXgAAACgBAwABAAAAAgAAABMCAwABAAAAAQAAAGmHBAABAAAAZgAAAAAAAABIAAAAAQAAAEgAAAABAAAABgAAkAcABAAAADAyMTABkQcABAAAAAECAwAAoAcABAAAADAxMDABoAMAAQAAAP//AAACoAQAAQAAAAoAAAADoAQAAQAAAAcAAAAAAAAA/9sAQwADAgIDAgIDAwMDBAMDBAUIBQUEBAUKBwcGCAwKDAwLCgsLDQ4SEA0OEQ4LCxAWEBETFBUVFQwPFxgWFBgSFBUU/9sAQwEDBAQFBAUJBQUJFA0LDRQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQU/8AAEQgABwAKAwERAAIRAQMRAf/EABUAAQEAAAAAAAAAAAAAAAAAAAMJ/8QAIBAAAQQBBAMAAAAAAAAAAAAAAQIDBAURABIhMQYjgf/EABYBAQEBAAAAAAAAAAAAAAAAAAEAAv/EABkRAAIDAQAAAAAAAAAAAAAAAAARAQIhQf/aAAwDAQACEQMRAD8AoZ5EzayKWW3Syo0GyKPTJlsF9ts9klsKTu46GQOfms2awJfAKywmt1sRNgqK7PS0gSHI4WltTmBuKQckJJzgE9aYa0tP/9k=';
+
 export const Hero = () => (
   <Slideshow>
     <SlideshowContent>
@@ -21,8 +24,10 @@ export const Hero = () => (
         <div className="relative">
           <Image
             alt="an assortment of brandless products against a blank background"
+            blurDataURL={SlideshowBlurDataURL}
             className="absolute -z-10 object-cover"
             fill
+            placeholder="blur"
             priority
             sizes="(max-width: 1536px) 100vw, 1536px"
             src={SlideshowBG}


### PR DESCRIPTION
## What/Why?
Add a base64 LQIP for the default carousel image; improves first page load perceptual performance and also the experience when first using Catalyst with cold CDN image caches.

## Testing
https://catalyst-horlf38ed-bigcommerce-platform.vercel.app/

Slow 3g example:


https://github.com/bigcommerce/catalyst/assets/8922457/5f935c4e-e827-4ebc-8bfa-45a570b4563e


