### PR TITLE
feat: pass ip information to request on non-cacheable requests

### DIFF
--- a/.changeset/odd-jokes-love.md
+++ b/.changeset/odd-jokes-love.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Pass customer ip address into requests that don't rely on cached values.

--- a/.changeset/twenty-walls-flash.md
+++ b/.changeset/twenty-walls-flash.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-client": minor
+---
+
+Add the ability to hook into the fetchOptions before the request is sent.

--- a/core/auth.ts
+++ b/core/auth.ts
@@ -90,7 +90,9 @@ const config = {
               },
             },
             customerId: user.id,
-            fetchOptions: { cache: 'no-store' },
+            fetchOptions: {
+              cache: 'no-store',
+            },
           });
         } catch (error) {
           // eslint-disable-next-line no-console
@@ -113,7 +115,9 @@ const config = {
               },
             },
             customerId,
-            fetchOptions: { cache: 'no-store' },
+            fetchOptions: {
+              cache: 'no-store',
+            },
           });
         } catch (error) {
           // eslint-disable-next-line no-console
@@ -134,6 +138,9 @@ const config = {
         const response = await client.fetch({
           document: LoginMutation,
           variables: { email, password },
+          fetchOptions: {
+            cache: 'no-store',
+          },
         });
 
         const result = response.data.login;

--- a/core/client/index.ts
+++ b/core/client/index.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@bigcommerce/catalyst-client';
+import { headers } from 'next/headers';
 import { getLocale } from 'next-intl/server';
 
 import { getChannelIdFromLocale } from '~/channels.config';
@@ -35,6 +36,19 @@ export const client = createClient({
       console.error('Warning: issue using `getLocale`, using default channel id instead.');
 
       return defaultChannelId;
+    }
+  },
+  beforeRequest: (fetchOptions) => {
+    if (fetchOptions?.cache && ['no-store', 'no-cache'].includes(fetchOptions.cache)) {
+      const ipAddress = headers().get('X-Forwarded-For');
+
+      if (ipAddress) {
+        return {
+          headers: {
+            'X-Forwarded-For': ipAddress,
+          },
+        };
+      }
     }
   },
 });


### PR DESCRIPTION
## What/Why?
Passes the customer IP on non-cacheable requests so we can enforce things like rate limiting.

## Testing
`x-real-ip` is the Vercel Server IP, while `x-forwarded-for` is my personal IP
![Screenshot 2024-09-18 at 15 03 50](https://github.com/user-attachments/assets/22a2b163-a4bb-49f1-b5a4-568b04b32c12)
