### PR TITLE
Add new env variable for Trusted Proxy

### DIFF
--- a/.changeset/silly-queens-explode.md
+++ b/.changeset/silly-queens-explode.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-client": minor
+---
+
+Support Trusted Proxy in client to support higher-traffic stores

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -198,3 +198,17 @@ When enabled, the client logger logs the following information:
 | CLI-configurable | false   |
 
 This environment variable sets a limit on the number of JS chunks webpack will generate via the `LimitChunkCountPlugin` in `next.config.js`. Generally speaking, using more chunks can improve performance, but will increase the number of requests to the origin to download these files. For hosts that charge for each asset request, this may make your site more expensive to serve. You can decrease this number to decrease the number of individual JS files that will be requested on each page, but each file will be larger, which may decrease Lighthouse scores due to more time spent on script parsing and more unused JS code in each chunk on a given page.
+
+### BIGCOMMERCE_TRUSTED_PROXY_SECRET
+
+> [!CAUTION]
+> This token is a **sensitive secret**. Do not expose outside environment variables.
+
+| Attribute        | Value    |
+| :--------------- | :------- |
+| Type             | string   |
+| Default          | no value |
+| Required         | false    |
+| CLI-configurable | false    |
+
+If BigCommerce has provided you with a Trusted Proxy secret, you may set it using this environment variable to have it automatically sent as a header on requests.

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -33,6 +33,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
   private beforeRequest?: (
     fetchOptions?: FetcherRequestInit,
   ) => Partial<FetcherRequestInit> | undefined;
+  private trustedProxySecret = process.env.BIGCOMMERCE_TRUSTED_PROXY_SECRET;
 
   constructor(private config: Config<FetcherRequestInit>) {
     if (!config.channelId) {
@@ -93,6 +94,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
         Authorization: `Bearer ${this.config.customerImpersonationToken}`,
         'User-Agent': this.backendUserAgent,
         ...(customerId && { 'X-Bc-Customer-Id': customerId }),
+        ...(this.trustedProxySecret && { 'X-BC-Trusted-Proxy-Secret': this.trustedProxySecret }),
         ...additionalFetchHeaders,
         ...headers,
       },
@@ -143,6 +145,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
         Accept: 'application/xml',
         'Content-Type': 'application/xml',
         'User-Agent': this.backendUserAgent,
+        ...(this.trustedProxySecret && { 'X-BC-Trusted-Proxy-Secret': this.trustedProxySecret }),
       },
     });
 


### PR DESCRIPTION
## What/Why?
If the store has Trusted Proxy enabled, the trusted proxy secret can be stored as an env variable in which case it will be sent as a header on all requests.

## Testing
Verified via logs