### PR TITLE
chore(tests): update email addresses to junk domains

### DIFF
--- a/core/tests/fixtures/utils/account/create.ts
+++ b/core/tests/fixtures/utils/account/create.ts
@@ -1,4 +1,4 @@
-import { faker, fi } from '@faker-js/faker';
+import { faker } from '@faker-js/faker';
 import { z } from 'zod';
 
 const Customer = z.object({
@@ -12,7 +12,7 @@ const CreateCustomersResponse = z.object({
 export async function createAccount() {
   const firstName = faker.person.firstName();
   const lastName = faker.person.lastName();
-  const email = faker.internet.email({ firstName, lastName });
+  const email = faker.internet.email({ firstName, lastName, provider: 'example.com' });
   // Prefix is added to ensure that the password requirements are met
   const password = faker.internet.password({ pattern: /[a-zA-Z0-9]/, prefix: '1At', length: 10 });
   const address1 = faker.location.streetAddress();

--- a/core/tests/ui/e2e/checkout.spec.ts
+++ b/core/tests/ui/e2e/checkout.spec.ts
@@ -60,7 +60,9 @@ test.describe('desktop', () => {
     await page.getByRole('link', { name: 'Cart Items 1' }).click();
     await page.getByRole('heading', { level: 1, name: 'Your cart' }).click();
     await page.getByRole('button', { name: 'Proceed to checkout' }).click();
-    await page.getByLabel('Email').fill(faker.internet.email({ firstName, lastName }));
+    await page
+      .getByLabel('Email')
+      .fill(faker.internet.email({ firstName, lastName, provider: 'example.com' }));
 
     await page.getByRole('button', { name: 'Continue' }).click();
 
@@ -122,7 +124,9 @@ test.describe('mobile', () => {
     await page.getByRole('link', { name: 'Cart Items 1' }).click();
     await page.getByRole('heading', { level: 1, name: 'Your cart' }).click();
     await page.getByRole('button', { name: 'Proceed to checkout' }).click();
-    await page.getByLabel('Email').fill(faker.internet.email({ firstName, lastName }));
+    await page
+      .getByLabel('Email')
+      .fill(faker.internet.email({ firstName, lastName, provider: 'example.com' }));
     await page.getByRole('button', { name: 'Continue' }).click();
 
     await waitForShippingForm(page, isMobile);

--- a/core/tests/ui/e2e/register.spec.ts
+++ b/core/tests/ui/e2e/register.spec.ts
@@ -10,9 +10,7 @@ test('Account register', async ({ page }) => {
 
   await page.getByRole('heading', { name: 'New account' }).waitFor();
 
-  await page
-    .getByLabel('Email Address')
-    .fill(faker.internet.email({ provider: 'mybigcommerce.com' }));
+  await page.getByLabel('Email Address').fill(faker.internet.email({ provider: 'example.com' }));
   await page.getByLabel('PasswordRequired', { exact: true }).fill(password);
   await page.getByLabel('Confirm PasswordRequired').fill(password);
   await page.getByLabel('First NameRequired').fill(faker.person.firstName());

--- a/core/tests/ui/e2e/reset.spec.ts
+++ b/core/tests/ui/e2e/reset.spec.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker';
 
 import { expect, test } from '~/tests/fixtures';
 
-const email = faker.internet.email({ provider: 'mybigcommerce.com' });
+const email = faker.internet.email({ provider: 'example.com' });
 
 test('Reset password', async ({ page }) => {
   await page.goto('/reset');


### PR DESCRIPTION
## What/Why?
Updating the creation of accounts/orders with emails addresses from the list of ["junk" domains](https://datatracker.ietf.org/doc/html/rfc2606#section-3)

## Testing
See https://github.com/bigcommerce/catalyst/actions/runs/11112645581