### PR TITLE
refactor: badge takes children

### DIFF
--- a/core/components/header/cart-icon.tsx
+++ b/core/components/header/cart-icon.tsx
@@ -44,7 +44,7 @@ export const CartIcon = ({ count }: CartIconProps) => {
     <>
       <span className="sr-only">Cart Items</span>
       <ShoppingCart aria-hidden="true" />
-      <Badge label={`${computedCount}`} />
+      <Badge>computedCount</Badge>
     </>
   );
 };

--- a/core/components/ui/badge/badge.tsx
+++ b/core/components/ui/badge/badge.tsx
@@ -2,11 +2,7 @@ import { ComponentPropsWithoutRef } from 'react';
 
 import { cn } from '~/lib/utils';
 
-interface Props extends ComponentPropsWithoutRef<'span'> {
-  label: string;
-}
-
-const Badge = ({ children, className, label, ...props }: Props) => {
+const Badge = ({ children, className, ...props }: ComponentPropsWithoutRef<'span'>) => {
   return (
     <span
       className={cn(
@@ -15,7 +11,7 @@ const Badge = ({ children, className, label, ...props }: Props) => {
       )}
       {...props}
     >
-      {label}
+      {children}
     </span>
   );
 };


### PR DESCRIPTION
## What/Why?
Badge's API should accept `children` so we don't need to manually type `string`, `number`, etc.

## Testing
N/A