### PR TITLE
feat(core): allow setting a channel id in kv

### DIFF
--- a/.changeset/dry-bears-type.md
+++ b/.changeset/dry-bears-type.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Allow setting a channel id to be used in kv store.

--- a/core/middlewares/with-routes.ts
+++ b/core/middlewares/with-routes.ts
@@ -71,6 +71,8 @@ let locale: string;
 const updateRouteCache = async (pathname: string, event: NextFetchEvent): Promise<RouteCache> => {
   const channelId = getChannelIdFromLocale(locale);
 
+  kv.setChannelId(channelId);
+
   const routeCache: RouteCache = {
     route: await getRoute(pathname, channelId),
     expiryTime: Date.now() + 1000 * 60 * 30, // 30 minutes
@@ -83,6 +85,8 @@ const updateRouteCache = async (pathname: string, event: NextFetchEvent): Promis
 
 const updateStatusCache = async (event: NextFetchEvent): Promise<StorefrontStatusCache> => {
   const channelId = getChannelIdFromLocale(locale);
+
+  kv.setChannelId(channelId);
 
   const status = await getStoreStatus(channelId);
 
@@ -120,6 +124,10 @@ const clearLocaleFromPath = (path: string) => {
 
 const getRouteInfo = async (request: NextRequest, event: NextFetchEvent) => {
   try {
+    const channelId = getChannelIdFromLocale(locale);
+
+    kv.setChannelId(channelId);
+
     const pathname = clearLocaleFromPath(request.nextUrl.pathname);
 
     let [routeCache, statusCache] = await kv.mget<RouteCache | StorefrontStatusCache>(


### PR DESCRIPTION
## What/Why?
With multi-channel work, we need to be able to get kv's for each specific channel. With this change we can set a channel id or use default as before.

## Testing
Locally each channel has individual kv pairs.