### PR TITLE
feat(core): add multipleChoices field(radio-buttons, picklist) for account & address forms

### DIFF
--- a/.changeset/grumpy-buttons-tan.md
+++ b/.changeset/grumpy-buttons-tan.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+add multipleChoices field(radio-buttons, picklist) for account & address forms

--- a/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/address-field-handlers.ts
+++ b/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/address-field-handlers.ts
@@ -25,6 +25,50 @@ type FieldState = Record<string, boolean>;
 type StateOrProvince = Countries[number]['statesOrProvinces'];
 type FieldStateSetFn<Type> = (state: Type | ((prevState: Type) => Type)) => void;
 
+const createPreSubmitPicklistValidationHandler = (
+  formFields: AddressFields,
+  validitationSetter: FieldStateSetFn<FieldState>,
+) => {
+  const picklists = formFields.filter(
+    ({ __typename: type, entityId, isBuiltIn, isRequired }) =>
+      type === 'PicklistFormField' &&
+      entityId !== FieldNameToFieldId.countryCode &&
+      !isBuiltIn &&
+      isRequired,
+  );
+
+  return (form: HTMLFormElement | null) => {
+    if (!form) return;
+
+    const multipleChoices = Object.fromEntries(
+      [...new FormData(form).entries()]
+        .filter(
+          (fieldEntry): fieldEntry is [string, string] =>
+            fieldEntry[0].includes('custom_multipleChoices-') && typeof fieldEntry[1] === 'string',
+        )
+        .map(([picklistKey, picklistValue]: [string, string]) => {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          const fieldId = picklistKey.split('-')[1]!;
+
+          return [fieldId, picklistValue];
+        }),
+    );
+
+    picklists.forEach(({ entityId: picklistId }) => {
+      const picklistFields = Object.keys(multipleChoices);
+
+      if (picklistFields.includes(picklistId.toString())) {
+        const currentValue = multipleChoices[picklistId];
+
+        validitationSetter((prevValidationState) => ({
+          ...prevValidationState,
+          [picklistId]: (currentValue && currentValue.length > 0) || false,
+        }));
+      }
+    });
+  };
+};
+
 const createTextInputValidationHandler =
   (textInputStateSetter: FieldStateSetFn<FieldState>, textInputState: FieldState) =>
   (e: ChangeEvent<HTMLInputElement>) => {
@@ -45,6 +89,15 @@ const createNumbersInputValidationHandler =
     const validationStatus = valueMissing || typeMismatch || rangeUnderflow || rangeOverflow;
 
     numbersInputStateSetter({ ...numbersInputState, [fieldId]: !validationStatus });
+  };
+
+const createRadioButtonsValidationHandler =
+  (radioButtonsStateSetter: FieldStateSetFn<FieldState>, radioButtonsState: FieldState) =>
+  (e: React.ChangeEvent<HTMLInputElement>) => {
+    const fieldId = Number(e.target.name.split('-')[1]);
+    const { valueMissing } = e.target.validity;
+
+    radioButtonsStateSetter({ ...radioButtonsState, [fieldId]: !valueMissing });
   };
 
 const createDatesValidationHandler =
@@ -121,8 +174,10 @@ const createCountryChangeHandler =
 export {
   createTextInputValidationHandler,
   createPicklistOrTextValidationHandler,
+  createRadioButtonsValidationHandler,
   createPasswordValidationHandler,
   createCountryChangeHandler,
   createNumbersInputValidationHandler,
   createDatesValidationHandler,
+  createPreSubmitPicklistValidationHandler,
 };

--- a/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/edit-address.tsx
+++ b/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/edit-address.tsx
@@ -14,6 +14,7 @@ import {
   NumbersOnly,
   Picklist,
   PicklistOrText,
+  RadioButtons,
   Text,
 } from '~/app/[locale]/(default)/login/register-customer/_components/register-customer-form/fields';
 import { Link } from '~/components/link';
@@ -31,6 +32,8 @@ import {
   createCountryChangeHandler,
   createDatesValidationHandler,
   createNumbersInputValidationHandler,
+  createPreSubmitPicklistValidationHandler,
+  createRadioButtonsValidationHandler,
   createTextInputValidationHandler,
 } from './address-field-handlers';
 import { Address } from './customer-edit-address';
@@ -107,6 +110,8 @@ export const EditAddress = ({
   const [textInputValid, setTextInputValid] = useState<Record<string, boolean>>({});
   const [numbersInputValid, setNumbersInputValid] = useState<Record<string, boolean>>({});
   const [datesValid, setDatesValid] = useState<Record<string, boolean>>({});
+  const [radioButtonsValid, setRadioButtonsValid] = useState<Record<string, boolean>>({});
+  const [picklistValid, setPicklistValid] = useState<Record<string, boolean>>({});
 
   const defaultStates = countries
     .filter((country) => country.code === address.countryCode)
@@ -123,6 +128,10 @@ export const EditAddress = ({
   );
   const handleCountryChange = createCountryChangeHandler(setCountryStates, countries);
   const handleDatesValidation = createDatesValidationHandler(setDatesValid, datesValid);
+  const handleRadioButtonsChange = createRadioButtonsValidationHandler(
+    setRadioButtonsValid,
+    radioButtonsValid,
+  );
 
   const onReCaptchaChange = (token: string | null) => {
     if (!token) {
@@ -134,7 +143,10 @@ export const EditAddress = ({
     setReCaptchaToken(token);
     setReCaptchaValid(true);
   };
-
+  const validatePicklistFields = createPreSubmitPicklistValidationHandler(
+    addressFields,
+    setPicklistValid,
+  );
   const onSubmit = async (formData: FormData) => {
     if (reCaptchaSettings?.isEnabledOnStorefront && !reCaptchaToken) {
       setReCaptchaValid(false);
@@ -187,8 +199,8 @@ export const EditAddress = ({
           <p>{formStatus.message}</p>
         </Message>
       )}
-      <Form action={onSubmit} ref={form}>
-        <div className="grid grid-cols-1 gap-y-3 lg:grid-cols-2 lg:gap-x-6">
+      <Form action={onSubmit} onClick={() => validatePicklistFields(form.current)} ref={form}>
+        <div className="grid grid-cols-1 gap-y-6 lg:grid-cols-2 lg:gap-x-6 lg:gap-y-2">
           {addressFields.map((field) => {
             const fieldId = field.entityId;
             const key = FieldNameToFieldId[fieldId];
@@ -260,24 +272,49 @@ export const EditAddress = ({
                 );
               }
 
-              case 'PicklistFormField':
+              case 'RadioButtonsFormField': {
+                const defaultMultipleChoiceValue =
+                  defaultCustomField?.__typename === `MultipleChoiceFormFieldValue`
+                    ? defaultCustomField.valueEntityId.toString()
+                    : undefined;
+
                 return (
                   <FieldWrapper fieldId={fieldId} key={fieldId}>
-                    <Picklist
-                      defaultValue={
-                        fieldId === FieldNameToFieldId.countryCode ? defaultValue : undefined
-                      }
+                    <RadioButtons
+                      defaultValue={defaultMultipleChoiceValue}
                       field={field}
+                      isValid={radioButtonsValid[fieldId]}
                       name={createFieldName(field, 'address')}
-                      onChange={
-                        fieldId === FieldNameToFieldId.countryCode ? handleCountryChange : undefined
-                      }
-                      options={countries.map(({ name, code }) => {
-                        return { label: name, entityId: code };
-                      })}
+                      onChange={handleRadioButtonsChange}
                     />
                   </FieldWrapper>
                 );
+              }
+
+              case 'PicklistFormField': {
+                const isCountrySelector = fieldId === FieldNameToFieldId.countryCode;
+                const defaultMultipleChoiceValue =
+                  defaultCustomField?.__typename === `MultipleChoiceFormFieldValue`
+                    ? defaultCustomField.valueEntityId.toString()
+                    : undefined;
+                const picklistOptions = isCountrySelector
+                  ? countries.map(({ name, code }) => ({ label: name, entityId: code }))
+                  : field.options;
+
+                return (
+                  <FieldWrapper fieldId={fieldId} key={fieldId}>
+                    <Picklist
+                      defaultValue={isCountrySelector ? defaultValue : defaultMultipleChoiceValue}
+                      field={field}
+                      isValid={picklistValid[fieldId]}
+                      name={createFieldName(field, 'address')}
+                      onChange={isCountrySelector ? handleCountryChange : undefined}
+                      onValidate={setPicklistValid}
+                      options={picklistOptions}
+                    />
+                  </FieldWrapper>
+                );
+              }
 
               case 'PicklistOrTextFormField': {
                 return (

--- a/core/app/[locale]/(default)/account/[tab]/_components/update-settings-form/index.tsx
+++ b/core/app/[locale]/(default)/account/[tab]/_components/update-settings-form/index.tsx
@@ -10,6 +10,8 @@ import {
   DateField,
   FieldWrapper,
   NumbersOnly,
+  Picklist,
+  RadioButtons,
 } from '~/app/[locale]/(default)/login/register-customer/_components/register-customer-form/fields';
 import { Link } from '~/components/link';
 import { Button } from '~/components/ui/button';
@@ -20,6 +22,8 @@ import { getCustomerSettingsQuery } from '../../page-data';
 import {
   createDatesValidationHandler,
   createNumbersInputValidationHandler,
+  createPreSubmitPicklistValidationHandler,
+  createRadioButtonsValidationHandler,
 } from '../addresses-content/address-field-handlers';
 
 import { updateCustomer } from './_actions/update-customer';
@@ -101,6 +105,8 @@ export const UpdateSettingsForm = ({
 
   const [textInputValid, setTextInputValid] = useState<Record<string, boolean>>({});
   const [numbersInputValid, setNumbersInputValid] = useState<Record<string, boolean>>({});
+  const [radioButtonsValid, setRadioButtonsValid] = useState<Record<string, boolean>>({});
+  const [picklistValid, setPicklistValid] = useState<Record<string, boolean>>({});
   const [datesValid, setDatesValid] = useState<Record<string, boolean>>({});
 
   const reCaptchaRef = useRef<ReCaptcha>(null);
@@ -122,6 +128,14 @@ export const UpdateSettingsForm = ({
     numbersInputValid,
   );
   const handleDatesValidation = createDatesValidationHandler(setDatesValid, datesValid);
+  const handleRadioButtonsChange = createRadioButtonsValidationHandler(
+    setRadioButtonsValid,
+    radioButtonsValid,
+  );
+  const validatePicklistFields = createPreSubmitPicklistValidationHandler(
+    customerFields,
+    setPicklistValid,
+  );
 
   const onReCaptchaChange = (token: string | null) => {
     if (!token) {
@@ -167,7 +181,7 @@ export const UpdateSettingsForm = ({
           <p>{formStatus.message}</p>
         </Message>
       )}
-      <Form action={onSubmit} ref={form}>
+      <Form action={onSubmit} onClick={() => validatePicklistFields(form.current)} ref={form}>
         <div className="mb-10 mt-8 grid grid-cols-1 gap-y-6 text-base lg:grid-cols-2 lg:gap-x-6 lg:gap-y-2">
           {addressFields.map((field) => {
             const fieldName = FieldNameToFieldId[field.entityId] ?? '';
@@ -247,6 +261,45 @@ export const UpdateSettingsForm = ({
                         name={createFieldName(field, 'customer')}
                         onChange={handleDatesValidation}
                         onValidate={setDatesValid}
+                      />
+                    </FieldWrapper>
+                  );
+                }
+
+                case 'RadioButtonsFormField': {
+                  const submittedValue =
+                    previouslySubmittedField?.__typename === `MultipleChoiceFormFieldValue`
+                      ? previouslySubmittedField.valueEntityId.toString()
+                      : undefined;
+
+                  return (
+                    <FieldWrapper fieldId={fieldId} key={fieldId}>
+                      <RadioButtons
+                        defaultValue={submittedValue}
+                        field={field}
+                        isValid={radioButtonsValid[fieldId]}
+                        name={createFieldName(field, 'customer')}
+                        onChange={handleRadioButtonsChange}
+                      />
+                    </FieldWrapper>
+                  );
+                }
+
+                case 'PicklistFormField': {
+                  const submittedValue =
+                    previouslySubmittedField?.__typename === `MultipleChoiceFormFieldValue`
+                      ? previouslySubmittedField.valueEntityId.toString()
+                      : undefined;
+
+                  return (
+                    <FieldWrapper fieldId={fieldId} key={fieldId}>
+                      <Picklist
+                        defaultValue={submittedValue}
+                        field={field}
+                        isValid={picklistValid[fieldId]}
+                        name={createFieldName(field, 'customer')}
+                        onValidate={setPicklistValid}
+                        options={field.options}
                       />
                     </FieldWrapper>
                   );

--- a/core/app/[locale]/(default)/login/register-customer/_components/register-customer-form/_actions/register-customer.ts
+++ b/core/app/[locale]/(default)/login/register-customer/_components/register-customer-form/_actions/register-customer.ts
@@ -5,6 +5,8 @@ import {
   registerCustomer as registerCustomerClient,
 } from '~/client/mutations/register-customer';
 
+import { parseAccountFormData } from '../fields/parse-fields';
+
 interface RegisterCustomerForm {
   formData: FormData;
   reCaptchaToken?: string;
@@ -21,26 +23,7 @@ const isRegisterCustomerInput = (data: unknown): data is Input => {
 export const registerCustomer = async ({ formData, reCaptchaToken }: RegisterCustomerForm) => {
   formData.delete('customer-confirmPassword');
 
-  const parsedData = Array.from(formData.entries()).reduce<{
-    [key: string]: FormDataEntryValue | Record<string, FormDataEntryValue>;
-    address: Record<string, FormDataEntryValue>;
-  }>(
-    (acc, [name, value]) => {
-      const key = name.split('-').at(-1) ?? '';
-      const sections = name.split('-').slice(0, -1);
-
-      if (sections.includes('customer')) {
-        acc[key] = value;
-      }
-
-      if (sections.includes('address')) {
-        acc.address[key] = value;
-      }
-
-      return acc;
-    },
-    { address: {} },
-  );
+  const parsedData = parseAccountFormData(formData);
 
   if (!isRegisterCustomerInput(parsedData)) {
     return {

--- a/core/app/[locale]/(default)/login/register-customer/_components/register-customer-form/fields/index.ts
+++ b/core/app/[locale]/(default)/login/register-customer/_components/register-customer-form/fields/index.ts
@@ -2,6 +2,7 @@ export * from './date';
 export * from './password';
 export * from './text';
 export * from './numbers-only';
+export * from './radio-buttons';
 export * from './picklist';
 export * from './picklist-or-text';
 export * from './shared/field-wrapper';

--- a/core/app/[locale]/(default)/login/register-customer/_components/register-customer-form/fields/picklist.tsx
+++ b/core/app/[locale]/(default)/login/register-customer/_components/register-customer-form/fields/picklist.tsx
@@ -1,4 +1,6 @@
-import { Field, FieldControl, FieldLabel } from '~/components/ui/form';
+import { useTranslations } from 'next-intl';
+
+import { Field, FieldControl, FieldLabel, FieldMessage } from '~/components/ui/form';
 import { Select, SelectContent, SelectItem } from '~/components/ui/select';
 
 import { AddressFields } from '..';
@@ -10,15 +12,45 @@ type PicklistType = Extract<
   { __typename: 'PicklistFormField' }
 >;
 
+type PicklistValidationState = Record<string, boolean>;
+
 interface PicklistProps {
   defaultValue?: string;
   field: PicklistType;
   name: string;
+  isValid?: boolean;
   onChange?: (value: string) => void;
+  onValidate?: (
+    state:
+      | PicklistValidationState
+      | ((prevState: PicklistValidationState) => PicklistValidationState),
+  ) => void;
   options: Array<{ label: string; entityId: string | number }>;
 }
 
-export const Picklist = ({ defaultValue, field, name, onChange, options }: PicklistProps) => {
+export const Picklist = ({
+  defaultValue,
+  field,
+  name,
+  isValid,
+  onChange,
+  onValidate,
+  options,
+}: PicklistProps) => {
+  const t = useTranslations('Account.Register.validationMessages');
+  const validationError = field.isRequired && isValid === false;
+  const validateAgainstMissingValue =
+    !field.isBuiltIn && field.isRequired
+      ? (value: string) => {
+          if (onValidate) {
+            onValidate((prevValidityState) => ({
+              ...prevValidityState,
+              [field.entityId.toString()]: value.length > 0,
+            }));
+          }
+        }
+      : undefined;
+
   return (
     <Field className="relative space-y-2 pb-7" name={name}>
       <FieldLabel htmlFor={`field-${field.entityId}`} isRequired={field.isRequired}>
@@ -29,9 +61,14 @@ export const Picklist = ({ defaultValue, field, name, onChange, options }: Pickl
           aria-label={field.choosePrefix}
           defaultValue={defaultValue}
           id={`field-${field.entityId}`}
-          onValueChange={field.entityId === FieldNameToFieldId.countryCode ? onChange : undefined}
+          onValueChange={
+            field.entityId === FieldNameToFieldId.countryCode
+              ? onChange
+              : validateAgainstMissingValue
+          }
           placeholder={field.choosePrefix}
           required={field.isRequired}
+          variant={isValid === false ? 'error' : undefined}
         >
           <SelectContent>
             {options.map(({ entityId, label }) => (
@@ -42,6 +79,11 @@ export const Picklist = ({ defaultValue, field, name, onChange, options }: Pickl
           </SelectContent>
         </Select>
       </FieldControl>
+      {validationError && (
+        <FieldMessage className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-error-secondary">
+          {t('empty')}
+        </FieldMessage>
+      )}
     </Field>
   );
 };

--- a/core/app/[locale]/(default)/login/register-customer/_components/register-customer-form/fields/radio-buttons.tsx
+++ b/core/app/[locale]/(default)/login/register-customer/_components/register-customer-form/fields/radio-buttons.tsx
@@ -1,0 +1,70 @@
+import { useTranslations } from 'next-intl';
+import { ChangeEvent } from 'react';
+
+import { Field, FieldLabel, FieldMessage } from '~/components/ui/form';
+import { Label } from '~/components/ui/label';
+import { RadioGroup, RadioItem } from '~/components/ui/radio-group';
+
+import { AddressFields } from '..';
+
+type RadioButtonsType = Extract<
+  NonNullable<AddressFields>[number],
+  { __typename: 'RadioButtonsFormField' }
+>;
+
+interface RadioButtonsTypeProps {
+  defaultValue?: string;
+  field: RadioButtonsType;
+  isValid?: boolean;
+  name: string;
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+}
+
+export const RadioButtons = ({
+  defaultValue,
+  field,
+  isValid,
+  name,
+  onChange,
+}: RadioButtonsTypeProps) => {
+  const t = useTranslations('Account.Register.validationMessages');
+  const validationError = field.isRequired && isValid === false;
+
+  return (
+    <Field className="relative space-y-2 pb-7" name={name}>
+      <FieldLabel htmlFor={`field-${field.entityId}`} isRequired={field.isRequired}>
+        {field.label}
+      </FieldLabel>
+      <RadioGroup
+        aria-label={name}
+        defaultValue={defaultValue}
+        name={name}
+        onChange={onChange}
+        onInvalid={onChange}
+        required={field.isRequired}
+      >
+        {field.options.map((option) => {
+          const itemId = option.entityId;
+
+          return (
+            <div className="mb-2 flex" key={itemId}>
+              <RadioItem
+                id={`${itemId}`}
+                value={`${itemId}`}
+                variant={validationError ? 'error' : undefined}
+              />
+              <Label className="w-full cursor-pointer ps-4 font-normal" htmlFor={`${itemId}`}>
+                <p className="inline-flex w-full justify-between">{option.label}</p>
+              </Label>
+            </div>
+          );
+        })}
+      </RadioGroup>
+      {validationError && (
+        <FieldMessage className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-error-secondary">
+          {t('empty')}
+        </FieldMessage>
+      )}
+    </Field>
+  );
+};

--- a/core/app/[locale]/(default)/login/register-customer/_components/register-customer-form/fields/utils.ts
+++ b/core/app/[locale]/(default)/login/register-customer/_components/register-customer-form/fields/utils.ts
@@ -29,9 +29,6 @@ export enum FieldTypeToFieldInput {
   'TextFormField' = 'texts',
   'RadioButtonsFormField' = 'multipleChoices',
   'MultilineTextFormField' = 'multilineTexts',
-  // TODO: add them later
-  'PicklistFormField' = 'mocked_PicklistFormField',
-  'PicklistOrTextFormField' = 'mocked_PicklistOrTextFormField',
 }
 
 export const CUSTOMER_FIELDS_TO_EXCLUDE = [
@@ -54,8 +51,11 @@ export const createFieldName = (
   const isCustomField = !isBuiltIn;
   let secondFieldType = fieldOrigin;
 
-  if (isCustomField) {
-    return `custom_${FieldTypeToFieldInput[fieldType]}-${fieldId}`;
+  if (isCustomField && fieldType !== 'PicklistOrTextFormField') {
+    const customFieldInputType =
+      fieldType === 'PicklistFormField' ? 'multipleChoices' : FieldTypeToFieldInput[fieldType];
+
+    return `custom_${customFieldInputType}-${fieldId}`;
   }
 
   if (fieldOrigin === 'address') {

--- a/core/components/ui/date-picker/date-picker.tsx
+++ b/core/components/ui/date-picker/date-picker.tsx
@@ -15,7 +15,7 @@ type DatePickerProps = Omit<InputProps, 'defaultValue' | 'onSelect'> & {
   disabledDays?: DayPickerSingleProps['disabled'];
 };
 
-export const DatePicker = React.forwardRef<React.ElementRef<'ref'>, DatePickerProps>(
+export const DatePicker = React.forwardRef<React.ElementRef<'div'>, DatePickerProps>(
   (
     {
       defaultValue,

--- a/core/components/ui/date-picker/date-picker.tsx
+++ b/core/components/ui/date-picker/date-picker.tsx
@@ -15,7 +15,7 @@ type DatePickerProps = Omit<InputProps, 'defaultValue' | 'onSelect'> & {
   disabledDays?: DayPickerSingleProps['disabled'];
 };
 
-export const DatePicker = React.forwardRef<React.ElementRef<'div'>, DatePickerProps>(
+export const DatePicker = React.forwardRef<React.ElementRef<'ref'>, DatePickerProps>(
   (
     {
       defaultValue,


### PR DESCRIPTION
## What/Why?
This PR adds `RadioButtons` and `Picklist` Fields (multipleChoises) for Address & Account forms.

## Testing
locally
<img width="534" alt="Screenshot 2024-07-02 at 14 17 45" src="https://github.com/bigcommerce/catalyst/assets/67792608/c9424c6f-9501-40a0-91d2-c06585d10906">

<img width="550" alt="Screenshot 2024-07-02 at 14 17 24" src="https://github.com/bigcommerce/catalyst/assets/67792608/89037c5a-3533-4be2-bfc0-2643a5394ee6">


https://github.com/bigcommerce/catalyst/assets/67792608/952d86fe-928f-4b61-b6b8-ecd729ef8004

