### PR TITLE
feat: optimistic updates on add to cart

### DIFF
--- a/.changeset/twelve-deers-nail.md
+++ b/.changeset/twelve-deers-nail.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Adds optimistic updates to all "Add to cart" buttons. This change makes the UI feel snappier and give quick feedback on user interaction.

--- a/core/app/[locale]/(default)/compare/_components/add-to-cart/index.tsx
+++ b/core/app/[locale]/(default)/compare/_components/add-to-cart/index.tsx
@@ -3,66 +3,72 @@
 import { FragmentOf } from 'gql.tada';
 import { AlertCircle, Check } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import { useFormStatus } from 'react-dom';
+import { useTransition } from 'react';
 import { toast } from 'react-hot-toast';
 
 import { AddToCartButton } from '~/components/add-to-cart-button';
+import { useCart } from '~/components/header/cart-provider';
 import { Link } from '~/components/link';
 
 import { addToCart } from '../../_actions/add-to-cart';
 
 import { AddToCartFragment } from './fragment';
 
-const Submit = ({ data: product }: { data: FragmentOf<typeof AddToCartFragment> }) => {
-  const { pending } = useFormStatus();
-
-  return <AddToCartButton data={product} loading={pending} />;
-};
-
 export const AddToCart = ({ data: product }: { data: FragmentOf<typeof AddToCartFragment> }) => {
   const t = useTranslations('Compare.AddToCart');
+  const cart = useCart();
+  const [isPending, startTransition] = useTransition();
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const formData = new FormData(event.currentTarget);
+    const quantity = Number(formData.get('quantity'));
+
+    // Optimistic update
+    cart.increment(quantity);
+    toast.success(
+      () => (
+        <div className="flex items-center gap-3">
+          <span>
+            {t.rich('success', {
+              cartItems: quantity,
+              cartLink: (chunks) => (
+                <Link
+                  className="font-semibold text-primary"
+                  href="/cart"
+                  prefetch="viewport"
+                  prefetchKind="full"
+                >
+                  {chunks}
+                </Link>
+              ),
+            })}
+          </span>
+        </div>
+      ),
+      { icon: <Check className="text-success-secondary" /> },
+    );
+
+    startTransition(async () => {
+      const result = await addToCart(formData);
+
+      if (result.error) {
+        cart.decrement(quantity);
+
+        toast.error(t('error'), {
+          icon: <AlertCircle className="text-error-secondary" />,
+        });
+      }
+    });
+  };
 
   return (
-    <form
-      action={async (formData: FormData) => {
-        const result = await addToCart(formData);
-        const quantity = Number(formData.get('quantity'));
-
-        if (result.error) {
-          toast.error(t('error'), {
-            icon: <AlertCircle className="text-error-secondary" />,
-          });
-
-          return;
-        }
-
-        toast.success(
-          () => (
-            <div className="flex items-center gap-3">
-              <span>
-                {t.rich('success', {
-                  cartItems: quantity,
-                  cartLink: (chunks) => (
-                    <Link
-                      className="font-semibold text-primary"
-                      href="/cart"
-                      prefetch="viewport"
-                      prefetchKind="full"
-                    >
-                      {chunks}
-                    </Link>
-                  ),
-                })}
-              </span>
-            </div>
-          ),
-          { icon: <Check className="text-success-secondary" /> },
-        );
-      }}
-    >
+    <form onSubmit={handleSubmit}>
       <input name="product_id" type="hidden" value={product.entityId} />
       <input name="quantity" type="hidden" value={1} />
-      <Submit data={product} />
+
+      <AddToCartButton data={product} loading={isPending} />
     </form>
   );
 };

--- a/core/app/providers.tsx
+++ b/core/app/providers.tsx
@@ -2,14 +2,17 @@
 
 import { PropsWithChildren } from 'react';
 
+import { CartProvider } from '~/components/header/cart-provider';
 import { CompareDrawerProvider } from '~/components/ui/compare-drawer';
 
 import { AccountStatusProvider } from './[locale]/(default)/account/(tabs)/_components/account-status-provider';
 
 export function Providers({ children }: PropsWithChildren) {
   return (
-    <AccountStatusProvider>
-      <CompareDrawerProvider>{children}</CompareDrawerProvider>
-    </AccountStatusProvider>
+    <CartProvider>
+      <AccountStatusProvider>
+        <CompareDrawerProvider>{children}</CompareDrawerProvider>
+      </AccountStatusProvider>
+    </CartProvider>
   );
 }

--- a/core/components/header/cart-icon.tsx
+++ b/core/components/header/cart-icon.tsx
@@ -2,10 +2,12 @@
 
 import { ShoppingCart } from 'lucide-react';
 import { useLocale } from 'next-intl';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { z } from 'zod';
 
 import { Badge } from '~/components/ui/badge';
+
+import { useCart } from './cart-provider';
 
 const CartQuantityResponseSchema = z.object({
   count: z.number(),
@@ -15,9 +17,8 @@ interface CartIconProps {
   count?: number;
 }
 
-export const CartIcon = ({ count }: CartIconProps) => {
-  const [fetchedCount, setFetchedCount] = useState<number | null>();
-  const computedCount = count ?? fetchedCount;
+export const CartIcon = ({ count: serverCount }: CartIconProps) => {
+  const { count, setCount } = useCart();
   const locale = useLocale();
 
   useEffect(() => {
@@ -25,18 +26,20 @@ export const CartIcon = ({ count }: CartIconProps) => {
       const response = await fetch(`/api/cart-quantity/?locale=${locale}`);
       const parsedData = CartQuantityResponseSchema.parse(await response.json());
 
-      setFetchedCount(parsedData.count);
+      setCount(parsedData.count);
     }
 
-    // When a page is rendered statically via the 'force-static' route config option, cookies().get() always returns undefined,
-    // which ultimately means that the `count` prop here will always be undefined on initial render, even if there actually is
-    // a populated cart. Thus, we perform a client-side check in this case.
-    if (count === undefined) {
+    if (serverCount !== undefined) {
+      setCount(serverCount);
+    } else {
+      // When a page is rendered statically via the 'force-static' route config option, cookies().get() always returns undefined,
+      // which ultimately means that the `serverCount` here will always be undefined on initial render, even if there actually is
+      // a populated cart. Thus, we perform a client-side check in this case.
       void fetchCartQuantity();
     }
-  }, [count, locale]);
+  }, [serverCount, locale, setCount]);
 
-  if (!computedCount) {
+  if (!count) {
     return <ShoppingCart aria-label="cart" />;
   }
 
@@ -44,7 +47,7 @@ export const CartIcon = ({ count }: CartIconProps) => {
     <>
       <span className="sr-only">Cart Items</span>
       <ShoppingCart aria-hidden="true" />
-      <Badge>{computedCount}</Badge>
+      <Badge>{count}</Badge>
     </>
   );
 };

--- a/core/components/header/cart-provider.tsx
+++ b/core/components/header/cart-provider.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { createContext, ReactNode, useCallback, useContext, useMemo, useState } from 'react';
+
+interface CartContext {
+  count: number;
+  increment: (step?: number) => void;
+  decrement: (step?: number) => void;
+  setCount: (newCount: number) => void;
+}
+
+const CartContext = createContext<CartContext | undefined>(undefined);
+
+export const CartProvider = ({ children }: { children: ReactNode }) => {
+  const [count, setCount] = useState(0);
+  const increment = useCallback((step = 1) => setCount((prev) => prev + step), []);
+  const decrement = useCallback((step = 1) => setCount((prev) => prev - step), []);
+
+  const value = useMemo(
+    () => ({ count, increment, decrement, setCount }),
+    [count, increment, decrement],
+  );
+
+  return <CartContext.Provider value={value}>{children}</CartContext.Provider>;
+};
+
+export const useCart = () => {
+  const context = useContext(CartContext);
+
+  if (context === undefined) {
+    throw new Error('useCart must be used within a CartProvider');
+  }
+
+  return context;
+};

--- a/core/components/product-card/add-to-cart/form/index.tsx
+++ b/core/components/product-card/add-to-cart/form/index.tsx
@@ -3,10 +3,11 @@
 import { FragmentOf } from 'gql.tada';
 import { AlertCircle, Check } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import { useFormStatus } from 'react-dom';
+import { useTransition } from 'react';
 import { toast } from 'react-hot-toast';
 
 import { AddToCartButton } from '~/components/add-to-cart-button';
+import { useCart } from '~/components/header/cart-provider';
 import { Link } from '~/components/link';
 
 import { AddToCartFragment } from '../fragment';
@@ -17,56 +18,60 @@ interface Props {
   data: FragmentOf<typeof AddToCartFragment>;
 }
 
-const SubmitButton = ({ data: product }: Props) => {
-  const { pending } = useFormStatus();
-
-  return <AddToCartButton className="mt-2" data={product} loading={pending} />;
-};
-
 export const Form = ({ data: product }: Props) => {
   const t = useTranslations('Components.ProductCard.AddToCart');
+  const cart = useCart();
+  const [isPending, startTransition] = useTransition();
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const formData = new FormData(event.currentTarget);
+    const quantity = Number(formData.get('quantity'));
+
+    // Optimistic update
+    cart.increment(quantity);
+    toast.success(
+      () => (
+        <div className="flex items-center gap-3">
+          <span>
+            {t.rich('success', {
+              cartItems: quantity,
+              cartLink: (chunks) => (
+                <Link
+                  className="font-semibold text-primary"
+                  href="/cart"
+                  prefetch="viewport"
+                  prefetchKind="full"
+                >
+                  {chunks}
+                </Link>
+              ),
+            })}
+          </span>
+        </div>
+      ),
+      { icon: <Check className="text-success-secondary" /> },
+    );
+
+    startTransition(async () => {
+      const result = await addToCart(formData);
+
+      if (result.error) {
+        cart.decrement(quantity);
+
+        toast.error(t('error'), {
+          icon: <AlertCircle className="text-error-secondary" />,
+        });
+      }
+    });
+  };
 
   return (
-    <form
-      action={async (formData: FormData) => {
-        const result = await addToCart(formData);
-        const quantity = Number(formData.get('quantity'));
-
-        if (result.error) {
-          toast.error(t('error'), {
-            icon: <AlertCircle className="text-error-secondary" />,
-          });
-
-          return;
-        }
-
-        toast.success(
-          () => (
-            <div className="flex items-center gap-3">
-              <span>
-                {t.rich('success', {
-                  cartItems: quantity,
-                  cartLink: (chunks) => (
-                    <Link
-                      className="font-semibold text-primary"
-                      href="/cart"
-                      prefetch="viewport"
-                      prefetchKind="full"
-                    >
-                      {chunks}
-                    </Link>
-                  ),
-                })}
-              </span>
-            </div>
-          ),
-          { icon: <Check className="text-success-secondary" /> },
-        );
-      }}
-    >
+    <form onSubmit={handleSubmit}>
       <input name="product_id" type="hidden" value={product.entityId} />
       <input name="quantity" type="hidden" value={1} />
-      <SubmitButton data={product} />
+      <AddToCartButton className="mt-2" data={product} loading={isPending} />;
     </form>
   );
 };


### PR DESCRIPTION
## What/Why?
`Add to cart` (in PDP, PLP, Compare) now supports some optimistic updates. We keep the loading spinner on the button but show the toast and update the badge right away.

If the request fails it will revert the changes and show the error toast.

## Testing

https://github.com/user-attachments/assets/8e8f494e-240c-44ff-b82b-e5a2b80136c0

