### PR TITLE
Add register account UI test and add MSW for mocking server-side API requests

### DIFF
--- a/core/app/[locale]/(default)/login/register-customer/page.tsx
+++ b/core/app/[locale]/(default)/login/register-customer/page.tsx
@@ -4,6 +4,7 @@ import { getMessages, getTranslations } from 'next-intl/server';
 
 import { auth } from '~/auth';
 import { LocaleType } from '~/i18n';
+import { bypassReCaptcha } from '~/lib/bypass-recaptcha';
 
 import { RegisterCustomerForm } from './_components/register-customer-form';
 import { getRegisterCustomerQuery } from './page-data';
@@ -63,9 +64,11 @@ export default async function RegisterCustomer({ params: { locale } }: Props) {
           countries={countries}
           customerFields={customerFields}
           defaultCountry={{ entityId, code, states: statesOrProvinces ?? [] }}
-          reCaptchaSettings={reCaptchaSettings}
+          reCaptchaSettings={bypassReCaptcha(reCaptchaSettings)}
         />
       </NextIntlClientProvider>
     </div>
   );
 }
+
+export const runtime = 'edge';

--- a/core/client/mocks/browser.ts
+++ b/core/client/mocks/browser.ts
@@ -1,0 +1,4 @@
+import { setupWorker } from 'msw/browser';
+import { handlers } from './handlers';
+
+export const worker = setupWorker(...handlers);

--- a/core/client/mocks/browser.ts
+++ b/core/client/mocks/browser.ts
@@ -1,4 +1,5 @@
 import { setupWorker } from 'msw/browser';
+
 import { handlers } from './handlers';
 
 export const worker = setupWorker(...handlers);

--- a/core/client/mocks/handlers.ts
+++ b/core/client/mocks/handlers.ts
@@ -6,42 +6,22 @@ if (process.env.BIGCOMMERCE_CHANNEL_ID && process.env.BIGCOMMERCE_CHANNEL_ID !==
   channel = `-${process.env.BIGCOMMERCE_CHANNEL_ID}`;
 }
 
-const gql = graphql.link(
+graphql.link(
   `https://store-${process.env.BIGCOMMERCE_STORE_HASH ?? ''}${channel}.${process.env.BIGCOMMERCE_GRAPHQL_API_DOMAIN ?? 'mybigcommerce.com'}/graphql`,
 );
 
 export const handlers = [
-  // More operations - https://mswjs.io/docs/api/graphql
-  gql.query('RootLayoutMetadataQuery', ({ query }) => {
-    console.log('Intercepted a "RootLayoutMetadataQuery" query:', query);
-
-    return HttpResponse.json({
-      data: {
-        site: {
-          settings: {
-            storeName: 'Intercepted Store Name',
-          },
-        },
-      },
-    });
-  }),
-
   graphql.mutation('registerCustomer', ({ query, variables }) => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { input, reCaptchaV2 } = variables;
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     console.log('Intercepted a "registerCustomer" mutation:', { query, input });
 
-    // Simulating successful registration
     return HttpResponse.json({
       data: {
         customer: {
           registerCustomer: {
             customer: {
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
               firstName: input.firstName,
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
               lastName: input.lastName,
             },
             errors: [],
@@ -50,9 +30,4 @@ export const handlers = [
       },
     });
   }),
-
-  // gql.operation(({ query, variables }) => {
-  // Intercept all GraphQL operations for debugging purposes.
-  // console.log('Intercepted a GraphQL query:', query);
-  // }),
 ];

--- a/core/client/mocks/handlers.ts
+++ b/core/client/mocks/handlers.ts
@@ -1,6 +1,7 @@
 import { graphql, HttpResponse } from 'msw';
 
 let channel = '';
+
 if (process.env.BIGCOMMERCE_CHANNEL_ID && process.env.BIGCOMMERCE_CHANNEL_ID !== '1') {
   channel = `-${process.env.BIGCOMMERCE_CHANNEL_ID}`;
 }

--- a/core/client/mocks/handlers.ts
+++ b/core/client/mocks/handlers.ts
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 import { graphql, HttpResponse } from 'msw';
 
 let channel = '';

--- a/core/client/mocks/handlers.ts
+++ b/core/client/mocks/handlers.ts
@@ -13,6 +13,7 @@ export const handlers = [
   // More operations - https://mswjs.io/docs/api/graphql
   gql.query('RootLayoutMetadataQuery', ({ query }) => {
     console.log('Intercepted a "RootLayoutMetadataQuery" query:', query);
+
     return HttpResponse.json({
       data: {
         site: {
@@ -23,8 +24,34 @@ export const handlers = [
       },
     });
   }),
-  gql.operation(({ query, variables }) => {
-    // Intercept all GraphQL operations for debugging purposes.
-    // console.log('Intercepted a GraphQL query:', query);
+
+  graphql.mutation('registerCustomer', ({ query, variables }) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { input, reCaptchaV2 } = variables;
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    console.log('Intercepted a "registerCustomer" mutation:', { query, input });
+
+    // Simulating successful registration
+    return HttpResponse.json({
+      data: {
+        customer: {
+          registerCustomer: {
+            customer: {
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
+              firstName: input.firstName,
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
+              lastName: input.lastName,
+            },
+            errors: [],
+          },
+        },
+      },
+    });
   }),
+
+  // gql.operation(({ query, variables }) => {
+  // Intercept all GraphQL operations for debugging purposes.
+  // console.log('Intercepted a GraphQL query:', query);
+  // }),
 ];

--- a/core/client/mocks/handlers.ts
+++ b/core/client/mocks/handlers.ts
@@ -1,0 +1,30 @@
+import { graphql, HttpResponse } from 'msw';
+
+let channel = '';
+if (process.env.BIGCOMMERCE_CHANNEL_ID && process.env.BIGCOMMERCE_CHANNEL_ID !== '1') {
+  channel = `-${process.env.BIGCOMMERCE_CHANNEL_ID}`;
+}
+
+const gql = graphql.link(
+  `https://store-${process.env.BIGCOMMERCE_STORE_HASH ?? ''}${channel}.${process.env.BIGCOMMERCE_GRAPHQL_API_DOMAIN ?? 'mybigcommerce.com'}/graphql`,
+);
+
+export const handlers = [
+  // More operations - https://mswjs.io/docs/api/graphql
+  gql.query('RootLayoutMetadataQuery', ({ query }) => {
+    console.log('Intercepted a "RootLayoutMetadataQuery" query:', query);
+    return HttpResponse.json({
+      data: {
+        site: {
+          settings: {
+            storeName: 'Intercepted Store Name',
+          },
+        },
+      },
+    });
+  }),
+  gql.operation(({ query, variables }) => {
+    // Intercept all GraphQL operations for debugging purposes.
+    // console.log('Intercepted a GraphQL query:', query);
+  }),
+];

--- a/core/client/mocks/server.ts
+++ b/core/client/mocks/server.ts
@@ -1,4 +1,5 @@
 import { setupServer } from 'msw/node';
+
 import { handlers } from './handlers';
 
 export const server = setupServer(...handlers);

--- a/core/client/mocks/server.ts
+++ b/core/client/mocks/server.ts
@@ -1,0 +1,4 @@
+import { setupServer } from 'msw/node';
+import { handlers } from './handlers';
+
+export const server = setupServer(...handlers);

--- a/core/instrumentation.ts
+++ b/core/instrumentation.ts
@@ -1,0 +1,6 @@
+export async function register() {
+  if (process.env.NEXT_PUBLIC_API_MOCKING === 'enabled' && process.env.NEXT_RUNTIME === 'nodejs') {
+    const { server } = await import('~/client/mocks/server');
+    server.listen();
+  }
+}

--- a/core/lib/bypass-recaptcha.ts
+++ b/core/lib/bypass-recaptcha.ts
@@ -1,0 +1,21 @@
+import { headers } from 'next/headers';
+import 'server-only';
+
+// eslint-disable-next-line valid-jsdoc
+/**
+ * Bypasses reCaptcha for automated tests.
+ *
+ * Returns the reCaptcha settings if the test is not running.
+ */
+export const bypassReCaptcha = <T>(reCaptchaSettings: T) => {
+  const vercelBypassKey = headers().get('X-Vercel-Protection-Bypass');
+  const verceSetBypassCookie = headers().get('X-Vercel-Set-Bypass-Cookie');
+
+  const shouldBypassreCaptcha = vercelBypassKey && verceSetBypassCookie === 'true';
+
+  if (shouldBypassreCaptcha) {
+    return;
+  }
+
+  return reCaptchaSettings;
+};

--- a/core/next.config.js
+++ b/core/next.config.js
@@ -14,6 +14,7 @@ const nextConfig = {
   reactStrictMode: true,
   experimental: {
     optimizePackageImports: ['@icons-pack/react-simple-icons'],
+    instrumentationHook: true,
   },
   typescript: {
     ignoreBuildErrors: !!process.env.CI,
@@ -36,6 +37,28 @@ const nextConfig = {
         ],
       },
     ];
+  },
+  webpack(config, { isServer }) {
+    /**
+     * @fixme This is completely redundant. webpack should understand
+     * export conditions and don't try to import "msw/browser" code
+     * that's clearly marked as client-side only in the app.
+     */
+    if (isServer) {
+      if (Array.isArray(config.resolve.alias)) {
+        config.resolve.alias.push({ name: 'msw/browser', alias: false });
+      } else {
+        config.resolve.alias['msw/browser'] = false;
+      }
+    } else {
+      if (Array.isArray(config.resolve.alias)) {
+        config.resolve.alias.push({ name: 'msw/node', alias: false });
+      } else {
+        config.resolve.alias['msw/node'] = false;
+      }
+    }
+
+    return config;
   },
 };
 

--- a/core/package.json
+++ b/core/package.json
@@ -38,6 +38,7 @@
     "graphql": "^16.9.0",
     "lodash.debounce": "^4.0.8",
     "lru-cache": "^10.2.2",
+    "msw": "^2.3.1",
     "lucide-react": "^0.397.0",
     "next": "14.1.4",
     "next-auth": "5.0.0-beta.17",

--- a/core/tests/test-data.ts
+++ b/core/tests/test-data.ts
@@ -1,0 +1,13 @@
+import { faker } from '@faker-js/faker';
+
+export const testUser = {
+  emailAddress: process.env.TEST_ACCOUNT_EMAIL || '',
+  password: process.env.TEST_ACCOUNT_PASSWORD || '',
+  streetAddress: faker.location.streetAddress(),
+  firstName: faker.person.firstName(),
+  lastName: faker.person.lastName(),
+  phoneNumber: faker.phone.number(),
+  state: faker.location.state(),
+  city: faker.location.city(),
+  zipCode: '76286',
+};

--- a/core/tests/ui/desktop/e2e/account.spec.ts
+++ b/core/tests/ui/desktop/e2e/account.spec.ts
@@ -1,14 +1,6 @@
-import { faker } from '@faker-js/faker';
 import { expect, Page, test } from '@playwright/test';
 
-const testUserEmail: string = process.env.TEST_ACCOUNT_EMAIL || '';
-const testUserPassword: string = process.env.TEST_ACCOUNT_PASSWORD || '';
-const streetAddress: string = faker.location.streetAddress();
-const firstName: string = faker.person.firstName();
-const lastName: string = faker.person.lastName();
-const state: string = faker.location.state();
-const city: string = faker.location.city();
-const zipCode = '76286';
+import { testUser } from '~/tests/test-data';
 
 async function loginWithUserAccount(page: Page, email: string, password: string) {
   await page.goto('/login/');
@@ -27,7 +19,7 @@ test('Account access is restricted for guest users', async ({ page }) => {
 });
 
 test('My Account tabs are displayed and clickable', async ({ page }) => {
-  await loginWithUserAccount(page, testUserEmail, testUserPassword);
+  await loginWithUserAccount(page, testUser.emailAddress, testUser.password);
 
   await expect(page).toHaveURL('/account/');
   await expect(page.getByRole('heading', { name: 'Orders' })).toBeVisible();
@@ -63,7 +55,7 @@ test('My Account tabs are displayed and clickable', async ({ page }) => {
 });
 
 test('Account dropdown is visible in header', async ({ page }) => {
-  await loginWithUserAccount(page, testUserEmail, testUserPassword);
+  await loginWithUserAccount(page, testUser.emailAddress, testUser.password);
 
   await page.goto('/');
 
@@ -73,31 +65,31 @@ test('Account dropdown is visible in header', async ({ page }) => {
 });
 
 test('Add and remove new address', async ({ page }) => {
-  await loginWithUserAccount(page, testUserEmail, testUserPassword);
+  await loginWithUserAccount(page, testUser.emailAddress, testUser.password);
   await page.goto('/account/addresses');
   await page.getByRole('heading', { name: 'Addresses' }).waitFor();
 
   await page.getByRole('link', { name: 'Add new address' }).click();
   await page.getByRole('heading', { name: 'New address' }).waitFor();
-  await page.getByRole('textbox', { name: 'First Name Required' }).fill(firstName);
-  await page.getByRole('textbox', { name: 'Last Name Required' }).fill(lastName);
-  await page.getByRole('textbox', { name: 'Address Line 1 Required' }).fill(streetAddress);
+  await page.getByRole('textbox', { name: 'First Name Required' }).fill(testUser.firstName);
+  await page.getByRole('textbox', { name: 'Last Name Required' }).fill(testUser.lastName);
+  await page.getByRole('textbox', { name: 'Address Line 1 Required' }).fill(testUser.streetAddress);
 
-  await page.getByRole('textbox', { name: 'Suburb/City Required' }).fill(city);
+  await page.getByRole('textbox', { name: 'Suburb/City Required' }).fill(testUser.city);
   await page.getByRole('combobox', { name: 'Choose state or province' }).click();
-  await page.getByLabel(state, { exact: true }).click();
-  await page.getByRole('textbox', { name: 'Zip/Postcode Required' }).fill(zipCode);
+  await page.getByLabel(testUser.state).click();
+  await page.getByRole('textbox', { name: 'Zip/Postcode Required' }).fill(testUser.zipCode);
 
   await page.getByRole('button', { name: 'Add new address' }).click();
 
   await page.getByRole('heading', { name: 'Addresses' }).waitFor();
-  await expect(page.getByText(streetAddress, { exact: true })).toBeVisible();
+  await expect(page.getByText(testUser.streetAddress, { exact: true })).toBeVisible();
 
   await page.getByRole('button', { name: 'Delete' }).nth(1).click();
 
   await page.getByRole('button', { name: 'Delete address' }).click();
 
-  await expect(page.getByText(streetAddress, { exact: true })).toBeVisible({
+  await expect(page.getByText(testUser.streetAddress, { exact: true })).toBeVisible({
     visible: false,
   });
 });

--- a/core/tests/ui/desktop/e2e/account.spec.ts
+++ b/core/tests/ui/desktop/e2e/account.spec.ts
@@ -77,7 +77,7 @@ test('Add and remove new address', async ({ page }) => {
 
   await page.getByRole('textbox', { name: 'Suburb/City Required' }).fill(testUser.city);
   await page.getByRole('combobox', { name: 'Choose state or province' }).click();
-  await page.getByLabel(testUser.state).click();
+  await page.getByLabel(testUser.state, { exact: true }).click();
   await page.getByRole('textbox', { name: 'Zip/Postcode Required' }).fill(testUser.zipCode);
 
   await page.getByRole('button', { name: 'Add new address' }).click();

--- a/core/tests/ui/desktop/e2e/login.spec.ts
+++ b/core/tests/ui/desktop/e2e/login.spec.ts
@@ -1,7 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-const testAccountEmail = process.env.TEST_ACCOUNT_EMAIL || '';
-const testAccountPassword = process.env.TEST_ACCOUNT_PASSWORD || '';
+import { testUser } from '~/tests/test-data';
 
 test('Account login and logout', async ({ page }) => {
   await page.goto('/');
@@ -9,8 +8,8 @@ test('Account login and logout', async ({ page }) => {
   await page.getByLabel('Login').click();
   await expect(page.getByLabel('Email')).toBeVisible();
 
-  await page.getByLabel('Email').fill(testAccountEmail);
-  await page.getByLabel('Password').fill(testAccountPassword);
+  await page.getByLabel('Email').fill(testUser.emailAddress);
+  await page.getByLabel('Password').fill(testUser.password);
   await page.getByRole('button', { name: 'Log in' }).click();
   await expect(page.getByRole('heading', { name: 'My Account' })).toBeVisible();
 

--- a/core/tests/ui/desktop/e2e/register.spec.ts
+++ b/core/tests/ui/desktop/e2e/register.spec.ts
@@ -19,6 +19,6 @@ test('Account register', async ({ page }) => {
   await page.getByLabel('Zip/PostcodeRequired').fill(testUser.zipCode);
 
   await page.getByRole('button', { name: 'Create account' }).click();
-  await page.getByRole('heading', { name: 'New account' }).waitFor();
+  await page.getByRole('heading', { name: 'My Account' }).waitFor();
   await expect(page).toHaveURL('account/');
 });

--- a/core/tests/ui/desktop/e2e/register.spec.ts
+++ b/core/tests/ui/desktop/e2e/register.spec.ts
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker';
 import { expect, test } from '@playwright/test';
 
 import { testUser } from '~/tests/test-data';
@@ -8,9 +9,11 @@ test('Account register', async ({ page }) => {
   await page.getByRole('link', { name: 'Create Account' }).click();
   await page.getByRole('heading', { name: 'New account' }).waitFor();
 
-  await page.getByLabel('Email Address').fill(testUser.emailAddress);
-  await page.getByLabel('PasswordRequired', { exact: true }).fill(testUser.password);
-  await page.getByLabel('Confirm PasswordRequired').fill(testUser.password);
+  const password = faker.internet.password();
+
+  await page.getByLabel('Email Address').fill(faker.internet.email());
+  await page.getByLabel('PasswordRequired', { exact: true }).fill(password);
+  await page.getByLabel('Confirm PasswordRequired').fill(password);
   await page.getByLabel('First NameRequired').fill(testUser.firstName);
   await page.getByLabel('Last NameRequired').fill(testUser.lastName);
   await page.getByLabel('Phone Number').fill(testUser.phoneNumber);

--- a/core/tests/ui/desktop/e2e/register.spec.ts
+++ b/core/tests/ui/desktop/e2e/register.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '@playwright/test';
+
+import { testUser } from '~/tests/test-data';
+
+test('Account register', async ({ page }) => {
+  await page.goto('/login');
+
+  await page.getByLabel('Create Account').click();
+  await page.getByRole('heading', { name: 'New account' }).waitFor();
+
+  await page.getByLabel('Email Address').fill(testUser.emailAddress);
+  await page.getByLabel('Password').fill(testUser.password);
+  await page.getByLabel('Confirm Password').fill(testUser.password);
+  await page.getByLabel('First Name').fill(testUser.firstName);
+  await page.getByLabel('Phone Number').fill(testUser.phoneNumber);
+  await page.getByLabel('Address Line 1').fill(testUser.streetAddress);
+  await page.getByLabel('Suburb/City').fill(testUser.city);
+  await page.getByLabel('Zip/Postcode').fill(testUser.zipCode);
+
+  await page.getByRole('button', { name: 'Create account' }).click();
+  await expect(page.getByRole('heading', { name: 'My Account' })).toBeVisible();
+
+  await page.getByLabel('Account').click();
+  await page.getByRole('button', { name: 'Log out' }).click();
+  await expect(page.getByRole('heading', { name: 'Log in' })).toBeVisible();
+});

--- a/core/tests/ui/desktop/e2e/register.spec.ts
+++ b/core/tests/ui/desktop/e2e/register.spec.ts
@@ -5,22 +5,20 @@ import { testUser } from '~/tests/test-data';
 test('Account register', async ({ page }) => {
   await page.goto('/login');
 
-  await page.getByLabel('Create Account').click();
+  await page.getByRole('link', { name: 'Create Account' }).click();
   await page.getByRole('heading', { name: 'New account' }).waitFor();
 
   await page.getByLabel('Email Address').fill(testUser.emailAddress);
-  await page.getByLabel('Password').fill(testUser.password);
-  await page.getByLabel('Confirm Password').fill(testUser.password);
-  await page.getByLabel('First Name').fill(testUser.firstName);
-  await page.getByLabel('Phone Number').fill(testUser.phoneNumber);
-  await page.getByLabel('Address Line 1').fill(testUser.streetAddress);
-  await page.getByLabel('Suburb/City').fill(testUser.city);
-  await page.getByLabel('Zip/Postcode').fill(testUser.zipCode);
+  await page.getByLabel('PasswordRequired', { exact: true }).fill(testUser.password);
+  await page.getByLabel('Confirm PasswordRequired').fill(testUser.password);
+  await page.getByLabel('First NameRequired').fill(testUser.firstName);
+  await page.getByLabel('Last NameRequired').fill(testUser.lastName);
+  await page.getByLabel('Phone NumberRequired').fill(testUser.phoneNumber);
+  await page.getByLabel('Address Line 1Required').fill(testUser.streetAddress);
+  await page.getByLabel('Suburb/CityRequired').fill(testUser.city);
+  await page.getByLabel('Zip/PostcodeRequired').fill(testUser.zipCode);
 
   await page.getByRole('button', { name: 'Create account' }).click();
-  await expect(page.getByRole('heading', { name: 'My Account' })).toBeVisible();
-
-  await page.getByLabel('Account').click();
-  await page.getByRole('button', { name: 'Log out' }).click();
-  await expect(page.getByRole('heading', { name: 'Log in' })).toBeVisible();
+  await page.getByRole('heading', { name: 'New account' }).waitFor();
+  await expect(page).toHaveURL('account/');
 });

--- a/core/tests/ui/desktop/e2e/register.spec.ts
+++ b/core/tests/ui/desktop/e2e/register.spec.ts
@@ -13,12 +13,17 @@ test('Account register', async ({ page }) => {
   await page.getByLabel('Confirm PasswordRequired').fill(testUser.password);
   await page.getByLabel('First NameRequired').fill(testUser.firstName);
   await page.getByLabel('Last NameRequired').fill(testUser.lastName);
-  await page.getByLabel('Phone NumberRequired').fill(testUser.phoneNumber);
+  await page.getByLabel('Phone Number').fill(testUser.phoneNumber);
   await page.getByLabel('Address Line 1Required').fill(testUser.streetAddress);
   await page.getByLabel('Suburb/CityRequired').fill(testUser.city);
   await page.getByLabel('Zip/PostcodeRequired').fill(testUser.zipCode);
 
   await page.getByRole('button', { name: 'Create account' }).click();
+  expect(
+    page.getByLabel(
+      `Dear ${testUser.firstName} ${testUser.lastName}, your account was successfully created. Redirecting to account...`,
+    ),
+  );
   await page.getByRole('heading', { name: 'My Account' }).waitFor();
   await expect(page).toHaveURL('account/');
 });

--- a/core/tests/visual-regression/components/tabs.spec.ts
+++ b/core/tests/visual-regression/components/tabs.spec.ts
@@ -1,15 +1,14 @@
 import { expect, test } from '@playwright/test';
 
-const testAccountEmail = process.env.TEST_ACCOUNT_EMAIL || '';
-const testAccountPassword = process.env.TEST_ACCOUNT_PASSWORD || '';
+import { testUser } from '~/tests/test-data';
 
 test('tabs', async ({ page }) => {
   // Arrange
   await page.goto('/');
   await page.getByRole('link', { name: 'Login' }).click();
   await expect(page.getByLabel('Email')).toBeVisible();
-  await page.getByLabel('Email').fill(testAccountEmail);
-  await page.getByLabel('Password').fill(testAccountPassword);
+  await page.getByLabel('Email').fill(testUser.emailAddress);
+  await page.getByLabel('Password').fill(testUser.password);
   await page.getByRole('button', { name: 'Log in' }).click();
   await page.getByRole('heading', { name: 'My Account', level: 1 }).waitFor();
   await page.getByRole('link', { name: 'Orders' }).click();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       lucide-react:
         specifier: ^0.397.0
         version: 0.397.0(react@18.3.1)
+      msw:
+        specifier: ^2.3.1
+        version: 2.3.1(typescript@5.4.5)
       next:
         specifier: 14.1.4
         version: 14.1.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -5447,6 +5450,7 @@ snapshots:
       - supports-color
 
   '@bigcommerce/eslint-plugin@1.3.0(@typescript-eslint/parser@7.12.0(eslint@8.57.0)(typescript@5.5.2))(eslint@8.57.0)(typescript@5.5.2)':
+  '@bigcommerce/eslint-config@2.9.0(eslint@8.57.0)(jest@29.7.0)(typescript@5.4.5)':
     dependencies:
       '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.57.0)(typescript@5.5.2)
       '@typescript-eslint/parser': 7.12.0(eslint@8.57.0)(typescript@5.5.2)
@@ -7997,10 +8001,10 @@ snapshots:
       '@typescript-eslint/parser': 7.2.0(eslint@8.57.0)(typescript@5.5.2)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-jsx-a11y: 6.9.0(eslint@8.57.0)
-      eslint-plugin-react: 7.34.3(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
+      eslint-plugin-react: 7.34.2(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
     optionalDependencies:
       typescript: 5.5.2


### PR DESCRIPTION
## What/Why?
POC of adding Playwright tests with mocking GraphQL server-side requests. Mock Service Worker is used as a helper tool.

This is done for testing Catalyst functionality without actually sending data to backend. This might be helpful to check FE side functionality works fine in Catalyst and at the same time avoid creating and removing real test users.

- added `register.spec.ts` file with UI test of register account functionality 
- added `core/client/mocks` folder for storing all mocking related files in one place
- added `core/instrumentation.ts` hook that enables MSW server to intercept API requests we need
- as MSW is not yet working perfectly fine with new Next.js App router, a temporary workaround is added to `core/next.config.js` file to make it work fine; see more info in [issue](https://github.com/mswjs/msw/issues/1644)
- added `core/tests/test-data.ts` file to store test user we use across different tests to avoid code duplication
- added recaptcha bypass to make test pass in CI test run (kudos to Chance👏)

## Testing
<img width="896" alt="Screenshot 2024-06-18 at 17 35 08" src="https://github.com/bigcommerce/catalyst/assets/81637332/ae6f851e-1399-4588-bcc9-bfcc8d249363">
