### PR TITLE
feat(core): add customer information onto the session

### DIFF
--- a/.changeset/bright-shirts-sort.md
+++ b/.changeset/bright-shirts-sort.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Adds customer information onto the session for consumption in both server and client components

--- a/core/client/mutations/login.ts
+++ b/core/client/mutations/login.ts
@@ -6,6 +6,9 @@ const LOGIN_MUTATION = graphql(`
     login(email: $email, password: $password) {
       customer {
         entityId
+        firstName
+        lastName
+        email
       }
     }
   }
@@ -17,5 +20,5 @@ export const login = async (email: string, password: string) => {
     variables: { email, password },
   });
 
-  return response.data.login.customer;
+  return response.data.login;
 };


### PR DESCRIPTION
## What/Why?
Adds some customer information onto the session in case we want to consume that information. This also refactors a bit of the code to add information onto the JWT.  This is to provide a better way to add the `customerAccessToken` onto the JWT and session later. This is achieved by [extending the session](https://authjs.dev/guides/extending-the-session) and by using [module augmentation](https://authjs.dev/getting-started/typescript#module-augmentation) via Typescript to get the right types.

## Testing
Logged in locally.