### PR TITLE
refactor(middleware): split with-routes

### DIFF
--- a/core/middleware.ts
+++ b/core/middleware.ts
@@ -1,8 +1,10 @@
 import { composeMiddlewares } from './middlewares/compose-middlewares';
 import { withAuth } from './middlewares/with-auth';
+import { withChannelId } from './middlewares/with-channel-id';
+import { withIntl } from './middlewares/with-intl';
 import { withRoutes } from './middlewares/with-routes';
 
-export const middleware = composeMiddlewares(withAuth, withRoutes);
+export const middleware = composeMiddlewares(withAuth, withIntl, withChannelId, withRoutes);
 
 export const config = {
   matcher: [

--- a/core/middlewares/with-channel-id.ts
+++ b/core/middlewares/with-channel-id.ts
@@ -1,0 +1,14 @@
+import { getChannelIdFromLocale } from '~/channels.config';
+
+import { type MiddlewareFactory } from './compose-middlewares';
+
+export const withChannelId: MiddlewareFactory = (next) => {
+  return (request, event) => {
+    const locale = request.headers.get('x-bc-locale') ?? '';
+    const channelId = getChannelIdFromLocale(locale) ?? '';
+
+    request.headers.set('x-bc-channel-id', channelId);
+
+    return next(request, event);
+  };
+};

--- a/core/middlewares/with-intl.ts
+++ b/core/middlewares/with-intl.ts
@@ -1,0 +1,40 @@
+import createMiddleware from 'next-intl/middleware';
+
+import { defaultLocale, localePrefix, locales } from '../i18n';
+
+import { type MiddlewareFactory } from './compose-middlewares';
+
+const intlMiddleware = createMiddleware({
+  locales,
+  localePrefix,
+  defaultLocale,
+  localeDetection: true,
+});
+
+export const withIntl: MiddlewareFactory = (next) => {
+  return async (request, event) => {
+    const intlResponse = intlMiddleware(request);
+
+    // If intlMiddleware redirects, return it immediately
+    if (intlResponse.redirected) {
+      return intlResponse;
+    }
+
+    // Extract locale from intlMiddleware response
+    const locale = intlResponse.headers.get('x-middleware-request-x-next-intl-locale') ?? '';
+
+    request.headers.set('x-bc-locale', locale);
+
+    // Continue the middleware chain
+    const response = await next(request, event);
+
+    // Copy headers from intlResponse to response, excluding 'x-middleware-rewrite'
+    intlResponse.headers.forEach((v, k) => {
+      if (k !== 'x-middleware-rewrite') {
+        response?.headers.set(k, v);
+      }
+    });
+
+    return response;
+  };
+};


### PR DESCRIPTION
## What/Why?
This PR splits the `with-routes` middleware into 3:
- with-intl
- with-channel-id
- with-routes

This simplifies `with-routes` and allows us to remove the `locale` var we were mutating/accessing all over the place.