### PR TITLE
fix(cli): single source of truth for manifest schema

### DIFF
--- a/.changeset/tough-cycles-sell.md
+++ b/.changeset/tough-cycles-sell.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": minor
+---
+
+fix: define a single source of truth for integrations manifest file

--- a/packages/create-catalyst/src/commands/integration.ts
+++ b/packages/create-catalyst/src/commands/integration.ts
@@ -9,16 +9,14 @@ import { z } from 'zod';
 
 const exec = promisify(execCb);
 
-interface Manifest {
-  name: string;
-  dependencies: {
-    add: string[];
-  };
-  devDependencies: {
-    add: string[];
-  };
-  environmentVariables: string[];
-}
+export const ManifestSchema = z.object({
+  name: z.string(),
+  dependencies: z.object({ add: z.array(z.string()) }),
+  devDependencies: z.object({ add: z.array(z.string()) }),
+  environmentVariables: z.array(z.string()),
+});
+
+type Manifest = z.infer<typeof ManifestSchema>;
 
 export const integration = new Command('integration')
   .argument('<integration-name>', 'Formatted name of the integration')

--- a/packages/create-catalyst/src/utils/apply-integration.ts
+++ b/packages/create-catalyst/src/utils/apply-integration.ts
@@ -4,7 +4,8 @@ import { downloadTemplate } from 'giget';
 import { addDependency, addDevDependency } from 'nypm';
 import { join } from 'path';
 import { promisify } from 'util';
-import * as z from 'zod';
+
+import { ManifestSchema } from '../commands/integration';
 
 import { PackageManager } from './pm';
 import { spinner } from './spinner';
@@ -43,17 +44,11 @@ export async function applyIntegration(
     return;
   }
 
-  const manifest = z
-    .object({
-      dependencies: z.array(z.string()),
-      devDependencies: z.array(z.string()),
-      environmentVariables: z.array(z.string()),
-    })
-    .parse(readJsonSync(join(integrationDir, 'manifest.json')));
+  const manifest = ManifestSchema.parse(readJsonSync(join(integrationDir, 'manifest.json')));
 
-  if (manifest.dependencies.length) {
+  if (manifest.dependencies.add.length) {
     await spinner(
-      addDependency(manifest.dependencies, {
+      addDependency(manifest.dependencies.add, {
         cwd: projectDir,
         silent: true,
         packageManager,
@@ -66,9 +61,9 @@ export async function applyIntegration(
     );
   }
 
-  if (manifest.devDependencies.length) {
+  if (manifest.devDependencies.add.length) {
     await spinner(
-      addDevDependency(manifest.devDependencies, {
+      addDevDependency(manifest.devDependencies.add, {
         cwd: projectDir,
         silent: true,
         packageManager,


### PR DESCRIPTION
## What/Why?
Mistakenly, the `applyIntegrations` utility function was not updated to reflect the new shape of the integration `manifest.json` file, so it failed during consumption. This PR defines a single Manifest schema with `zod` and uses it as a single source of truth for all references to manifest throughout the CLI.

## Testing
Testing built CLI:

https://github.com/user-attachments/assets/567eb4be-e89b-46d4-a117-071e36cd3cc4

