### PR TITLE
fix: pre selected options on PDP page

### DIFF
--- a/core/app/[locale]/(default)/product/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/product/[slug]/page-data.ts
@@ -13,9 +13,17 @@ import { WarrantyFragment } from './_components/warranty';
 
 const ProductPageQuery = graphql(
   `
-    query ProductPageQuery($entityId: Int!, $optionValueIds: [OptionValueId!]) {
+    query ProductPageQuery(
+      $entityId: Int!
+      $optionValueIds: [OptionValueId!]
+      $useDefaultOptionSelections: Boolean
+    ) {
       site {
-        product(entityId: $entityId, optionValueIds: $optionValueIds) {
+        product(
+          entityId: $entityId
+          optionValueIds: $optionValueIds
+          useDefaultOptionSelections: $useDefaultOptionSelections
+        ) {
           ...GalleryFragment
           ...DetailsFragment
           ...DescriptionFragment

--- a/core/app/[locale]/(default)/product/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/page.tsx
@@ -28,7 +28,11 @@ export async function generateMetadata({
   const productId = Number(params.slug);
   const optionValueIds = getOptionValueIds({ searchParams });
 
-  const product = await getProduct({ entityId: productId, optionValueIds });
+  const product = await getProduct({
+    entityId: productId,
+    optionValueIds,
+    useDefaultOptionSelections: optionValueIds.length === 0 ? true : undefined,
+  });
 
   if (!product) {
     return {};
@@ -66,7 +70,11 @@ export default async function Product({ params, searchParams }: ProductPageProps
 
   const optionValueIds = getOptionValueIds({ searchParams });
 
-  const product = await getProduct({ entityId: productId, optionValueIds });
+  const product = await getProduct({
+    entityId: productId,
+    optionValueIds,
+    useDefaultOptionSelections: optionValueIds.length === 0 ? true : undefined,
+  });
 
   if (!product) {
     return notFound();


### PR DESCRIPTION
## What/Why?
First pass on default options selection fix. This PR applies the default options overlay for the query done in the PDP page. When no product options are selected on page load (no query params) the overlay is applied.

## Testing
1. Set default product options on a product
2. Navigate to the product's PDP page
3. Product options should be selected and the correct image / sku are displayed.