### PR TITLE
fix(tests): handle optimistic cart updates

### DIFF
--- a/core/tests/ui/e2e/cart.spec.ts
+++ b/core/tests/ui/e2e/cart.spec.ts
@@ -9,6 +9,7 @@ test.beforeEach(async ({ page }) => {
   ).toBeVisible();
 
   await page.getByRole('button', { name: 'Add to Cart' }).first().click();
+  await page.getByRole('button', { name: 'Add to Cart' }).first().isEnabled();
 });
 
 test('Add a single product to cart', async ({ page }) => {

--- a/core/tests/ui/e2e/checkout.spec.ts
+++ b/core/tests/ui/e2e/checkout.spec.ts
@@ -57,6 +57,7 @@ test.describe('desktop', () => {
     ).toBeVisible();
 
     await page.getByRole('button', { name: 'Add to Cart' }).first().click();
+    await page.getByRole('button', { name: 'Add to Cart' }).first().isEnabled();
     await page.getByRole('link', { name: 'Cart Items 1' }).click();
     await page.getByRole('heading', { level: 1, name: 'Your cart' }).click();
     await page.getByRole('button', { name: 'Proceed to checkout' }).click();
@@ -91,6 +92,7 @@ test.describe('desktop', () => {
       page.getByRole('heading', { level: 1, name: '[Sample] Laundry Detergent' }),
     ).toBeVisible();
     await page.getByRole('button', { name: 'Add to Cart' }).first().click();
+    await page.getByRole('button', { name: 'Add to Cart' }).first().isEnabled();
     await page.getByRole('link', { name: 'Cart Items 1' }).click();
     await page.getByRole('heading', { level: 1, name: 'Your cart' }).click();
     await page.getByRole('button', { name: 'Proceed to checkout' }).click();
@@ -121,6 +123,7 @@ test.describe('mobile', () => {
     ).toBeVisible();
 
     await page.getByRole('button', { name: 'Add to Cart' }).first().click();
+    await page.getByRole('button', { name: 'Add to Cart' }).first().isEnabled();
     await page.getByRole('link', { name: 'Cart Items 1' }).click();
     await page.getByRole('heading', { level: 1, name: 'Your cart' }).click();
     await page.getByRole('button', { name: 'Proceed to checkout' }).click();

--- a/core/tests/ui/e2e/coupon.spec.ts
+++ b/core/tests/ui/e2e/coupon.spec.ts
@@ -9,6 +9,7 @@ test.beforeEach(async ({ page }) => {
   ).toBeVisible();
 
   await page.getByRole('button', { name: 'Add to Cart' }).first().click();
+  await page.getByRole('button', { name: 'Add to Cart' }).first().isEnabled();
 
   await page.getByRole('link', { name: 'Cart Items 1' }).click();
 

--- a/core/tests/ui/e2e/shipping.spec.ts
+++ b/core/tests/ui/e2e/shipping.spec.ts
@@ -27,6 +27,7 @@ test.beforeEach(async ({ page }) => {
   ).toBeVisible();
 
   await page.getByRole('button', { name: 'Add to Cart' }).first().click();
+  await page.getByRole('button', { name: 'Add to Cart' }).first().isEnabled();
   await page.getByRole('link', { name: 'Cart Items 1' }).click();
 
   await expect(page.getByRole('heading', { level: 1, name: 'Your cart' })).toBeVisible();

--- a/core/tests/visual-regression/components/button.spec.ts
+++ b/core/tests/visual-regression/components/button.spec.ts
@@ -34,6 +34,7 @@ test('As a child', async ({ page }) => {
 
   // Act
   await page.getByRole('button', { name: 'Add to Cart' }).first().click();
+  await page.getByRole('button', { name: 'Add to Cart' }).first().isEnabled();
   await page.getByRole('link', { name: 'Cart Items 1' }).click();
   await page.getByText('Shipping cost').waitFor();
 

--- a/core/tests/visual-regression/components/input.spec.ts
+++ b/core/tests/visual-regression/components/input.spec.ts
@@ -9,6 +9,7 @@ test('Input with placeholder', async ({ page }) => {
 
   // Act
   await page.getByRole('button', { name: 'Add to Cart' }).first().click();
+  await page.getByRole('button', { name: 'Add to Cart' }).first().isEnabled();
   await page.getByRole('link', { name: 'Cart Items 1' }).click();
   await page.getByText('Shipping cost').waitFor();
   await page.getByRole('button', { name: 'Add' }).first().click();


### PR DESCRIPTION
## What/Why?
Broke a few tests on https://github.com/bigcommerce/catalyst/pull/1445 this PR fixes them.

## Testing
👁️ CI