### PR TITLE
fix: type for slideshow should not include ref

### DIFF
--- a/core/components/ui/slideshow/slideshow.tsx
+++ b/core/components/ui/slideshow/slideshow.tsx
@@ -1,8 +1,8 @@
 import useEmblaCarousel from 'embla-carousel-react';
 import { ArrowLeft, ArrowRight, Pause, Play } from 'lucide-react';
-import { ComponentPropsWithRef, ReactNode, useEffect, useReducer, useState } from 'react';
+import { ComponentPropsWithoutRef, ReactNode, useEffect, useReducer, useState } from 'react';
 
-interface Props extends ComponentPropsWithRef<'section'> {
+interface Props extends ComponentPropsWithoutRef<'section'> {
   slides: ReactNode[];
   interval?: number;
 }


### PR DESCRIPTION
## What/Why?
Since slideshow handles its own ref internally, and we do not use a ref passed from props, we can use `ComponentPropsWithoutRef` when defining the props for slideshow. This also makes it easier to register in Makeswift.

## Testing
N/A