### PR TITLE
Add Wishlist test and update wishlist naming

### DIFF
--- a/.changeset/strange-cobras-impress.md
+++ b/.changeset/strange-cobras-impress.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Add Wishlist test and update wishlist naming

--- a/core/components/header/index.tsx
+++ b/core/components/header/index.tsx
@@ -76,7 +76,7 @@ export const Header = async ({ cart, data }: Props) => {
             { path: '/account/orders', name: 'Orders' },
             { path: '/account/messages', name: 'Messages' },
             { path: '/account/addresses', name: 'Addresses' },
-            { path: '/account/wishlists', name: 'Wish lists' },
+            { path: '/account/wishlists', name: 'Wishlists' },
             { path: '/account/recently-viewed', name: 'Recently viewed' },
             { path: '/account/settings', name: 'Account settings' },
             { action: logout, name: 'Log out' },

--- a/core/messages/ja.json
+++ b/core/messages/ja.json
@@ -171,7 +171,7 @@
             "messages": "メッセージ",
             "addresses": "住所",
             "newAddress": "New address",
-            "wishlists": "Wish lists",
+            "wishlists": "Wishlists",
             "recentlyViewed": "Recently viewed",
             "settings": "アカウント設定",
             "changePassword": "パスワード変更",

--- a/core/tests/ui/desktop/e2e/account.spec.ts
+++ b/core/tests/ui/desktop/e2e/account.spec.ts
@@ -35,7 +35,7 @@ test('My Account tabs are displayed and clickable', async ({ page }) => {
   await expect(page.getByRole('link', { name: 'Orders' })).toBeVisible();
   await expect(page.getByRole('link', { name: 'Messages' })).toBeVisible();
   await expect(page.getByRole('link', { name: 'Addresses' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'Wish lists' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Wishlists' })).toBeVisible();
   await expect(page.getByRole('link', { name: 'Recently viewed' })).toBeVisible();
   await expect(page.getByRole('link', { name: 'Account settings' })).toBeVisible();
 
@@ -51,9 +51,9 @@ test('My Account tabs are displayed and clickable', async ({ page }) => {
   await expect(page).toHaveURL('/account/addresses/');
   await expect(page.getByRole('heading', { name: 'Addresses' })).toBeVisible();
 
-  await page.getByRole('link', { name: 'Wish lists' }).click();
+  await page.getByRole('link', { name: 'Wishlists' }).click();
   await expect(page).toHaveURL('/account/wishlists/');
-  await expect(page.getByRole('heading', { name: 'Wish lists' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Wishlists' })).toBeVisible();
 
   await page.getByRole('link', { name: 'Recently viewed' }).click();
   await expect(page).toHaveURL('/account/recently-viewed/');
@@ -102,4 +102,21 @@ test('Add and remove new address', async ({ page }) => {
   await expect(page.getByText(streetAddress, { exact: true })).toBeVisible({
     visible: false,
   });
+});
+
+test('Add and remove new wishlist', async ({ page }) => {
+  await loginWithUserAccount(page, testUserEmail, testUserPassword);
+  await page.goto('/account/wishlists');
+  await page.getByRole('heading', { name: 'Wishlists' }).waitFor();
+
+  await page.getByRole('button', { name: 'New wishlist' }).click();
+  await page.getByLabel('Wishlist name').fill('test');
+  await page.getByRole('button', { name: 'Create' }).click();
+  await expect(page.getByText('Your wishlist test was created successfully')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'test' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Delete' }).click();
+  await page.getByRole('button', { name: /Delete/ }).click();
+  await expect(page.getByText('Your wishlist test was deleted successfully')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'test' })).toBeHidden();
 });


### PR DESCRIPTION
## What/Why?
- Create add/delete Wishlist test
- Fix Wishlist naming in some places, since we agreed with Turner that "wishlist" is the correct one over the "wish list"

## Testing
<img width="991" alt="Screenshot 2024-08-27 at 11 23 01" src="https://github.com/user-attachments/assets/4bd6b168-ecec-4e6b-a6c0-0c03106fa020">