### PR TITLE
Move sitemap fetching into the client

### DIFF
--- a/.changeset/afraid-coats-play.md
+++ b/.changeset/afraid-coats-play.md
@@ -1,0 +1,6 @@
+---
+"@bigcommerce/catalyst-client": minor
+"@bigcommerce/catalyst-core": patch
+---
+
+Move Sitemap Index fetching into the client & normalize user agents

--- a/core/app/sitemap.xml/route.ts
+++ b/core/app/sitemap.xml/route.ts
@@ -3,12 +3,16 @@
  * Proxy to the existing BigCommerce sitemap index on the canonical URL
  */
 
-const storeHash = process.env.BIGCOMMERCE_STORE_HASH;
-const channelId = process.env.BIGCOMMERCE_CHANNEL_ID;
-const canonicalDomain: string = process.env.BIGCOMMERCE_GRAPHQL_API_DOMAIN ?? 'mybigcommerce.com';
+import { client } from '~/client';
 
-const remoteSitemapUrl = `https://store-${storeHash}-${channelId}.${canonicalDomain}/xmlsitemap.php`;
+export const GET = async () => {
+  const sitemapIndex = await client.fetchSitemapIndex();
 
-export const GET = async () => fetch(remoteSitemapUrl);
+  return new Response(sitemapIndex, {
+    headers: {
+      'Content-Type': 'application/xml',
+    },
+  });
+};
 
 export const runtime = 'edge';

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -107,7 +107,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
 
   async fetchAvailableCountries() {
     const response = await fetch(
-      `https://api.bigcommerce.com/stores/${this.config.storeHash}/v2/countries?limit=250`,
+      `https://${adminApiHostname}/stores/${this.config.storeHash}/v2/countries?limit=250`,
       {
         method: 'GET',
         headers: {
@@ -128,7 +128,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
 
   async fetchCountryStates(id: number) {
     const response = await fetch(
-      `https://api.bigcommerce.com/stores/${this.config.storeHash}/v2/countries/${id}/states?limit=60`,
+      `https://${adminApiHostname}/stores/${this.config.storeHash}/v2/countries/${id}/states?limit=60`,
       {
         method: 'GET',
         headers: {
@@ -149,7 +149,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
 
   async fetchShippingZones() {
     const response = await fetch(
-      `https://api.bigcommerce.com/stores/${this.config.storeHash}/v2/shipping/zones`,
+      `https://${adminApiHostname}/stores/${this.config.storeHash}/v2/shipping/zones`,
       {
         method: 'GET',
         headers: {
@@ -190,7 +190,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
   private async getCanonicalUrl(channelId?: string) {
     const resolvedChannelId = channelId ?? (await this.getChannelId(this.defaultChannelId));
 
-    return `https://store-${this.config.storeHash}-${resolvedChannelId}.mybigcommerce.com`;
+    return `https://store-${this.config.storeHash}-${resolvedChannelId}.${graphqlApiDomain}`;
   }
 
   private async getGraphQLEndpoint(channelId?: string) {


### PR DESCRIPTION
## What/Why?
Moves sitemap index fetching into the client so it gets the benefits of everything the client offers (such as user agent), as well as making the client more useful within other systems who may also wish to use a sitemap.

I fixed some missing user agents on admin API requests while I was at it and also fixed hardcoded hostnames.

## Testing
Preview build + server logs