### PR TITLE
feat(core): cache all kv adapters with in-memory kv

### DIFF
--- a/core/lib/kv/adapters/memory.ts
+++ b/core/lib/kv/adapters/memory.ts
@@ -13,21 +13,6 @@ export class MemoryKvAdapter implements KvAdapter {
     max: 500,
   });
 
-  async get<Data>(key: string) {
-    const entry = this.kv.get(key);
-
-    if (!entry) {
-      return null;
-    }
-
-    if (entry.expiresAt < Date.now()) {
-      return null;
-    }
-
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    return entry.value as Data;
-  }
-
   async mget<Data>(...keys: string[]) {
     const entries = keys.map((key) => this.kv.get(key)?.value);
 
@@ -42,5 +27,20 @@ export class MemoryKvAdapter implements KvAdapter {
     });
 
     return value;
+  }
+
+  private async get<Data>(key: string) {
+    const entry = this.kv.get(key);
+
+    if (!entry) {
+      return null;
+    }
+
+    if (entry.expiresAt < Date.now()) {
+      return null;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    return entry.value as Data;
   }
 }

--- a/core/lib/kv/adapters/upstash.ts
+++ b/core/lib/kv/adapters/upstash.ts
@@ -10,12 +10,6 @@ export class UpstashKvAdapter implements KvAdapter {
   private upstashKv = Redis.fromEnv();
   private memoryKv = memoryKv;
 
-  async get<Data>(key: string) {
-    const memoryValue = await this.memoryKv.get<Data>(key);
-
-    return memoryValue ?? this.upstashKv.get<Data>(key);
-  }
-
   async mget<Data>(...keys: string[]) {
     const memoryValues = await this.memoryKv.mget<Data>(...keys);
 

--- a/core/lib/kv/adapters/vercel.ts
+++ b/core/lib/kv/adapters/vercel.ts
@@ -10,12 +10,6 @@ export class VercelKvAdapter implements KvAdapter {
   private vercelKv = kv;
   private memoryKv = memoryKv;
 
-  async get<Data>(key: string) {
-    const memoryValue = await this.memoryKv.get<Data>(key);
-
-    return memoryValue ?? this.vercelKv.get<Data>(key);
-  }
-
   async mget<Data>(...keys: string[]) {
     const memoryValues = await this.memoryKv.mget<Data>(...keys);
 

--- a/core/lib/kv/index.ts
+++ b/core/lib/kv/index.ts
@@ -1,11 +1,15 @@
+import { MemoryKvAdapter } from './adapters/memory';
 import { KvAdapter, SetCommandOptions } from './types';
 
 interface Config {
   logger?: boolean;
 }
 
+const memoryKv = new MemoryKvAdapter();
+
 class KV<Adapter extends KvAdapter> implements KvAdapter {
   private kv?: Adapter;
+  private memoryKv = memoryKv;
   private namespace: string;
 
   constructor(
@@ -20,23 +24,41 @@ class KV<Adapter extends KvAdapter> implements KvAdapter {
   }
 
   async get<Data>(key: string) {
-    const kv = await this.getKv();
-    const fullKey = `${this.namespace}_${key}`;
+    const [value] = await this.mget<Data>(key);
 
-    const value = await kv.get<Data>(fullKey);
-
-    this.logger(`GET - Key: ${fullKey} - Value: ${JSON.stringify(value, null, 2)}`);
-
-    return value;
+    return value ?? null;
   }
 
   async mget<Data>(...keys: string[]) {
     const kv = await this.getKv();
     const fullKeys = keys.map((key) => `${this.namespace}_${key}`);
 
+    const memoryValues = (await this.memoryKv.mget<Data>(...fullKeys)).filter(Boolean);
+
+    if (memoryValues.length === keys.length) {
+      this.logger(
+        `MGET - Keys: ${fullKeys.toString()} - Value: ${JSON.stringify(memoryValues, null, 2)}`,
+      );
+
+      return memoryValues;
+    }
+
     const values = await kv.mget<Data>(...fullKeys);
 
     this.logger(`MGET - Keys: ${fullKeys.toString()} - Value: ${JSON.stringify(values, null, 2)}`);
+
+    // Store the values in memory kv
+    await Promise.all(
+      values.map(async (value, index) => {
+        const key = fullKeys[index];
+
+        if (!key) {
+          return;
+        }
+
+        await this.memoryKv.set(key, value);
+      }),
+    );
 
     return values;
   }
@@ -51,7 +73,9 @@ class KV<Adapter extends KvAdapter> implements KvAdapter {
 
     this.logger(`SET - Key: ${fullKey} - Value: ${JSON.stringify(value, null, 2)}`);
 
-    return kv.set(fullKey, value, opts);
+    await Promise.all([this.memoryKv.set(fullKey, value, opts), kv.set(fullKey, value, opts)]);
+
+    return value;
   }
 
   private async getKv() {
@@ -88,8 +112,6 @@ async function createKVAdapter() {
 
     return new UpstashKvAdapter();
   }
-
-  const { MemoryKvAdapter } = await import('./adapters/memory');
 
   return new MemoryKvAdapter();
 }

--- a/core/lib/kv/types.ts
+++ b/core/lib/kv/types.ts
@@ -1,7 +1,6 @@
 export type SetCommandOptions = Record<string, unknown>;
 
 export interface KvAdapter {
-  get<Data>(key: string): Promise<Data | null>;
   mget<Data>(...keys: string[]): Promise<Array<Data | null>>;
   set<Data, Options extends SetCommandOptions = SetCommandOptions>(
     key: string,


### PR DESCRIPTION
## What/Why?
This PR adds an in-memory cache for all kv adapters. Should help reduce number of reads to remote KVs and improve performance.

## Testing
