### PR TITLE
feat: update for compatibility with @bigcommerce/catalyst-core@0.15.0

### DIFF
--- a/integrations/makeswift/integration.patch
+++ b/integrations/makeswift/integration.patch
@@ -1,5 +1,5 @@
 diff --git a/core/.env.example b/core/.env.example
-index b0425c70..f26e063e 100644
+index b0f4ee46..e962f421 100644
 --- a/core/.env.example
 +++ b/core/.env.example
 @@ -1,3 +1,7 @@
@@ -11,17 +11,17 @@ index b0425c70..f26e063e 100644
  # The control panel URL is of the form `https://store-{hash}.mybigcommerce.com`. 
  BIGCOMMERCE_STORE_HASH=
 diff --git a/core/app/[locale]/(default)/[...rest]/page.tsx b/core/app/[locale]/(default)/[...rest]/page.tsx
-index 71d40507..70c1c4ed 100644
+index 71d40507..2d20fa4f 100644
 --- a/core/app/[locale]/(default)/[...rest]/page.tsx
 +++ b/core/app/[locale]/(default)/[...rest]/page.tsx
-@@ -1,5 +1,43 @@
+@@ -1,5 +1,46 @@
 +import { Page as MakeswiftPage } from '@makeswift/runtime/next';
 +import { getSiteVersion } from '@makeswift/runtime/next/server';
  import { notFound } from 'next/navigation';
  
 -export default function CatchAllPage() {
 -  notFound();
-+import { defaultLocale, locales } from '~/i18n';
++import { defaultLocale, locales } from '~/i18n/routing';
 +import { client } from '~/lib/makeswift/client';
 +import { MakeswiftProvider } from '~/lib/makeswift/provider';
 +
@@ -33,13 +33,16 @@ index 71d40507..70c1c4ed 100644
 +export async function generateStaticParams() {
 +  const pages = await client.getPages().toArray();
 +
-+  return pages.flatMap((page) =>
-+    locales.map((locale) => ({
-+      rest: page.path.split('/').filter((segment) => segment !== ''),
-+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-+      locale: locale === defaultLocale ? undefined : locale,
-+    })),
-+  );
++  return pages
++    .filter((page) => page.path !== '/')
++    .flatMap((page) =>
++      locales.map((locale) => ({
++        rest: page.path.split('/').filter((segment) => segment !== ''),
++        // Remove eslint disable once more locales are added
++        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
++        locale: locale === defaultLocale ? undefined : locale,
++      })),
++    );
 +}
 +
 +export default async function CatchAllPage({ params }: { params: CatchAllParams }) {
@@ -61,7 +64,7 @@ index 71d40507..70c1c4ed 100644
 +
 +export const runtime = 'nodejs';
 diff --git a/core/app/[locale]/layout.tsx b/core/app/[locale]/layout.tsx
-index 521f4ffa..26fb0fb9 100644
+index faf15d53..a66fb02b 100644
 --- a/core/app/[locale]/layout.tsx
 +++ b/core/app/[locale]/layout.tsx
 @@ -1,3 +1,4 @@
@@ -69,7 +72,7 @@ index 521f4ffa..26fb0fb9 100644
  import { Analytics } from '@vercel/analytics/react';
  import { SpeedInsights } from '@vercel/speed-insights/next';
  import type { Metadata } from 'next';
-@@ -75,6 +76,9 @@ export default function RootLayout({ children, params: { locale } }: RootLayoutP
+@@ -73,6 +74,9 @@ export default function RootLayout({ children, params: { locale } }: Props) {
  
    return (
      <html className={`${inter.variable} font-sans`} lang={locale}>
@@ -78,7 +81,7 @@ index 521f4ffa..26fb0fb9 100644
 +      </head>
        <body className="flex h-screen min-w-[375px] flex-col">
          <Notifications />
-         <NextIntlClientProvider locale={locale} messages={{ Providers: messages.Providers ?? {} }}>
+         <NextIntlClientProvider locale={locale} messages={messages}>
 diff --git a/core/app/api/makeswift/[...makeswift]/route.ts b/core/app/api/makeswift/[...makeswift]/route.ts
 new file mode 100644
 index 00000000..52186316
@@ -117,7 +120,7 @@ index 00000000..4013f3ff
 +};
 diff --git a/core/app/api/product-card-carousel/[type]/route.ts b/core/app/api/product-card-carousel/[type]/route.ts
 new file mode 100644
-index 00000000..6a47e7a8
+index 00000000..bea1b56f
 --- /dev/null
 +++ b/core/app/api/product-card-carousel/[type]/route.ts
 @@ -0,0 +1,52 @@
@@ -127,7 +130,7 @@ index 00000000..6a47e7a8
 +import { getSessionCustomerId } from '~/auth';
 +import { client } from '~/client';
 +import { graphql } from '~/client/graphql';
-+import { ProductCardCarouselFragment } from '~/components/product-card-carousel';
++import { ProductCardCarouselFragment } from '~/components/product-card-carousel/fragment';
 +
 +const GetProductCardCarousel = graphql(
 +  `
@@ -175,7 +178,7 @@ index 00000000..6a47e7a8
 +export const runtime = 'edge';
 diff --git a/core/components/ui/accordions/accordion.makeswift.tsx b/core/components/ui/accordions/accordion.makeswift.tsx
 new file mode 100644
-index 00000000..2073f07a
+index 00000000..a70a94e8
 --- /dev/null
 +++ b/core/components/ui/accordions/accordion.makeswift.tsx
 @@ -0,0 +1,35 @@
@@ -193,8 +196,8 @@ index 00000000..2073f07a
 +      type: Shape({
 +        type: {
 +          content: Slot(),
-+          value: TextInput({
-+            label: 'Value',
++          title: TextInput({
++            label: 'Title',
 +            defaultValue: 'Lorem Ipsum?',
 +            placeholder: 'Unique value',
 +          }),
@@ -216,7 +219,7 @@ index 00000000..2073f07a
 +});
 diff --git a/core/components/ui/carousel/carousel.makeswift.tsx b/core/components/ui/carousel/carousel.makeswift.tsx
 new file mode 100644
-index 00000000..a5e69ba5
+index 00000000..c2c1d9a6
 --- /dev/null
 +++ b/core/components/ui/carousel/carousel.makeswift.tsx
 @@ -0,0 +1,75 @@
@@ -224,7 +227,7 @@ index 00000000..a5e69ba5
 +import { useEffect, useState } from 'react';
 +
 +import { ResultOf } from '~/client/graphql';
-+import { ProductCardCarouselFragment } from '~/components/product-card-carousel';
++import { ProductCardCarouselFragment } from '~/components/product-card-carousel/fragment';
 +import { ProductCard } from '~/components/ui/product-card';
 +import { runtime } from '~/lib/makeswift/runtime';
 +
@@ -297,7 +300,7 @@ index 00000000..a5e69ba5
 +);
 diff --git a/core/components/ui/slideshow/slideshow.makeswift.tsx b/core/components/ui/slideshow/slideshow.makeswift.tsx
 new file mode 100644
-index 00000000..042a19f7
+index 00000000..4010405b
 --- /dev/null
 +++ b/core/components/ui/slideshow/slideshow.makeswift.tsx
 @@ -0,0 +1,83 @@
@@ -343,7 +346,7 @@ index 00000000..042a19f7
 +          description: slide.description,
 +          image: slide.image
 +            ? {
-+                alt: slide.image.alt,
++                altText: slide.image.alt,
 +                blurDataUrl: slide.image.blurDataUrl,
 +                src: slide.image.src,
 +              }
@@ -422,6 +425,19 @@ index 00000000..8f8135fd
 +    }),
 +  },
 +});
+diff --git a/core/components/ui/tabs/tabs.tsx b/core/components/ui/tabs/tabs.tsx
+index 2178a860..df24b2d4 100644
+--- a/core/components/ui/tabs/tabs.tsx
++++ b/core/components/ui/tabs/tabs.tsx
+@@ -10,7 +10,7 @@ interface Props {
+   className?: string;
+   defaultValue?: string;
+   label: string;
+-  onValueChange: (value: string) => void;
++  onValueChange?: (value: string) => void;
+   tabs: Tab[];
+   value?: string;
+ }
 diff --git a/core/lib/makeswift/client.ts b/core/lib/makeswift/client.ts
 new file mode 100644
 index 00000000..c1dc2108
@@ -479,17 +495,24 @@ index 00000000..e988b5cf
 +
 +export const runtime = new ReactRuntime();
 diff --git a/core/middleware.ts b/core/middleware.ts
-index 0be31944..4aaeda80 100644
+index c9928bdd..1724c1ea 100644
 --- a/core/middleware.ts
 +++ b/core/middleware.ts
-@@ -1,8 +1,9 @@
- import { composeMiddlewares } from './middlewares/compose-middlewares';
+@@ -2,9 +2,16 @@ import { composeMiddlewares } from './middlewares/compose-middlewares';
  import { withAuth } from './middlewares/with-auth';
+ import { withChannelId } from './middlewares/with-channel-id';
+ import { withIntl } from './middlewares/with-intl';
 +import { withMakeswift } from './middlewares/with-makeswift';
  import { withRoutes } from './middlewares/with-routes';
  
--export const middleware = composeMiddlewares(withAuth, withRoutes);
-+export const middleware = composeMiddlewares(withAuth, withMakeswift, withRoutes);
+-export const middleware = composeMiddlewares(withAuth, withIntl, withChannelId, withRoutes);
++export const middleware = composeMiddlewares(
++  withAuth,
++  withMakeswift,
++  withIntl,
++  withChannelId,
++  withRoutes,
++);
  
  export const config = {
    matcher: [
@@ -539,7 +562,7 @@ index 00000000..e1eed268
 +  };
 +};
 diff --git a/core/next.config.js b/core/next.config.js
-index f49bd33d..7bea180b 100644
+index de72984d..82c50cf3 100644
 --- a/core/next.config.js
 +++ b/core/next.config.js
 @@ -1,6 +1,8 @@
@@ -551,9 +574,13 @@ index f49bd33d..7bea180b 100644
  const withNextIntl = createNextIntlPlugin();
  
  const { cspHeader } = require('./lib/content-security-policy');
-@@ -58,4 +60,4 @@ const nextConfig = {
-   },
- };
+@@ -67,6 +69,9 @@ let nextConfig = {
+ // Apply withNextIntl to the config
+ nextConfig = withNextIntl(nextConfig);
  
--module.exports = withNextIntl(nextConfig);
-+module.exports = withMakeswift(withNextIntl(nextConfig));
++// Apply withMakeswift to the config
++nextConfig = withMakeswift(nextConfig);
++
+ if (process.env.ANALYZE === 'true') {
+   const withBundleAnalyzer = require('@next/bundle-analyzer')();
+ 


### PR DESCRIPTION
## What/Why?
Changes any `~/i18n` imports to `~/i18n/routing` appropriately. Sends `undefined` as locale value to Makeswift for default locale, so that by default any locale will work with Makeswift. Updates product carousel fragment location. Updates small changes in various component prop API keys.

## Testing
Creating a local catalyst storefront and applying the Makeswift integration works locally after building the CLI.