### PR TITLE
fix(core): separate promotions and coupons for order summary

### DIFF
--- a/.changeset/famous-grapes-argue.md
+++ b/.changeset/famous-grapes-argue.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+separate promotions and coupons for order summary

--- a/core/app/[locale]/(default)/account/(tabs)/orders/_components/order-details.tsx
+++ b/core/app/[locale]/(default)/account/(tabs)/orders/_components/order-details.tsx
@@ -44,13 +44,7 @@ const OrderSummaryInfo = async ({
   const t = await getTranslations('Account.Orders');
   const format = await getFormatter();
   const { subtotal, shipping, tax, discounts, grandTotal } = summaryInfo;
-  const totalDiscountSum = discounts.couponDiscounts.reduce((sum, discount) => {
-    let totalDiscount = sum;
-
-    totalDiscount += discount.discountedAmount.value;
-
-    return totalDiscount;
-  }, 0);
+  const { nonCouponDiscountTotal, couponDiscounts } = discounts;
 
   return (
     <div className="border border-gray-200 p-6">
@@ -65,20 +59,30 @@ const OrderSummaryInfo = async ({
             })}
           </span>
         </p>
-        <p className="flex justify-between">
-          <span>{t('orderDiscount')}</span>
-          <span>
-            {discounts.couponDiscounts.length > 0
-              ? format.number(totalDiscountSum, {
-                  style: 'currency',
-                  currency: discounts.couponDiscounts[0]?.discountedAmount.currencyCode,
-                })
-              : format.number(0, {
-                  style: 'currency',
-                  currency: subtotal.currencyCode,
-                })}
-          </span>
-        </p>
+        {nonCouponDiscountTotal.value > 0 && (
+          <p className="flex justify-between">
+            <span>{t('orderDiscount')}</span>
+            <span>
+              -
+              {format.number(nonCouponDiscountTotal.value, {
+                style: 'currency',
+                currency: nonCouponDiscountTotal.currencyCode,
+              })}
+            </span>
+          </p>
+        )}
+        {couponDiscounts.map(({ couponCode, discountedAmount }, index) => (
+          <p className="flex justify-between" key={index}>
+            <span>{t('orderAppliedCoupon', { code: couponCode })}</span>
+            <span>
+              -
+              {format.number(discountedAmount.value, {
+                style: 'currency',
+                currency: discountedAmount.currencyCode,
+              })}
+            </span>
+          </p>
+        ))}
         <p className="flex justify-between">
           <span>{t('orderShipping')}</span>
           <span>

--- a/core/app/[locale]/(default)/account/(tabs)/orders/_components/product-snippet.tsx
+++ b/core/app/[locale]/(default)/account/(tabs)/orders/_components/product-snippet.tsx
@@ -14,10 +14,6 @@ export const OrderItemFragment = graphql(`
     brand
     name
     quantity
-    image {
-      altText
-      url: urlTemplate
-    }
     subTotalListPrice {
       value
       currencyCode
@@ -43,7 +39,7 @@ export type ProductSnippetFragment = Omit<
 };
 
 export const assembleProductData = (orderItem: FragmentOf<typeof OrderItemFragment>) => {
-  const { entityId: productId, name, brand, subTotalListPrice, image, productOptions } = orderItem;
+  const { entityId: productId, name, brand, subTotalListPrice, productOptions } = orderItem;
 
   return {
     entityId: productId,
@@ -52,10 +48,8 @@ export const assembleProductData = (orderItem: FragmentOf<typeof OrderItemFragme
       name: brand ?? '',
       path: '', // will be added later
     },
-    defaultImage: {
-      url: image?.url ?? '',
-      altText: image?.altText ?? name,
-    },
+    // NOTE: update later when API is ready
+    defaultImage: null,
     productOptions,
     path: '', // will be added later
     quantity: orderItem.quantity,

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -158,6 +158,7 @@
       "orderSubtotal": "Subtotal:",
       "orderGrandtotal": "Grand total:",
       "orderDiscount": "Discount:",
+      "orderAppliedCoupon": "Coupon code ({code}):",
       "orderShipping": "Shipping:",
       "orderTax": "Tax:",
       "printInvoice": "Print Invoice",


### PR DESCRIPTION
## What/Why?
This PR updates view for coupons and non coupons discounts in order making them separate items for order's summary.

## Testing
locally



https://github.com/user-attachments/assets/9e1e4452-2b2e-460e-a6b0-5719914c72db






https://github.com/user-attachments/assets/a279451c-198f-4115-8ec7-8fbe9e585c74

