### PR TITLE
fix(core): prepend locale for redirected urls in tests

### DIFF
--- a/.changeset/clever-fans-tickle.md
+++ b/.changeset/clever-fans-tickle.md
@@ -1,0 +1,6 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Prepend locale for redirected urls in tests.
+More info: https://github.com/amannn/next-intl/issues/1335

--- a/core/tests/fixtures/utils/account/account.ts
+++ b/core/tests/fixtures/utils/account/account.ts
@@ -15,7 +15,9 @@ export class Account {
     await this.page.getByLabel('Email').fill(this.email);
     await this.page.getByLabel('Password').fill(this.password);
     await this.page.getByRole('button', { name: 'Log in' }).click();
-    await this.page.waitForURL('/account/');
+    // Prepending locale to URL as a workaround for issue in next-intl
+    // More info: https://github.com/amannn/next-intl/issues/1335
+    await this.page.waitForURL('/en/account/');
   }
 
   async logout() {

--- a/core/tests/ui/e2e/account.spec.ts
+++ b/core/tests/ui/e2e/account.spec.ts
@@ -12,7 +12,9 @@ test('My Account tabs are displayed and clickable', async ({ page, account }) =>
 
   await customer.login();
 
-  await expect(page).toHaveURL('/account/');
+  // Prepending locale to URL as a workaround for issue in next-intl
+  // More info: https://github.com/amannn/next-intl/issues/1335
+  await expect(page).toHaveURL('/en/account/');
   await expect(page.getByRole('link', { name: 'Addresses' })).toBeVisible();
   await expect(page.getByRole('link', { name: 'Account settings' })).toBeVisible();
 

--- a/core/tests/ui/e2e/login.spec.ts
+++ b/core/tests/ui/e2e/login.spec.ts
@@ -12,12 +12,14 @@ test('Account login and logout', async ({ page, account }) => {
   await page.getByLabel('Password').fill(customer.password);
   await page.getByRole('button', { name: 'Log in' }).click();
 
-  await page.waitForURL('/account/');
+  await page.waitForURL('/en/account/');
 
   await expect(page.getByRole('heading', { name: 'My Account' })).toBeVisible();
 
   await customer.logout();
 
+  // Prepending locale to URL as a workaround for issue in next-intl
+  // More info: https://github.com/amannn/next-intl/issues/1335
   await page.waitForURL('/en/login/');
 
   await expect(page.getByRole('heading', { name: 'Log in' })).toBeVisible();


### PR DESCRIPTION
## What/Why?
Fixes tests looking for url without prepending locale. Due to recent changes, we need to prepend locale for certain redirects. More info: https://github.com/bigcommerce/catalyst/pull/1361

## Testing
Locally.