### PR TITLE
Add link header to preconnect to CDN

### DIFF
--- a/.changeset/stale-deers-relate.md
+++ b/.changeset/stale-deers-relate.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Add link header to preconnect to CDN

--- a/core/next.config.js
+++ b/core/next.config.js
@@ -52,6 +52,10 @@ const nextConfig = {
             key: 'Content-Security-Policy',
             value: cspHeader.replace(/\n/g, ''),
           },
+          {
+            key: 'Link',
+            value: `<https://${process.env.BIGCOMMERCE_CDN_HOSTNAME ?? 'cdn11.bigcommerce.com'}>; rel=preconnect`,
+          },
         ],
       },
     ];


### PR DESCRIPTION
## What/Why?
Adds a `Link` header to preconnect to `cdn11.bigcommerce.com` to improve load time for images for first-time visitors.

## Testing
<img width="726" alt="image" src="https://github.com/user-attachments/assets/5bc3177f-d956-4ae6-a6a7-b0e6877ec727">
https://www.webpagetest.org/result/240819_AiDcNC_E24/1/details/#waterfall_view_step1