### PR TITLE
fix(core): manually pass in channel id for get favicon query

### DIFF
--- a/.changeset/tidy-coats-press.md
+++ b/.changeset/tidy-coats-press.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Pass in default channel to favicon query, since `getLocale` can't be used in routes.

--- a/core/app/favicon.ico/route.ts
+++ b/core/app/favicon.ico/route.ts
@@ -9,10 +9,12 @@
  *
  */
 
+import { getChannelIdFromLocale } from '~/channels.config';
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
+import { defaultLocale } from '~/i18n/routing';
 
-const GET_FAVICON_QUERY = graphql(`
+const GetFaviconQuery = graphql(`
   query GetFavicon {
     site {
       settings {
@@ -24,7 +26,8 @@ const GET_FAVICON_QUERY = graphql(`
 
 export const GET = async () => {
   const { data } = await client.fetch({
-    document: GET_FAVICON_QUERY,
+    document: GetFaviconQuery,
+    channelId: getChannelIdFromLocale(defaultLocale),
   });
 
   const faviconUrl = data.site.settings?.faviconUrl;

--- a/core/client/index.ts
+++ b/core/client/index.ts
@@ -32,7 +32,7 @@ export const client = createClient({
       return getChannelIdFromLocale(locale) ?? defaultChannelId;
     } catch {
       // eslint-disable-next-line no-console
-      console.error('Error using `getLocale`, using default channel id instead.');
+      console.error('Warning: issue using `getLocale`, using default channel id instead.');
 
       return defaultChannelId;
     }


### PR DESCRIPTION
## What/Why?
Pass in default channel to favicon query, since `getLocale` can't be used in routes.

## Testing
Locally, I no longer see the console error.