### PR TITLE
refactor(cli)!: simplify installDependencies to install all monorepo deps

### DIFF
--- a/.changeset/fair-lobsters-own.md
+++ b/.changeset/fair-lobsters-own.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": minor
+---
+
+BREAKING: Refactor `installDependencies` so that it installs all dependencies found in the root package.json file of the monorepo

--- a/packages/create-catalyst/src/commands/create.ts
+++ b/packages/create-catalyst/src/commands/create.ts
@@ -135,7 +135,7 @@ export const create = new Command('create')
 
       console.log(`\nUsing ${chalk.bold(packageManager)}\n`);
 
-      await installDependencies(projectDir, packageManager);
+      await installDependencies(projectDir);
 
       console.log(
         [
@@ -239,7 +239,7 @@ export const create = new Command('create')
 
     console.log(`\nUsing ${chalk.bold(packageManager)}\n`);
 
-    await installDependencies(projectDir, packageManager);
+    await installDependencies(projectDir);
 
     await spinner(exec(`${packageManager} run --prefix ${projectDir} generate`), {
       text: 'Creating GraphQL schema...',

--- a/packages/create-catalyst/src/utils/install-dependencies.ts
+++ b/packages/create-catalyst/src/utils/install-dependencies.ts
@@ -1,25 +1,14 @@
 import chalk from 'chalk';
-import { addDependency, addDevDependency, installDependencies as installDeps } from 'nypm';
+import { installDependencies as installDeps } from 'nypm';
 
-import { type PackageManager } from './pm';
 import { spinner } from './spinner';
 
-const installAllDeps = async (projectDir: string, packageManager: PackageManager) => {
-  await installDeps({ cwd: projectDir, silent: true, packageManager });
-  await addDependency('@bigcommerce/catalyst-client', {
-    cwd: projectDir,
-    silent: true,
-    packageManager,
-  });
-  await addDevDependency('@bigcommerce/eslint-config-catalyst', {
-    cwd: projectDir,
-    silent: true,
-    packageManager,
-  });
+const installAllDeps = async (projectDir: string) => {
+  await installDeps({ cwd: projectDir, silent: true, packageManager: 'pnpm' });
 };
 
-export const installDependencies = async (projectDir: string, packageManager: PackageManager) =>
-  spinner(installAllDeps(projectDir, packageManager), {
+export const installDependencies = async (projectDir: string) =>
+  spinner(installAllDeps(projectDir), {
     text: `Installing dependencies. This could take a minute...`,
     successText: `Dependencies installed successfully`,
     failText: (err) => chalk.red(`Failed to install dependencies: ${err.message}`),


### PR DESCRIPTION
## What/Why?
> 💡 This PR is part of the CLI refactor changes described in #1430

> [!IMPORTANT]
> This PR stacks on #1439

Refactor `installDependencies` so that it installs all dependencies found in the root `package.json` file of the monorepo

## Testing
Locally