### PR TITLE
refactor(cli): add isExecException to check if an error is an ExecException

### DIFF
--- a/.changeset/shy-tips-accept.md
+++ b/.changeset/shy-tips-accept.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": patch
+---
+
+Adds a typeguard to narrow Errors thrown by `execSync` to be of the type `ExecException`

--- a/packages/create-catalyst/src/utils/is-exec-exception.ts
+++ b/packages/create-catalyst/src/utils/is-exec-exception.ts
@@ -1,0 +1,5 @@
+import { ExecException } from 'node:child_process';
+
+export function isExecException(error: unknown): error is ExecException {
+  return typeof error === 'object' && error !== null && 'stdout' in error && 'stderr' in error;
+}


### PR DESCRIPTION
## What/Why?
> 💡 This PR is part of the CLI refactor changes described in #1430

Adds a typeguard to narrow Errors thrown by `execSync` to be of `ExecException` types.

## Testing
Locally