### PR TITLE
Set explicit cache policy on favicon fetch at build time

### DIFF
--- a/.changeset/twenty-owls-remember.md
+++ b/.changeset/twenty-owls-remember.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+no-store on favicon fetch at build time

--- a/core/app/favicon.ico/route.ts
+++ b/core/app/favicon.ico/route.ts
@@ -28,6 +28,7 @@ export const GET = async () => {
   const { data } = await client.fetch({
     document: GetFaviconQuery,
     channelId: getChannelIdFromLocale(defaultLocale),
+    fetchOptions: { cache: 'no-store' }, // disable caching to get the latest favicon at build time
   });
 
   const faviconUrl = data.site.settings?.faviconUrl;


### PR DESCRIPTION
## What/Why?
Explicitly no-store the favicon fetch at build time; ensures we get a fresh favicon every build.

## Testing
N/A