### PR TITLE
feat(core): add dates field for account & addresses forms

### DIFF
--- a/.changeset/gentle-boxes-tease.md
+++ b/.changeset/gentle-boxes-tease.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+add dates field for account & address forms

--- a/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/add-address.tsx
+++ b/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/add-address.tsx
@@ -8,6 +8,7 @@ import ReCaptcha from 'react-google-recaptcha';
 
 import {
   createFieldName,
+  DateField,
   FieldNameToFieldId,
   FieldWrapper,
   NumbersOnly,
@@ -24,6 +25,7 @@ import { addAddress } from '../../_actions/add-address';
 
 import {
   createCountryChangeHandler,
+  createDatesValidationHandler,
   createNumbersInputValidationHandler,
   createTextInputValidationHandler,
 } from './address-field-handlers';
@@ -95,6 +97,7 @@ export const AddAddress = ({
 
   const [textInputValid, setTextInputValid] = useState<Record<string, boolean>>({});
   const [numbersInputValid, setNumbersInputValid] = useState<Record<string, boolean>>({});
+  const [datesValid, setDatesValid] = useState<Record<string, boolean>>({});
   const [countryStates, setCountryStates] = useState(defaultCountry.states);
 
   const handleTextInputValidation = createTextInputValidationHandler(
@@ -106,6 +109,7 @@ export const AddAddress = ({
     setNumbersInputValid,
     numbersInputValid,
   );
+  const handleDatesValidation = createDatesValidationHandler(setDatesValid, datesValid);
 
   const onReCaptchaChange = (token: string | null) => {
     if (!token) {
@@ -160,13 +164,15 @@ export const AddAddress = ({
       <Form action={onSubmit} ref={form}>
         <div className="grid grid-cols-1 gap-y-6 lg:grid-cols-2 lg:gap-x-6 lg:gap-y-2">
           {addressFields.map((field) => {
+            const fieldId = field.entityId;
+
             switch (field.__typename) {
               case 'TextFormField': {
                 return (
-                  <FieldWrapper fieldId={field.entityId} key={field.entityId}>
+                  <FieldWrapper fieldId={fieldId} key={fieldId}>
                     <Text
                       field={field}
-                      isValid={textInputValid[field.entityId]}
+                      isValid={textInputValid[fieldId]}
                       name={createFieldName(field, 'address')}
                       onChange={handleTextInputValidation}
                     />
@@ -176,10 +182,10 @@ export const AddAddress = ({
 
               case 'NumberFormField': {
                 return (
-                  <FieldWrapper fieldId={field.entityId} key={field.entityId}>
+                  <FieldWrapper fieldId={fieldId} key={fieldId}>
                     <NumbersOnly
                       field={field}
-                      isValid={numbersInputValid[field.entityId]}
+                      isValid={numbersInputValid[fieldId]}
                       name={createFieldName(field, 'address')}
                       onChange={handleNumbersInputValidation}
                     />
@@ -187,21 +193,31 @@ export const AddAddress = ({
                 );
               }
 
+              case 'DateFormField': {
+                return (
+                  <FieldWrapper fieldId={fieldId} key={fieldId}>
+                    <DateField
+                      field={field}
+                      isValid={datesValid[fieldId]}
+                      name={createFieldName(field, 'address')}
+                      onChange={handleDatesValidation}
+                      onValidate={setDatesValid}
+                    />
+                  </FieldWrapper>
+                );
+              }
+
               case 'PicklistFormField':
                 return (
-                  <FieldWrapper fieldId={field.entityId} key={field.entityId}>
+                  <FieldWrapper fieldId={fieldId} key={fieldId}>
                     <Picklist
                       defaultValue={
-                        field.entityId === FieldNameToFieldId.countryCode
-                          ? defaultCountry.code
-                          : undefined
+                        fieldId === FieldNameToFieldId.countryCode ? defaultCountry.code : undefined
                       }
                       field={field}
                       name={createFieldName(field, 'address')}
                       onChange={
-                        field.entityId === FieldNameToFieldId.countryCode
-                          ? handleCountryChange
-                          : undefined
+                        fieldId === FieldNameToFieldId.countryCode ? handleCountryChange : undefined
                       }
                       options={countries.map(({ name, code }) => {
                         return { label: name, entityId: code };
@@ -212,10 +228,10 @@ export const AddAddress = ({
 
               case 'PicklistOrTextFormField':
                 return (
-                  <FieldWrapper fieldId={field.entityId} key={field.entityId}>
+                  <FieldWrapper fieldId={fieldId} key={fieldId}>
                     <PicklistOrText
                       defaultValue={
-                        field.entityId === FieldNameToFieldId.stateOrProvince
+                        fieldId === FieldNameToFieldId.stateOrProvince
                           ? countryStates[0]?.name
                           : undefined
                       }

--- a/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/address-field-handlers.ts
+++ b/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/address-field-handlers.ts
@@ -47,6 +47,15 @@ const createNumbersInputValidationHandler =
     numbersInputStateSetter({ ...numbersInputState, [fieldId]: !validationStatus });
   };
 
+const createDatesValidationHandler =
+  (dateStateSetter: FieldStateSetFn<FieldState>, dateFieldState: FieldState) =>
+  (e: React.ChangeEvent<HTMLInputElement>) => {
+    const fieldId = Number(e.target.id);
+    const validationStatus = e.target.validity.valueMissing;
+
+    dateStateSetter({ ...dateFieldState, [fieldId]: !validationStatus });
+  };
+
 const createPasswordValidationHandler =
   (passwordStateSetter: FieldStateSetFn<FieldState>, fields: AddressFields) =>
   (e: ChangeEvent<HTMLInputElement>) => {
@@ -64,9 +73,9 @@ const createPasswordValidationHandler =
 
       case 'confirmPassword': {
         const confirmPassword = e.target.value;
-        const field = fields.filter(
+        const field = fields.find(
           ({ entityId }) => entityId === Number(FieldNameToFieldId.password),
-        )[0];
+        );
 
         if (!isAddressOrAccountFormField(field)) {
           return;
@@ -115,4 +124,5 @@ export {
   createPasswordValidationHandler,
   createCountryChangeHandler,
   createNumbersInputValidationHandler,
+  createDatesValidationHandler,
 };

--- a/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/edit-address.tsx
+++ b/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/edit-address.tsx
@@ -8,6 +8,7 @@ import ReCaptcha from 'react-google-recaptcha';
 
 import {
   createFieldName,
+  DateField,
   FieldNameToFieldId,
   FieldWrapper,
   NumbersOnly,
@@ -28,6 +29,7 @@ import { Modal } from '../modal';
 import { AddressFields, Countries } from './add-address';
 import {
   createCountryChangeHandler,
+  createDatesValidationHandler,
   createNumbersInputValidationHandler,
   createTextInputValidationHandler,
 } from './address-field-handlers';
@@ -104,6 +106,7 @@ export const EditAddress = ({
 
   const [textInputValid, setTextInputValid] = useState<Record<string, boolean>>({});
   const [numbersInputValid, setNumbersInputValid] = useState<Record<string, boolean>>({});
+  const [datesValid, setDatesValid] = useState<Record<string, boolean>>({});
 
   const defaultStates = countries
     .filter((country) => country.code === address.countryCode)
@@ -119,6 +122,7 @@ export const EditAddress = ({
     numbersInputValid,
   );
   const handleCountryChange = createCountryChangeHandler(setCountryStates, countries);
+  const handleDatesValidation = createDatesValidationHandler(setDatesValid, datesValid);
 
   const onReCaptchaChange = (token: string | null) => {
     if (!token) {
@@ -194,9 +198,7 @@ export const EditAddress = ({
             if (isExistedField(key)) {
               defaultValue = address[key] ?? undefined;
             } else {
-              defaultCustomField = address.formFields.filter(
-                ({ entityId }) => entityId === fieldId,
-              )[0];
+              defaultCustomField = address.formFields.find(({ entityId }) => entityId === fieldId);
             }
 
             switch (field.__typename) {
@@ -233,6 +235,26 @@ export const EditAddress = ({
                       isValid={numbersInputValid[fieldId]}
                       name={createFieldName(field, 'address')}
                       onChange={handleNumbersInputValidation}
+                    />
+                  </FieldWrapper>
+                );
+              }
+
+              case 'DateFormField': {
+                const defaultDate =
+                  defaultCustomField?.__typename === `DateFormFieldValue`
+                    ? defaultCustomField.date.utc
+                    : undefined;
+
+                return (
+                  <FieldWrapper fieldId={fieldId} key={fieldId}>
+                    <DateField
+                      defaultValue={defaultDate}
+                      field={field}
+                      isValid={datesValid[fieldId]}
+                      name={createFieldName(field, 'address')}
+                      onChange={handleDatesValidation}
+                      onValidate={setDatesValid}
                     />
                   </FieldWrapper>
                 );

--- a/core/app/[locale]/(default)/account/[tab]/_components/update-settings-form/_actions/update-customer.ts
+++ b/core/app/[locale]/(default)/account/[tab]/_components/update-settings-form/_actions/update-customer.ts
@@ -1,6 +1,29 @@
 'use server';
 
-import { updateCustomer as updateCustomerClient } from '~/client/mutations/update-customer';
+import { revalidatePath } from 'next/cache';
+
+import { parseAccountFormData } from '~/app/[locale]/(default)/login/register-customer/_components/register-customer-form/fields/parse-fields';
+import {
+  Input as AddCustomerAddressInput,
+  updateCustomer as updateCustomerClient,
+} from '~/client/mutations/update-customer';
+
+const isUpdateCustomerInput = (data: unknown): data is AddCustomerAddressInput => {
+  if (
+    typeof data === 'object' &&
+    data !== null &&
+    ('firstName' in data ||
+      'lastName' in data ||
+      'email' in data ||
+      'phone' in data ||
+      'company' in data ||
+      'formFields' in data)
+  ) {
+    return true;
+  }
+
+  return false;
+};
 
 interface UpdateCustomerForm {
   formData: FormData;
@@ -10,9 +33,18 @@ interface UpdateCustomerForm {
 export const updateCustomer = async ({ formData, reCaptchaToken }: UpdateCustomerForm) => {
   formData.delete('g-recaptcha-response');
 
-  const formFields = Object.fromEntries(formData.entries());
+  const parsed = parseAccountFormData(formData);
 
-  const response = await updateCustomerClient({ formFields, reCaptchaToken });
+  if (!isUpdateCustomerInput(parsed)) {
+    return {
+      status: 'error',
+      error: 'Something went wrong with proccessing user input.',
+    };
+  }
+
+  const response = await updateCustomerClient({ formFields: parsed, reCaptchaToken });
+
+  revalidatePath('/account/settings', 'page');
 
   if (response.errors.length === 0) {
     const { customer } = response;

--- a/core/app/[locale]/(default)/account/[tab]/_components/update-settings-form/fields/text.tsx
+++ b/core/app/[locale]/(default)/account/[tab]/_components/update-settings-form/fields/text.tsx
@@ -9,6 +9,7 @@ import { FieldNameToFieldId } from '..';
 interface TextProps {
   defaultValue?: string;
   entityId: number;
+  name?: string;
   isRequired?: boolean;
   isValid?: boolean;
   label: string;
@@ -21,17 +22,18 @@ export const Text = ({
   entityId,
   isRequired = false,
   isValid,
+  name,
   label,
   onChange,
   type = 'text',
 }: TextProps) => {
   const t = useTranslations('Account.Settings.validationMessages');
-  const fieldName = FieldNameToFieldId[entityId];
-  const name = fieldName ?? `field-${entityId}`;
+  const nameById = FieldNameToFieldId[entityId];
+  const fieldName = name ?? nameById ?? `field-${entityId}`;
 
   return (
-    <Field className="relative space-y-2 pb-7" name={name}>
-      <FieldLabel htmlFor={name} isRequired={isRequired}>
+    <Field className="relative space-y-2 pb-7" name={fieldName}>
+      <FieldLabel htmlFor={fieldName} isRequired={isRequired}>
         {label}
       </FieldLabel>
       <FieldControl asChild>
@@ -50,7 +52,7 @@ export const Text = ({
           className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-error-secondary"
           match="valueMissing"
         >
-          {t(fieldName ?? 'empty')}
+          {t(nameById ?? 'empty')}
         </FieldMessage>
       )}
     </Field>

--- a/core/app/[locale]/(default)/account/[tab]/page-data.ts
+++ b/core/app/[locale]/(default)/account/[tab]/page-data.ts
@@ -46,6 +46,9 @@ const CustomerSettingsQuery = graphql(
           ... on TextFormFieldValue {
             text
           }
+          ... on MultilineTextFormFieldValue {
+            multilineText
+          }
         }
       }
       site {

--- a/core/app/[locale]/(default)/login/register-customer/_components/register-customer-form/fields/date.tsx
+++ b/core/app/[locale]/(default)/login/register-customer/_components/register-customer-form/fields/date.tsx
@@ -1,0 +1,98 @@
+import { useTranslations } from 'next-intl';
+import React, { ChangeEvent, useState } from 'react';
+
+import { DatePicker } from '~/components/ui/date-picker';
+import { Field, FieldControl, FieldLabel, FieldMessage } from '~/components/ui/form';
+
+import { AddressFields } from '..';
+
+const getDisabledDays = ({
+  earliest,
+  latest,
+}: {
+  earliest: string | null;
+  latest: string | null;
+}) => {
+  if (earliest && latest) {
+    return [{ before: new Date(earliest), after: new Date(latest) }];
+  }
+
+  if (earliest) {
+    return [{ before: new Date(earliest) }];
+  }
+
+  if (latest) {
+    return [{ after: new Date(latest) }];
+  }
+
+  return [];
+};
+
+type DateType = Extract<NonNullable<AddressFields>[number], { __typename: 'DateFormField' }>;
+
+interface DateProps {
+  defaultValue?: Date | string;
+  field: DateType;
+  isValid?: boolean;
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+  onValidate?: (
+    state:
+      | Record<string, boolean>
+      | ((prevState: Record<string, boolean>) => Record<string, boolean>),
+  ) => void;
+  name: string;
+}
+
+export const DateField = ({
+  defaultValue,
+  field,
+  isValid,
+  onChange,
+  onValidate,
+  name,
+}: DateProps) => {
+  const selectedDate = defaultValue || field.defaultDate || undefined;
+  const [date, setDate] = useState<Date | string | undefined>(selectedDate);
+  const t = useTranslations('Account.Register.validationMessages');
+  const disabledDays = getDisabledDays({ earliest: field.minDate, latest: field.maxDate });
+  const handleDateSelect = field.isRequired
+    ? (d: Date | undefined) => {
+        if (onValidate) {
+          onValidate((datesState: Record<string, boolean>) => ({
+            ...datesState,
+            [field.entityId.toString()]: Boolean(d),
+          }));
+        }
+
+        setDate(d);
+      }
+    : (d?: Date) => setDate(d);
+
+  return (
+    <Field className="relative space-y-2 pb-7" name={name}>
+      <FieldLabel htmlFor={`field-${field.entityId}`} isRequired={field.isRequired}>
+        {field.label}
+      </FieldLabel>
+      <FieldControl asChild>
+        <DatePicker
+          disabledDays={disabledDays}
+          id={`${field.entityId}`}
+          onChange={field.isRequired ? onChange : undefined}
+          onInvalid={field.isRequired ? onChange : undefined}
+          onSelect={handleDateSelect}
+          required={field.isRequired}
+          selected={date ? new Date(date) : undefined}
+          variant={isValid === false ? 'error' : undefined}
+        />
+      </FieldControl>
+      {field.isRequired && !isValid && (
+        <FieldMessage
+          className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-error-secondary"
+          match="valueMissing"
+        >
+          {t('empty')}
+        </FieldMessage>
+      )}
+    </Field>
+  );
+};

--- a/core/app/[locale]/(default)/login/register-customer/_components/register-customer-form/fields/index.ts
+++ b/core/app/[locale]/(default)/login/register-customer/_components/register-customer-form/fields/index.ts
@@ -1,3 +1,4 @@
+export * from './date';
 export * from './password';
 export * from './text';
 export * from './numbers-only';

--- a/core/app/[locale]/(default)/login/register-customer/_components/register-customer-form/fields/text.tsx
+++ b/core/app/[locale]/(default)/login/register-customer/_components/register-customer-form/fields/text.tsx
@@ -30,7 +30,7 @@ export const Text = ({ defaultValue, field, isValid, name, onChange, type }: Tex
       </FieldLabel>
       <FieldControl asChild>
         <Input
-          defaultValue={field.defaultText ?? defaultValue}
+          defaultValue={defaultValue ?? field.defaultText ?? ''}
           id={`field-${field.entityId}`}
           maxLength={field.maxLength ?? undefined}
           onChange={field.isRequired ? onChange : undefined}

--- a/core/app/[locale]/(default)/login/register-customer/_components/register-customer-form/index.tsx
+++ b/core/app/[locale]/(default)/login/register-customer/_components/register-customer-form/index.tsx
@@ -6,6 +6,7 @@ import { useFormStatus } from 'react-dom';
 import ReCaptcha from 'react-google-recaptcha';
 
 import {
+  createDatesValidationHandler,
   createNumbersInputValidationHandler,
   isAddressOrAccountFormField,
 } from '~/app/[locale]/(default)/account/[tab]/_components/addresses-content/address-field-handlers';
@@ -19,6 +20,7 @@ import { registerCustomer } from './_actions/register-customer';
 import {
   createFieldName,
   CUSTOMER_FIELDS_TO_EXCLUDE,
+  DateField,
   FieldNameToFieldId,
   FieldWrapper,
   NumbersOnly,
@@ -97,7 +99,7 @@ export const RegisterCustomerForm = ({
     [FieldNameToFieldId.confirmPassword]: true,
   });
   const [numbersInputValid, setNumbersInputValid] = useState<Record<string, boolean>>({});
-
+  const [datesValid, setDatesValid] = useState<Record<string, boolean>>({});
   const [countryStates, setCountryStates] = useState(defaultCountry.states);
 
   const reCaptchaRef = useRef<ReCaptcha>(null);
@@ -118,6 +120,7 @@ export const RegisterCustomerForm = ({
     setNumbersInputValid,
     numbersInputValid,
   );
+  const handleDatesValidation = createDatesValidationHandler(setDatesValid, datesValid);
   const handlePasswordValidation = (e: ChangeEvent<HTMLInputElement>) => {
     const fieldId = e.target.id.split('-')[1] ?? '';
 
@@ -240,26 +243,28 @@ export const RegisterCustomerForm = ({
           {customerFields
             .filter((field) => !CUSTOMER_FIELDS_TO_EXCLUDE.includes(field.entityId))
             .map((field) => {
+              const fieldId = field.entityId;
+
               switch (field.__typename) {
                 case 'TextFormField':
                   return (
-                    <FieldWrapper fieldId={field.entityId} key={field.entityId}>
+                    <FieldWrapper fieldId={fieldId} key={fieldId}>
                       <Text
                         field={field}
-                        isValid={textInputValid[field.entityId]}
+                        isValid={textInputValid[fieldId]}
                         name={createFieldName(field, 'customer')}
                         onChange={handleTextInputValidation}
-                        type={FieldNameToFieldId[field.entityId]}
+                        type={FieldNameToFieldId[fieldId]}
                       />
                     </FieldWrapper>
                   );
 
                 case 'NumberFormField': {
                   return (
-                    <FieldWrapper fieldId={field.entityId} key={field.entityId}>
+                    <FieldWrapper fieldId={fieldId} key={fieldId}>
                       <NumbersOnly
                         field={field}
-                        isValid={numbersInputValid[field.entityId]}
+                        isValid={numbersInputValid[fieldId]}
                         name={createFieldName(field, 'customer')}
                         onChange={handleNumbersInputValidation}
                       />
@@ -267,12 +272,26 @@ export const RegisterCustomerForm = ({
                   );
                 }
 
+                case 'DateFormField': {
+                  return (
+                    <FieldWrapper fieldId={fieldId} key={fieldId}>
+                      <DateField
+                        field={field}
+                        isValid={datesValid[fieldId]}
+                        name={createFieldName(field, 'customer')}
+                        onChange={handleDatesValidation}
+                        onValidate={setDatesValid}
+                      />
+                    </FieldWrapper>
+                  );
+                }
+
                 case 'PasswordFormField': {
                   return (
-                    <FieldWrapper fieldId={field.entityId} key={field.entityId}>
+                    <FieldWrapper fieldId={fieldId} key={fieldId}>
                       <Password
                         field={field}
-                        isValid={passwordValid[field.entityId]}
+                        isValid={passwordValid[fieldId]}
                         name={createFieldName(field, 'customer')}
                         onChange={handlePasswordValidation}
                       />
@@ -287,34 +306,60 @@ export const RegisterCustomerForm = ({
         </div>
         <div className="grid grid-cols-1 gap-y-6 lg:grid-cols-2 lg:gap-x-6 lg:gap-y-2">
           {addressFields.map((field) => {
+            const fieldId = field.entityId;
+
             switch (field.__typename) {
-              case 'TextFormField':
+              case 'TextFormField': {
                 return (
-                  <FieldWrapper fieldId={field.entityId} key={field.entityId}>
+                  <FieldWrapper fieldId={fieldId} key={fieldId}>
                     <Text
                       field={field}
-                      isValid={textInputValid[field.entityId]}
+                      isValid={textInputValid[fieldId]}
                       name={createFieldName(field, 'address')}
                       onChange={handleTextInputValidation}
                     />
                   </FieldWrapper>
                 );
+              }
 
-              case 'PicklistFormField':
+              case 'NumberFormField': {
                 return (
-                  <FieldWrapper fieldId={field.entityId} key={field.entityId}>
+                  <FieldWrapper fieldId={fieldId} key={fieldId}>
+                    <NumbersOnly
+                      field={field}
+                      isValid={numbersInputValid[fieldId]}
+                      name={createFieldName(field, 'address')}
+                      onChange={handleNumbersInputValidation}
+                    />
+                  </FieldWrapper>
+                );
+              }
+
+              case 'DateFormField': {
+                return (
+                  <FieldWrapper fieldId={fieldId} key={fieldId}>
+                    <DateField
+                      field={field}
+                      isValid={datesValid[fieldId]}
+                      name={createFieldName(field, 'address')}
+                      onChange={handleDatesValidation}
+                      onValidate={setDatesValid}
+                    />
+                  </FieldWrapper>
+                );
+              }
+
+              case 'PicklistFormField': {
+                return (
+                  <FieldWrapper fieldId={fieldId} key={fieldId}>
                     <Picklist
                       defaultValue={
-                        field.entityId === FieldNameToFieldId.countryCode
-                          ? defaultCountry.code
-                          : undefined
+                        fieldId === FieldNameToFieldId.countryCode ? defaultCountry.code : undefined
                       }
                       field={field}
                       name={createFieldName(field, 'address')}
                       onChange={
-                        field.entityId === FieldNameToFieldId.countryCode
-                          ? handleCountryChange
-                          : undefined
+                        fieldId === FieldNameToFieldId.countryCode ? handleCountryChange : undefined
                       }
                       options={countries.map(({ code, name }) => {
                         return { entityId: code, label: name };
@@ -322,13 +367,14 @@ export const RegisterCustomerForm = ({
                     />
                   </FieldWrapper>
                 );
+              }
 
-              case 'PicklistOrTextFormField':
+              case 'PicklistOrTextFormField': {
                 return (
-                  <FieldWrapper fieldId={field.entityId} key={field.entityId}>
+                  <FieldWrapper fieldId={fieldId} key={fieldId}>
                     <PicklistOrText
                       defaultValue={
-                        field.entityId === FieldNameToFieldId.stateOrProvince
+                        fieldId === FieldNameToFieldId.stateOrProvince
                           ? countryStates[0]?.name
                           : undefined
                       }
@@ -340,6 +386,7 @@ export const RegisterCustomerForm = ({
                     />
                   </FieldWrapper>
                 );
+              }
 
               default:
                 return null;

--- a/core/client/mutations/update-customer.ts
+++ b/core/client/mutations/update-customer.ts
@@ -32,7 +32,7 @@ const UPDATE_CUSTOMER_MUTATION = graphql(`
 `);
 
 type Variables = VariablesOf<typeof UPDATE_CUSTOMER_MUTATION>;
-type Input = Variables['input'];
+export type Input = Variables['input'];
 
 interface UpdateCustomer {
   formFields: Input;

--- a/core/components/ui/date-picker/date-picker.tsx
+++ b/core/components/ui/date-picker/date-picker.tsx
@@ -8,7 +8,7 @@ import { Calendar } from '../calendar';
 import { Input, InputIcon, InputProps } from '../input';
 import { Popover, PopoverContent, PopoverTrigger } from '../popover';
 
-type DatePickerProps = Omit<InputProps, 'defaultValue'> & {
+type DatePickerProps = Omit<InputProps, 'defaultValue' | 'onSelect'> & {
   defaultValue?: string | Date;
   selected?: DayPickerSingleProps['selected'];
   onSelect?: DayPickerSingleProps['onSelect'];
@@ -41,7 +41,7 @@ export const DatePicker = React.forwardRef<React.ElementRef<'div'>, DatePickerPr
           <PopoverTrigger asChild>
             <Input
               placeholder={placeholder}
-              readOnly={true}
+              readOnly={!required}
               required={required}
               type="text"
               value={formattedSelected ?? formattedDate ?? ''}


### PR DESCRIPTION
## What/Why?

This PR adds brings `DatesFormField` for Address & Account forms.

## Testing
Locally

<img width="543" alt="Screenshot 2024-06-25 at 17 46 35" src="https://github.com/bigcommerce/catalyst/assets/67792608/a3f84720-d63a-48dc-b262-c75250fc0b99">

<img width="1144" alt="Screenshot 2024-06-25 at 17 48 01" src="https://github.com/bigcommerce/catalyst/assets/67792608/cf2b450a-56bc-4716-8116-4a1bf3319cfe">

