### PR TITLE
feat(cli): start to collect telemetry from write key

### DIFF
--- a/.changeset/rich-beers-jam.md
+++ b/.changeset/rich-beers-jam.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-client": minor
+---
+
+Start collecting telemetry.

--- a/.github/workflows/changesets-release.yml
+++ b/.github/workflows/changesets-release.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Build Packages
         run: pnpm --filter "./packages/**" build
+        env:
+          CLI_SEGMENT_WRITE_KEY: ${{ secrets.CLI_SEGMENT_WRITE_KEY }}
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets


### PR DESCRIPTION
## What/Why?
Passes the `CLI_SEGMENT_WRITE_KEY` env var into the build command to start collecting telemetry.

## Testing
See #1479 