### PR TITLE
refactor(cli): update required Node.js version

### DIFF
--- a/.changeset/small-experts-divide.md
+++ b/.changeset/small-experts-divide.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": minor
+---
+
+BREAKING: Change required Node.js version to `^20` (instead of `>=20`)

--- a/packages/create-catalyst/bin/index.cjs
+++ b/packages/create-catalyst/bin/index.cjs
@@ -2,12 +2,12 @@
 
 const semver = require('semver');
 
-const catalystRequiredNodeVersion = '>=20';
+const catalystRequiredNodeVersion = '^20';
 const userNodeVersion = process.version;
 
 if (!semver.satisfies(userNodeVersion, catalystRequiredNodeVersion)) {
-  console.error(`\n\x1b[31mYou are using Node.js version: ${userNodeVersion}.`);
-  console.error(`Catalyst requires Node.js version: ${catalystRequiredNodeVersion}.\x1b[0m\n`);
+  console.error(`\n\x1b[31mYou are using Node.js ${userNodeVersion}.`);
+  console.error(`Catalyst requires Node.js version ${catalystRequiredNodeVersion}.\x1b[0m\n`);
   process.exit(1);
 }
 


### PR DESCRIPTION
## What/Why?
> 💡 This PR is part of the CLI refactor changes described in #1430

Previously, we allowed any Node.js version 20 or greater. We have been experiencing issues with people using less-stable odd-numbered Node.js versions (like `21`) or Node.js versions that are still new and not something we have fully tested with Catalyst (like `22`)

## Testing
Locally