### PR TITLE
fix: rename leftover references to NEXT_PUBLIC_DEFAULT_REVALIDATE_TARGET

### DIFF
--- a/.changeset/wise-games-try.md
+++ b/.changeset/wise-games-try.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": minor
+---
+
+Renames leftover `NEXT_PUBLIC_DEFAULT_REVALIDATE_TARGET` environment variables - continuation of bigcommerce/catalyst#1317

--- a/.env.example
+++ b/.env.example
@@ -33,4 +33,4 @@ TURBO_REMOTE_CACHE_SIGNATURE_KEY=
 # The time persisted is not defined
 # https://nextjs.org/docs/app/building-your-application/caching#data-cache
 # This sets a sensible revalidation target for cached requests
-NEXT_PUBLIC_DEFAULT_REVALIDATE_TARGET=3600
+DEFAULT_REVALIDATE_TARGET=3600

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -224,7 +224,7 @@ The `TRAILING_SLASH` variable defaults to `true` and must be explicitly set to `
 
 Catalyst uses the existing URLs of your BigCommerce objects, such as products and categories, as the URL paths on your storefront. Default [paths for BigCommerce products, categories, etc.](https://support.bigcommerce.com/s/article/Store-Settings#url-structure) create URLs with a trailing slash, while the [Next.js default behavior](https://nextjs.org/docs/app/api-reference/next-config-js/trailingSlash) does not use trailing slashes on URLs.
 
-### NEXT_PUBLIC_DEFAULT_REVALIDATE_TARGET
+### DEFAULT_REVALIDATE_TARGET
 
 | Attribute        | Value                                          |
 | :--------------- | :--------------------------------------------- |

--- a/packages/create-catalyst/src/utils/write-env.ts
+++ b/packages/create-catalyst/src/utils/write-env.ts
@@ -24,7 +24,7 @@ export const writeEnv = (
       `AUTH_SECRET=${randomBytes(32).toString('hex')}`,
       `CLIENT_LOGGER=false`,
       `ENABLE_ADMIN_ROUTE=true`,
-      `NEXT_PUBLIC_DEFAULT_REVALIDATE_TARGET=3600`,
+      `DEFAULT_REVALIDATE_TARGET=3600`,
     ].join('\n'),
   );
 };


### PR DESCRIPTION
> [!NOTE]
> Stacks on #1365 

## What/Why?
Renames a few more references to `NEXT_PUBLIC_DEFAULT_REVLIDATE_TARGET` env var, missed in https://github.com/bigcommerce/catalyst/pull/1317

## Testing
Search all repository files for `"NEXT_PUBLIC_DEFAULT_REVALIDATE_TARGET"`