### PR TITLE
refactor(core): elevate consent mode into bodl provider

### DIFF
--- a/core/lib/bodl/analytics.d.ts
+++ b/core/lib/bodl/analytics.d.ts
@@ -73,4 +73,23 @@ declare namespace Analytics {
       productRemoved: (payload: ProductRemovedPayload) => void;
     }
   }
+
+  export namespace Consent {
+    interface ConsentLoadedPayload {
+      functional: boolean;
+      analytics: boolean;
+      advertising: boolean;
+    }
+
+    interface ConsentUpdatedPayload {
+      functional: boolean;
+      analytics: boolean;
+      advertising: boolean;
+    }
+
+    export interface Events {
+      consentLoaded: (payload: ConsentLoadedPayload) => void;
+      consentUpdated: (payload: ConsentUpdatedPayload) => void;
+    }
+  }
 }

--- a/core/lib/bodl/providers/ga4/google_analytics4.js
+++ b/core/lib/bodl/providers/ga4/google_analytics4.js
@@ -286,74 +286,6 @@ export function subscribeOnBodlEvents(measurementId, consentModeEnabled) {
     }
   }
 
-  function setupConsent() {
-    if (!consentModeEnabled) {
-      return;
-    }
-
-    function transformConsentPayload(payload) {
-      var BODL_TO_GA4_CONSENT_CATEGORIES_MAP = {
-        advertising: ['ad_storage', 'ad_user_data', 'ad_personalization'],
-        analytics: ['analytics_storage'],
-        functional: ['functionality_storage'],
-      };
-
-      var transformed = {};
-
-      Object.keys(payload).forEach(function (category) {
-        var mapped = BODL_TO_GA4_CONSENT_CATEGORIES_MAP[category];
-        var permission = payload[category] ? 'granted' : 'denied';
-
-        if (Array.isArray(mapped)) {
-          mapped.forEach(function (ga4category) {
-            transformed[ga4category] = permission;
-          });
-        }
-      });
-
-      return transformed;
-    }
-
-    var DEFAULTS = {
-      advertising: false,
-      analytics: false,
-      functional: false,
-    };
-
-    function isConsentChanged(currentConsent) {
-      return Object.keys(DEFAULTS).some(function (category) {
-        return DEFAULTS[category] !== currentConsent[category];
-      });
-    }
-
-    function setupDefaults() {
-      gtag('consent', 'default', transformConsentPayload(DEFAULTS));
-    }
-
-    function subscribeOnConsentEvents() {
-      if (typeof window.bodlEvents.consent === 'undefined') {
-        return;
-      }
-
-      if (typeof window.bodlEvents.consent.loaded === 'function') {
-        window.bodlEvents.consent.loaded(function (payload) {
-          if (isConsentChanged(payload)) {
-            gtag('consent', 'update', transformConsentPayload(payload));
-          }
-        });
-      }
-
-      if (typeof window.bodlEvents.consent.updated === 'function') {
-        window.bodlEvents.consent.updated(function (payload) {
-          gtag('consent', 'update', transformConsentPayload(payload));
-        });
-      }
-    }
-
-    setupDefaults();
-    subscribeOnConsentEvents();
-  }
-
   function subscribeOnEcommerceEvents() {
     subscribeOnCheckoutEvents();
     subscribeOnCartEvents();
@@ -361,6 +293,5 @@ export function subscribeOnBodlEvents(measurementId, consentModeEnabled) {
     subscribeOnPromotionEvents();
   }
 
-  setupConsent();
   subscribeOnEcommerceEvents();
 }

--- a/core/package.json
+++ b/core/package.json
@@ -68,6 +68,7 @@
     "@next/bundle-analyzer": "^14.2.14",
     "@playwright/test": "^1.47.2",
     "@tailwindcss/container-queries": "^0.1.1",
+    "@types/gtag.js": "^0.0.20",
     "@types/lodash.debounce": "^4.0.9",
     "@types/node": "^20.16.10",
     "@types/react": "^18.3.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
       '@tailwindcss/container-queries':
         specifier: ^0.1.1
         version: 0.1.1(tailwindcss@3.4.13)
+      '@types/gtag.js':
+        specifier: ^0.0.20
+        version: 0.0.20
       '@types/lodash.debounce':
         specifier: ^4.0.9
         version: 4.0.9
@@ -2011,6 +2014,9 @@ packages:
 
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
+
+  '@types/gtag.js@0.0.20':
+    resolution: {integrity: sha512-wwAbk3SA2QeU67unN7zPxjEHmPmlXwZXZvQEpbEUQuMCRGgKyE1m6XDuTUA9b6pCGb/GqJmdfMOY5LuDjJSbbg==}
 
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
@@ -5646,10 +5652,10 @@ snapshots:
       '@typescript-eslint/parser': 8.4.0(eslint@8.57.1)(typescript@5.6.2)
       eslint: 8.57.1
       eslint-config-prettier: 9.1.0(eslint@8.57.1)
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.2))(eslint-plugin-import@2.30.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.2))(eslint-plugin-import@2.30.0)(eslint@8.57.1)
       eslint-plugin-gettext: 1.2.0
-      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.2))(eslint-plugin-import@2.30.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-jest: 28.8.3(@typescript-eslint/eslint-plugin@8.4.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(jest@29.7.0)(typescript@5.6.2)
+      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-plugin-jest: 28.8.3(@typescript-eslint/eslint-plugin@8.4.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(jest@29.7.0(@types/node@20.16.10))(typescript@5.6.2)
       eslint-plugin-jest-formatting: 3.1.0(eslint@8.57.1)
       eslint-plugin-jsdoc: 50.2.2(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.0(eslint@8.57.1)
@@ -5677,10 +5683,10 @@ snapshots:
       '@typescript-eslint/parser': 8.4.0(eslint@8.57.1)(typescript@5.6.2)
       eslint: 8.57.1
       eslint-config-prettier: 9.1.0(eslint@8.57.1)
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.2))(eslint-plugin-import@2.30.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.2))(eslint-plugin-import@2.30.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-gettext: 1.2.0
-      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
-      eslint-plugin-jest: 28.8.3(@typescript-eslint/eslint-plugin@8.4.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(jest@29.7.0)(typescript@5.6.2)
+      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.2))(eslint-plugin-import@2.30.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-jest: 28.8.3(@typescript-eslint/eslint-plugin@8.4.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(jest@29.7.0(@types/node@20.16.10))(typescript@5.6.2)
       eslint-plugin-jest-formatting: 3.1.0(eslint@8.57.1)
       eslint-plugin-jsdoc: 50.2.2(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.0(eslint@8.57.1)
@@ -7251,6 +7257,8 @@ snapshots:
     dependencies:
       '@types/node': 20.16.10
 
+  '@types/gtag.js@0.0.20': {}
+
   '@types/istanbul-lib-coverage@2.0.6': {}
 
   '@types/istanbul-lib-report@3.0.3':
@@ -8457,7 +8465,7 @@ snapshots:
     dependencies:
       eslint: 8.57.1
 
-  eslint-plugin-jest@28.8.3(@typescript-eslint/eslint-plugin@8.4.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(jest@29.7.0)(typescript@5.6.2):
+  eslint-plugin-jest@28.8.3(@typescript-eslint/eslint-plugin@8.4.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(jest@29.7.0(@types/node@20.16.10))(typescript@5.6.2):
     dependencies:
       '@typescript-eslint/utils': 8.4.0(eslint@8.57.1)(typescript@5.6.2)
       eslint: 8.57.1


### PR DESCRIPTION
## What/Why?
Extracts consent mode events into the Bodl provider. Technically consent mode is not fully flushed out as we don't have a consent banner to trigger these events, however we should still support it for countries that require GDPR restrictions.

## Testing
![Screenshot 2024-10-07 at 14 20 54](https://github.com/user-attachments/assets/338055c2-8eae-40e4-b549-e5f056c799b3)
![Screenshot 2024-10-07 at 14 21 19](https://github.com/user-attachments/assets/c18bb9e5-ad94-42ce-a5e9-10a2b5e872e3)
