### PR TITLE
fix(core): rename DEFAULT_REVALIDATE_TARGET env variable

### DIFF
--- a/.changeset/proud-colts-relate.md
+++ b/.changeset/proud-colts-relate.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Rename NEXT_PUBLIC_DEFAULT_REVALIDATE_TARGET to DEFAULT_REVALIDATE_TARGET since we don't need this exposed to the client.

--- a/core/.env.example
+++ b/core/.env.example
@@ -33,4 +33,4 @@ TURBO_REMOTE_CACHE_SIGNATURE_KEY=
 # The time persisted is not defined
 # https://nextjs.org/docs/app/building-your-application/caching#data-cache
 # This sets a sensible revalidation target for cached requests
-NEXT_PUBLIC_DEFAULT_REVALIDATE_TARGET=3600
+DEFAULT_REVALIDATE_TARGET=3600

--- a/core/client/revalidate-target.ts
+++ b/core/client/revalidate-target.ts
@@ -1,3 +1,3 @@
-export const revalidate = process.env.NEXT_PUBLIC_DEFAULT_REVALIDATE_TARGET
-  ? Number(process.env.NEXT_PUBLIC_DEFAULT_REVALIDATE_TARGET)
+export const revalidate = process.env.DEFAULT_REVALIDATE_TARGET
+  ? Number(process.env.DEFAULT_REVALIDATE_TARGET)
   : 3600;


### PR DESCRIPTION
## What/Why?
Rename `NEXT_PUBLIC_DEFAULT_REVALIDATE_TARGET` to `DEFAULT_REVALIDATE_TARGET` since we don't need this exposed to the client.

## Testing
Locally.