### PR TITLE
fix(core): move orders connection under customer in respect with api

### DIFF
--- a/.changeset/weak-beds-tickle.md
+++ b/.changeset/weak-beds-tickle.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+move orders connection under customer in respect with api

--- a/core/app/[locale]/(default)/account/(tabs)/orders/page-data.ts
+++ b/core/app/[locale]/(default)/account/(tabs)/orders/page-data.ts
@@ -31,7 +31,7 @@ const OrderShipmentFragment = graphql(`
 const CustomerAllOrders = graphql(
   `
     query CustomerAllOrders($after: String, $before: String, $first: Int, $last: Int) {
-      site {
+      customer {
         orders(after: $after, before: $before, first: $first, last: $last) {
           pageInfo {
             ...PaginationFragment
@@ -199,7 +199,7 @@ export const getCustomerOrders = cache(
       fetchOptions: { cache: 'no-store' },
     });
 
-    const orders = response.data.site.orders;
+    const orders = response.data.customer?.orders;
 
     if (!orders) {
       return undefined;


### PR DESCRIPTION
## What/Why?
This PR updates `CustomerAllOrders` query in respect with changes in API where `OrdersConnection` has been moved under `Customer`.

## Testing
locally