### PR TITLE
Fix/infinite product redirects

### DIFF
--- a/.changeset/great-turtles-breathe.md
+++ b/.changeset/great-turtles-breathe.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Updates the with-routes middleware to fallback on locale based rewrite logic if the redirect is a dynamic entity redirect.

--- a/core/middlewares/with-routes.ts
+++ b/core/middlewares/with-routes.ts
@@ -249,21 +249,26 @@ export const withRoutes: MiddlewareFactory = () => {
     // Use 301 status code as it is more universally supported by crawlers
     const redirectConfig = { status: 301 };
 
-    if (route?.redirect) {
+    if (route?.node && route.node.__typename === 'Product') {
+      // If there's a valid Product node, process it as a normal product page
+      const productUrl = new URL(`/${locale}/product/${route.node.entityId}`, request.url);
+  
+      return NextResponse.rewrite(productUrl);
+    } else if (route?.redirect) {
       switch (route.redirect.to.__typename) {
         case 'ManualRedirect': {
           // For manual redirects, redirect to the full URL to handle cases
           // where the destination URL might be external to the site
           return NextResponse.redirect(route.redirect.toUrl, redirectConfig);
         }
-
+  
         default: {
           // For all other cases, assume an internal redirect and construct the URL
           // based on the current request URL to maintain internal redirection
           // in non-production environments
           const redirectPathname = new URL(route.redirect.toUrl).pathname;
           const redirectUrl = new URL(redirectPathname, request.url);
-
+  
           return NextResponse.redirect(redirectUrl, redirectConfig);
         }
       }

--- a/core/middlewares/with-routes.ts
+++ b/core/middlewares/with-routes.ts
@@ -249,7 +249,12 @@ export const withRoutes: MiddlewareFactory = () => {
     // Use 301 status code as it is more universally supported by crawlers
     const redirectConfig = { status: 301 };
 
-    if (route?.redirect) {
+    if (route?.node && route.node.__typename === 'Product') {
+      // If there's a valid Product node, process it as a normal product page
+      const productUrl = new URL(`/${locale}/product/${route.node.entityId}`, request.url);
+
+      return NextResponse.rewrite(productUrl);
+    } else if (route?.redirect) {
       switch (route.redirect.to.__typename) {
         case 'ManualRedirect': {
           // For manual redirects, redirect to the full URL to handle cases
@@ -268,7 +273,7 @@ export const withRoutes: MiddlewareFactory = () => {
         }
       }
     }
-
+    
     const customerId = await getSessionCustomerId();
     let postfix = '';
 

--- a/core/middlewares/with-routes.ts
+++ b/core/middlewares/with-routes.ts
@@ -249,12 +249,7 @@ export const withRoutes: MiddlewareFactory = () => {
     // Use 301 status code as it is more universally supported by crawlers
     const redirectConfig = { status: 301 };
 
-    if (route?.node && route.node.__typename === 'Product') {
-      // If there's a valid Product node, process it as a normal product page
-      const productUrl = new URL(`/${locale}/product/${route.node.entityId}`, request.url);
-
-      return NextResponse.rewrite(productUrl);
-    } else if (route?.redirect) {
+    if (route?.redirect) {
       switch (route.redirect.to.__typename) {
         case 'ManualRedirect': {
           // For manual redirects, redirect to the full URL to handle cases
@@ -273,7 +268,7 @@ export const withRoutes: MiddlewareFactory = () => {
         }
       }
     }
-    
+
     const customerId = await getSessionCustomerId();
     let postfix = '';
 


### PR DESCRIPTION
## What/Why?
see https://github.com/bigcommerce/catalyst/issues/1320 for history

TLDR: Initial issue comment was incorrect. It seems to actually be a logical error when there are both a "redirect" and valid "node"

I am fairly certain there might be a "fix" upstream from this, but this fix resolves a showstopper bug (at least on our site)

We see this in an infinite loop:
```
. . . . [
@bigcommerce/catalyst-core:dev:   {
@bigcommerce/catalyst-core:dev:     "route": {
@bigcommerce/catalyst-core:dev:       "redirect": {
@bigcommerce/catalyst-core:dev:         "__typename": "Redirect",
@bigcommerce/catalyst-core:dev:         "to": {
@bigcommerce/catalyst-core:dev:           "__typename": "ProductRedirect"
@bigcommerce/catalyst-core:dev:         },
@bigcommerce/catalyst-core:dev:         "toUrl": "https://www.upliftdesk.com/uplift-v2-standing-desk-v2-or-v2-commercial/"
@bigcommerce/catalyst-core:dev:       },
@bigcommerce/catalyst-core:dev:       "node": {
@bigcommerce/catalyst-core:dev:         "__typename": "Product",
@bigcommerce/catalyst-core:dev:         "id": "UHJvZHVjdDo4OTA=",
@bigcommerce/catalyst-core:dev:         "entityId": 890
@bigcommerce/catalyst-core:dev:       }
@bigcommerce/catalyst-core:dev:     },
@bigcommerce/catalyst-core:dev:     "expiryTime": 1728411357384
@bigcommerce/catalyst-core:dev:   },
@bigcommerce/catalyst-core:dev:   {
@bigcommerce/catalyst-core:dev:     "status": "LAUNCHED",
@bigcommerce/catalyst-core:dev:     "expiryTime": 1728409857069
@bigcommerce/catalyst-core:dev:   }
@bigcommerce/catalyst-core:dev: ]
```

## Testing
I am unsure how to test without giving access to my forked copy / dev site. Please contact me for additional testing steps.

As far as I can tell, these are the criteria:

- Product route
- Has redirect
- Has valid node

## Context
The code fix is what we are using live, but our CLI install is about a month old and hasn't been upgraded since.


I have confirmed that this solution fixes the redirect loop on the latest version of cata on a local env, but I cannot confirm that the product page fully loads.