### PR TITLE
fix(core): update localeSwitcher to use link instead of form

### DIFF
--- a/.changeset/hot-buses-invent.md
+++ b/.changeset/hot-buses-invent.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Update localeSwitcher to use a link instead of a form.

--- a/core/components/ui/header/locale-switcher.tsx
+++ b/core/components/ui/header/locale-switcher.tsx
@@ -2,10 +2,10 @@
 
 import * as PopoverPrimitive from '@radix-ui/react-popover';
 import { useTranslations } from 'next-intl';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { Link } from '~/components/link';
-import { defaultLocale, LocaleType } from '~/i18n/routing';
+import { LocaleType } from '~/i18n/routing';
 
 import { Button } from '../button';
 import { Select } from '../form';
@@ -109,7 +109,7 @@ const LocaleSwitcher = ({ activeLocale, locales }: Props) => {
                 value={languageSelected}
               />
               <Button asChild>
-                <Link className="hover:text-white" href="/" locale={newLocale?.id ?? defaultLocale}>
+                <Link className="hover:text-white" href="/" locale={newLocale?.id}>
                   {t('goToSite')}
                 </Link>
               </Button>

--- a/core/components/ui/header/locale-switcher.tsx
+++ b/core/components/ui/header/locale-switcher.tsx
@@ -52,9 +52,13 @@ const LocaleSwitcher = ({ activeLocale, locales }: Props) => {
     [locales],
   );
 
-  const newLocale = useMemo(() => locales.find(
-      (locale) => locale.language === languageSelected && locale.region === regionSelected,
-    ), [languageSelected, regionSelected]);
+  const newLocale = useMemo(
+    () =>
+      locales.find(
+        (locale) => locale.language === languageSelected && locale.region === regionSelected,
+      ),
+    [languageSelected, locales, regionSelected],
+  );
 
   if (!selectedLocale) {
     return null;

--- a/core/components/ui/header/locale-switcher.tsx
+++ b/core/components/ui/header/locale-switcher.tsx
@@ -37,7 +37,6 @@ const LocaleSwitcher = ({ activeLocale, locales }: Props) => {
 
   const [regionSelected, setRegionSelected] = useState(selectedLocale?.region || '');
   const [languageSelected, setLanguageSelected] = useState(selectedLocale?.language || '');
-  const [newLocale, setNewLocale] = useState<LocaleType | null>(null);
 
   const languagesByRegionMap = useMemo(
     () =>
@@ -53,17 +52,9 @@ const LocaleSwitcher = ({ activeLocale, locales }: Props) => {
     [locales],
   );
 
-  useEffect(() => {
-    if (regionSelected && languageSelected) {
-      const nextLocale = locales.find(
-        (locale) => locale.language === languageSelected && locale.region === regionSelected,
-      );
-
-      if (nextLocale) {
-        setNewLocale(nextLocale.id);
-      }
-    }
-  }, [regionSelected, languageSelected, locales]);
+  const newLocale = useMemo(() => locales.find(
+      (locale) => locale.language === languageSelected && locale.region === regionSelected,
+    ), [languageSelected, regionSelected]);
 
   if (!selectedLocale) {
     return null;
@@ -118,7 +109,7 @@ const LocaleSwitcher = ({ activeLocale, locales }: Props) => {
                 value={languageSelected}
               />
               <Button asChild>
-                <Link className="hover:text-white" href="/" locale={newLocale ?? defaultLocale}>
+                <Link className="hover:text-white" href="/" locale={newLocale?.id ?? defaultLocale}>
                   {t('goToSite')}
                 </Link>
               </Button>


### PR DESCRIPTION
## What/Why?
Use link instead of form. Simplifies logic and behaves better.

## Testing
Locally, it redirects to correct locale without use, even when always showing locale prefix.