### PR TITLE
fix(core): change locale prefix to  to prevent caching issues

### DIFF
--- a/.changeset/gentle-eyes-double.md
+++ b/.changeset/gentle-eyes-double.md
@@ -1,0 +1,8 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Change LocalePrefix mode to `as-needed`, since there's an issue that is causing caching problems when using `never`.
+
+More info about LocalePrefixes: https://next-intl-docs.vercel.app/docs/routing#shared-configuration
+Open issue: https://github.com/amannn/next-intl/issues/786

--- a/core/i18n/routing.ts
+++ b/core/i18n/routing.ts
@@ -64,13 +64,13 @@ export const localeLanguageRegionMap: LocaleEntry[] = [
 
 enum LocalePrefixes {
   ALWAYS = 'always',
-  NEVER = 'never',
+  // Don't use NEVER as there is a issue that causes cache problems and returns the wrong messages.
+  // More info: https://github.com/amannn/next-intl/issues/786
+  // NEVER = 'never',
   ASNEEDED = 'as-needed', // removes prefix on default locale
 }
 
-// Temporary we use NEVER prefix to prioritize accept-language header
-// & disable internationalized routes due to incomplete multilingual implementation
-export const localePrefix: LocalePrefix = LocalePrefixes.NEVER;
+export const localePrefix: LocalePrefix = LocalePrefixes.ASNEEDED;
 
 export const defaultLocale = 'en';
 


### PR DESCRIPTION
## What/Why?
When using locale switcher with [locale prefix](https://next-intl-docs.vercel.app/docs/routing#shared-configuration) `never`, there is a caching issue that prevents the correct messages to show when navigating between pages. There is an [open issue](https://github.com/amannn/next-intl/issues/786) about this. 

This change sets locale prefix to `as-needed`, so locale prefix will only be shown if not using the default locale.

## Testing
Correct messages are shown when locale switching without the need to hard refresh.