### PR TITLE
feat: command to help generate integration patches

### DIFF
--- a/.changeset/angry-seas-march.md
+++ b/.changeset/angry-seas-march.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": minor
+---
+
+add `integration` command to help with developing native Catalyst integrations

--- a/packages/create-catalyst/src/commands/integration.ts
+++ b/packages/create-catalyst/src/commands/integration.ts
@@ -1,0 +1,120 @@
+import { Command } from '@commander-js/extra-typings';
+import { exec as execCb } from 'child_process';
+import { outputFileSync, writeJsonSync } from 'fs-extra/esm';
+import kebabCase from 'lodash.kebabcase';
+import { coerce, compare } from 'semver';
+import { promisify } from 'util';
+import { z } from 'zod';
+
+const exec = promisify(execCb);
+
+interface Manifest {
+  name: string;
+  dependencies: {
+    add: string[];
+  };
+  devDependencies: {
+    add: string[];
+  };
+  environmentVariables: string[];
+}
+
+export const integration = new Command('integration')
+  .argument('<integration-name>', 'Formatted name of the integration')
+  .option('--commit-hash <hash>', 'Override integration source branch with a specific commit hash')
+  .action(async (integrationNameRaw, options) => {
+    // @todo check for integration name conflicts
+    const integrationName = z.string().transform(kebabCase).parse(integrationNameRaw);
+
+    const manifest: Manifest = {
+      name: integrationName,
+      dependencies: { add: [] },
+      devDependencies: { add: [] },
+      environmentVariables: [],
+    };
+
+    await exec('git fetch --tags');
+
+    const { stdout: headRefStdOut } = await exec('git rev-parse --abbrev-ref HEAD');
+    let [sourceRef] = headRefStdOut.split('\n');
+
+    if (options.commitHash) {
+      sourceRef = options.commitHash;
+    }
+
+    const { stdout: catalystTags } = await exec('git tag --list @bigcommerce/catalyst-core@\\*');
+    const [latestCoreTag] = catalystTags
+      .split('\n')
+      .filter(Boolean)
+      .sort((a, b) => {
+        const versionA = coerce(a.replace('@bigcommerce/catalyst-core@', ''));
+        const versionB = coerce(b.replace('@bigcommerce/catalyst-core@', ''));
+
+        if (versionA && versionB) {
+          return compare(versionA, versionB);
+        }
+
+        return 0;
+      })
+      .reverse();
+
+    const PackageDependenciesSchema = z.object({
+      dependencies: z.object({}).passthrough(),
+      devDependencies: z.object({}).passthrough(),
+    });
+
+    const getPackageDeps = async (ref: string) => {
+      const { stdout } = await exec(`git show ${ref}:core/package.json`);
+
+      return PackageDependenciesSchema.parse(JSON.parse(stdout));
+    };
+
+    const integrationJson = await getPackageDeps(sourceRef);
+    const latestCoreTagJson = await getPackageDeps(latestCoreTag);
+
+    const diffObjectKeys = (a: Record<string, unknown>, b: Record<string, unknown>) => {
+      return Object.keys(a).filter((key) => !Object.keys(b).includes(key));
+    };
+
+    manifest.dependencies.add = diffObjectKeys(
+      integrationJson.dependencies,
+      latestCoreTagJson.dependencies,
+    );
+    manifest.devDependencies.add = diffObjectKeys(
+      integrationJson.devDependencies,
+      latestCoreTagJson.devDependencies,
+    );
+
+    const { stdout: envVarDiff } = await exec(
+      `git diff ${latestCoreTag}...${sourceRef} -- core/.env.example`,
+    );
+
+    if (envVarDiff.length > 0) {
+      const envVars: string[] = [];
+      const lines = envVarDiff.split('\n');
+      const addedEnvVarPattern = /^\+([A-Z_]+)=/;
+
+      lines.forEach((line) => {
+        const match = line.match(addedEnvVarPattern);
+
+        if (match) {
+          envVars.push(match[1]);
+        }
+      });
+
+      if (envVars.length > 0) {
+        manifest.environmentVariables = envVars;
+      }
+    }
+
+    const { stdout: integrationDiff } = await exec(
+      `git diff ${latestCoreTag}...${sourceRef} -- ':(exclude)core/package.json' ':(exclude)pnpm-lock.yaml'`,
+    );
+
+    outputFileSync(`integrations/${integrationName}/integration.patch`, integrationDiff);
+    writeJsonSync(`integrations/${integrationName}/manifest.json`, manifest, {
+      spaces: 2,
+    });
+
+    console.log('Integration created successfully.');
+  });

--- a/packages/create-catalyst/src/index.ts
+++ b/packages/create-catalyst/src/index.ts
@@ -7,6 +7,7 @@ import PACKAGE_INFO from '../package.json';
 
 import { create } from './commands/create';
 import { init } from './commands/init';
+import { integration } from './commands/integration';
 
 console.log(chalk.cyanBright(`\n◢ ${PACKAGE_INFO.name} v${PACKAGE_INFO.version}\n`));
 
@@ -15,6 +16,7 @@ program
   .version(PACKAGE_INFO.version)
   .description('A command line tool to create a new Catalyst project.')
   .addCommand(create, { isDefault: true })
-  .addCommand(init);
+  .addCommand(init)
+  .addCommand(integration);
 
 program.parse(process.argv);


### PR DESCRIPTION
## What/Why?
Adds a command to the `create-catalyst` CLI that can be executed by running `[npm|pnpm|yarn] create @bigcommerce/catalyst@latest integration` once published. Also updates the `packages/create-catalyst/README.md` with some documentation that partners interested in developing integrations can follow.

When you execute this new command following the steps below, the command will create a folder with two new files:
* `integration.patch`
* `manifest.json` 

The expectation is that the folder containing these two files will be committed to a branch, and that branch will then be used to open a PR into `bigcommerce/catalyst:main`. Once merged, the `pnpm create @bigcommerce/catalyst@latest create` CLI will then be able to accept an argument for which integration you want to scaffold your Catalyst project with, check that the argument you passed exists in the `integrations` folder on `bigcommerce/catalyst:main`, read the `manifest.json` to, install dependencies, devDependencies, add environment variables, and then read the `integration.patch` file to apply the patch. 

## Testing
Clone https://github.com/bigcommerce/catalyst and run the following commands to test this command with the Makeswift integration:
1. `git fetch --all`
2. `git switch integrations/create-patch`
3. `pnpm install`
4. `pnpm -F @bigcommerce/create-catalyst build`
5. `git branch integrations/makeswift origin/integrations/makeswift`
6. `node packages/create-catalyst/dist/index.js integration --integration-name "Makeswift" --source-branch "integrations/makeswift"`