### PR TITLE
fix(cli): do not exit process if user ref cannot be checked out

### DIFF
--- a/packages/create-catalyst/src/utils/checkout-ref.ts
+++ b/packages/create-catalyst/src/utils/checkout-ref.ts
@@ -26,15 +26,14 @@ export function checkoutRef(repoDir: string, ref: string): void {
       } else {
         console.error(`Error checking out ref '${ref}':`, stderr.trim());
       }
-    } else if (error instanceof Error) {
-      // General error handling
-      console.error(`Error checking out ref '${ref}':`, error.message);
-    } else {
-      // Unknown error type
-      console.error(`Unknown error occurred while checking out ref '${ref}'.`);
     }
 
-    // Exit the process with a non-zero exit code
-    process.exit(1);
+    if (error instanceof Error) {
+      // General error handling
+      console.error(`Error checking out ref '${ref}':`, error.message);
+    }
+
+    // Unknown error type
+    console.error(`Unknown error occurred while checking out ref '${ref}'.`);
   }
 }


### PR DESCRIPTION
## What/Why?
`checkoutRef` is called from within `cloneCatalyst`, which is called before important logic such as `writeEnv` inside of `create.ts`. If we allow the process to exit before `writeEnv`, the user has to start the entire `create` flow from scratch which is frustrating. 

## Testing
Locally