### PR TITLE
Remove generic defaults for meta information

### DIFF
--- a/core/app/[locale]/layout.tsx
+++ b/core/app/[locale]/layout.tsx
@@ -37,14 +37,13 @@ export async function generateMetadata(): Promise<Metadata> {
     fetchOptions: { next: { revalidate } },
   });
 
-  const title = data.site.settings?.storeName ?? 'Catalyst Store';
+  const title = data.site.settings?.storeName ?? '';
 
   return {
     title: {
       template: `${title} - %s`,
       default: title,
     },
-    description: 'Example store built with Catalyst',
     other: {
       platform: 'bigcommerce.catalyst',
       build_sha: process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA ?? '',


### PR DESCRIPTION
## What/Why?
It's better to return empty strings than bad defaults for this meta information, so I'm removing these generic references to Catalyst in favor of empty strings.

For the case of the page title - stores will generally have a Store Name set (it's part of the trial form), so the case that this fails to return something is very unlikely.

In the case of meta description, we will update the API to return this information and update this file once again when that's ready. It can be specified manually by end users until that time (and it already pulls from the API on most entity pages like products, etc).

## Testing
Preview URL