### PR TITLE
feat: optional flag to apply integrations during create

### DIFF
--- a/.changeset/hip-eels-push.md
+++ b/.changeset/hip-eels-push.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": minor
+---
+
+add `--integration` option to `create-catalyst` to apply an integration to your newly created storefront

--- a/packages/create-catalyst/src/commands/create.ts
+++ b/packages/create-catalyst/src/commands/create.ts
@@ -8,6 +8,7 @@ import { join } from 'path';
 import { promisify } from 'util';
 import { z } from 'zod';
 
+import { applyIntegrations } from '../utils/apply-integrations';
 import { checkStorefrontLimit } from '../utils/check-storefront-limit';
 import { cloneCatalyst } from '../utils/clone-catalyst';
 import { getLatestCoreTag } from '../utils/get-latest-core-tag';
@@ -29,6 +30,8 @@ export const create = new Command('create')
   .option('--access-token <token>', 'BigCommerce access token')
   .option('--channel-id <id>', 'BigCommerce channel ID')
   .option('--customer-impersonation-token <token>', 'BigCommerce customer impersonation token')
+  // @todo make the API singular
+  .option('--integrations <providers...>', 'Integrations to include in your project')
   .addOption(
     new Option(
       '--gh-ref <ref>',
@@ -146,6 +149,8 @@ export const create = new Command('create')
 
       await installDependencies(projectDir, packageManager);
 
+      await applyIntegrations(options.integrations, { projectDir, packageManager });
+
       console.log(
         [
           `\n${chalk.green('Success!')} Created '${projectName}' at '${projectDir}'\n`,
@@ -256,6 +261,8 @@ export const create = new Command('create')
       successText: 'Created GraphQL schema',
       failText: (err) => chalk.red(`Failed to create GraphQL schema: ${err.message}`),
     });
+
+    await applyIntegrations(options.integrations, { projectDir, packageManager });
 
     console.log(
       `\n${chalk.green('Success!')} Created '${projectName}' at '${projectDir}'\n`,

--- a/packages/create-catalyst/src/commands/create.ts
+++ b/packages/create-catalyst/src/commands/create.ts
@@ -8,7 +8,7 @@ import { join } from 'path';
 import { promisify } from 'util';
 import { z } from 'zod';
 
-import { applyIntegrations } from '../utils/apply-integrations';
+import { applyIntegration } from '../utils/apply-integration';
 import { checkStorefrontLimit } from '../utils/check-storefront-limit';
 import { cloneCatalyst } from '../utils/clone-catalyst';
 import { getLatestCoreTag } from '../utils/get-latest-core-tag';
@@ -30,8 +30,7 @@ export const create = new Command('create')
   .option('--access-token <token>', 'BigCommerce access token')
   .option('--channel-id <id>', 'BigCommerce channel ID')
   .option('--customer-impersonation-token <token>', 'BigCommerce customer impersonation token')
-  // @todo make the API singular
-  .option('--integrations <providers...>', 'Integrations to include in your project')
+  .option('--integration <provider>', 'Integration to apply to your new storefront')
   .addOption(
     new Option(
       '--gh-ref <ref>',
@@ -149,7 +148,7 @@ export const create = new Command('create')
 
       await installDependencies(projectDir, packageManager);
 
-      await applyIntegrations(options.integrations, { projectDir, packageManager });
+      await applyIntegration(options.integration, { projectDir, packageManager });
 
       console.log(
         [
@@ -262,7 +261,7 @@ export const create = new Command('create')
       failText: (err) => chalk.red(`Failed to create GraphQL schema: ${err.message}`),
     });
 
-    await applyIntegrations(options.integrations, { projectDir, packageManager });
+    await applyIntegration(options.integration, { projectDir, packageManager });
 
     console.log(
       `\n${chalk.green('Success!')} Created '${projectName}' at '${projectDir}'\n`,

--- a/packages/create-catalyst/src/utils/apply-integration.ts
+++ b/packages/create-catalyst/src/utils/apply-integration.ts
@@ -11,19 +11,14 @@ import { spinner } from './spinner';
 
 const exec = promisify(execCallback);
 
-export async function applyIntegrations(
-  integrations: string[] | undefined,
+export async function applyIntegration(
+  integration: string | undefined,
   { projectDir, packageManager }: { projectDir: string; packageManager: PackageManager },
 ) {
-  if (!integrations) {
+  if (!integration) {
     return;
   }
 
-  if (integrations.length > 1) {
-    console.warn('Applying multiple integrations is not supported yet');
-  }
-
-  const integration = integrations[0];
   const integrationDir = join(projectDir, 'integrations', integration);
 
   await spinner(

--- a/packages/create-catalyst/src/utils/apply-integration.ts
+++ b/packages/create-catalyst/src/utils/apply-integration.ts
@@ -37,7 +37,7 @@ export async function applyIntegration(
     readJsonSync(join(integrationDir, 'manifest.json'));
   } catch (err) {
     console.error(
-      `\nNo manifest.json found in the ${integration} integration folder. Please check that the integration exists in the Catalyst monorepo`,
+      `\nNo manifest.json found in the ${integration} integration folder. Please check that the integration exists in the Catalyst monorepo: https://github.com/bigcommerce/catalyst`,
     );
 
     return;
@@ -60,7 +60,7 @@ export async function applyIntegration(
       }),
       {
         text: 'Installing integration dependencies...',
-        successText: 'Integration Dependencies installed successfully',
+        successText: 'Integration dependencies installed successfully',
         failText: (err) => `Failed to install dependencies: ${err.message}`,
       },
     );

--- a/packages/create-catalyst/src/utils/apply-integrations.ts
+++ b/packages/create-catalyst/src/utils/apply-integrations.ts
@@ -1,0 +1,99 @@
+import { exec as execCallback } from 'child_process';
+import { readJsonSync } from 'fs-extra/esm';
+import { downloadTemplate } from 'giget';
+import { addDependency, addDevDependency } from 'nypm';
+import { join } from 'path';
+import { promisify } from 'util';
+import * as z from 'zod';
+
+import { PackageManager } from './pm';
+import { spinner } from './spinner';
+
+const exec = promisify(execCallback);
+
+export async function applyIntegrations(
+  integrations: string[] | undefined,
+  { projectDir, packageManager }: { projectDir: string; packageManager: PackageManager },
+) {
+  if (!integrations) {
+    return;
+  }
+
+  if (integrations.length > 1) {
+    console.warn('Applying multiple integrations is not supported yet');
+  }
+
+  const integration = integrations[0];
+  const integrationDir = join(projectDir, 'integrations', integration);
+
+  await spinner(
+    downloadTemplate(`github:bigcommerce/catalyst/integrations/${integration}#main`, {
+      dir: integrationDir,
+      offline: false,
+    }),
+    {
+      text: `Cloning ${integration} integration...`,
+      successText: `${integration} integration cloned successfully`,
+      failText: (err) => `Failed to clone ${integration} integration: ${err.message}`,
+    },
+  );
+
+  try {
+    readJsonSync(join(integrationDir, 'manifest.json'));
+  } catch (err) {
+    console.error(
+      `\nNo manifest.json found in the ${integration} integration folder. Please check that the integration exists in the Catalyst monorepo`,
+    );
+
+    return;
+  }
+
+  const manifest = z
+    .object({
+      dependencies: z.array(z.string()),
+      devDependencies: z.array(z.string()),
+      environmentVariables: z.array(z.string()),
+    })
+    .parse(readJsonSync(join(integrationDir, 'manifest.json')));
+
+  if (manifest.dependencies.length) {
+    await spinner(
+      addDependency(manifest.dependencies, {
+        cwd: projectDir,
+        silent: true,
+        packageManager,
+      }),
+      {
+        text: 'Installing integration dependencies...',
+        successText: 'Integration Dependencies installed successfully',
+        failText: (err) => `Failed to install dependencies: ${err.message}`,
+      },
+    );
+  }
+
+  if (manifest.devDependencies.length) {
+    await spinner(
+      addDevDependency(manifest.devDependencies, {
+        cwd: projectDir,
+        silent: true,
+        packageManager,
+      }),
+      {
+        text: 'Installing integration development dependencies...',
+        successText: 'Integration development dependencies installed successfully',
+        failText: (err) => `Failed to install integration development dependencies: ${err.message}`,
+      },
+    );
+  }
+
+  await spinner(
+    exec(`git apply -p2 ${join(integrationDir, 'integration.patch')}`, { cwd: projectDir }),
+    {
+      text: 'Applying integration patch...',
+      successText: 'Integration patch applied successfully',
+      failText: (err) => `Failed to apply integration patch: ${err.message}`,
+    },
+  );
+
+  console.log('\nIntegration applied successfully! Feel free to delete the `integrations` folder.');
+}


### PR DESCRIPTION
## What/Why?
The second half of #1192 - the functionality in this PR is optionally invoked at the end of the `create` command, and will apply a single integration using the `integration.patch` + `manifest.json` files created by the `integration` command.

## Testing
Clone https://github.com/bigcommerce/catalyst and run the following commands to test this command with the Makeswift integration:
1. `git fetch --all`
2. `git switch integrations/apply-patch`
3. `pnpm install`
4. Modify the ref that the function uses to retrieve the `.patch` file, by changing the following line inside of the `applyIntegration` function:
```diff
-    downloadTemplate(`github:bigcommerce/catalyst/integrations/${integration}#main`, {
+    downloadTemplate(`github:bigcommerce/catalyst/integrations/${integration}#integrations/makeswift-patch`, {
```
5. `pnpm -F @bigcommerce/create-catalyst build`
6. Then, switch to a directory in which you'd like to create a new Catalyst project and run `node ~/PATH/TO/YOUR/CATALYST/MONOREPO/packages/create-catalyst/dist/index.js create --package-manager "pnpm" --integrations "makeswift"`