### PR TITLE
feat(core): update customer account modal component

### DIFF
--- a/.changeset/odd-berries-play.md
+++ b/.changeset/odd-berries-play.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+update customer account modal component

--- a/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/address-book.tsx
+++ b/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/address-book.tsx
@@ -49,11 +49,12 @@ const AddressChangeButtons = ({ addressId, isAddressRemovable, onDelete }: Addre
         actionHandler={handleDeleteAddress}
         confirmationText={t('confirmDeleteAddress')}
         title={t('deleteModalTitle')}
-      >
-        <Button aria-label={t('deleteButton')} disabled={!isAddressRemovable} variant="subtle">
-          {t('deleteButton')}
-        </Button>
-      </Modal>
+        trigger={
+          <Button aria-label={t('deleteButton')} disabled={!isAddressRemovable} variant="subtle">
+            {t('deleteButton')}
+          </Button>
+        }
+      />
     </div>
   );
 };

--- a/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/edit-address.tsx
+++ b/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/edit-address.tsx
@@ -284,15 +284,16 @@ export const EditAddress = ({
             actionHandler={onDeleteAddress}
             confirmationText={t('confirmDeleteAddress')}
             title={t('deleteModalTitle')}
-          >
-            <Button
-              className="ms-auto items-center px-8 md:w-fit"
-              disabled={!canBeDeleted}
-              variant="subtle"
-            >
-              {t('deleteButton')}
-            </Button>
-          </Modal>
+            trigger={
+              <Button
+                className="ms-auto items-center px-8 md:w-fit"
+                disabled={!canBeDeleted}
+                variant="subtle"
+              >
+                {t('deleteButton')}
+              </Button>
+            }
+          />
         </div>
       </Form>
     </>

--- a/core/app/[locale]/(default)/account/[tab]/_components/modal.tsx
+++ b/core/app/[locale]/(default)/account/[tab]/_components/modal.tsx
@@ -1,7 +1,5 @@
-'use client';
-
 import { X } from 'lucide-react';
-import { MouseEventHandler, PropsWithChildren } from 'react';
+import { Dispatch, MouseEventHandler, PropsWithChildren, SetStateAction } from 'react';
 
 import { Button } from '~/components/ui/button';
 import {
@@ -19,9 +17,13 @@ import {
 interface Props extends PropsWithChildren {
   actionHandler?: MouseEventHandler<HTMLButtonElement>;
   title: string;
+  trigger: React.ReactNode;
   descriptionText?: string;
   confirmationText?: string;
   abortText?: string;
+  open?: boolean;
+  setOpen?: Dispatch<SetStateAction<boolean>>;
+  showCancelButton?: boolean;
 }
 
 export const Modal = ({
@@ -29,21 +31,25 @@ export const Modal = ({
   actionHandler,
   confirmationText = 'OK',
   descriptionText,
+  open,
+  setOpen,
+  showCancelButton = true,
   title,
+  trigger,
   children,
 }: Props) => {
   return (
-    <Dialog>
+    <Dialog onOpenChange={setOpen} open={open}>
       <DialogTrigger aria-controls="modal-content" asChild>
-        {children}
+        {trigger}
       </DialogTrigger>
       <DialogPortal>
         <DialogOverlay />
         <DialogContent className="w-full sm:w-8/12 md:w-6/12 lg:w-5/12" id="modal-content">
-          <div className="flex justify-between gap-4 p-6">
-            <DialogTitle>{title}</DialogTitle>
+          <div className="flex items-start justify-between gap-4 p-6">
+            <DialogTitle className="text-xl lg:text-2xl">{title}</DialogTitle>
             <DialogCancel asChild>
-              <Button className="ms-auto w-min p-2" type="button" variant="subtle">
+              <Button className="ms-auto w-min p-0" type="button" variant="subtle">
                 <X>
                   <title>{abortText}</title>
                 </X>
@@ -52,16 +58,23 @@ export const Modal = ({
           </div>
           {Boolean(descriptionText) && <DialogDescription>{descriptionText}</DialogDescription>}
           <div className="flex flex-col gap-2 p-6 lg:flex-row">
-            <DialogAction asChild>
-              <Button className="w-full lg:w-fit" onClick={actionHandler} variant="primary">
-                {confirmationText}
-              </Button>
-            </DialogAction>
-            <DialogCancel asChild>
-              <Button className="w-full lg:w-fit" variant="subtle">
-                {abortText}
-              </Button>
-            </DialogCancel>
+            {children}
+            <div className="flex flex-col lg:flex-row">
+              {actionHandler && (
+                <DialogAction asChild>
+                  <Button className="w-full lg:w-fit" onClick={actionHandler} variant="primary">
+                    {confirmationText}
+                  </Button>
+                </DialogAction>
+              )}
+              {showCancelButton && (
+                <DialogCancel asChild>
+                  <Button className="mt-2 w-full lg:ms-2 lg:mt-0 lg:w-fit" variant="subtle">
+                    {abortText}
+                  </Button>
+                </DialogCancel>
+              )}
+            </div>
           </div>
         </DialogContent>
       </DialogPortal>


### PR DESCRIPTION
## What/Why?
This pr has changes for account modal:

- functional - props and update
- visual - tablet and desktop design updates

<img width="738" alt="account-popup" src="https://github.com/bigcommerce/catalyst/assets/66325265/307ccef6-3fde-4420-b01a-125443658fbb">


## Testing
Locally