### PR TITLE
chore(core): add translations changeset workflow

### DIFF
--- a/.changeset/translations-patch-8f3fe68b.md
+++ b/.changeset/translations-patch-8f3fe68b.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Update translations.

--- a/.changeset/translations-patch-8f3fe68b.md
+++ b/.changeset/translations-patch-8f3fe68b.md
@@ -1,5 +1,0 @@
----
-"@bigcommerce/catalyst-core": patch
----
-
-Update translations.

--- a/.github/workflows/translations-changeset.yml
+++ b/.github/workflows/translations-changeset.yml
@@ -4,13 +4,12 @@ on:
   pull_request:
     types:
       - opened
-      - reopened
     branches:
       - main
 
 jobs:
   create-translations-patch:
-    if: github.actor == 'jorgemoya'
+    if: github.actor == 'bc-svc-local'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## What/Why?
Auto generate patch changeset for translations PRs.

<img width="410" alt="Screenshot 2024-09-16 at 3 21 52 PM" src="https://github.com/user-attachments/assets/504b38b4-04f3-4dba-903d-5c7da4f1f95d">

## Testing
Tested it locally in this PR, generates patch and commits as the bot. No longer shown since I rebased to previous commit.