### PR TITLE
chore: group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,15 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'monday'
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
     ignore:
       - dependency-name: '@types/node'
         update-types: ['version-update:semver-major']
       - dependency-name: 'eslint'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'react-day-picker'
         update-types: ['version-update:semver-major']


### PR DESCRIPTION
## What/Why?
Group dependabot updates into a single PR. We end up doing this every week manually.