### PR TITLE
fix(core): add minor changes to address form layout

### DIFF
--- a/.changeset/empty-students-scream.md
+++ b/.changeset/empty-students-scream.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+add minor changes to address form layout

--- a/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/add-address.tsx
+++ b/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/add-address.tsx
@@ -149,7 +149,7 @@ export const AddAddress = ({
         </Message>
       )}
       <Form action={onSubmit} ref={form}>
-        <div className="grid grid-cols-1 gap-y-6 lg:grid-cols-2 lg:gap-x-6 lg:gap-y-2">
+        <div className="grid grid-cols-1 gap-y-3 lg:grid-cols-2 lg:gap-x-6">
           {addressFields.map((field) => {
             switch (field.__typename) {
               case 'TextFormField': {

--- a/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/edit-address.tsx
+++ b/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/edit-address.tsx
@@ -186,7 +186,7 @@ export const EditAddress = ({
         </Message>
       )}
       <Form action={onSubmit} ref={form}>
-        <div className="grid grid-cols-1 gap-y-6 lg:grid-cols-2 lg:gap-x-6 lg:gap-y-2">
+        <div className="grid grid-cols-1 gap-y-3 lg:grid-cols-2 lg:gap-x-6">
           {addressFields.map((field) => {
             const key = FieldNameToFieldId[field.entityId];
 

--- a/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/index.tsx
+++ b/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/index.tsx
@@ -34,7 +34,7 @@ export const AddressesContent = async ({
   if (customerAction === 'add-new-address') {
     return (
       <div className="mx-auto mb-14 lg:w-2/3">
-        <h1 className="my-8 text-3xl font-black lg:text-4xl">{t('newAddress')}</h1>
+        <h1 className="mb-8 text-3xl font-black lg:text-4xl">{t('newAddress')}</h1>
         <CustomerNewAddress />
       </div>
     );
@@ -47,7 +47,7 @@ export const AddressesContent = async ({
 
     return (
       <div className="mx-auto mb-14 lg:w-2/3">
-        <h1 className="my-8 text-3xl font-black lg:text-4xl">{t('editAddress')}</h1>
+        <h1 className="mb-8 text-3xl font-black lg:text-4xl">{t('editAddress')}</h1>
         {activeAddress && Object.keys(activeAddress).length > 0 ? (
           <CustomerEditAddress address={activeAddress} isAddressRemovable={addresses.length > 1} />
         ) : null}


### PR DESCRIPTION
## What/Why?
The PR adds changes to address form layout like:
- gap between form elements reduced to `gap-y-3`
- removing top margin on heading;

## Testing
locally

<img width="1043" alt="Screenshot 2024-07-11 at 14 39 26" src="https://github.com/bigcommerce/catalyst/assets/67792608/1eae9b78-5083-4348-b9f1-b8892d2ff443">
<img width="658" alt="Screenshot 2024-07-11 at 14 40 33" src="https://github.com/bigcommerce/catalyst/assets/67792608/c32e81a0-7f64-41b7-b8d9-cec7cd701329">

