### PR TITLE
SEO improvements

### DIFF
--- a/.changeset/early-fishes-tell.md
+++ b/.changeset/early-fishes-tell.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Use default SEO settings from store for pages without SEO information specified, normalize SEO implementation across pages

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page-data.ts
@@ -9,6 +9,11 @@ const BrandQuery = graphql(`
     site {
       brand(entityId: $entityId) {
         name
+        seo {
+          pageTitle
+          metaDescription
+          metaKeywords
+        }
       }
     }
   }

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
@@ -27,10 +27,16 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   const brand = await getBrand({ entityId: brandId });
 
-  const title = brand?.name;
+  if (!brand) {
+    return {};
+  }
+
+  const { pageTitle, metaDescription, metaKeywords } = brand.seo;
 
   return {
-    title,
+    title: pageTitle || brand.name,
+    description: metaDescription,
+    keywords: metaKeywords ? metaKeywords.split(',') : null,
   };
 }
 

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/static/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/static/page.tsx
@@ -11,6 +11,8 @@ import BrandPage from '../page';
 
 export default BrandPage;
 
+export { generateMetadata } from '../page';
+
 const BrandsQuery = graphql(`
   query BrandsQuery($first: Int, $entityIds: [Int!]) {
     site {

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page-data.ts
@@ -15,6 +15,11 @@ const CategoryPageQuery = graphql(
         category(entityId: $categoryId) {
           name
           ...BreadcrumbsFragment
+          seo {
+            pageTitle
+            metaDescription
+            metaKeywords
+          }
         }
         ...CategoryTreeFragment
       }

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -31,10 +31,18 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     categoryId,
   });
 
-  const title = data.category?.name;
+  const category = data.category;
+
+  if (!category) {
+    return {};
+  }
+
+  const { pageTitle, metaDescription, metaKeywords } = category.seo;
 
   return {
-    title,
+    title: pageTitle || category.name,
+    description: metaDescription,
+    keywords: metaKeywords ? metaKeywords.split(',') : null,
   };
 }
 

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/static/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/static/page.tsx
@@ -12,6 +12,8 @@ import CategoryPage from '../page';
 
 export default CategoryPage;
 
+export { generateMetadata } from '../page';
+
 const CategoryTreeQuery = graphql(
   `
     query CategoryTreeQuery($categoryId: Int) {

--- a/core/app/[locale]/(default)/blog/[blogId]/page-data.ts
+++ b/core/app/[locale]/(default)/blog/[blogId]/page-data.ts
@@ -26,6 +26,8 @@ const BlogPageQuery = graphql(
               }
               seo {
                 pageTitle
+                metaDescription
+                metaKeywords
               }
             }
           }

--- a/core/app/[locale]/(default)/blog/[blogId]/page.tsx
+++ b/core/app/[locale]/(default)/blog/[blogId]/page.tsx
@@ -21,10 +21,16 @@ export async function generateMetadata({ params: { blogId } }: Props): Promise<M
   const data = await getBlogPageData({ entityId: Number(blogId) });
   const blogPost = data?.content.blog?.post;
 
-  const title = blogPost?.seo.pageTitle ?? 'Blog';
+  if (!blogPost) {
+    return {};
+  }
+
+  const { pageTitle, metaDescription, metaKeywords } = blogPost.seo;
 
   return {
-    title,
+    title: pageTitle || blogPost.name,
+    description: metaDescription,
+    keywords: metaKeywords ? metaKeywords.split(',') : null,
   };
 }
 

--- a/core/app/[locale]/(default)/blog/page-data.ts
+++ b/core/app/[locale]/(default)/blog/page-data.ts
@@ -29,6 +29,7 @@ const BlogPostsPageQuery = graphql(
         content {
           blog {
             name
+            description
             posts(first: $first, after: $after, last: $last, before: $before, filters: $filters) {
               edges {
                 node {

--- a/core/app/[locale]/(default)/blog/page.tsx
+++ b/core/app/[locale]/(default)/blog/page.tsx
@@ -17,10 +17,12 @@ interface Props {
 export async function generateMetadata({ searchParams }: Props): Promise<Metadata> {
   const blogPosts = await getBlogPosts(searchParams);
 
-  const title = blogPosts?.name ?? 'Blog';
-
   return {
-    title,
+    title: blogPosts?.name ?? 'Blog',
+    description:
+      blogPosts?.description && blogPosts.description.length > 150
+        ? `${blogPosts.description.substring(0, 150)}...`
+        : blogPosts?.description,
   };
 }
 

--- a/core/app/[locale]/(default)/webpages/contact/[id]/page.tsx
+++ b/core/app/[locale]/(default)/webpages/contact/[id]/page.tsx
@@ -51,15 +51,15 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const webpage = data.node?.__typename === 'ContactPage' ? data.node : null;
 
   if (!webpage) {
-    notFound();
+    return {};
   }
 
-  const { seo } = webpage;
+  const { pageTitle, metaDescription, metaKeywords } = webpage.seo;
 
   return {
-    title: seo.pageTitle,
-    description: seo.metaDescription,
-    keywords: seo.metaKeywords,
+    title: pageTitle,
+    description: metaDescription,
+    keywords: metaKeywords,
   };
 }
 

--- a/core/app/[locale]/(default)/webpages/normal/[id]/page.tsx
+++ b/core/app/[locale]/(default)/webpages/normal/[id]/page.tsx
@@ -46,15 +46,15 @@ export async function generateMetadata({ params: { id } }: Props): Promise<Metad
   const webpage = await getWebpageData({ id });
 
   if (!webpage) {
-    notFound();
+    return {};
   }
 
-  const { seo } = webpage;
+  const { pageTitle, metaDescription, metaKeywords } = webpage.seo;
 
   return {
-    title: seo.pageTitle,
-    description: seo.metaDescription,
-    keywords: seo.metaKeywords,
+    title: pageTitle || webpage.name,
+    description: metaDescription,
+    keywords: metaKeywords ? metaKeywords.split(',') : null,
   };
 }
 

--- a/core/app/[locale]/layout.tsx
+++ b/core/app/[locale]/layout.tsx
@@ -26,6 +26,11 @@ const RootLayoutMetadataQuery = graphql(`
     site {
       settings {
         storeName
+        seo {
+          pageTitle
+          metaDescription
+          metaKeywords
+        }
       }
     }
   }
@@ -37,13 +42,17 @@ export async function generateMetadata(): Promise<Metadata> {
     fetchOptions: { next: { revalidate } },
   });
 
-  const title = data.site.settings?.storeName ?? '';
+  const storeName = data.site.settings?.storeName ?? '';
+
+  const { pageTitle, metaDescription, metaKeywords } = data.site.settings?.seo || {};
 
   return {
     title: {
-      template: `${title} - %s`,
-      default: title,
+      template: `%s - ${storeName}`,
+      default: pageTitle || storeName,
     },
+    description: metaDescription,
+    keywords: metaKeywords ? metaKeywords.split(',') : null,
     other: {
       platform: 'bigcommerce.catalyst',
       build_sha: process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA ?? '',


### PR DESCRIPTION
## What/Why?

- Take advantage of the new `seo` field on `site.settings` to set default metadata on the layout level. This metadata will be used, if specified in the channel settings, to set the page title, meta description, and meta keywords on any pages that do not specify more specific values.
- Normalize/standardize how we set up SEO metadata across page entity types for consistency
- Fix a bug where `generateMetadata` was not exported on our static pages for categories and brands

## Testing
Manually/locally tested different scenarios with/without store settings and page-local settings.