### PR TITLE
fix: decode Webpage id to fix 404 on Webpages with nonsafe ids (#1301)

### DIFF
--- a/.changeset/few-panthers-judge.md
+++ b/.changeset/few-panthers-judge.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+fix: decode webpage id to fix 404 on some Webpages

--- a/core/app/[locale]/(default)/webpages/normal/[id]/page.tsx
+++ b/core/app/[locale]/(default)/webpages/normal/[id]/page.tsx
@@ -43,7 +43,7 @@ const getWebpageData = cache(async (variables: { id: string }) => {
 });
 
 export async function generateMetadata({ params: { id } }: Props): Promise<Metadata> {
-  const webpage = await getWebpageData({ id });
+  const webpage = await getWebpageData({ id: decodeURIComponent(id) });
 
   if (!webpage) {
     return {};
@@ -59,7 +59,7 @@ export async function generateMetadata({ params: { id } }: Props): Promise<Metad
 }
 
 export default async function WebPage({ params: { id } }: Props) {
-  const webpage = await getWebpageData({ id });
+  const webpage = await getWebpageData({ id: decodeURIComponent(id) });
 
   if (!webpage) {
     notFound();


### PR DESCRIPTION
OSS contribution from: https://github.com/bigcommerce/catalyst/pull/1301