### PR TITLE
fix(core): issue with imports in change password form

### DIFF
--- a/core/app/[locale]/(default)/account/[tab]/_actions/submit-customer-change-password-form.ts
+++ b/core/app/[locale]/(default)/account/[tab]/_actions/submit-customer-change-password-form.ts
@@ -2,8 +2,13 @@
 
 import { z } from 'zod';
 
-import { CustomerChangePasswordSchema } from '~/client/mutations/submit-change-password';
+import { ChangePasswordFieldsSchema } from '~/client/mutations/submit-change-password';
 import { submitCustomerChangePassword } from '~/client/mutations/submit-customer-change-password';
+
+export const CustomerChangePasswordSchema = ChangePasswordFieldsSchema.omit({
+  customerId: true,
+  customerToken: true,
+});
 
 export interface State {
   status: 'idle' | 'error' | 'success';

--- a/core/app/[locale]/(default)/account/[tab]/_components/change-password-form.tsx
+++ b/core/app/[locale]/(default)/account/[tab]/_components/change-password-form.tsx
@@ -5,7 +5,6 @@ import { ChangeEvent, useEffect, useRef, useState } from 'react';
 import { useFormState, useFormStatus } from 'react-dom';
 import { z } from 'zod';
 
-import { CustomerChangePasswordSchema } from '~/client/mutations/submit-change-password';
 import { logout } from '~/components/header/_actions/logout';
 import { Link } from '~/components/link';
 import { Button } from '~/components/ui/button';
@@ -21,7 +20,10 @@ import { Input } from '~/components/ui/input';
 import { Message } from '~/components/ui/message';
 import { useRouter } from '~/navigation';
 
-import { submitCustomerChangePasswordForm } from '../_actions/submit-customer-change-password-form';
+import {
+  CustomerChangePasswordSchema,
+  submitCustomerChangePasswordForm,
+} from '../_actions/submit-customer-change-password-form';
 
 type Passwords = z.infer<typeof CustomerChangePasswordSchema>;
 

--- a/core/client/mutations/submit-change-password.ts
+++ b/core/client/mutations/submit-change-password.ts
@@ -3,17 +3,12 @@ import { z } from 'zod';
 import { client } from '..';
 import { graphql, VariablesOf } from '../graphql';
 
-const ChangePasswordFieldsSchema = z.object({
+export const ChangePasswordFieldsSchema = z.object({
   customerId: z.string(),
   customerToken: z.string(),
   currentPassword: z.string().min(1),
   newPassword: z.string().min(1),
   confirmPassword: z.string().min(1),
-});
-
-export const CustomerChangePasswordSchema = ChangePasswordFieldsSchema.omit({
-  customerId: true,
-  customerToken: true,
 });
 
 export const ChangePasswordSchema = ChangePasswordFieldsSchema.omit({


### PR DESCRIPTION
## What/Why?
Due to recent changes, change password form was erroring out because it's a client component importing a schema from a file with a our `client` defined within and it would throw an error because it can't read from `env` file.

![Screenshot 2024-07-10 at 11 31 11 AM](https://github.com/bigcommerce/catalyst/assets/196129/94a38c03-0872-4478-8d5d-253ffdc53f93)

This fixes the issue by moving around the schema definitions so that it doesn't clash when importing in a client component.

## Testing
Locally it doesn't error.