### PR TITLE
fix(core): improve redirect behavior after creating new address

### DIFF
--- a/.changeset/giant-carpets-boil.md
+++ b/.changeset/giant-carpets-boil.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+improve redirect behavior after creating new address

--- a/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/add-address.tsx
+++ b/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/add-address.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useFormStatus } from 'react-dom';
 import ReCaptcha from 'react-google-recaptcha';
 
@@ -96,6 +96,10 @@ export const AddAddress = ({
   const [countryStates, setCountryStates] = useState(defaultCountry.states);
 
   const { setAccountState } = useAccountStatusContext();
+
+  useEffect(() => {
+    setAccountState({ status: 'idle' });
+  }, [setAccountState]);
 
   const handleTextInputValidation = createTextInputValidationHandler(
     setTextInputValid,

--- a/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/add-address.tsx
+++ b/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/add-address.tsx
@@ -20,6 +20,7 @@ import { Field, Form, FormSubmit } from '~/components/ui/form';
 import { Message } from '~/components/ui/message';
 
 import { addAddress } from '../../_actions/add-address';
+import { useAccountStatusContext } from '../account-status-provider';
 
 import {
   createCountryChangeHandler,
@@ -94,6 +95,8 @@ export const AddAddress = ({
   const [textInputValid, setTextInputValid] = useState<Record<string, boolean>>({});
   const [countryStates, setCountryStates] = useState(defaultCountry.states);
 
+  const { setAccountState } = useAccountStatusContext();
+
   const handleTextInputValidation = createTextInputValidationHandler(
     setTextInputValid,
     textInputValid,
@@ -120,15 +123,14 @@ export const AddAddress = ({
     const submit = await addAddress({ formData, reCaptchaToken });
 
     if (submit.status === 'success') {
-      form.current?.reset();
-      setFormStatus({
+      setAccountState({
         status: 'success',
-        message: t('successMessage'),
+        message: t('addNewAddressSuccessMessage'),
       });
 
-      setTimeout(() => {
-        router.replace('/account/addresses');
-      }, 3000);
+      router.push('/account/addresses');
+
+      return;
     }
 
     if (submit.status === 'error') {

--- a/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/address-book.tsx
+++ b/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/address-book.tsx
@@ -21,6 +21,7 @@ interface AddressChangeProps {
 }
 
 const AddressChangeButtons = ({ addressId, isAddressRemovable, onDelete }: AddressChangeProps) => {
+  const { setAccountState } = useAccountStatusContext();
   const t = useTranslations('Account.Addresses');
 
   const handleDeleteAddress = async () => {
@@ -30,6 +31,11 @@ const AddressChangeButtons = ({ addressId, isAddressRemovable, onDelete }: Addre
       onDelete((prevAddressBook) =>
         prevAddressBook.filter(({ entityId }) => entityId !== addressId),
       );
+
+      setAccountState({
+        status: 'success',
+        message: t('deleteAddress'),
+      });
     }
   };
 

--- a/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/edit-address.tsx
+++ b/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/edit-address.tsx
@@ -137,15 +137,14 @@ export const EditAddress = ({
     const submit = await updateAddress({ addressId: address.entityId, formData });
 
     if (submit.status === 'success') {
-      form.current?.reset();
-      setFormStatus({
+      setAccountState({
         status: 'success',
         message: t('successMessage'),
       });
 
-      setTimeout(() => {
-        router.replace('/account/addresses');
-      }, 3000);
+      router.push('/account/addresses');
+
+      return;
     }
 
     if (submit.status === 'error') {
@@ -168,14 +167,11 @@ export const EditAddress = ({
       setAccountState({ status, message });
     }
 
-    window.scrollTo({
-      top: 0,
-      behavior: 'smooth',
-    });
+    router.push('/account/addresses');
+  };
 
-    setTimeout(() => {
-      router.replace('/account/addresses');
-    }, 500);
+  const onCancelChange = () => {
+    setAccountState({ status: 'idle' });
   };
 
   return (
@@ -277,7 +273,12 @@ export const EditAddress = ({
           <FormSubmit asChild>
             <SubmitButton messages={{ submit: t('submit'), submitting: t('submitting') }} />
           </FormSubmit>
-          <Button asChild className="items-center px-8 md:ms-6 md:w-fit" variant="secondary">
+          <Button
+            asChild
+            className="items-center px-8 md:ms-6 md:w-fit"
+            onClick={onCancelChange}
+            variant="secondary"
+          >
             <Link href="/account/addresses">{t('cancel')}</Link>
           </Button>
           <Modal

--- a/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/edit-address.tsx
+++ b/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/edit-address.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useFormStatus } from 'react-dom';
 import ReCaptcha from 'react-google-recaptcha';
 
@@ -101,6 +101,10 @@ export const EditAddress = ({
   const [isReCaptchaValid, setReCaptchaValid] = useState(true);
   const { setAccountState } = useAccountStatusContext();
 
+  useEffect(() => {
+    setAccountState({ status: 'idle' });
+  }, [setAccountState]);
+
   const [textInputValid, setTextInputValid] = useState<Record<string, boolean>>({});
 
   const defaultStates = countries
@@ -168,10 +172,6 @@ export const EditAddress = ({
     }
 
     router.push('/account/addresses');
-  };
-
-  const onCancelChange = () => {
-    setAccountState({ status: 'idle' });
   };
 
   return (
@@ -273,12 +273,7 @@ export const EditAddress = ({
           <FormSubmit asChild>
             <SubmitButton messages={{ submit: t('submit'), submitting: t('submitting') }} />
           </FormSubmit>
-          <Button
-            asChild
-            className="items-center px-8 md:ms-6 md:w-fit"
-            onClick={onCancelChange}
-            variant="secondary"
-          >
+          <Button asChild className="items-center px-8 md:ms-6 md:w-fit" variant="secondary">
             <Link href="/account/addresses">{t('cancel')}</Link>
           </Button>
           <Modal

--- a/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/index.tsx
+++ b/core/app/[locale]/(default)/account/[tab]/_components/addresses-content/index.tsx
@@ -27,7 +27,7 @@ export const AddressesContent = async ({
   pageInfo,
 }: Props) => {
   const locale = await getLocale();
-  const t = await getTranslations({ locale, namespace: 'Account.Home' });
+  const t = await getTranslations({ locale, namespace: 'Account.Addresses' });
   const { hasNextPage, hasPreviousPage, startCursor, endCursor } = pageInfo;
 
   if (customerAction === 'add-new-address') {

--- a/core/app/[locale]/(default)/account/[tab]/layout.tsx
+++ b/core/app/[locale]/(default)/account/[tab]/layout.tsx
@@ -44,7 +44,7 @@ export default async function AccountTabLayout({
 
   return (
     <NextIntlClientProvider locale={locale} messages={{ Account: messages.Account ?? {} }}>
-      <AccountStatusProvider>
+      <AccountStatusProvider isPermanentBanner={true}>
         <h1 className="my-8 text-4xl font-black lg:my-8 lg:text-5xl">{t('heading')}</h1>
         <nav aria-label={t('accountTabsLabel')}>
           <ul className="mb-8 flex items-start overflow-x-auto">

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -184,6 +184,7 @@
       "editAddress": "Edit address",
       "editButton": "Edit",
       "deleteButton": "Delete",
+      "deleteAddress": "Address deleted from your account.",
       "confirmDeleteAddress": "Delete address",
       "deleteModalTitle": "Are you sure you want to delete address?",
       "recaptchaText": "Pass ReCAPTCHA check",

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -170,17 +170,18 @@
       "orders": "Orders",
       "messages": "Messages",
       "addresses": "Addresses",
-      "newAddress": "New address",
       "wishlists": "Wish lists",
       "recentlyViewed": "Recently viewed",
       "settings": "Account settings",
-      "changePassword": "Change password",
-      "editAddress": "Edit address"
+      "changePassword": "Change password"
     },
     "Addresses": {
       "defaultAddress": "Default",
       "alternativeAddress": "Alternative",
+      "newAddress": "New address",
       "addNewAddress": "Add new address",
+      "addNewAddressSuccessMessage": "Address added to your account",
+      "editAddress": "Edit address",
       "editButton": "Edit",
       "deleteButton": "Delete",
       "confirmDeleteAddress": "Delete address",

--- a/core/tests/ui/desktop/e2e/account.spec.ts
+++ b/core/tests/ui/desktop/e2e/account.spec.ts
@@ -78,7 +78,6 @@ test('Account dropdown is visible in header', async ({ page }) => {
 test('Add and remove new address', async ({ page }) => {
   await loginWithUserAccount(page, testUserEmail, testUserPassword);
   await page.goto('/account/addresses');
-  await page.getByRole('heading', { name: 'Addresses' }).waitFor();
 
   await page.getByRole('link', { name: 'Add new address' }).click();
   await page.getByRole('heading', { name: 'New address' }).waitFor();
@@ -93,12 +92,14 @@ test('Add and remove new address', async ({ page }) => {
 
   await page.getByRole('button', { name: 'Add new address' }).click();
 
-  await page.getByRole('heading', { name: 'Addresses' }).waitFor();
+  await expect(page.getByText('Address added to your account')).toBeVisible();
   await expect(page.getByText(streetAddress, { exact: true })).toBeVisible();
 
   await page.getByRole('button', { name: 'Delete' }).nth(1).click();
 
   await page.getByRole('button', { name: 'Delete address' }).click();
+
+  await expect(page.getByText('Address deleted from your account')).toBeVisible();
 
   await expect(page.getByText(streetAddress, { exact: true })).toBeVisible({
     visible: false,


### PR DESCRIPTION
## What/Why?
This PR improves redirect behavior after adding a new address, namely, it adds a banner about the successful creation of a new address.

## Testing
locally

**before:**

https://github.com/user-attachments/assets/58b6aff4-c7a2-43af-8455-8e356bdef625

**after:**

https://github.com/user-attachments/assets/69c71315-80fc-43bf-b8c5-4304ab114246
