### PR TITLE
chore(functional): Send notifications only on open pr

### DIFF
--- a/.github/workflows/pull-request-data.js
+++ b/.github/workflows/pull-request-data.js
@@ -8,4 +8,5 @@ module.exports = async ({ github, context, core }) => {
     core.setOutput('pr', result?.data[0]?.number || '');
     core.setOutput('title', result?.data[0]?.title || '');
     core.setOutput('url', result?.data[0]?.html_url || '');
+    core.setOutput('draft', `${result?.data[0]?.draft}` || 'true');
 }

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -151,7 +151,7 @@ jobs:
 
       - name: Send slack notification
         uses: slackapi/slack-github-action@v1.26.0
-        if: failure()
+        if: ${{ steps.pr_details.outputs.draft != 'true' && failure() }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
@@ -213,7 +213,7 @@ jobs:
 
       - name: Send slack notification
         uses: slackapi/slack-github-action@v1.26.0
-        if: failure()
+        if: ${{ steps.pr_details.outputs.draft != 'true' && failure() }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:


### PR DESCRIPTION
## What/Why?
We want to send notifications on test runs only for open pull requests to cut down the nosie from draft pr's.

## Testing
**Notifications are sent for a pull request in open state**
<img width="402" alt="Screenshot 2024-08-16 at 10 39 44 AM" src="https://github.com/user-attachments/assets/3db41565-45bc-4cda-9956-42f7a66accc4">

**Notifications are skipped for a pull request in draft state**
<img width="401" alt="Screenshot 2024-08-16 at 10 31 30 AM" src="https://github.com/user-attachments/assets/173acc2a-4916-499e-af3b-bfd17a5d9824">
