### PR TITLE
feat(core): add missing metadata in account home page

### DIFF
--- a/.changeset/heavy-toes-own.md
+++ b/.changeset/heavy-toes-own.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Add missing metadata in account settings page.

--- a/core/app/[locale]/(default)/account/page.tsx
+++ b/core/app/[locale]/(default)/account/page.tsx
@@ -1,5 +1,6 @@
 import { BookUser, Settings } from 'lucide-react';
 import { useTranslations } from 'next-intl';
+import { getTranslations } from 'next-intl/server';
 import { ReactNode } from 'react';
 
 import { Link } from '~/components/link';
@@ -27,6 +28,14 @@ const AccountItem = ({ children, title, description, href }: AccountItem) => {
     </Link>
   );
 };
+
+export async function generateMetadata() {
+  const t = await getTranslations('Account.Home');
+
+  return {
+    title: t('title'),
+  };
+}
 
 export default function Account() {
   const t = useTranslations('Account.Home');

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -133,7 +133,8 @@
   },
   "Account": {
     "Home": {
-      "heading": "My Account",
+      "title": "My account",
+      "heading": "My account",
       "accountTabsLabel": "Account Tabs",
       "orders": "Orders",
       "messages": "Messages",


### PR DESCRIPTION
## What/Why?
Missing metadata, use translated message.

## Testing
Locally.