### PR TITLE
fix(tests): Run UI tests with disabling security

### DIFF
--- a/core/playwright.config.ts
+++ b/core/playwright.config.ts
@@ -12,6 +12,9 @@ export default defineConfig({
   },
   reporter: [['list'], ['html']],
   use: {
+    launchOptions: {
+      args: ['--disable-web-security'],
+    },
     baseURL: process.env.PLAYWRIGHT_TEST_BASE_URL,
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',


### PR DESCRIPTION
## What/Why?
Tests run on chromium are running into CORS error and disabling the web security through playwright config is getting them to pass again.

## Testing
As part of CI. Also tested locally.