### PR TITLE
feat: optionally disable Vercel's insights and analytics

### DIFF
--- a/.changeset/flat-tables-hang.md
+++ b/.changeset/flat-tables-hang.md
@@ -1,0 +1,9 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+If app is not running on Vercel's infra, `<Analytics />` and `<SpeedInsights />` are not rendered.
+
+Opt-in to disable vercel analytics and speed insights by setting the following env vars to `true`
+
+- `DISABLE_VERCEL_ANALYTICS`
+- `DISABLE_VERCEL_SPEED_INSIGHTS`

--- a/.changeset/flat-tables-hang.md
+++ b/.changeset/flat-tables-hang.md
@@ -3,7 +3,7 @@
 ---
 If app is not running on Vercel's infra, `<Analytics />` and `<SpeedInsights />` are not rendered.
 
-Opt-in to disable vercel analytics and speed insights by setting the following env vars to `true`
+Opt-out of vercel analytics and speed insights by setting the following env vars to `true`
 
 - `DISABLE_VERCEL_ANALYTICS`
 - `DISABLE_VERCEL_SPEED_INSIGHTS`

--- a/core/app/[locale]/layout.tsx
+++ b/core/app/[locale]/layout.tsx
@@ -60,6 +60,19 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
+const VercelComponents = () => {
+  if (process.env.VERCEL !== '1') {
+    return null;
+  }
+
+  return (
+    <>
+      {process.env.DISABLE_VERCEL_ANALYTICS !== 'true' && <Analytics />}
+      {process.env.DISABLE_VERCEL_SPEED_INSIGHTS !== 'true' && <SpeedInsights />}
+    </>
+  );
+};
+
 interface Props extends PropsWithChildren {
   params: { locale: string };
 }
@@ -78,8 +91,7 @@ export default function RootLayout({ children, params: { locale } }: Props) {
         <NextIntlClientProvider locale={locale} messages={messages}>
           <Providers>{children}</Providers>
         </NextIntlClientProvider>
-        <Analytics />
-        <SpeedInsights />
+        <VercelComponents />
       </body>
     </html>
   );


### PR DESCRIPTION
## What/Why?
If app is not running on Vercel's infra, `<Analytics />` and `<SpeedInsights />` are not rendered.

Opt-in to disable vercel analytics and speed insights by setting the following env vars to `true`

- `DISABLE_VERCEL_ANALYTICS`
- `DISABLE_VERCEL_SPEED_INSIGHTS`
