### PR TITLE
refactor(core): move script binding to bodl initialization

### DIFF
--- a/core/lib/bodl/providers/ga4/google_analytics4.js
+++ b/core/lib/bodl/providers/ga4/google_analytics4.js
@@ -1,12 +1,6 @@
-export function subscribeOnBodlEvents(measurementId, developerId, consentModeEnabled) {
-  window.dataLayer = window.dataLayer || [];
-
+export function subscribeOnBodlEvents(measurementId, consentModeEnabled) {
   if (!window || typeof window.bodlEvents === 'undefined') {
     return;
-  }
-
-  function gtag() {
-    dataLayer.push(arguments);
   }
 
   function addDestination(payload) {
@@ -360,26 +354,6 @@ export function subscribeOnBodlEvents(measurementId, developerId, consentModeEna
     subscribeOnConsentEvents();
   }
 
-  function setupGtag() {
-    function configureGtag() {
-      gtag('js', new Date());
-      gtag('set', 'developer_id.' + developerId, true);
-      gtag('config', measurementId);
-    }
-
-    function addGtagScript() {
-      var script = document.createElement('script');
-
-      script.src = `https://www.googletagmanager.com/gtag/js?id=${measurementId}`;
-      script.async = true;
-
-      document.head.appendChild(script);
-    }
-
-    addGtagScript();
-    configureGtag();
-  }
-
   function subscribeOnEcommerceEvents() {
     subscribeOnCheckoutEvents();
     subscribeOnCartEvents();
@@ -388,6 +362,5 @@ export function subscribeOnBodlEvents(measurementId, developerId, consentModeEna
   }
 
   setupConsent();
-  setupGtag();
   subscribeOnEcommerceEvents();
 }


### PR DESCRIPTION
## What/Why?
Pulls setting up the script of bodl events and gtag into the `Bodl` class. This helps create a consistent location for where we are binding the DOM scripts.

## Testing
![Screenshot 2024-10-02 at 13 28 10](https://github.com/user-attachments/assets/9562c83b-7b35-4805-a3f1-6e31769a6fce)
