### PR TITLE
Add ISR link

### DIFF
--- a/docs/caching.md
+++ b/docs/caching.md
@@ -36,7 +36,7 @@ In addition to Next.js's built-in caching, Catalyst offers further optimizations
 
 ### Guest vs. Logged-in Customer Caching
 
-Catalyst includes paths containing a `/static/page.tsx` file with `export const dynamic = 'force-static';` for generating static pages at build time for guest shoppers. These static pages are periodically rebuilt using Incremental Static Regeneration (ISR), without requiring a re-build of the entire storefront. The revalidation period is controlled by the same `DEFAULT_REVALIDATE_TARGET` environment variable as the Data Cache.
+Catalyst includes paths containing a `/static/page.tsx` file with `export const dynamic = 'force-static';` for generating static pages at build time for guest shoppers. These static pages are periodically rebuilt using [Incremental Static Regeneration (ISR)](https://nextjs.org/docs/app/building-your-application/data-fetching/incremental-static-regeneration), without requiring a re-build of the entire storefront. The revalidation period is controlled by the same `DEFAULT_REVALIDATE_TARGET` environment variable as the Data Cache.
 
 - **Guest shoppers**: Requests are rewritten to statically built pages for better performance. Pages are periodically rebuilt using ISR.
 - **Logged-in customers**: Dynamic rendering is used, and requests are rewritten to the regular path (`/page.tsx`).


### PR DESCRIPTION
## What/Why?
Add link to ISR docs; I wanted to put these in the docs originally but the link was 404ing at that time. It is now fixed

Note - this redirects to Canary docs for now, I suspect that is temporary.

## Testing
Click on it