### PR TITLE
chore(core): dont render breadcrumbs for top level categories

### DIFF
--- a/.changeset/fifty-queens-provide.md
+++ b/.changeset/fifty-queens-provide.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Breadcrumbs for top level category pages are no longer rendered

--- a/core/components/breadcrumbs/index.tsx
+++ b/core/components/breadcrumbs/index.tsx
@@ -16,5 +16,9 @@ export const Breadcrumbs = ({ category }: Props) => {
     href: path ?? '#',
   }));
 
+  if (breadcrumbs.length < 2) {
+    return null;
+  }
+
   return <ComponentsBreadcrumbs breadcrumbs={breadcrumbs} />;
 };


### PR DESCRIPTION
## What/Why?
Breadcrumbs for top level category pages are no longer rendered

## Testing
![26ABnIIg@2x](https://github.com/user-attachments/assets/34380673-1be3-4553-9cd7-3b75cf0d49e3)