### PR TITLE
fix: use system environment variables for robots

### DIFF
--- a/.changeset/giant-carrots-peel.md
+++ b/.changeset/giant-carrots-peel.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Uses the deployment URL for the robots.txt sitemap field rather than another environment variable.

--- a/core/app/robots.ts
+++ b/core/app/robots.ts
@@ -1,27 +1,30 @@
 import type { MetadataRoute } from 'next';
 
+function parseUrl(url?: string): URL {
+  let incomingUrl = '';
+  const defaultUrl = new URL('http://localhost:3000/');
+
+  if (url && !url.startsWith('http')) {
+    incomingUrl = `https://${url}`;
+  }
+
+  return new URL(incomingUrl || defaultUrl);
+}
+
 // Disallow routes that have no SEO value or should not be indexed
 const disallow = ['/cart', '/account'];
 
 // Robots.txt config https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots#generate-a-robots-file
-const robotsConfig: MetadataRoute.Robots = {
-  rules: [
-    {
-      userAgent: '*',
-      allow: ['/'],
-      disallow,
-    },
-  ],
-};
-
-// Infer base URL from environment variables
-const baseUrl = process.env.PRODUCTION_BASE_URL || process.env.NEXTAUTH_URL;
-
-// Set sitemap URL if base URL is defined, as sitemap URL must be an absolute URL
-if (baseUrl) {
-  robotsConfig.sitemap = `${baseUrl}/sitemap.xml`;
-}
-
 export default function robots(): MetadataRoute.Robots {
-  return robotsConfig;
+  return {
+    // Infer base URL from environment variables
+    sitemap: parseUrl(process.env.NEXTAUTH_URL || process.env.VERCEL_URL || '').origin,
+    rules: [
+      {
+        userAgent: '*',
+        allow: ['/'],
+        disallow,
+      },
+    ],
+  };
 }


### PR DESCRIPTION
## What/Why?
Uses the deployment URL for robots.txt.

## Testing
https://catalyst-latest-git-fix-robots-bigcommerce-platform.vercel.app/robots.txt

![Screenshot 2024-07-09 at 17 09 52](https://github.com/bigcommerce/catalyst/assets/10539418/3c3c1893-b4f6-4fe2-be87-33841fd854df)
