### PR TITLE
feat: add loading animations to PLP pages

### DIFF
--- a/core/app/[locale]/(default)/(faceted)/_components/facets.tsx
+++ b/core/app/[locale]/(default)/(faceted)/_components/facets.tsx
@@ -2,7 +2,7 @@
 
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { FormEvent, useRef } from 'react';
+import { FormEvent, useRef, useTransition } from 'react';
 
 import { Link } from '~/components/link';
 import {
@@ -46,6 +46,8 @@ export const Facets = ({ facets, pageType }: Props) => {
   const ref = useRef<HTMLFormElement>(null);
   const router = useRouter();
   const pathname = usePathname();
+  const [isPending, startTransition] = useTransition();
+
   const searchParams = useSearchParams();
   const t = useTranslations('FacetedGroup.FacetedSearch.Facets');
 
@@ -81,12 +83,14 @@ export const Facets = ({ facets, pageType }: Props) => {
       newSearchParams.append('term', searchParam);
     }
 
-    router.push(`${pathname}?${newSearchParams.toString()}`);
+    startTransition(() => {
+      router.push(`${pathname}?${newSearchParams.toString()}`);
+    });
   };
 
   return (
     <Accordion defaultValue={defaultOpenFacets} type="multiple">
-      <form onSubmit={handleSubmit} ref={ref}>
+      <form data-pending={isPending ? '' : undefined} onSubmit={handleSubmit} ref={ref}>
         {facets.map((facet) => {
           if (facet.__typename === 'BrandSearchFilter' && pageType !== 'brand') {
             return (

--- a/core/app/[locale]/(default)/(faceted)/_components/refine-by.tsx
+++ b/core/app/[locale]/(default)/(faceted)/_components/refine-by.tsx
@@ -2,6 +2,7 @@
 
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
+import { useTransition } from 'react';
 
 import { Tag, TagAction, TagContent } from '~/components/ui/tag';
 
@@ -110,6 +111,8 @@ export const RefineBy = (props: Props) => {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+
   const refinements = mapFacetsToRefinements(props);
   const t = useTranslations('FacetedGroup.FacetedSearch.RefineBy');
 
@@ -120,11 +123,15 @@ export const RefineBy = (props: Props) => {
 
     const params = new URLSearchParams(filteredParams);
 
-    router.push(`${pathname}?${params.toString()}`);
+    startTransition(() => {
+      router.push(`${pathname}?${params.toString()}`);
+    });
   };
 
   const clearAllRefinements = () => {
-    router.push(pathname);
+    startTransition(() => {
+      router.push(pathname);
+    });
   };
 
   if (!refinements.length) {
@@ -132,7 +139,7 @@ export const RefineBy = (props: Props) => {
   }
 
   return (
-    <div>
+    <div data-pending={isPending ? '' : undefined}>
       <div className="flex flex-row items-center justify-between pb-2">
         <h3 className="text-2xl font-bold">{t('refineBy')}</h3>
         {/* TODO: Make subtle variant */}

--- a/core/app/[locale]/(default)/(faceted)/_components/sort-by.tsx
+++ b/core/app/[locale]/(default)/(faceted)/_components/sort-by.tsx
@@ -2,6 +2,7 @@
 
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
+import { useTransition } from 'react';
 
 import { Select, SelectContent, SelectItem } from '~/components/ui/select';
 
@@ -9,6 +10,8 @@ export function SortBy() {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+
   const t = useTranslations('FacetedGroup.SortBy');
   const value = searchParams.get('sort') ?? 'featured';
 
@@ -17,7 +20,9 @@ export function SortBy() {
 
     params.set('sort', sortValue);
 
-    router.push(`${pathname}?${params.toString()}`);
+    startTransition(() => {
+      router.push(`${pathname}?${params.toString()}`);
+    });
   };
 
   return (
@@ -27,6 +32,8 @@ export function SortBy() {
       onValueChange={onSort}
       value={value}
     >
+      <span className="hidden" data-pending={isPending ? '' : undefined} />
+
       <SelectContent>
         <SelectItem value="featured">{t('featuredItems')}</SelectItem>
         <SelectItem value="newest">{t('newestItems')}</SelectItem>

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
@@ -57,7 +57,7 @@ export default async function Brand({ params: { slug, locale }, searchParams }: 
   const { hasNextPage, hasPreviousPage, endCursor, startCursor } = productsCollection.pageInfo;
 
   return (
-    <div>
+    <div className="group">
       <NextIntlClientProvider
         locale={locale}
         messages={{
@@ -94,7 +94,10 @@ export default async function Brand({ params: { slug, locale }, searchParams }: 
             pageType="brand"
           />
 
-          <section aria-labelledby="product-heading" className="col-span-4 lg:col-span-3">
+          <section
+            aria-labelledby="product-heading"
+            className="col-span-4 group-has-[[data-pending]]:animate-pulse lg:col-span-3"
+          >
             <h2 className="sr-only" id="product-heading">
               {t('products')}
             </h2>

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -61,7 +61,7 @@ export default async function Category({ params: { locale, slug }, searchParams 
   const { hasNextPage, hasPreviousPage, endCursor, startCursor } = productsCollection.pageInfo;
 
   return (
-    <div>
+    <div className="group">
       <Breadcrumbs category={category} />
       <NextIntlClientProvider
         locale={locale}
@@ -103,7 +103,10 @@ export default async function Category({ params: { locale, slug }, searchParams 
             <SubCategories categoryTree={categoryTree} />
           </FacetedSearch>
 
-          <section aria-labelledby="product-heading" className="col-span-4 lg:col-span-3">
+          <section
+            aria-labelledby="product-heading"
+            className="col-span-4 group-has-[[data-pending]]:animate-pulse lg:col-span-3"
+          >
             <h2 className="sr-only" id="product-heading">
               {t('products')}
             </h2>

--- a/core/app/[locale]/(default)/(faceted)/search/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/search/page.tsx
@@ -60,7 +60,7 @@ export default async function Search({ params: { locale }, searchParams }: Props
   const { hasNextPage, hasPreviousPage, endCursor, startCursor } = productsCollection.pageInfo;
 
   return (
-    <div>
+    <div className="group">
       <NextIntlClientProvider
         locale={locale}
         messages={{
@@ -99,7 +99,10 @@ export default async function Search({ params: { locale }, searchParams }: Props
             headingId="desktop-filter-heading"
             pageType="search"
           />
-          <section aria-labelledby="product-heading" className="col-span-4 lg:col-span-3">
+          <section
+            aria-labelledby="product-heading"
+            className="col-span-4 group-has-[[data-pending]]:animate-pulse lg:col-span-3"
+          >
             <h2 className="sr-only" id="product-heading">
               {t('products')}
             </h2>


### PR DESCRIPTION
## What/Why?
Added a css pulse animation when adding/removing facets. This provides users with visual feedback, indicating that an action is in progress, similar to a loading spinner.

## Testing
Using the preview, click around Categories / Brands / Search pages, pulse animation while adding faces.