### PR TITLE
test(core): run address tests in serial mode

### DIFF
--- a/core/tests/ui/desktop/e2e/addresses.spec.ts
+++ b/core/tests/ui/desktop/e2e/addresses.spec.ts
@@ -26,6 +26,8 @@ async function logout(page: Page) {
   await page.getByRole('menuitem', { name: 'Log out' }).click();
 }
 
+test.describe.configure({ mode: 'serial' });
+
 test('Add new address', async ({ page }) => {
   await loginWithUserAccount(page, testUserEmail, testUserPassword);
   await page.goto('/account/addresses');


### PR DESCRIPTION
## What/Why?
Runs the address tests in serial mode as it uses a logged in customer. When #1262 get's merged, logging a user out will invalidate the session in other parallel tests so we need to run them serially.

## Testing
See CI for passing test runs.