### PR TITLE
fix: do not write access token to env file

### DIFF
--- a/.changeset/small-sheep-divide.md
+++ b/.changeset/small-sheep-divide.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": minor
+---
+
+Changes the default behavior of the `create-catalyst` CLI such that it no longer writes the access token created by the OAuth device flow to the created project's `.env.local` file

--- a/packages/create-catalyst/src/commands/create.ts
+++ b/packages/create-catalyst/src/commands/create.ts
@@ -247,7 +247,6 @@ export const create = new Command('create')
     writeEnv(projectDir, {
       channelId: channelId.toString(),
       storeHash,
-      accessToken,
       customerImpersonationToken,
     });
 

--- a/packages/create-catalyst/src/commands/init.ts
+++ b/packages/create-catalyst/src/commands/init.ts
@@ -129,7 +129,6 @@ export const init = new Command('init')
     writeEnv(projectDir, {
       channelId: channelId.toString(),
       storeHash,
-      accessToken,
       customerImpersonationToken,
     });
   });

--- a/packages/create-catalyst/src/utils/write-env.ts
+++ b/packages/create-catalyst/src/utils/write-env.ts
@@ -7,23 +7,21 @@ export const writeEnv = (
   {
     channelId,
     storeHash,
-    accessToken,
     customerImpersonationToken,
   }: {
     channelId: string;
     storeHash: string;
-    accessToken: string;
     customerImpersonationToken: string;
   },
 ) => {
   outputFileSync(
     join(projectDir, '.env.local'),
     [
-      `AUTH_SECRET=${randomBytes(32).toString('hex')}`,
       `BIGCOMMERCE_STORE_HASH=${storeHash}`,
       `BIGCOMMERCE_CHANNEL_ID=${channelId}`,
-      `BIGCOMMERCE_ACCESS_TOKEN=${accessToken}`,
       `BIGCOMMERCE_CUSTOMER_IMPERSONATION_TOKEN=${customerImpersonationToken}`,
+      '',
+      `AUTH_SECRET=${randomBytes(32).toString('hex')}`,
       `CLIENT_LOGGER=false`,
       `ENABLE_ADMIN_ROUTE=true`,
       `NEXT_PUBLIC_DEFAULT_REVALIDATE_TARGET=3600`,


### PR DESCRIPTION
## What/Why?
A BigCommerce access token is no longer required to run Catalyst. If a merchant wants to use an access token, they should manually create one following: https://www.catalyst.dev/docs/environment-variables#bigcommerce_access_token

## Testing
Built and ran `node packages/create-catalyst/bin/index.cjs` locally, checked `.env.local` in created project to confirm access token not present:

```shell
BIGCOMMERCE_STORE_HASH=storehash
BIGCOMMERCE_CHANNEL_ID=12345
BIGCOMMERCE_CUSTOMER_IMPERSONATION_TOKEN=eyJ...

AUTH_SECRET=e85b...
CLIENT_LOGGER=false
ENABLE_ADMIN_ROUTE=true
NEXT_PUBLIC_DEFAULT_REVALIDATE_TARGET=3600
```