### PR TITLE
fix(core): make selected account tab visible for user by default on mobile devices

### DIFF
--- a/.changeset/soft-moles-judge.md
+++ b/.changeset/soft-moles-judge.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+make selected account tab visible on mobile devices

--- a/core/app/[locale]/(default)/account/[tab]/_components/account-status-provider.tsx
+++ b/core/app/[locale]/(default)/account/[tab]/_components/account-status-provider.tsx
@@ -1,10 +1,19 @@
 'use client';
 
-import { createContext, ReactNode, useContext, useEffect, useState } from 'react';
+import {
+  createContext,
+  ReactNode,
+  RefObject,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 
 import { State as AccountState } from '../_actions/submit-customer-change-password-form';
 
 export const AccountStatusContext = createContext<{
+  activeTabRef: RefObject<HTMLAnchorElement>;
   accountState: AccountState;
   setAccountState: (state: AccountState | ((prevState: AccountState) => AccountState)) => void;
 } | null>(null);
@@ -17,6 +26,7 @@ export const AccountStatusProvider = ({
   isPermanentBanner?: boolean;
 }) => {
   const [accountState, setAccountState] = useState<AccountState>({ status: 'idle', message: '' });
+  const activeTabRef = useRef<HTMLAnchorElement>(null);
 
   useEffect(() => {
     if (accountState.status !== 'idle' && !isPermanentBanner) {
@@ -27,7 +37,7 @@ export const AccountStatusProvider = ({
   }, [accountState, setAccountState, isPermanentBanner]);
 
   return (
-    <AccountStatusContext.Provider value={{ accountState, setAccountState }}>
+    <AccountStatusContext.Provider value={{ accountState, setAccountState, activeTabRef }}>
       {children}
     </AccountStatusContext.Provider>
   );

--- a/core/app/[locale]/(default)/account/[tab]/_components/account-tabs.tsx
+++ b/core/app/[locale]/(default)/account/[tab]/_components/account-tabs.tsx
@@ -1,12 +1,14 @@
 'use client';
 
 import { useTranslations } from 'next-intl';
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, useEffect } from 'react';
 
 import { Link } from '~/components/link';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs';
 
 import { TabType } from '../layout';
+
+import { useAccountStatusContext } from './account-status-provider';
 
 interface Props extends PropsWithChildren {
   tabs: TabType[];
@@ -15,6 +17,17 @@ interface Props extends PropsWithChildren {
 
 export const AccountTabs = ({ children, activeTab, tabs }: Props) => {
   const t = useTranslations('Account.Home');
+  const { activeTabRef } = useAccountStatusContext();
+
+  useEffect(() => {
+    if (activeTabRef.current) {
+      activeTabRef.current.scrollIntoView({
+        behavior: 'smooth',
+        block: 'nearest',
+        inline: 'center',
+      });
+    }
+  }, [activeTab, activeTabRef]);
 
   return (
     <Tabs activationMode="manual" defaultValue={activeTab}>
@@ -26,6 +39,7 @@ export const AccountTabs = ({ children, activeTab, tabs }: Props) => {
               href={`/account/${tab}`}
               prefetch="viewport"
               prefetchKind="full"
+              ref={activeTab === tab ? activeTabRef : null}
             >
               {tab === 'recently-viewed' ? t('recentlyViewed') : t(tab)}
             </Link>


### PR DESCRIPTION
## What/Why?
This PR makes selected account tab visible for user by default on Mobile devices even after reloading the page.

## Testing
locally

**before:**

https://github.com/bigcommerce/catalyst/assets/82589781/dc82a192-ef8c-4131-ab55-9e60381590e5

**after:**

https://github.com/bigcommerce/catalyst/assets/82589781/25e83dce-6b51-43b5-b67f-691a10b68328
