### PR TITLE
fix(core): redirect using next/navigation instead of next-auth

### DIFF
--- a/.changeset/brown-glasses-enjoy.md
+++ b/.changeset/brown-glasses-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Uses `next/navigation` for logging in as a customer instead of the built-in `redirectTo` option. That option was not following the `trailingSlash` config set in `next.config.js` which caused test failures.

--- a/core/app/[locale]/(default)/login/_actions/submit-login-form.ts
+++ b/core/app/[locale]/(default)/login/_actions/submit-login-form.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { isRedirectError } from 'next/dist/client/components/redirect';
+import { redirect } from 'next/navigation';
 
 import { Credentials, signIn } from '~/auth';
 
@@ -13,9 +14,12 @@ export const submitLoginForm = async (_previousState: unknown, formData: FormDat
 
     await signIn('credentials', {
       ...credentials,
-      // TODO: Redirect to previous page
-      redirectTo: '/account',
+      // We want to use next/navigation for the redirect as it
+      // follows basePath and trailing slash configurations.
+      redirect: false,
     });
+
+    redirect('/account');
   } catch (error: unknown) {
     // We need to throw this error to trigger the redirect as Next.js uses error boundaries to redirect.
     if (isRedirectError(error)) {

--- a/core/app/[locale]/(default)/login/_components/login-form.tsx
+++ b/core/app/[locale]/(default)/login/_components/login-form.tsx
@@ -44,7 +44,7 @@ export const LoginForm = () => {
 
   const t = useTranslations('Account.Login');
 
-  const isFormInvalid = state?.status === 'error';
+  const isFormInvalid = state.status === 'error';
 
   const handleInputValidation = (e: ChangeEvent<HTMLInputElement>) => {
     const validationStatus = e.target.validity.valueMissing;

--- a/core/app/[locale]/(default)/login/register-customer/_components/register-customer-form/_actions/login.ts
+++ b/core/app/[locale]/(default)/login/register-customer/_components/register-customer-form/_actions/login.ts
@@ -1,19 +1,25 @@
 'use server';
 
 import { isRedirectError } from 'next/dist/client/components/redirect';
+import { redirect } from 'next/navigation';
 
-import { signIn } from '~/auth';
+import { Credentials, signIn } from '~/auth';
 
-export const login = async (
-  email: FormDataEntryValue | null,
-  password: FormDataEntryValue | null,
-) => {
+export const login = async (formData: FormData) => {
   try {
-    return await signIn('credentials', {
-      email,
-      password,
-      redirectTo: '/account',
+    const credentials = Credentials.parse({
+      email: formData.get('customer-email'),
+      password: formData.get('customer-password'),
     });
+
+    await signIn('credentials', {
+      ...credentials,
+      // We want to use next/navigation for the redirect as it
+      // follows basePath and trailing slash configurations.
+      redirect: false,
+    });
+
+    redirect('/account');
   } catch (error: unknown) {
     if (isRedirectError(error)) {
       throw error;

--- a/core/app/[locale]/(default)/login/register-customer/_components/register-customer-form/index.tsx
+++ b/core/app/[locale]/(default)/login/register-customer/_components/register-customer-form/index.tsx
@@ -197,7 +197,7 @@ export const RegisterCustomerForm = ({
       });
 
       setTimeout(() => {
-        void login(formData.get('customer-email'), formData.get('customer-password'));
+        void login(formData);
       }, 3000);
     }
 

--- a/core/playwright.config.ts
+++ b/core/playwright.config.ts
@@ -13,8 +13,8 @@ const coverageReportOptions: CoverageReportOptions = {
 
   sourceFilter: (sourcePath) => {
     return (
-        sourcePath.startsWith('bigcommerce/catalyst-core') &&
-        (sourcePath.endsWith('.ts') || sourcePath.endsWith('.tsx'))
+      sourcePath.startsWith('bigcommerce/catalyst-core') &&
+      (sourcePath.endsWith('.ts') || sourcePath.endsWith('.tsx'))
     );
   },
 
@@ -42,12 +42,15 @@ export default defineConfig({
   },
   fullyParallel: !!process.env.CI,
   reporter: process.env.CI
-      ? [['list'], ['monocart-reporter']]
-      : [['list'], ['monocart-reporter',
-        {
-          coverage: coverageReportOptions,
-        },
-      ],
+    ? [['list'], ['monocart-reporter']]
+    : [
+        ['list'],
+        [
+          'monocart-reporter',
+          {
+            coverage: coverageReportOptions,
+          },
+        ],
       ],
   globalTeardown: './tests/global-teardown.js',
   use: {

--- a/core/tests/ui/desktop/e2e/account.spec.ts
+++ b/core/tests/ui/desktop/e2e/account.spec.ts
@@ -40,27 +40,27 @@ test('My Account tabs are displayed and clickable', async ({ page }) => {
   await expect(page.getByRole('heading', { name: 'Account settings' })).toBeVisible();
 
   await page.getByRole('heading', { name: 'Orders' }).click();
-  await expect(page).toHaveURL('account/orders/');
+  await expect(page).toHaveURL('/account/orders/');
   await expect(page.getByRole('heading', { name: 'Orders' })).toBeVisible();
 
   await page.getByRole('tab', { name: 'Messages' }).click();
-  await expect(page).toHaveURL('account/messages/');
+  await expect(page).toHaveURL('/account/messages/');
   await expect(page.getByRole('heading', { name: 'Messages' })).toBeVisible();
 
   await page.getByRole('tab', { name: 'Addresses' }).click();
-  await expect(page).toHaveURL('account/addresses/');
+  await expect(page).toHaveURL('/account/addresses/');
   await expect(page.getByRole('heading', { name: 'Addresses' })).toBeVisible();
 
   await page.getByRole('tab', { name: 'Wish lists' }).click();
-  await expect(page).toHaveURL('account/wishlists/');
+  await expect(page).toHaveURL('/account/wishlists/');
   await expect(page.getByRole('heading', { name: 'Wish lists' })).toBeVisible();
 
   await page.getByRole('tab', { name: 'Recently viewed' }).click();
-  await expect(page).toHaveURL('account/recently-viewed/');
+  await expect(page).toHaveURL('/account/recently-viewed/');
   await expect(page.getByRole('heading', { name: 'Recently viewed' })).toBeVisible();
 
   await page.getByRole('tab', { name: 'Account settings' }).click();
-  await expect(page).toHaveURL('account/settings/');
+  await expect(page).toHaveURL('/account/settings/');
   await expect(page.getByRole('heading', { name: 'Account settings' })).toBeVisible();
 });
 

--- a/core/tests/ui/desktop/e2e/register.spec.ts
+++ b/core/tests/ui/desktop/e2e/register.spec.ts
@@ -3,7 +3,8 @@ import { expect } from '@playwright/test';
 
 import { test } from '~/tests/fixtures';
 
-const password = faker.internet.password({ pattern: /[a-zA-Z0-9]/, length: 10 });
+// Prefix is added to ensure that the password requirements are met
+const password = faker.internet.password({ pattern: /[a-zA-Z0-9]/, prefix: '1At', length: 10 });
 const firstName = faker.person.firstName();
 const lastName = faker.person.lastName();
 


### PR DESCRIPTION
## What/Why?
`next-auth` does not follow the `trailingSlash` configuration so we want to use the redirect from `next/navigation` to handle it. This was causing our functional test suite to be "flaky".

## Testing
See functional test runs.