### PR TITLE
fix(functional): Update register spec password required

### DIFF
--- a/core/tests/ui/desktop/e2e/register.spec.ts
+++ b/core/tests/ui/desktop/e2e/register.spec.ts
@@ -3,7 +3,7 @@ import { expect } from '@playwright/test';
 
 import { test } from '~/tests/fixtures';
 
-const password = faker.internet.password({ length: 10 });
+const password = faker.internet.password({ pattern: /[a-zA-Z0-9]/, length: 10 });
 const firstName = faker.person.firstName();
 const lastName = faker.person.lastName();
 


### PR DESCRIPTION
## What/Why?
Make sure the password length and requirements are correctly met for the faker generated password used to register a test customer.

Here's what the failed attempt test was using for password to register the customer(it did not contain numerics)
<img width="342" alt="Screenshot 2024-07-25 at 2 56 43 PM" src="https://github.com/user-attachments/assets/3cb76414-69b5-4fde-a39e-fac202905934">
 

## Testing
Local tests and tests on this job.