### PR TITLE
fix: remove formAction CSP header

### DIFF
--- a/core/lib/content-security-policy.js
+++ b/core/lib/content-security-policy.js
@@ -11,8 +11,8 @@ const builder = require('content-security-policy-builder');
 const cspHeader = builder({
   directives: {
     baseUri: ['self'],
-    formAction: ['self'],
     frameAncestors: [frameAncestors],
+    // formAction: ['self'],
     // defaultSrc: ['self'],
     // scriptSrc: ['self'],
     // styleSrc: ['self'],


### PR DESCRIPTION
## What/Why?
Removes the `formAction` CSP header as it causes React Server Actions to fail if they have a redirect, e.g. our search action. In order to add this back, you'd need to add in either the production URL and/or localhost in order for it to work correctly. I want us to create a utility function for fetching the right URL as we've been doing it in a few places now. Can add this back in later when that comes into fruition.

## Testing
See the automated tests.