### PR TITLE
Remove special treatment of channel ID 1

### DIFF
--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -151,10 +151,6 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
   }
 
   private getEndpoint() {
-    if (!this.config.channelId || this.config.channelId === '1') {
-      return `https://store-${this.config.storeHash}.${graphqlApiDomain}/graphql`;
-    }
-
     return `https://store-${this.config.storeHash}-${this.config.channelId}.${graphqlApiDomain}/graphql`;
   }
 


### PR DESCRIPTION
## What/Why?
Historically, we had to treat channel `1` on a store as special because we did not have a channel canonical domain specific to channel 1, so you had to use `store-HASH-CHANNELID.mybigcommerce.com` as the hostname for all non-default channels, but `store-HASH.mybigcommerce.com` for channel 1.

This has been normalized across the platform such that `store-HASH-1.mybigcommerce.com` hostnames are now available.

Therefore, this PR removes the special snowflake code that treats channel 1 differently, which means one less thing to think about when dealing with default channels.

⚠️ I have also changed the behavior when the `BIGCOMMERCE_CHANNEL_ID` env variable is not specified; the previous code would essentially fall back to channel 1 in this case; after this change, those requests will fail. I believe this is actually desirable as users of Catalyst are not set up for success if they do not explicitly specify a channel ID on their requests.

## Testing
TBD