### PR TITLE
fix(chore): Fetch pull request details at the start

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -89,10 +89,11 @@ jobs:
       - name: Add comment to PR
         id: comment_to_pr
         uses: marocchino/sticky-pull-request-comment@v2.9.0
+        if: ${{ steps.find_pull_request.outputs.result }}
         with:
           recreate: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          number: ${{ steps.find_pull_request.outputs.result && fromJson(steps.find_pull_request.outputs.result).number }}
+          number: ${{ fromJson(steps.find_pull_request.outputs.result).number }}
           header: lighthouse
           message: |
             # ⚡️🏠 Lighthouse report

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -15,9 +15,6 @@ jobs:
     name: Lighthouse Audit
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
     if: ${{ contains(fromJson('["Production – catalyst-latest", "Preview – catalyst-latest"]'), github.event.deployment_status.environment) }}
 
     steps:
@@ -95,7 +92,7 @@ jobs:
         with:
           recreate: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          number: ${{ fromJson(steps.find_pull_request.outputs.result).number }}
+          number: ${{ steps.find_pull_request.outputs.result && fromJson(steps.find_pull_request.outputs.result).number }}
           header: lighthouse
           message: |
             # ⚡️🏠 Lighthouse report
@@ -114,9 +111,6 @@ jobs:
     name: Playwright UI Tests
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
     if: ${{ contains(fromJson('["Production – catalyst-latest", "Preview – catalyst-latest"]'), github.event.deployment_status.environment) }}
 
     steps:
@@ -184,9 +178,6 @@ jobs:
     name: Playwright Visual Regression Tests
     timeout-minutes: 30
     runs-on: macos-14
-    permissions:
-      contents: read
-      pull-requests: read
     if: ${{ contains(fromJson('["Production – catalyst-latest", "Preview – catalyst-latest"]'), github.event.deployment_status.environment) }}
 
     steps:

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -15,11 +15,27 @@ jobs:
     name: Lighthouse Audit
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     if: ${{ contains(fromJson('["Production – catalyst-latest", "Preview – catalyst-latest"]'), github.event.deployment_status.environment) }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Find pull request
+        id: find_pull_request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            return (
+              await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                commit_sha: context.sha,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              })
+            ).data[0];
 
       - name: Lighthouse house audit on desktop
         id: lighthouse_audit_desktop
@@ -73,19 +89,6 @@ jobs:
             const comment = lighthouseCommentMaker({ lighthouseOutputs });
             core.setOutput("comment", comment);
 
-      - name: Find pull request
-        id: find_pull_request
-        uses: actions/github-script@v7
-        with:
-          script: |
-            return (
-              await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                commit_sha: context.sha,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-              })
-            ).data[0];
-
       - name: Add comment to PR
         id: comment_to_pr
         uses: marocchino/sticky-pull-request-comment@v2.9.0
@@ -111,6 +114,9 @@ jobs:
     name: Playwright UI Tests
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     if: ${{ contains(fromJson('["Production – catalyst-latest", "Preview – catalyst-latest"]'), github.event.deployment_status.environment) }}
 
     steps:
@@ -178,6 +184,9 @@ jobs:
     name: Playwright Visual Regression Tests
     timeout-minutes: 30
     runs-on: macos-14
+    permissions:
+      contents: read
+      pull-requests: read
     if: ${{ contains(fromJson('["Production – catalyst-latest", "Preview – catalyst-latest"]'), github.event.deployment_status.environment) }}
 
     steps:


### PR DESCRIPTION
## What/Why?
It looks like `find_pull_request` on lighthouse audit workflow doesn't finish and make the output available before the next step(`comment_to_pr`) is looking for the result. Moving the step to a few steps above to make the output readily available should fix the failing workflow due to this.

## Testing
CI results.