### PR TITLE
Add makeswift env vars

### DIFF
--- a/core/.env.example
+++ b/core/.env.example
@@ -2,6 +2,10 @@
 # In the Makeswift builder, go to Settings > Host and copy the API key for the site.
 MAKESWIFT_SITE_API_KEY=
 
+# These are optional, for running against Makeswift's staging environment.
+MAKESWIFT_API_ORIGIN=https://api.makeswift.com
+MAKESWIFT_APP_ORIGIN=https://app.makeswift.com
+
 # The hash visible in the subject store's URL when signed in to the store control panel.
 # The control panel URL is of the form `https://store-{hash}.mybigcommerce.com`. 
 BIGCOMMERCE_STORE_HASH=

--- a/core/app/api/makeswift/[...makeswift]/route.ts
+++ b/core/app/api/makeswift/[...makeswift]/route.ts
@@ -7,6 +7,8 @@ strict(process.env.MAKESWIFT_SITE_API_KEY, 'MAKESWIFT_SITE_API_KEY is required')
 
 const handler = MakeswiftApiHandler(process.env.MAKESWIFT_SITE_API_KEY, {
   runtime,
+  apiOrigin: process.env.MAKESWIFT_API_ORIGIN,
+  appOrigin: process.env.MAKESWIFT_APP_ORIGIN,
 });
 
 export { handler as GET, handler as POST };

--- a/core/lib/makeswift/client.ts
+++ b/core/lib/makeswift/client.ts
@@ -7,4 +7,5 @@ strict(process.env.MAKESWIFT_SITE_API_KEY, 'MAKESWIFT_SITE_API_KEY is required')
 
 export const client = new Makeswift(process.env.MAKESWIFT_SITE_API_KEY, {
   runtime,
+  apiOrigin: process.env.MAKESWIFT_API_ORIGIN,
 });


### PR DESCRIPTION
## What/Why?
So we can point Catalyst to Makeswift's staging environment

## Testing
Add

```
MAKESWIFT_API_ORIGIN=https://api.staging.makeswift.com
MAKESWIFT_APP_ORIGIN=https://app.staging.makeswift.com
```

to your staging environment