### PR TITLE
fix(core): resolve 500 server error on locale change

### DIFF
--- a/.changeset/healthy-cars-talk.md
+++ b/.changeset/healthy-cars-talk.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Fixes a server crash when user switches language settings

--- a/core/middlewares/with-intl.ts
+++ b/core/middlewares/with-intl.ts
@@ -10,8 +10,8 @@ export const withIntl: MiddlewareFactory = (next) => {
   return async (request, event) => {
     const intlResponse = intlMiddleware(request);
 
-    // If intlMiddleware redirects, return it immediately
-    if (intlResponse.redirected) {
+    // If intlMiddleware redirects, or returns a non-200 return it immediately
+    if (!intlResponse.ok) {
       return intlResponse;
     }
 


### PR DESCRIPTION
## What/Why?
With the recent changes to our middleware, there is an issue when switching locales form the UI. `intlResponse.redirected` is false when status is 307 🤔 