### PR TITLE
fix: remove pagination cursors from search params on sort change

### DIFF
--- a/core/app/[locale]/(default)/(faceted)/_components/sort-by.tsx
+++ b/core/app/[locale]/(default)/(faceted)/_components/sort-by.tsx
@@ -19,6 +19,8 @@ export function SortBy() {
     const params = new URLSearchParams(searchParams);
 
     params.set('sort', sortValue);
+    params.delete('before');
+    params.delete('after');  
 
     startTransition(() => {
       router.push(`${pathname}?${params.toString()}`);


### PR DESCRIPTION
## What/Why?
removes pagination cursors from search params when changing sort option

old cursors were sticking around in the url after changing sort which messed up pagination.

## Testing

1. find a search with enough results for pagination
2. click through a few pages
3. change the sort option
4. it should reload on first page result of new sort selection & remove the cursors from params





------------------------------------

Extends from slack conversation in bigcommercedevs/#catalyst 