### PR TITLE
fix(core): set the product quantity back to it's original value when there's an error updating it

### DIFF
--- a/core/app/[locale]/(default)/cart/_components/item-quantity/index.tsx
+++ b/core/app/[locale]/(default)/cart/_components/item-quantity/index.tsx
@@ -171,6 +171,8 @@ export const ItemQuantity = ({ product }: { product: Product }) => {
       toast.error(t('errorMessage'), {
         icon: <AlertCircle className="text-error-secondary" />,
       });
+
+      setProductQuantity(quantity);
     }
   };
 


### PR DESCRIPTION
This is intended to set the product quantity back to its original value when there's an error while incrementing the quantity in the cart. Without this, you can increment the value from 1, 2, 3, 4 ,5, etc, even if there's only, say 2 in stock. Resetting it after the error prevents the UI from being left in an inconsistent state.