### PR TITLE
refactor(cli): parse env using dotenv

### DIFF
--- a/.changeset/plenty-impalas-jog.md
+++ b/.changeset/plenty-impalas-jog.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": patch
+---
+
+refactor: parse env using `dotenv` package

--- a/packages/create-catalyst/package.json
+++ b/packages/create-catalyst/package.json
@@ -22,6 +22,7 @@
     "@inquirer/prompts": "^5.3.8",
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
+    "dotenv": "^16.4.5",
     "fs-extra": "^11.2.0",
     "giget": "^1.2.3",
     "lodash.kebabcase": "^4.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,6 +283,9 @@ importers:
       commander:
         specifier: ^12.1.0
         version: 12.1.0
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.4.5
       fs-extra:
         specifier: ^11.2.0
         version: 11.2.0


### PR DESCRIPTION
## What/Why?
Parse environment variable diff using `dotenv.parse` instead of custom regex expression

## Testing
`pnpm dev && node ./packages/create-catalyst/dist/index.js integration name`