### PR TITLE
feat(cli): add ability to pass arbitrary GitHub repository to clone from

### DIFF
--- a/packages/create-catalyst/src/commands/create.ts
+++ b/packages/create-catalyst/src/commands/create.ts
@@ -23,7 +23,8 @@ export const create = new Command('create')
   .option('--access-token <token>', 'BigCommerce access token')
   .option('--channel-id <id>', 'BigCommerce channel ID')
   .option('--customer-impersonation-token <token>', 'BigCommerce customer impersonation token')
-  .option('--gh-ref <ref>', 'Clone a specific ref from the bigcommerce/catalyst repository')
+  .option('--gh-ref <ref>', 'Clone a specific ref from the source repository')
+  .option('--repository <repository>', 'GitHub repository to clone from', 'bigcommerce/catalyst')
   .addOption(
     new Option('--bigcommerce-hostname <hostname>', 'BigCommerce hostname')
       .default('bigcommerce.com')
@@ -36,7 +37,7 @@ export const create = new Command('create')
   )
   // eslint-disable-next-line complexity
   .action(async (options) => {
-    const { ghRef } = options;
+    const { ghRef, repository } = options;
 
     try {
       execSync('which git', { stdio: 'ignore' });
@@ -120,7 +121,7 @@ export const create = new Command('create')
     if (!storeHash || !accessToken) {
       console.log(`\nCreating '${projectName}' at '${projectDir}'\n`);
 
-      cloneCatalyst({ projectDir, projectName, ghRef });
+      cloneCatalyst({ repository, projectName, projectDir, ghRef });
 
       await installDependencies(projectDir);
 
@@ -216,7 +217,7 @@ export const create = new Command('create')
 
     console.log(`\nCreating '${projectName}' at '${projectDir}'\n`);
 
-    cloneCatalyst({ projectDir, projectName, ghRef });
+    cloneCatalyst({ repository, projectName, projectDir, ghRef });
 
     writeEnv(projectDir, {
       channelId: channelId.toString(),

--- a/packages/create-catalyst/src/utils/clone-catalyst.ts
+++ b/packages/create-catalyst/src/utils/clone-catalyst.ts
@@ -4,21 +4,22 @@ import { checkoutRef } from './checkout-ref';
 import { hasGitHubSSH } from './has-github-ssh';
 
 export const cloneCatalyst = ({
+  repository,
   projectName,
   projectDir,
   ghRef,
 }: {
+  repository: string;
   projectName: string;
   projectDir: string;
   ghRef?: string;
 }) => {
-  const repositoryName = 'bigcommerce/catalyst';
   const useSSH = hasGitHubSSH();
 
-  console.log(`Cloning ${repositoryName} using ${useSSH ? 'SSH' : 'HTTPS'}...\n`);
+  console.log(`Cloning ${repository} using ${useSSH ? 'SSH' : 'HTTPS'}...\n`);
 
   const cloneCommand = `git clone ${
-    useSSH ? `git@github.com:${repositoryName}` : `https://github.com/${repositoryName}`
+    useSSH ? `git@github.com:${repository}` : `https://github.com/${repository}`
   }.git${projectName ? ` ${projectName}` : ''}`;
 
   execSync(cloneCommand, { stdio: 'inherit' });


### PR DESCRIPTION
## What/Why?
This PR adds the ability to pass in an arbitrary repository in the form of `org-or-user/repository-name` that the `cloneCatalyst` function will use to determine which GitHub repository to clone locally. 

This PR also refactors the types for the arguments passed to the `cloneCatalyst` function; we want Typescript to complain if the arguments are not passed at all, but also want the ability to pass `undefined` as values for those arguments.

## Testing
Tested + verified locally