### PR TITLE
Speed up builds by excluding node_modules from tailwind config

### DIFF
--- a/.changeset/gentle-experts-do.md
+++ b/.changeset/gentle-experts-do.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Exclude node_modules from tailwind config to improve build time

--- a/core/tailwind.config.js
+++ b/core/tailwind.config.js
@@ -1,6 +1,10 @@
 /** @type {import('tailwindcss').Config} */
 const config = {
-  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  content: [
+    './app/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+    '!./node_modules/**', // Exclude everything in node_modules to speed up builds
+  ],
   theme: {
     extend: {
       colors: {
@@ -47,11 +51,10 @@ const config = {
 
   plugins: [
     // @ts-ignore
-    /* eslint-disable global-require */
+
     require('tailwindcss-radix')(),
     require('tailwindcss-animate'),
     require('@tailwindcss/container-queries'),
-    /* eslint-enable global-require */
   ],
 };
 


### PR DESCRIPTION
## What/Why?
https://github.com/vercel/next.js/issues/37825#issuecomment-1633364694

Our build time was spending over 60 seconds on `Creating an optimized production build...` so I tried removing the `node_modules` folder from the `content` in tailwind config, and I see much faster build times now.

## Testing
Preview build

Before:
<img width="912" alt="image" src="https://github.com/user-attachments/assets/a6f64958-8265-4730-a99d-3fe22605319f">
<img width="236" alt="image" src="https://github.com/user-attachments/assets/9dcb84da-07bf-498f-a793-cc55d8e4e416">


After:
<img width="868" alt="image" src="https://github.com/user-attachments/assets/64814915-f1fe-4f7c-bb57-d2dec3568882">

<img width="236" alt="image" src="https://github.com/user-attachments/assets/684dd6d1-3e90-439f-b351-df92caf2bd3e">
