### PR TITLE
refactor: message component

### DIFF
--- a/core/components/ui/message/message.tsx
+++ b/core/components/ui/message/message.tsx
@@ -1,32 +1,28 @@
-import { cva } from 'class-variance-authority';
 import { AlertCircle, Check, Info } from 'lucide-react';
-import { ComponentPropsWithRef, ElementRef, forwardRef } from 'react';
+import { ComponentPropsWithoutRef } from 'react';
 
 import { cn } from '~/lib/utils';
 
-const messageVariants = cva('flex w-full gap-x-2.5 justify-start p-3 text-base', {
-  variants: {
-    variant: {
-      info: 'bg-secondary/[.15] [&>svg]:text-primary',
-      success: 'bg-success-secondary/[.15] [&>svg]:text-success',
-      error: 'bg-error-secondary/[.15] [&>svg]:text-error',
-    },
-  },
-});
-
-interface MessageProps extends ComponentPropsWithRef<'div'> {
+interface Props extends ComponentPropsWithoutRef<'div'> {
   readonly variant?: 'info' | 'error' | 'success';
 }
 
-export const Message = forwardRef<ElementRef<'div'>, MessageProps>(
-  ({ className, children, variant = 'info', ...props }, ref) => (
-    <div className={cn(messageVariants({ variant, className }))} ref={ref} {...props}>
-      {variant === 'info' && <Info className="flex-none" />}
-      {variant === 'error' && <AlertCircle className="flex-none" />}
-      {variant === 'success' && <Check className="flex-none" />}
-      {children}
-    </div>
-  ),
+const Message = ({ className, children, variant = 'info', ...props }: Props) => (
+  <div
+    className={cn(
+      'flex w-full justify-start gap-x-2.5 p-3 text-base',
+      variant === 'info' && 'bg-secondary/[.15] [&>svg]:text-primary',
+      variant === 'success' && 'bg-success-secondary/[.15] [&>svg]:text-success',
+      variant === 'error' && 'bg-error-secondary/[.15] [&>svg]:text-error',
+      className,
+    )}
+    {...props}
+  >
+    {variant === 'info' && <Info className="flex-none" />}
+    {variant === 'error' && <AlertCircle className="flex-none" />}
+    {variant === 'success' && <Check className="flex-none" />}
+    {children}
+  </div>
 );
 
-Message.displayName = 'Message';
+export { Message };


### PR DESCRIPTION
## What/Why?
Refactors message component, removes `cva` and `forwardRef`

## Testing
![rcpysHMV@2x](https://github.com/user-attachments/assets/fcbf934f-62f3-46cd-875c-88410b82ecd9)
