### PR TITLE
feat(functional): Send gh workflow results to slack

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -151,7 +151,8 @@ jobs:
               "Job": "${{ github.job }}",
               "Status": "Fail",
               "Pull_Request": "https://github.com/bigcommerce/catalyst/pull/${{ steps.finder.outputs.pr }}",
-              "Commit_Message" : "${{ steps.finder.outputs.title }}"
+              "Commit_Message" : "${{ steps.finder.outputs.title }}",
+              "Job_Run": "https://github.com/bigcommerce/catalyst/actions/runs/${{ github.run_id }}"
             }
 
   visual-regression-tests:
@@ -207,5 +208,6 @@ jobs:
               "Job": "${{ github.job }}",
               "Status": "Fail",
               "Pull_Request": "https://github.com/bigcommerce/catalyst/pull/${{ steps.finder.outputs.pr }}",
-              "Commit_Message" : "${{ steps.finder.outputs.title }}"
+              "Commit_Message" : "${{ steps.finder.outputs.title }}",
+              "Job_Run": "https://github.com/bigcommerce/catalyst/actions/runs/${{ github.run_id }}"
             }

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -149,7 +149,7 @@ jobs:
           payload: |
             {
               "Job": "${{ github.job }}",
-              "Status": "Fail",
+              "Status": "Failed",
               "Pull_Request": "https://github.com/bigcommerce/catalyst/pull/${{ steps.finder.outputs.pr }}",
               "Commit_Message" : "${{ steps.finder.outputs.title }}",
               "Job_Run": "https://github.com/bigcommerce/catalyst/actions/runs/${{ github.run_id }}"
@@ -206,7 +206,7 @@ jobs:
           payload: |
             {
               "Job": "${{ github.job }}",
-              "Status": "Fail",
+              "Status": "Failed",
               "Pull_Request": "https://github.com/bigcommerce/catalyst/pull/${{ steps.finder.outputs.pr }}",
               "Commit_Message" : "${{ steps.finder.outputs.title }}",
               "Job_Run": "https://github.com/bigcommerce/catalyst/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -124,6 +124,10 @@ jobs:
           cd core
           npx playwright install --with-deps
 
+      - name: Find pull request
+        uses: jwalton/gh-find-current-pr@v1.3.3
+        id: finder
+
       - name: Run Playwright tests
         run: |
           cd core
@@ -135,6 +139,20 @@ jobs:
           name: playwright-report-ui
           path: core/test-results/
           retention-days: 30
+
+      - name: Send slack notification
+        uses: slackapi/slack-github-action@v1.26.0
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          payload: |
+            {
+              "Job": "${{ github.job }}",
+              "Status": "Fail",
+              "Pull_Request": "https://github.com/bigcommerce/catalyst/pull/${{ steps.finder.outputs.pr }}",
+              "Commit_Message" : "${{ steps.finder.outputs.title }}"
+            }
 
   visual-regression-tests:
     name: Playwright Visual Regression Tests
@@ -162,6 +180,10 @@ jobs:
           cd core
           npx playwright install chromium
 
+      - name: Find pull request
+        uses: jwalton/gh-find-current-pr@v1.3.3
+        id: finder
+
       - name: Run Playwright tests
         run: |
           cd core
@@ -174,3 +196,16 @@ jobs:
           path: core/test-results/
           retention-days: 30
 
+      - name: Send slack notification
+        uses: slackapi/slack-github-action@v1.26.0
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          payload: |
+            {
+              "Job": "${{ github.job }}",
+              "Status": "Fail",
+              "Pull_Request": "https://github.com/bigcommerce/catalyst/pull/${{ steps.finder.outputs.pr }}",
+              "Commit_Message" : "${{ steps.finder.outputs.title }}"
+            }


### PR DESCRIPTION
## What/Why?
Send notifications to slack team channel with the necessary information to alert any job failures. When a job from the regression tests workflow fails, this step will send a message with failure notification and the pull request associated with the workflow which caused the failure.

For this to work, I've added a slack workflow which provides a webhook. It accepts the payload we send as part of this step on failure and dispatches the message to the configured slack channel.

## Testing
Tested by sending messages to channel.

<img width="658" alt="Screenshot 2024-08-07 at 10 07 41 AM" src="https://github.com/user-attachments/assets/ce5b5433-e698-4376-a48d-6bc7e56b7006">


