### PR TITLE
refactor(cli)!: ensure pnpm is installed on the machine running the CLI

### DIFF
--- a/.changeset/pretty-dryers-perform.md
+++ b/.changeset/pretty-dryers-perform.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": minor
+---
+
+BREAKING: Ensure `pnpm` is installed on the machine running the CLI

--- a/packages/create-catalyst/src/commands/create.ts
+++ b/packages/create-catalyst/src/commands/create.ts
@@ -1,7 +1,7 @@
 import { Command, Option } from '@commander-js/extra-typings';
 import { input, select } from '@inquirer/prompts';
 import chalk from 'chalk';
-import { exec as execCallback } from 'child_process';
+import { exec as execCallback, execSync } from 'child_process';
 import { pathExistsSync } from 'fs-extra/esm';
 import kebabCase from 'lodash.kebabcase';
 import { join } from 'path';
@@ -64,7 +64,16 @@ export const create = new Command('create')
       .default(false)
       .hideHelp(),
   )
+  // eslint-disable-next-line complexity
   .action(async (options) => {
+    try {
+      execSync('which pnpm', { stdio: 'ignore' });
+    } catch {
+      console.error(chalk.red('Error: pnpm is required to create a Catalyst project\n'));
+      console.error(chalk.yellow('Tip: Enable it by running `corepack enable pnpm`\n'));
+      process.exit(1);
+    }
+
     const { packageManager, codeEditor, includeFunctionalTests } = options;
 
     const URLSchema = z.string().url();


### PR DESCRIPTION
## What/Why?
> 💡 This PR is part of the CLI refactor changes described in #1430

> [!IMPORTANT]
> This PR stacks on #1433

Ensure `pnpm` is installed on the machine running the CLI

## Testing
Locally