### PR TITLE
fix(core): variant selection with pre-selected options

### DIFF
--- a/.changeset/soft-ladybugs-perform.md
+++ b/.changeset/soft-ladybugs-perform.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Fixes a bug where product variant was not reliably being selected on PDP when using pre-selected options.

--- a/core/app/[locale]/(default)/product/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/page.tsx
@@ -41,7 +41,7 @@ export async function generateMetadata({ params, searchParams }: Props): Promise
   const product = await getProduct({
     entityId: productId,
     optionValueIds,
-    useDefaultOptionSelections: optionValueIds.length === 0 ? true : undefined,
+    useDefaultOptionSelections: true,
   });
 
   if (!product) {
@@ -80,7 +80,7 @@ export default async function Product({ params: { locale, slug }, searchParams }
   const product = await getProduct({
     entityId: productId,
     optionValueIds,
-    useDefaultOptionSelections: optionValueIds.length === 0 ? true : undefined,
+    useDefaultOptionSelections: true,
   });
 
   if (!product) {


### PR DESCRIPTION
## What/Why?
When a product has pre-selected options, the state of the PDP was not selecting the correct variant.

## Testing

https://github.com/user-attachments/assets/674d6bf9-a8fc-45bd-bd37-68710bf63fc6

