### PR TITLE
fix(functional): Add environment details to message

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -74,8 +74,17 @@ jobs:
             core.setOutput("comment", comment);
 
       - name: Find pull request
-        uses: jwalton/gh-find-current-pr@v1.3.3
-        id: finder
+        id: find_pull_request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            return (
+              await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                commit_sha: context.sha,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              })
+            ).data[0];
 
       - name: Add comment to PR
         id: comment_to_pr
@@ -83,7 +92,7 @@ jobs:
         with:
           recreate: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          number: ${{ steps.finder.outputs.pr }}
+          number: ${{ fromJson(steps.find_pull_request.outputs.result).number }}
           header: lighthouse
           message: |
             # ⚡️🏠 Lighthouse report
@@ -125,8 +134,17 @@ jobs:
           npx playwright install --with-deps
 
       - name: Find pull request
-        uses: jwalton/gh-find-current-pr@v1.3.3
-        id: finder
+        id: find_pull_request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            return (
+              await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                commit_sha: context.sha,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              })
+            ).data[0];
 
       - name: Run Playwright tests
         run: |
@@ -150,8 +168,9 @@ jobs:
             {
               "Job": "${{ github.job }}",
               "Status": "Failed",
-              "Pull_Request": "https://github.com/bigcommerce/catalyst/pull/${{ steps.finder.outputs.pr }}",
-              "Commit_Message" : "${{ steps.finder.outputs.title }}",
+              "Environment": "${{ github.event.deployment_status.environment }}",
+              "Pull_Request": "${{ fromJson(steps.find_pull_request.outputs.result).html_url }}",
+              "Commit_Message" : "${{ fromJson(steps.find_pull_request.outputs.result).title }}",
               "Job_Run": "https://github.com/bigcommerce/catalyst/actions/runs/${{ github.run_id }}"
             }
 
@@ -182,8 +201,17 @@ jobs:
           npx playwright install chromium
 
       - name: Find pull request
-        uses: jwalton/gh-find-current-pr@v1.3.3
-        id: finder
+        id: find_pull_request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            return (
+              await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                commit_sha: context.sha,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              })
+            ).data[0];
 
       - name: Run Playwright tests
         run: |
@@ -207,7 +235,8 @@ jobs:
             {
               "Job": "${{ github.job }}",
               "Status": "Failed",
-              "Pull_Request": "https://github.com/bigcommerce/catalyst/pull/${{ steps.finder.outputs.pr }}",
-              "Commit_Message" : "${{ steps.finder.outputs.title }}",
+              "Environment": "${{ github.event.deployment_status.environment }}",
+              "Pull_Request": "${{ fromJson(steps.find_pull_request.outputs.result).html_url }}",
+              "Commit_Message" : "${{ fromJson(steps.find_pull_request.outputs.result).title }}",
               "Job_Run": "https://github.com/bigcommerce/catalyst/actions/runs/${{ github.run_id }}"
             }


### PR DESCRIPTION
## What/Why?
Add environment details to slack message to distinguish between the releases. Along with it, I updated the script to rely on `actions/github-script` to fetch the pull request information. 

## Testing
<img width="672" alt="Screenshot 2024-08-09 at 11 01 39 AM" src="https://github.com/user-attachments/assets/e0426db6-70ce-4fa0-9b48-687fa5e7ba61">
