### PR TITLE
fix: remove pagination cursors from search params on sort change

### DIFF
--- a/core/app/[locale]/(default)/(faceted)/_components/sort-by.tsx
+++ b/core/app/[locale]/(default)/(faceted)/_components/sort-by.tsx
@@ -19,6 +19,8 @@ export function SortBy() {
     const params = new URLSearchParams(searchParams);
 
     params.set('sort', sortValue);
+    params.delete('before');
+    params.delete('after');
 
     startTransition(() => {
       router.push(`${pathname}?${params.toString()}`);


### PR DESCRIPTION
## What/Why?
Contribution from #1328 

## Testing
See #1328 