### PR TITLE
fix(core): adds missing error field on update customer mutation

### DIFF
--- a/.changeset/selfish-insects-rule.md
+++ b/.changeset/selfish-insects-rule.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Fixes a missing GraphQL field for the updateCustomer mutation.

--- a/core/client/mutations/update-customer.ts
+++ b/core/client/mutations/update-customer.ts
@@ -13,6 +13,9 @@ const UPDATE_CUSTOMER_MUTATION = graphql(`
         }
         errors {
           __typename
+          ... on UnexpectedUpdateCustomerError {
+            message
+          }
           ... on EmailAlreadyInUseError {
             message
           }


### PR DESCRIPTION
## What/Why?
Looks like a new field for errors was added to the API for the updated customer mutation. This PR fixes by adding that field fragment to the query.

See the broken build: https://github.com/bigcommerce/catalyst/actions/runs/9935948451/job/27443143789

## Testing
See CI.