### PR TITLE
fix(chore): Fetch pull request data

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -22,17 +22,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Find pull request
-        id: find_pull_request
-        uses: actions/github-script@v7
-        with:
-          script: |
-            return (
-              await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                commit_sha: context.sha,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-              })
-            ).data[0];
+        uses: jwalton/gh-find-current-pr@v1.3.3
+        id: finder
 
       - name: Lighthouse house audit on desktop
         id: lighthouse_audit_desktop
@@ -89,11 +80,11 @@ jobs:
       - name: Add comment to PR
         id: comment_to_pr
         uses: marocchino/sticky-pull-request-comment@v2.9.0
-        if: ${{ steps.find_pull_request.outputs.result }}
+        if: ${{ steps.finder.outputs.pr }}
         with:
           recreate: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          number: ${{ fromJson(steps.find_pull_request.outputs.result).number }}
+          number: ${{ steps.finder.outputs.pr }}
           header: lighthouse
           message: |
             # ⚡️🏠 Lighthouse report
@@ -135,17 +126,8 @@ jobs:
           npx playwright install --with-deps
 
       - name: Find pull request
-        id: find_pull_request
-        uses: actions/github-script@v7
-        with:
-          script: |
-            return (
-              await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                commit_sha: context.sha,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-              })
-            ).data[0];
+        uses: jwalton/gh-find-current-pr@v1.3.3
+        id: finder
 
       - name: Run Playwright tests
         run: |
@@ -170,8 +152,8 @@ jobs:
               "Job": "${{ github.job }}",
               "Status": "Failed",
               "Environment": "${{ github.event.deployment_status.environment }}",
-              "Pull_Request": "${{ fromJson(steps.find_pull_request.outputs.result).html_url }}",
-              "Commit_Message" : "${{ fromJson(steps.find_pull_request.outputs.result).title }}",
+              "Pull_Request": "https://github.com/bigcommerce/catalyst/pull/${{ steps.finder.outputs.pr }}",
+              "Commit_Message" : "${{ steps.finder.outputs.title }}",
               "Job_Run": "https://github.com/bigcommerce/catalyst/actions/runs/${{ github.run_id }}"
             }
 
@@ -202,17 +184,8 @@ jobs:
           npx playwright install chromium
 
       - name: Find pull request
-        id: find_pull_request
-        uses: actions/github-script@v7
-        with:
-          script: |
-            return (
-              await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                commit_sha: context.sha,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-              })
-            ).data[0];
+        uses: jwalton/gh-find-current-pr@v1.3.3
+        id: finder
 
       - name: Run Playwright tests
         run: |
@@ -237,7 +210,7 @@ jobs:
               "Job": "${{ github.job }}",
               "Status": "Failed",
               "Environment": "${{ github.event.deployment_status.environment }}",
-              "Pull_Request": "${{ fromJson(steps.find_pull_request.outputs.result).html_url }}",
-              "Commit_Message" : "${{ fromJson(steps.find_pull_request.outputs.result).title }}",
+              "Pull_Request": "https://github.com/bigcommerce/catalyst/pull/${{ steps.finder.outputs.pr }}",
+              "Commit_Message" : "${{ steps.finder.outputs.title }}",
               "Job_Run": "https://github.com/bigcommerce/catalyst/actions/runs/${{ github.run_id }}"
             }


### PR DESCRIPTION
## What/Why?
Github `action-script` is unreliable when trying to fetch pull request data and thus we are going back to using the previous ways to grab the information we needed. 

## Testing
Tests as part of CI.