### PR TITLE
fix(core): fix wishlist book item image size

### DIFF
--- a/.changeset/thirty-owls-fry.md
+++ b/.changeset/thirty-owls-fry.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+fix wishlist book item image size

--- a/core/app/[locale]/(default)/account/(tabs)/wishlists/_components/wishlist-book.tsx
+++ b/core/app/[locale]/(default)/account/(tabs)/wishlists/_components/wishlist-book.tsx
@@ -125,7 +125,7 @@ const Wishlist = ({ setWishlistBook, wishlist }: WishlistProps) => {
                 return (
                   <li className="w-32 sm:w-40 md:w-36" key={productId}>
                     <Link className="mb-2 flex" href={product.path}>
-                      <div className="h-32 w-full sm:h-40 md:h-36">
+                      <div className="flex h-32 w-full sm:h-40 md:h-36">
                         {defaultImage ? (
                           <BcImage
                             alt={defaultImage.altText}


### PR DESCRIPTION
## What/Why?
This pr contains the fix for vertical image on Wishlist Book

<img width="1027" alt="before" src="https://github.com/user-attachments/assets/ec92b1eb-aee3-41a2-9a8e-bcf0ad3bcaaa">

<img width="1027" alt="after" src="https://github.com/user-attachments/assets/c1f06877-40c5-4542-a43a-c2d2531fd260">

## Testing
Locally
