### PR TITLE
refactor(cli)!: remove auto generation of gql types on project creation

### DIFF
--- a/.changeset/brave-shirts-carry.md
+++ b/.changeset/brave-shirts-carry.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": minor
+---
+
+BREAKING: Remove automatic generation of GraphQL type definitions on project creation. This results in faster project creation and generation will happen already as part of starting the development sever or kicking off a build

--- a/packages/create-catalyst/src/commands/create.ts
+++ b/packages/create-catalyst/src/commands/create.ts
@@ -1,11 +1,10 @@
 import { Command, Option } from '@commander-js/extra-typings';
 import { input, select } from '@inquirer/prompts';
 import chalk from 'chalk';
-import { exec as execCallback, execSync } from 'child_process';
+import { execSync } from 'child_process';
 import { pathExistsSync } from 'fs-extra/esm';
 import kebabCase from 'lodash.kebabcase';
 import { join } from 'path';
-import { promisify } from 'util';
 import { z } from 'zod';
 
 import { checkStorefrontLimit } from '../utils/check-storefront-limit';
@@ -14,10 +13,7 @@ import { Https } from '../utils/https';
 import { installDependencies } from '../utils/install-dependencies';
 import { login } from '../utils/login';
 import { parse } from '../utils/parse';
-import { spinner } from '../utils/spinner';
 import { writeEnv } from '../utils/write-env';
-
-const exec = promisify(execCallback);
 
 export const create = new Command('create')
   .description('Command to scaffold and connect a Catalyst storefront to your BigCommerce store')
@@ -229,12 +225,6 @@ export const create = new Command('create')
     });
 
     await installDependencies(projectDir);
-
-    await spinner(exec(`pnpm run --prefix ${projectDir} generate`), {
-      text: 'Creating GraphQL schema...',
-      successText: 'Created GraphQL schema',
-      failText: (err) => chalk.red(`Failed to create GraphQL schema: ${err.message}`),
-    });
 
     console.log(
       `\n${chalk.green('Success!')} Created '${projectName}' at '${projectDir}'\n`,


### PR DESCRIPTION
## What/Why?
> 💡 This PR is part of the CLI refactor changes described in #1430

> [!IMPORTANT]
> This PR stacks on #1441

Remove automatic generation of GraphQL type definitions on project creation. There is no root-level `generate` Turbo task, which means the environment variables aren't being picked up correctly. 

We could refactor `writeEnv` to write two env files, one in root and one in `core/` but I'm not confident that's the right solution.

## Testing
Locally