### PR TITLE
fix(core): update quantity of items in order truncated card

### DIFF
--- a/core/app/[locale]/(default)/account/(tabs)/orders/_components/order-details.tsx
+++ b/core/app/[locale]/(default)/account/(tabs)/orders/_components/order-details.tsx
@@ -1,5 +1,5 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
-import { getFormatter, getLocale, getTranslations } from 'next-intl/server';
+import { getFormatter, getTranslations } from 'next-intl/server';
 
 import { Link } from '~/components/link';
 import { Button } from '~/components/ui/button';
@@ -10,8 +10,7 @@ import { OrderDetailsDataType } from '../page-data';
 import { assembleProductData, ProductSnippet } from './product-snippet';
 
 const OrderState = async ({ orderState }: { orderState: OrderDetailsDataType['orderState'] }) => {
-  const locale = await getLocale();
-  const t = await getTranslations({ locale, namespace: 'Account.Orders' });
+  const t = await getTranslations('Account.Orders');
   const format = await getFormatter();
   const { orderId, orderDate, status } = orderState;
 
@@ -42,8 +41,7 @@ const OrderSummaryInfo = async ({
 }: {
   summaryInfo: OrderDetailsDataType['summaryInfo'];
 }) => {
-  const locale = await getLocale();
-  const t = await getTranslations({ locale, namespace: 'Account.Orders' });
+  const t = await getTranslations('Account.Orders');
   const format = await getFormatter();
   const { subtotal, shipping, tax, discounts, grandTotal } = summaryInfo;
   const totalDiscountSum = discounts.couponDiscounts.reduce((sum, discount) => {
@@ -135,8 +133,7 @@ const combineShippingMethodInfo = async (
     return [];
   }
 
-  const locale = await getLocale();
-  const t = await getTranslations({ locale, namespace: 'Account.Orders' });
+  const t = await getTranslations('Account.Orders');
   const format = await getFormatter();
   const { shippingProviderName, shippingMethodName, shippedAt } = shipment;
   const providerWithMethod = `${shippingProviderName} - ${shippingMethodName}`;
@@ -158,8 +155,7 @@ const ShippingInfo = async ({
   isMutiConsignments: boolean;
   shippingNumber?: number;
 }) => {
-  const locale = await getLocale();
-  const t = await getTranslations({ locale, namespace: 'Account.Orders' });
+  const t = await getTranslations('Account.Orders');
   const orderShipments = consignments.shipping?.map(({ shipments, shippingAddress }) => ({
     shipments: removeEdgesAndNodes(shipments),
     shippingAddress,
@@ -235,8 +231,7 @@ const ShippingInfo = async ({
 };
 
 export const OrderDetails = async ({ data }: { data: OrderDetailsDataType }) => {
-  const locale = await getLocale();
-  const t = await getTranslations({ locale, namespace: 'Account.Orders' });
+  const t = await getTranslations('Account.Orders');
   const { orderState, summaryInfo, consignments } = data;
   const isMultiShippingConsignments = consignments.shipping && consignments.shipping.length > 1;
 

--- a/core/app/[locale]/(default)/account/(tabs)/orders/_components/orders-content.tsx
+++ b/core/app/[locale]/(default)/account/(tabs)/orders/_components/orders-content.tsx
@@ -1,5 +1,5 @@
 import { notFound } from 'next/navigation';
-import { getLocale, getTranslations } from 'next-intl/server';
+import { getTranslations } from 'next-intl/server';
 
 import { Pagination } from '~/components/ui/pagination';
 
@@ -18,8 +18,7 @@ interface Props {
 }
 
 export const OrdersContent = async ({ orderId, orders, pageInfo }: Props) => {
-  const locale = await getLocale();
-  const t = await getTranslations({ locale, namespace: 'Account.Orders' });
+  const t = await getTranslations('Account.Orders');
   const { hasNextPage, hasPreviousPage, startCursor, endCursor } = pageInfo;
 
   if (orderId) {

--- a/core/app/[locale]/(default)/account/(tabs)/orders/_components/orders-list.tsx
+++ b/core/app/[locale]/(default)/account/(tabs)/orders/_components/orders-list.tsx
@@ -222,14 +222,10 @@ export const OrdersList = ({ customerOrders }: OrdersListProps) => {
                 })}
               </ul>
               <TruncatedCard
-                itemsQuantity={(consignments.shipping ?? []).reduce((orderItems, shipment) => {
-                  const totalQuantity = shipment.lineItems.reduce(
-                    (total, items) => total + items.quantity,
-                    0,
-                  );
-
-                  return orderItems + totalQuantity;
-                }, 0)}
+                itemsQuantity={(consignments.shipping ?? []).reduce(
+                  (orderItems, shipment) => orderItems + shipment.lineItems.length,
+                  0,
+                )}
               />
               <ManageOrderButtons
                 className="hidden lg:ms-auto lg:inline-flex lg:flex-col lg:gap-2"


### PR DESCRIPTION
## What/Why?
This PR updates  behaviour of `truncatedCard` for items quantity in Order. For instance, previously if we have 8 items of the same T-short, we showed as total quantity 8, while now it has been corrected  to 1 item. Additionally, usage for `getTranslations` has been updated as it's refactored across Catalyst other pages.

## Testing
locally


https://github.com/user-attachments/assets/0d9b1008-5cdb-4fed-8741-394dd13b1d81


https://github.com/user-attachments/assets/35b89b5e-3a0f-4fb3-9ee2-74a592b8d918



