### PR TITLE
Correct translation key for Warranty in Product Details

### DIFF
--- a/core/app/[locale]/(default)/product/[slug]/_components/warranty.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/_components/warranty.tsx
@@ -13,7 +13,7 @@ interface Props {
 }
 
 export const Warranty = ({ product }: Props) => {
-  const t = useTranslations('Product.Details');
+  const t = useTranslations('Product.DescriptionAndReviews');
 
   if (!product.warranty) {
     return null;


### PR DESCRIPTION
This pull request addresses an issue with the incorrect translation key used for the warranty section on product pages. The current code utilizes the key `Product.Details`, which results in displaying "Product.Details.warranty" on the product page instead of the correct translation.