### PR TITLE
Fix: Decode Webpage Id to fix 404 on Webpages with nonsafe ids

### DIFF
--- a/.changeset/few-panthers-judge.md
+++ b/.changeset/few-panthers-judge.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+fix: decode webpage id to fix 404 on some Webpages

--- a/core/app/[locale]/(default)/webpages/normal/[id]/page.tsx
+++ b/core/app/[locale]/(default)/webpages/normal/[id]/page.tsx
@@ -43,7 +43,7 @@ const getWebpageData = cache(async (variables: { id: string }) => {
 });
 
 export async function generateMetadata({ params: { id } }: Props): Promise<Metadata> {
-  const webpage = await getWebpageData({ id });
+  const webpage = await getWebpageData({ id: decodeURIComponent(id) });
 
   if (!webpage) {
     return {};
@@ -59,7 +59,7 @@ export async function generateMetadata({ params: { id } }: Props): Promise<Metad
 }
 
 export default async function WebPage({ params: { id } }: Props) {
-  const webpage = await getWebpageData({ id });
+  const webpage = await getWebpageData({ id: decodeURIComponent(id) });
 
   if (!webpage) {
     notFound();


### PR DESCRIPTION
## What/Why?

Pages with non url safe ids causes to 404 response.

Page Data and PageMetadata request sends the urlencoded id strings. this cause no response. I checked the  Contact page but it already been fix

Example id: `Tm9ybWFsUGFnZToxMA==` and graphgl has the variable `{id:"Tm9ybWFsUGFnZToxMA%3D%3D"}`


<img width="1440" alt="Screenshot 2024-08-22 at 17 24 41" src="https://github.com/user-attachments/assets/8fe364aa-6f45-4db5-84bb-1c2934b0e8d3">


<img width="1440" alt="Screenshot 2024-08-22 at 17 22 12" src="https://github.com/user-attachments/assets/4046fd91-6ad2-4515-92a6-71865045e361">


## Testing

Go to a page with nonurlsafe id