### PR TITLE
Switch CLI to generate multi-channel tokens

### DIFF
--- a/.changeset/green-keys-tickle.md
+++ b/.changeset/green-keys-tickle.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": minor
+---
+
+Generate multi-channel GraphQL Storefront API tokens on catalyst provisioning

--- a/packages/create-catalyst/src/commands/create.ts
+++ b/packages/create-catalyst/src/commands/create.ts
@@ -226,7 +226,7 @@ export const create = new Command('create')
 
         const {
           data: { token },
-        } = await bc.customerImpersonationToken(channelId);
+        } = await bc.customerImpersonationToken();
 
         customerImpersonationToken = token;
       }

--- a/packages/create-catalyst/src/commands/init.ts
+++ b/packages/create-catalyst/src/commands/init.ts
@@ -117,7 +117,7 @@ export const init = new Command('init')
 
       const {
         data: { token },
-      } = await bc.customerImpersonationToken(channelId);
+      } = await bc.customerImpersonationToken();
 
       customerImpersonationToken = token;
     }

--- a/packages/create-catalyst/src/utils/https.ts
+++ b/packages/create-catalyst/src/utils/https.ts
@@ -228,11 +228,11 @@ export class Https {
     }
   }
 
-  async customerImpersonationToken(channelId: number) {
+  async customerImpersonationToken() {
     const res = await this.api('/v3/storefront/api-token-customer-impersonation', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ expires_at: 2147483647, channel_id: channelId }),
+      body: JSON.stringify({ expires_at: 2147483647, channel_ids: [] }),
     });
 
     if (!res.ok) {


### PR DESCRIPTION
## What/Why?
Switch the `create-catalyst` CLI to generate multi-channel GraphQL tokens so that a given catalyst storefront can serve multiple channels

## Testing
Manually by @matthewvolk 