### PR TITLE
Add sitemap index on /sitemap.xml

### DIFF
--- a/.changeset/real-ladybugs-complain.md
+++ b/.changeset/real-ladybugs-complain.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Added /sitemap.xml as a proxy to hosted BigCommerce sitemap

--- a/core/app/robots.ts
+++ b/core/app/robots.ts
@@ -1,0 +1,27 @@
+import type { MetadataRoute } from 'next';
+
+// Disallow routes that have no SEO value or should not be indexed
+const disallow = ['/cart', '/account'];
+
+// Robots.txt config https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots#generate-a-robots-file
+const robotsConfig: MetadataRoute.Robots = {
+  rules: [
+    {
+      userAgent: '*',
+      allow: ['/'],
+      disallow,
+    },
+  ],
+};
+
+// Infer base URL from environment variables
+const baseUrl = process.env.PRODUCTION_BASE_URL || process.env.NEXTAUTH_URL;
+
+// Set sitemap URL if base URL is defined, as sitemap URL must be an absolute URL
+if (baseUrl) {
+  robotsConfig.sitemap = `${baseUrl}/sitemap.xml`;
+}
+
+export default function robots(): MetadataRoute.Robots {
+  return robotsConfig;
+}

--- a/core/app/robots.txt
+++ b/core/app/robots.txt
@@ -1,2 +1,0 @@
-User-Agent: *
-Allow: /

--- a/core/app/sitemap.xml/route.ts
+++ b/core/app/sitemap.xml/route.ts
@@ -1,0 +1,14 @@
+/* eslint-disable check-file/folder-naming-convention */
+/*
+ * Proxy to the existing BigCommerce sitemap index on the canonical URL
+ */
+
+const storeHash = process.env.BIGCOMMERCE_STORE_HASH;
+const channelId = process.env.BIGCOMMERCE_CHANNEL_ID;
+const canonicalDomain: string = process.env.BIGCOMMERCE_GRAPHQL_API_DOMAIN ?? 'mybigcommerce.com';
+
+const remoteSitemapUrl = `https://store-${storeHash}-${channelId}.${canonicalDomain}/xmlsitemap.php`;
+
+export const GET = async () => fetch(remoteSitemapUrl);
+
+export const runtime = 'edge';

--- a/core/app/xmlsitemap.php/route.ts
+++ b/core/app/xmlsitemap.php/route.ts
@@ -1,0 +1,13 @@
+/* eslint-disable check-file/folder-naming-convention */
+import { permanentRedirect } from 'next/navigation';
+
+/*
+ * This route is used to redirect the legacy Stencil sitemap that lives on /xmlsitemap.php
+ * to Catalyst's new location on /sitemap.xml
+ * This is for the benefit of websites who already have a sitemap submitted to Webmaster Tools
+ * on /xmlsitemap.php
+ */
+
+export const GET = () => permanentRedirect('/sitemap.xml');
+
+export const runtime = 'edge';

--- a/core/middleware.ts
+++ b/core/middleware.ts
@@ -16,7 +16,8 @@ export const config = {
      * - admin (admin panel)
      * - sitemap.xml (sitemap route)
      * - xmlsitemap.php (legacy sitemap route)
+     * - robots.txt (robots route)
      */
-    '/((?!api|admin|_next/static|_next/image|_vercel|favicon.ico|xmlsitemap.php|sitemap.xml).*)',
+    '/((?!api|admin|_next/static|_next/image|_vercel|favicon.ico|xmlsitemap.php|sitemap.xml|robots.txt).*)',
   ],
 };

--- a/core/middleware.ts
+++ b/core/middleware.ts
@@ -13,7 +13,10 @@ export const config = {
      * - _next/image (image optimization files)
      * - _vercel (vercel internals, eg: web vitals)
      * - favicon.ico (favicon file)
+     * - admin (admin panel)
+     * - sitemap.xml (sitemap route)
+     * - xmlsitemap.php (legacy sitemap route)
      */
-    '/((?!api|admin|_next/static|_next/image|_vercel|favicon.ico).*)',
+    '/((?!api|admin|_next/static|_next/image|_vercel|favicon.ico|xmlsitemap.php|sitemap.xml).*)',
   ],
 };


### PR DESCRIPTION
## What/Why?
Adds a new sitemap route on /sitemap.xml which proxies to the upstream hosted sitemap on the BigCommerce server.

For users who wish to use 100% of BigCommerce's URL capabilities, this is a complete sitemap.

In the future, we may iterate on this to generate the sitemap in code, using this BC sitemap data as an input but allowing the output to be customized in code.

## Testing
Awaiting a server-side change before E2E testing.