### PR TITLE
(REFERENCE) Add gift certificates page with purchase, check, and redeem tabs

### DIFF
--- a/core/app/[locale]/(default)/cart/_components/cart-item.tsx
+++ b/core/app/[locale]/(default)/cart/_components/cart-item.tsx
@@ -4,7 +4,7 @@ import { FragmentOf, graphql } from '~/client/graphql';
 import { BcImage } from '~/components/bc-image';
 
 import { ItemQuantity } from './item-quantity';
-import { RemoveItem } from './remove-item';
+import { RemoveItem, RemoveGiftCertificate } from './remove-item';
 
 const PhysicalItemFragment = graphql(`
   fragment PhysicalItemFragment on CartPhysicalItem {
@@ -122,6 +122,28 @@ const DigitalItemFragment = graphql(`
   }
 `);
 
+const GiftCertificateItemFragment = graphql(`
+  fragment GiftCertificateItemFragment on CartGiftCertificate {
+    entityId
+    name
+    theme
+    amount {
+      currencyCode
+      value
+    }
+    isTaxable
+    sender {
+      email
+      name
+    }
+    recipient {
+      email
+      name
+    }
+    message
+  }
+`);
+
 export const CartItemFragment = graphql(
   `
     fragment CartItemFragment on CartLineItems {
@@ -131,14 +153,18 @@ export const CartItemFragment = graphql(
       digitalItems {
         ...DigitalItemFragment
       }
+      giftCertificates {
+        ...GiftCertificateItemFragment
+      }
     }
   `,
-  [PhysicalItemFragment, DigitalItemFragment],
+  [PhysicalItemFragment, DigitalItemFragment, GiftCertificateItemFragment],
 );
 
 type FragmentResult = FragmentOf<typeof CartItemFragment>;
 type PhysicalItem = FragmentResult['physicalItems'][number];
 type DigitalItem = FragmentResult['digitalItems'][number];
+type GiftCertificateItem = FragmentResult['giftCertificates'][number];
 
 export type Product = PhysicalItem | DigitalItem;
 
@@ -235,7 +261,7 @@ export const CartItem = ({ currencyCode, product }: Props) => {
             <div className="flex flex-col gap-2 md:items-end">
               <div>
                 {product.originalPrice.value &&
-                product.originalPrice.value !== product.listPrice.value ? (
+                  product.originalPrice.value !== product.listPrice.value ? (
                   <p className="text-lg font-bold line-through">
                     {format.number(product.originalPrice.value * product.quantity, {
                       style: 'currency',
@@ -257,6 +283,59 @@ export const CartItem = ({ currencyCode, product }: Props) => {
 
           <div className="mt-4 md:hidden">
             <RemoveItem currency={currencyCode} product={product} />
+          </div>
+        </div>
+      </div>
+    </li>
+  );
+};
+
+interface GiftCertificateProps {
+  giftCertificate: GiftCertificateItem;
+  currencyCode: string;
+}
+
+export const CartGiftCertificate = ({ currencyCode, giftCertificate }: GiftCertificateProps) => {
+  const format = useFormatter();
+
+  return (
+    <li>
+      <div className="flex gap-4 border-t border-t-gray-200 py-4 md:flex-row">
+        <div className="flex justify-center items-center w-24 md:w-[144px]">
+          <h2 className="text-lg font-bold">{giftCertificate.theme}</h2>
+        </div>
+
+        <div className="flex-1">
+          <div className="flex flex-col gap-2 md:flex-row">
+            <div className="flex flex-1 flex-col gap-2">
+              <p className="text-xl font-bold md:text-2xl">{format.number(giftCertificate.amount.value, {
+                style: 'currency',
+                currency: currencyCode,
+              })} Gift Certificate</p>
+              
+              <p className="text-md text-gray-500">{giftCertificate.message}</p>
+              <p className="text-sm text-gray-500">To: {giftCertificate.recipient.name} ({giftCertificate.recipient.email})</p>
+              <p className="text-sm text-gray-500">From: {giftCertificate.sender.name} ({giftCertificate.sender.email})</p>
+
+              <div className="hidden md:block">
+                <RemoveGiftCertificate currency={currencyCode} giftCertificate={giftCertificate} />
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2 md:items-end">
+              <div>
+                <p className="text-lg font-bold">
+                  {format.number(giftCertificate.amount.value, {
+                    style: 'currency',
+                    currency: currencyCode,
+                  })}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-4 md:hidden">
+            <RemoveGiftCertificate currency={currencyCode} giftCertificate={giftCertificate} />
           </div>
         </div>
       </div>

--- a/core/app/[locale]/(default)/cart/_components/cart-item.tsx
+++ b/core/app/[locale]/(default)/cart/_components/cart-item.tsx
@@ -4,7 +4,7 @@ import { FragmentOf, graphql } from '~/client/graphql';
 import { BcImage } from '~/components/bc-image';
 
 import { ItemQuantity } from './item-quantity';
-import { RemoveItem, RemoveGiftCertificate } from './remove-item';
+import { RemoveGiftCertificate, RemoveItem } from './remove-item';
 
 const PhysicalItemFragment = graphql(`
   fragment PhysicalItemFragment on CartPhysicalItem {
@@ -261,7 +261,7 @@ export const CartItem = ({ currencyCode, product }: Props) => {
             <div className="flex flex-col gap-2 md:items-end">
               <div>
                 {product.originalPrice.value &&
-                  product.originalPrice.value !== product.listPrice.value ? (
+                product.originalPrice.value !== product.listPrice.value ? (
                   <p className="text-lg font-bold line-through">
                     {format.number(product.originalPrice.value * product.quantity, {
                       style: 'currency',
@@ -301,21 +301,28 @@ export const CartGiftCertificate = ({ currencyCode, giftCertificate }: GiftCerti
   return (
     <li>
       <div className="flex gap-4 border-t border-t-gray-200 py-4 md:flex-row">
-        <div className="flex justify-center items-center w-24 md:w-[144px]">
+        <div className="flex w-24 items-center justify-center md:w-[144px]">
           <h2 className="text-lg font-bold">{giftCertificate.theme}</h2>
         </div>
 
         <div className="flex-1">
           <div className="flex flex-col gap-2 md:flex-row">
             <div className="flex flex-1 flex-col gap-2">
-              <p className="text-xl font-bold md:text-2xl">{format.number(giftCertificate.amount.value, {
-                style: 'currency',
-                currency: currencyCode,
-              })} Gift Certificate</p>
-              
+              <p className="text-xl font-bold md:text-2xl">
+                {format.number(giftCertificate.amount.value, {
+                  style: 'currency',
+                  currency: currencyCode,
+                })}{' '}
+                Gift Certificate
+              </p>
+
               <p className="text-md text-gray-500">{giftCertificate.message}</p>
-              <p className="text-sm text-gray-500">To: {giftCertificate.recipient.name} ({giftCertificate.recipient.email})</p>
-              <p className="text-sm text-gray-500">From: {giftCertificate.sender.name} ({giftCertificate.sender.email})</p>
+              <p className="text-sm text-gray-500">
+                To: {giftCertificate.recipient.name} ({giftCertificate.recipient.email})
+              </p>
+              <p className="text-sm text-gray-500">
+                From: {giftCertificate.sender.name} ({giftCertificate.sender.email})
+              </p>
 
               <div className="hidden md:block">
                 <RemoveGiftCertificate currency={currencyCode} giftCertificate={giftCertificate} />

--- a/core/app/[locale]/(default)/cart/_components/remove-item.tsx
+++ b/core/app/[locale]/(default)/cart/_components/remove-item.tsx
@@ -15,6 +15,7 @@ import { RemoveFromCartButton } from './remove-from-cart-button';
 type FragmentResult = FragmentOf<typeof CartItemFragment>;
 type PhysicalItem = FragmentResult['physicalItems'][number];
 type DigitalItem = FragmentResult['digitalItems'][number];
+type GiftCertificate = FragmentResult['giftCertificates'][number];
 
 export type Product = PhysicalItem | DigitalItem;
 
@@ -59,6 +60,57 @@ export const RemoveItem = ({ currency, product }: Props) => {
       currency,
       product_value: product.listPrice.value * product.quantity,
       line_items: [lineItemTransform(product)],
+    });
+  };
+
+  return (
+    <form action={onSubmitRemoveItem}>
+      <RemoveFromCartButton />
+    </form>
+  );
+};
+
+interface GiftCertificateProps {
+  currency: string;
+  giftCertificate: GiftCertificate;
+}
+
+const giftCertificateTransform = (item: GiftCertificate) => {
+  return {
+    product_id: item.entityId.toString(),
+    product_name: `${item.theme} Gift Certificate`,
+    brand_name: undefined,
+    sku: undefined,
+    sale_price: undefined,
+    purchase_price: item.amount.value,
+    base_price: undefined,
+    retail_price: undefined,
+    currency: item.amount.currencyCode,
+    variant_id: undefined,
+    quantity: 1,
+  };
+};
+
+export const RemoveGiftCertificate = ({ currency, giftCertificate }: GiftCertificateProps) => {
+  const t = useTranslations('Cart.SubmitRemoveItem');
+
+  const onSubmitRemoveItem = async () => {
+    const { status } = await removeItem({
+      lineItemEntityId: giftCertificate.entityId,
+    });
+
+    if (status === 'error') {
+      toast.error(t('errorMessage'), {
+        icon: <AlertCircle className="text-error-secondary" />,
+      });
+
+      return;
+    }
+
+    bodl.cart.productRemoved({
+      currency,
+      product_value: giftCertificate.amount.value,
+      line_items: [giftCertificateTransform(giftCertificate)],
     });
   };
 

--- a/core/app/[locale]/(default)/cart/page.tsx
+++ b/core/app/[locale]/(default)/cart/page.tsx
@@ -6,7 +6,7 @@ import { client } from '~/client';
 import { graphql } from '~/client/graphql';
 import { TAGS } from '~/client/tags';
 
-import { CartItem, CartItemFragment } from './_components/cart-item';
+import { CartGiftCertificate, CartItem, CartItemFragment } from './_components/cart-item';
 import { CartViewed } from './_components/cart-viewed';
 import { CheckoutButton } from './_components/checkout-button';
 import { CheckoutSummary, CheckoutSummaryFragment } from './_components/checkout-summary';
@@ -76,6 +76,7 @@ export default async function Cart() {
   }
 
   const lineItems = [...cart.lineItems.physicalItems, ...cart.lineItems.digitalItems];
+  const giftCertificates = [...cart.lineItems.giftCertificates];
 
   return (
     <div>
@@ -84,6 +85,9 @@ export default async function Cart() {
         <ul className="col-span-2">
           {lineItems.map((product) => (
             <CartItem currencyCode={cart.currencyCode} key={product.entityId} product={product} />
+          ))}
+          {giftCertificates.map((giftCertificate) => (
+            <CartGiftCertificate currencyCode={cart.currencyCode} key={giftCertificate.name} giftCertificate={giftCertificate} />
           ))}
         </ul>
 

--- a/core/app/[locale]/(default)/cart/page.tsx
+++ b/core/app/[locale]/(default)/cart/page.tsx
@@ -87,7 +87,11 @@ export default async function Cart() {
             <CartItem currencyCode={cart.currencyCode} key={product.entityId} product={product} />
           ))}
           {giftCertificates.map((giftCertificate) => (
-            <CartGiftCertificate currencyCode={cart.currencyCode} key={giftCertificate.name} giftCertificate={giftCertificate} />
+            <CartGiftCertificate
+              currencyCode={cart.currencyCode}
+              giftCertificate={giftCertificate}
+              key={giftCertificate.name}
+            />
           ))}
         </ul>
 

--- a/core/app/[locale]/(default)/gift-certificates/_actions/add-to-cart.tsx
+++ b/core/app/[locale]/(default)/gift-certificates/_actions/add-to-cart.tsx
@@ -1,0 +1,99 @@
+'use server';
+
+import { revalidateTag } from 'next/cache';
+import { cookies } from 'next/headers';
+import { getFormatter, getTranslations } from 'next-intl/server';
+
+import { addCartLineItem } from '~/client/mutations/add-cart-line-item';
+import { createCartWithGiftCertificate } from '../_mutations/create-cart-with-gift-certificate';
+import { getCart } from '~/client/queries/get-cart';
+import { TAGS } from '~/client/tags';
+
+const GIFT_CERTIFICATE_THEMES = ['GENERAL', 'BIRTHDAY', 'BOY', 'CELEBRATION', 'CHRISTMAS', 'GIRL', 'NONE'];
+type giftCertificateTheme = "GENERAL" | "BIRTHDAY" | "BOY" | "CELEBRATION" | "CHRISTMAS" | "GIRL" | "NONE";
+
+export const addGiftCertificateToCart = async (data: FormData) => {
+  const format = await getFormatter();
+  const t = await getTranslations('GiftCertificate.Actions.AddToCart');
+
+  let theme = String(data.get('theme')) as giftCertificateTheme;
+  const amount = Number(data.get('amount'));
+  const senderEmail = String(data.get('senderEmail'));
+  const senderName = String(data.get('senderName'));
+  const recipientEmail = String(data.get('recipientEmail'));
+  const recipientName = String(data.get('recipientName'));
+  const message = data.get('message') ? String(data.get('message')) : null;
+
+  if (!GIFT_CERTIFICATE_THEMES.includes(theme)) {
+    theme = 'GENERAL'
+  }
+
+  const giftCertificate = {
+    name: t('certificateName', {
+      amount: format.number(amount, {
+        style: 'currency',
+        currency: 'USD', // TODO: Determine this from the selected currency
+      })
+    }),
+    theme,
+    amount,
+    "quantity": 1,
+    "sender": {
+      "email": senderEmail,
+      "name": senderName,
+    },
+    "recipient": {
+      "email": recipientEmail,
+      "name": recipientName,
+    },
+    message,
+  }
+
+  const cartId = cookies().get('cartId')?.value;
+  let cart;
+
+  try {
+    cart = await getCart(cartId);
+
+    if (cart) {
+      cart = await addCartLineItem(cart.entityId, {
+        giftCertificates: [
+          giftCertificate
+        ],
+      });
+
+      if (!cart?.entityId) {
+        return { status: 'error', error: t('error') };
+      }
+
+      revalidateTag(TAGS.cart);
+
+      return { status: 'success', data: cart };
+    }
+
+    cart = await createCartWithGiftCertificate([giftCertificate]);
+
+    if (!cart?.entityId) {
+      return { status: 'error', error: t('error') };
+    }
+
+    cookies().set({
+      name: 'cartId',
+      value: cart.entityId,
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: true,
+      path: '/',
+    });
+
+    revalidateTag(TAGS.cart);
+
+    return { status: 'success', data: cart };
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      return { status: 'error', error: error.message };
+    }
+
+    return { status: 'error', error: t('error') };
+  }
+};

--- a/core/app/[locale]/(default)/gift-certificates/_actions/add-to-cart.tsx
+++ b/core/app/[locale]/(default)/gift-certificates/_actions/add-to-cart.tsx
@@ -3,78 +3,131 @@
 import { revalidateTag } from 'next/cache';
 import { cookies } from 'next/headers';
 import { getFormatter, getTranslations } from 'next-intl/server';
+import { z } from 'zod';
 
 import { addCartLineItem } from '~/client/mutations/add-cart-line-item';
-import { createCartWithGiftCertificate } from '../_mutations/create-cart-with-gift-certificate';
 import { getCart } from '~/client/queries/get-cart';
 import { TAGS } from '~/client/tags';
 
-const GIFT_CERTIFICATE_THEMES = ['GENERAL', 'BIRTHDAY', 'BOY', 'CELEBRATION', 'CHRISTMAS', 'GIRL', 'NONE'];
-type giftCertificateTheme = "GENERAL" | "BIRTHDAY" | "BOY" | "CELEBRATION" | "CHRISTMAS" | "GIRL" | "NONE";
+import { createCartWithGiftCertificate } from '../_mutations/create-cart-with-gift-certificate';
 
-export const addGiftCertificateToCart = async (data: FormData) => {
+const giftCertificateThemes = [
+  'GENERAL',
+  'BIRTHDAY',
+  'BOY',
+  'CELEBRATION',
+  'CHRISTMAS',
+  'GIRL',
+  'NONE',
+] as const;
+
+const GiftCertificateThemeSchema = z.enum(giftCertificateThemes);
+
+const ValidatedFormDataSchema = z.object({
+  theme: GiftCertificateThemeSchema,
+  amount: z.number().positive(),
+  senderEmail: z.string().email(),
+  senderName: z.string().min(1),
+  recipientEmail: z.string().email(),
+  recipientName: z.string().min(1),
+  message: z.string().nullable(),
+});
+
+type ValidatedFormData = z.infer<typeof ValidatedFormDataSchema>;
+
+const CartResponseSchema = z.object({
+  status: z.enum(['success', 'error']),
+  data: z.unknown().optional(),
+  error: z.string().optional(),
+});
+
+type CartResponse = z.infer<typeof CartResponseSchema>;
+
+function parseFormData(data: FormData): ValidatedFormData {
+  const theme = data.get('theme');
+  const amount = data.get('amount');
+  const senderEmail = data.get('senderEmail');
+  const senderName = data.get('senderName');
+  const recipientEmail = data.get('recipientEmail');
+  const recipientName = data.get('recipientName');
+  const message = data.get('message');
+
+  // Parse and validate the form data
+  const validatedData = ValidatedFormDataSchema.parse({
+    theme,
+    amount: amount ? Number(amount) : undefined,
+    senderEmail,
+    senderName,
+    recipientEmail,
+    recipientName,
+    message: message ? String(message) : null,
+  });
+
+  return validatedData;
+}
+
+export async function addGiftCertificateToCart(data: FormData): Promise<CartResponse> {
   const format = await getFormatter();
   const t = await getTranslations('GiftCertificate.Actions.AddToCart');
 
-  let theme = String(data.get('theme')) as giftCertificateTheme;
-  const amount = Number(data.get('amount'));
-  const senderEmail = String(data.get('senderEmail'));
-  const senderName = String(data.get('senderName'));
-  const recipientEmail = String(data.get('recipientEmail'));
-  const recipientName = String(data.get('recipientName'));
-  const message = data.get('message') ? String(data.get('message')) : null;
-
-  if (!GIFT_CERTIFICATE_THEMES.includes(theme)) {
-    theme = 'GENERAL'
-  }
-
-  const giftCertificate = {
-    name: t('certificateName', {
-      amount: format.number(amount, {
-        style: 'currency',
-        currency: 'USD', // TODO: Determine this from the selected currency
-      })
-    }),
-    theme,
-    amount,
-    "quantity": 1,
-    "sender": {
-      "email": senderEmail,
-      "name": senderName,
-    },
-    "recipient": {
-      "email": recipientEmail,
-      "name": recipientName,
-    },
-    message,
-  }
-
-  const cartId = cookies().get('cartId')?.value;
-  let cart;
-
   try {
-    cart = await getCart(cartId);
+    const validatedData = parseFormData(data);
+
+    const giftCertificate = {
+      name: t('certificateName', {
+        amount: format.number(validatedData.amount, {
+          style: 'currency',
+          currency: 'USD',
+        }),
+      }),
+      theme: validatedData.theme,
+      amount: validatedData.amount,
+      quantity: 1,
+      sender: {
+        email: validatedData.senderEmail,
+        name: validatedData.senderName,
+      },
+      recipient: {
+        email: validatedData.recipientEmail,
+        name: validatedData.recipientName,
+      },
+      message: validatedData.message,
+    };
+
+    const cartId = cookies().get('cartId')?.value;
+    let cart;
+
+    if (cartId) {
+      cart = await getCart(cartId);
+    }
 
     if (cart) {
       cart = await addCartLineItem(cart.entityId, {
-        giftCertificates: [
-          giftCertificate
-        ],
+        giftCertificates: [giftCertificate],
       });
 
       if (!cart?.entityId) {
-        return { status: 'error', error: t('error') };
+        return CartResponseSchema.parse({
+          status: 'error',
+          error: t('error'),
+        });
       }
 
       revalidateTag(TAGS.cart);
 
-      return { status: 'success', data: cart };
+      return CartResponseSchema.parse({
+        status: 'success',
+        data: cart,
+      });
     }
 
     cart = await createCartWithGiftCertificate([giftCertificate]);
 
     if (!cart?.entityId) {
-      return { status: 'error', error: t('error') };
+      return CartResponseSchema.parse({
+        status: 'error',
+        error: t('error'),
+      });
     }
 
     cookies().set({
@@ -88,12 +141,33 @@ export const addGiftCertificateToCart = async (data: FormData) => {
 
     revalidateTag(TAGS.cart);
 
-    return { status: 'success', data: cart };
+    return CartResponseSchema.parse({
+      status: 'success',
+      data: cart,
+    });
   } catch (error: unknown) {
-    if (error instanceof Error) {
-      return { status: 'error', error: error.message };
+    if (error instanceof z.ZodError) {
+      // Handle validation errors
+      const errorMessage = error.errors
+        .map((err) => `${err.path.join('.')}: ${err.message}`)
+        .join(', ');
+
+      return CartResponseSchema.parse({
+        status: 'error',
+        error: errorMessage,
+      });
     }
 
-    return { status: 'error', error: t('error') };
+    if (error instanceof Error) {
+      return CartResponseSchema.parse({
+        status: 'error',
+        error: error.message,
+      });
+    }
+
+    return CartResponseSchema.parse({
+      status: 'error',
+      error: t('error'),
+    });
   }
-};
+}

--- a/core/app/[locale]/(default)/gift-certificates/_actions/lookup-balance.tsx
+++ b/core/app/[locale]/(default)/gift-certificates/_actions/lookup-balance.tsx
@@ -1,55 +1,75 @@
-'use server'
+'use server';
 
 import { getTranslations } from 'next-intl/server';
+import { z } from 'zod';
 
-export async function lookupGiftCertificateBalance(code: string) {
+const giftCertificateSchema = z.object({
+  code: z.string(),
+  balance: z.string(),
+  currency_code: z.string(),
+});
+
+interface SuccessResponse {
+  balance: number;
+  currencyCode: string;
+}
+
+interface ErrorResponse {
+  error: string;
+  details?: unknown;
+}
+
+type LookupResponse = SuccessResponse | ErrorResponse;
+
+export async function lookupGiftCertificateBalance(code: string): Promise<LookupResponse> {
   const t = await getTranslations('GiftCertificate.Actions.Lookup');
 
   if (!code) {
-    return { error: t('noCode') }
+    return { error: t('noCode') };
   }
 
-  const apiUrl = `https://api.bigcommerce.com/stores/${process.env.BIGCOMMERCE_STORE_HASH}/v2/gift_certificates`
+  const apiUrl = `https://api.bigcommerce.com/stores/${process.env.BIGCOMMERCE_STORE_HASH}/v2/gift_certificates`;
   const headers = {
     'Content-Type': 'application/json',
     'X-Auth-Token': process.env.GIFT_CERTIFICATE_V3_API_TOKEN ?? '',
-    'Accept': 'application/json'
-  }
+    Accept: 'application/json',
+  };
 
   try {
     const response = await fetch(`${apiUrl}?limit=1&code=${encodeURIComponent(code)}`, {
       method: 'GET',
-      headers: headers
-    })
+      headers,
+    });
 
     if (response.status === 404 || response.status === 204) {
-      return { error: t('notFound') }
+      return { error: t('notFound') };
     }
 
     if (!response.ok) {
-      console.error(`v2 Gift Certificate API responded with status ${response.status}: ${response.statusText}`)
-      return { error: t('error') }
+      return { error: t('error') };
     }
 
-    const data = await response.json()
+    const parseResult = z.array(giftCertificateSchema).safeParse(await response.json());
 
-    if (Array.isArray(data) && data.length > 0 && typeof data[0].balance !== 'undefined') {
-      // There isn't a way to query the exact code in the v2 Gift Certificate API, 
-      // so we'll loop through the results to make sure it's not a partial match
-      for (const certificate of data) {
-        if (certificate.code === code) {
-          return { balance: parseFloat(data[0].balance), currencyCode: data[0].currency_code }
-        }
-      }
-
-      // No exact match, so consider it not found
-      return { error: t('notFound') }
-    } else {
-      console.error('Unexpected v2 Gift Certificate API response structure')
-      return { error: t('error') }
+    if (!parseResult.success) {
+      return { error: t('error') };
     }
+
+    const data = parseResult.data;
+    const certificate = data.find((cert) => cert.code === code);
+
+    if (!certificate) {
+      return { error: t('notFound') };
+    }
+
+    return {
+      balance: parseFloat(certificate.balance),
+      currencyCode: certificate.currency_code,
+    };
   } catch (error) {
-    console.error('Error checking gift certificate balance:', error)
-    return { error: t('error') }
+    return {
+      error: t('error'),
+      details: error,
+    };
   }
 }

--- a/core/app/[locale]/(default)/gift-certificates/_actions/lookup-balance.tsx
+++ b/core/app/[locale]/(default)/gift-certificates/_actions/lookup-balance.tsx
@@ -1,0 +1,55 @@
+'use server'
+
+import { getTranslations } from 'next-intl/server';
+
+export async function lookupGiftCertificateBalance(code: string) {
+  const t = await getTranslations('GiftCertificate.Actions.Lookup');
+
+  if (!code) {
+    return { error: t('noCode') }
+  }
+
+  const apiUrl = `https://api.bigcommerce.com/stores/${process.env.BIGCOMMERCE_STORE_HASH}/v2/gift_certificates`
+  const headers = {
+    'Content-Type': 'application/json',
+    'X-Auth-Token': process.env.GIFT_CERTIFICATE_V3_API_TOKEN ?? '',
+    'Accept': 'application/json'
+  }
+
+  try {
+    const response = await fetch(`${apiUrl}?limit=1&code=${encodeURIComponent(code)}`, {
+      method: 'GET',
+      headers: headers
+    })
+
+    if (response.status === 404 || response.status === 204) {
+      return { error: t('notFound') }
+    }
+
+    if (!response.ok) {
+      console.error(`v2 Gift Certificate API responded with status ${response.status}: ${response.statusText}`)
+      return { error: t('error') }
+    }
+
+    const data = await response.json()
+
+    if (Array.isArray(data) && data.length > 0 && typeof data[0].balance !== 'undefined') {
+      // There isn't a way to query the exact code in the v2 Gift Certificate API, 
+      // so we'll loop through the results to make sure it's not a partial match
+      for (const certificate of data) {
+        if (certificate.code === code) {
+          return { balance: parseFloat(data[0].balance), currencyCode: data[0].currency_code }
+        }
+      }
+
+      // No exact match, so consider it not found
+      return { error: t('notFound') }
+    } else {
+      console.error('Unexpected v2 Gift Certificate API response structure')
+      return { error: t('error') }
+    }
+  } catch (error) {
+    console.error('Error checking gift certificate balance:', error)
+    return { error: t('error') }
+  }
+}

--- a/core/app/[locale]/(default)/gift-certificates/_components/balance-checker.tsx
+++ b/core/app/[locale]/(default)/gift-certificates/_components/balance-checker.tsx
@@ -1,46 +1,55 @@
-'use client'
+'use client';
 
-import { useState } from 'react'
 import { useFormatter, useTranslations } from 'next-intl';
+import { useState } from 'react';
+
 import { Button } from '~/components/ui/button';
 import { Input } from '~/components/ui/form';
 import { Message } from '~/components/ui/message';
 
 export default function GiftCertificateBalanceClient({
-  checkBalanceAction
+  checkBalanceAction,
 }: {
-  checkBalanceAction: (code: string) => Promise<{ balance?: number; currencyCode?: string; error?: string }>
+  checkBalanceAction: (
+    code: string,
+  ) => Promise<{ balance?: number; currencyCode?: string; error?: string }>;
 }) {
-  const [result, setResult] = useState<{ balance?: number; currencyCode?: string; error?: string } | null>(null)
-  const [isLoading, setIsLoading] = useState(false)
+  const [result, setResult] = useState<{
+    balance?: number;
+    currencyCode?: string;
+    error?: string;
+  } | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
 
   const t = useTranslations('GiftCertificate.Check');
   const format = useFormatter();
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    setIsLoading(true)
-    const formData = new FormData(event.currentTarget)
-    const code = formData.get('code') as string
-    const response = await checkBalanceAction(code)
-    setResult(response)
-    setIsLoading(false)
-  }
+    event.preventDefault();
+    setIsLoading(true);
+
+    const formData = new FormData(event.currentTarget);
+    const code = formData.get('code')?.toString() || '';
+    const response = await checkBalanceAction(code);
+
+    setResult(response);
+    setIsLoading(false);
+  };
 
   return (
     <div className="mx-auto mb-10 mt-8 lg:w-2/3">
-      <h2 className="text-2xl font-bold mb-4">{t('heading')}</h2>
+      <h2 className="mb-4 text-2xl font-bold">{t('heading')}</h2>
 
       <form onSubmit={handleSubmit}>
         <div className="space-y-4">
           <Input
-            type="text"
+            className="w-full"
             name="code"
             placeholder={t('placeholder')}
             required
-            className="w-full"
+            type="text"
           />
-          <Button type="submit" className="w-full" disabled={isLoading}>
+          <Button className="w-full" disabled={isLoading} type="submit">
             {isLoading ? t('buttonPendingText') : t('buttonSubmitText')}
           </Button>
         </div>
@@ -49,21 +58,23 @@ export default function GiftCertificateBalanceClient({
       {result && (
         <div className="w-full text-center">
           {result.balance !== undefined ? (
-            <Message variant="success" className="mt-4">
-              <strong>{t('balanceResult', {
-                balance: format.number(result.balance, {
-                  style: 'currency',
-                  currency: result.currencyCode,
-                })
-              })}</strong>
+            <Message className="mt-4" variant="success">
+              <strong>
+                {t('balanceResult', {
+                  balance: format.number(result.balance, {
+                    style: 'currency',
+                    currency: result.currencyCode,
+                  }),
+                })}
+              </strong>
             </Message>
           ) : (
-            <Message variant="error" className="mt-4">
+            <Message className="mt-4" variant="error">
               {result.error}
             </Message>
           )}
         </div>
       )}
     </div>
-  )
+  );
 }

--- a/core/app/[locale]/(default)/gift-certificates/_components/balance-checker.tsx
+++ b/core/app/[locale]/(default)/gift-certificates/_components/balance-checker.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import { useState } from 'react'
+import { useFormatter, useTranslations } from 'next-intl';
+import { Button } from '~/components/ui/button';
+import { Input } from '~/components/ui/form';
+import { Message } from '~/components/ui/message';
+
+export default function GiftCertificateBalanceClient({
+  checkBalanceAction
+}: {
+  checkBalanceAction: (code: string) => Promise<{ balance?: number; currencyCode?: string; error?: string }>
+}) {
+  const [result, setResult] = useState<{ balance?: number; currencyCode?: string; error?: string } | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+
+  const t = useTranslations('GiftCertificate.Check');
+  const format = useFormatter();
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setIsLoading(true)
+    const formData = new FormData(event.currentTarget)
+    const code = formData.get('code') as string
+    const response = await checkBalanceAction(code)
+    setResult(response)
+    setIsLoading(false)
+  }
+
+  return (
+    <div className="mx-auto mb-10 mt-8 lg:w-2/3">
+      <h2 className="text-2xl font-bold mb-4">{t('heading')}</h2>
+
+      <form onSubmit={handleSubmit}>
+        <div className="space-y-4">
+          <Input
+            type="text"
+            name="code"
+            placeholder={t('placeholder')}
+            required
+            className="w-full"
+          />
+          <Button type="submit" className="w-full" disabled={isLoading}>
+            {isLoading ? t('buttonPendingText') : t('buttonSubmitText')}
+          </Button>
+        </div>
+      </form>
+
+      {result && (
+        <div className="w-full text-center">
+          {result.balance !== undefined ? (
+            <Message variant="success" className="mt-4">
+              <strong>{t('balanceResult', {
+                balance: format.number(result.balance, {
+                  style: 'currency',
+                  currency: result.currencyCode,
+                })
+              })}</strong>
+            </Message>
+          ) : (
+            <Message variant="error" className="mt-4">
+              {result.error}
+            </Message>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/core/app/[locale]/(default)/gift-certificates/_components/gift-certificate-tabs.tsx
+++ b/core/app/[locale]/(default)/gift-certificates/_components/gift-certificate-tabs.tsx
@@ -1,14 +1,17 @@
-'use client'
+'use client';
 
-import { useState } from 'react'
 import { useTranslations } from 'next-intl';
+import { useState } from 'react';
+
 import { Tabs } from '~/components/ui/tabs';
-import GiftCertificateBalanceClient from './balance-checker';
-import RedeemGiftCertificateDetails from './redeem-details';
-import GiftCertificatePurchaseForm from './purchase-form';
+
 import { lookupGiftCertificateBalance } from '../_actions/lookup-balance';
 
-const defaultTab = "Purchase Gift Certificate"
+import GiftCertificateBalanceClient from './balance-checker';
+import GiftCertificatePurchaseForm from './purchase-form';
+import RedeemGiftCertificateDetails from './redeem-details';
+
+const defaultTab = 'Purchase Gift Certificate';
 
 export default function GiftCertificateTabs() {
   const [activeTab, setActiveTab] = useState(defaultTab);
@@ -17,27 +20,28 @@ export default function GiftCertificateTabs() {
   const tabs = [
     {
       value: t('purchase'),
-      content: <GiftCertificatePurchaseForm />
+      content: <GiftCertificatePurchaseForm />,
     },
     {
       value: t('check'),
-      content: <GiftCertificateBalanceClient checkBalanceAction={lookupGiftCertificateBalance} />
+      content: <GiftCertificateBalanceClient checkBalanceAction={lookupGiftCertificateBalance} />,
     },
     {
       value: t('redeem'),
-      content: <RedeemGiftCertificateDetails />
-    }
+      content: <RedeemGiftCertificateDetails />,
+    },
   ];
 
   return (
     <div className="mx-auto mb-10 mt-8 lg:w-2/3">
       <Tabs
+        className="justify-center"
         defaultValue={defaultTab}
         label={t('label')}
         onValueChange={setActiveTab}
         tabs={tabs}
         value={activeTab}
-        className="justify-center"
-      /></div>
-  )
+      />
+    </div>
+  );
 }

--- a/core/app/[locale]/(default)/gift-certificates/_components/gift-certificate-tabs.tsx
+++ b/core/app/[locale]/(default)/gift-certificates/_components/gift-certificate-tabs.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { useState } from 'react'
+import { useTranslations } from 'next-intl';
+import { Tabs } from '~/components/ui/tabs';
+import GiftCertificateBalanceClient from './balance-checker';
+import RedeemGiftCertificateDetails from './redeem-details';
+import GiftCertificatePurchaseForm from './purchase-form';
+import { lookupGiftCertificateBalance } from '../_actions/lookup-balance';
+
+const defaultTab = "Purchase Gift Certificate"
+
+export default function GiftCertificateTabs() {
+  const [activeTab, setActiveTab] = useState(defaultTab);
+  const t = useTranslations('GiftCertificate.Tabs');
+
+  const tabs = [
+    {
+      value: t('purchase'),
+      content: <GiftCertificatePurchaseForm />
+    },
+    {
+      value: t('check'),
+      content: <GiftCertificateBalanceClient checkBalanceAction={lookupGiftCertificateBalance} />
+    },
+    {
+      value: t('redeem'),
+      content: <RedeemGiftCertificateDetails />
+    }
+  ];
+
+  return (
+    <div className="mx-auto mb-10 mt-8 lg:w-2/3">
+      <Tabs
+        defaultValue={defaultTab}
+        label={t('label')}
+        onValueChange={setActiveTab}
+        tabs={tabs}
+        value={activeTab}
+        className="justify-center"
+      /></div>
+  )
+}

--- a/core/app/[locale]/(default)/gift-certificates/_components/purchase-form.tsx
+++ b/core/app/[locale]/(default)/gift-certificates/_components/purchase-form.tsx
@@ -1,4 +1,4 @@
-'use client'
+'use client';
 
 import { useTranslations } from 'next-intl';
 import { useRef, useState } from 'react';
@@ -13,33 +13,40 @@ import {
   Form,
   FormSubmit,
   Input,
-  TextArea,
   Select,
+  TextArea,
 } from '~/components/ui/form';
 import { Message } from '~/components/ui/message';
 
 import { addGiftCertificateToCart } from '../_actions/add-to-cart';
 
-const GIFT_CERTIFICATE_THEMES = ['GENERAL', 'BIRTHDAY', 'BOY', 'CELEBRATION', 'CHRISTMAS', 'GIRL', 'NONE'];
+const GIFT_CERTIFICATE_THEMES = [
+  'GENERAL',
+  'BIRTHDAY',
+  'BOY',
+  'CELEBRATION',
+  'CHRISTMAS',
+  'GIRL',
+  'NONE',
+];
 
 const defaultValues = {
-  theme: "GENERAL",
-  amount: 25.00,
+  theme: 'GENERAL',
+  amount: 25.0,
   senderName: 'Nate Stewart',
   senderEmail: 'nate.stewart@bigcommerce.com',
   recipientName: 'Nathan Booker',
   recipientEmail: 'nathan.booker@bigcommerce.com',
-  message: 'Hey, sorry I missed your birthday (again). No one is perfect, although I fully expect you to hold it against me. Anyway, let\'s get to work 🚀',
-}
+  message:
+    "Hey, sorry I missed your birthday (again). No one is perfect, although I fully expect you to hold it against me. Anyway, let's get to work 🚀",
+};
 
 interface FormStatus {
   status: 'success' | 'error';
   message: string;
 }
 
-interface FieldValidation {
-  [key: string]: boolean;
-}
+type FieldValidation = Record<string, boolean>;
 
 const Submit = () => {
   const { pending } = useFormStatus();
@@ -47,7 +54,7 @@ const Submit = () => {
 
   return (
     <FormSubmit asChild>
-      <Button type="submit" className="w-full" disabled={pending}>
+      <Button className="w-full" disabled={pending} type="submit">
         {pending ? t('buttonPendingText') : t('buttonSubmitText')}
       </Button>
     </FormSubmit>
@@ -79,7 +86,7 @@ export default function GiftCertificatePurchaseForm() {
     const { name, validity } = e.target;
     const isValid = !validity.valueMissing && !validity.typeMismatch;
 
-    setFieldValidation(prev => ({
+    setFieldValidation((prev) => ({
       ...prev,
       [name]: isValid,
     }));
@@ -88,7 +95,7 @@ export default function GiftCertificatePurchaseForm() {
   return (
     <>
       <div className="mx-auto mb-10 mt-8 lg:w-2/3">
-        <h2 className="text-2xl font-bold mb-4">{t('heading')}</h2>
+        <h2 className="mb-4 text-2xl font-bold">{t('heading')}</h2>
       </div>
       {formStatus && (
         <Message className="mx-auto lg:w-[830px]" variant={formStatus.status}>
@@ -101,32 +108,37 @@ export default function GiftCertificatePurchaseForm() {
         ref={form}
       >
         <Field className="relative space-y-2 pb-7" name="theme">
-          <FieldLabel htmlFor="theme" isRequired>{t('themeLabel')}</FieldLabel>
+          <FieldLabel htmlFor="theme" isRequired>
+            {t('themeLabel')}
+          </FieldLabel>
           <FieldControl asChild>
             <Select
+              defaultValue={defaultValues.theme}
               name="theme"
               options={GIFT_CERTIFICATE_THEMES.map((theme) => ({
-                value: theme, label: theme.charAt(0).toUpperCase() + theme.substring(1).toLowerCase()
+                value: theme,
+                label: theme.charAt(0).toUpperCase() + theme.substring(1).toLowerCase(),
               }))}
-              defaultValue={defaultValues.theme}
               required
             />
           </FieldControl>
         </Field>
         <Field className="relative space-y-2 pb-7" name="amount">
-          <FieldLabel htmlFor="amount" isRequired>{t('amountLabel')}</FieldLabel>
+          <FieldLabel htmlFor="amount" isRequired>
+            {t('amountLabel')}
+          </FieldLabel>
           <FieldControl asChild>
             <Input
               defaultValue={defaultValues.amount}
-              type="number"
+              error={fieldValidation.amount === false}
               id="amount"
-              name="amount"
               min="1"
-              step="0.01"
-              required
+              name="amount"
               onChange={handleInputValidation}
               onInvalid={handleInputValidation}
-              error={fieldValidation.amount === false}
+              required
+              step="0.01"
+              type="number"
             />
           </FieldControl>
           <FieldMessage
@@ -137,17 +149,19 @@ export default function GiftCertificatePurchaseForm() {
           </FieldMessage>
         </Field>
         <Field className="relative space-y-2 pb-7" name="senderEmail">
-          <FieldLabel htmlFor="senderEmail" isRequired>{t('senderEmailLabel')}</FieldLabel>
+          <FieldLabel htmlFor="senderEmail" isRequired>
+            {t('senderEmailLabel')}
+          </FieldLabel>
           <FieldControl asChild>
             <Input
               defaultValue={defaultValues.senderEmail}
-              type="email"
+              error={fieldValidation.senderEmail === false}
               id="senderEmail"
               name="senderEmail"
-              required
               onChange={handleInputValidation}
               onInvalid={handleInputValidation}
-              error={fieldValidation.senderEmail === false}
+              required
+              type="email"
             />
           </FieldControl>
           <FieldMessage
@@ -164,17 +178,19 @@ export default function GiftCertificatePurchaseForm() {
           </FieldMessage>
         </Field>
         <Field className="relative space-y-2 pb-7" name="senderName">
-          <FieldLabel htmlFor="senderName" isRequired>{t('senderNameLabel')}</FieldLabel>
+          <FieldLabel htmlFor="senderName" isRequired>
+            {t('senderNameLabel')}
+          </FieldLabel>
           <FieldControl asChild>
             <Input
               defaultValue={defaultValues.senderName}
-              type="text"
+              error={fieldValidation.senderName === false}
               id="senderName"
               name="senderName"
-              required
               onChange={handleInputValidation}
               onInvalid={handleInputValidation}
-              error={fieldValidation.senderName === false}
+              required
+              type="text"
             />
           </FieldControl>
           <FieldMessage
@@ -185,17 +201,19 @@ export default function GiftCertificatePurchaseForm() {
           </FieldMessage>
         </Field>
         <Field className="relative space-y-2 pb-7" name="recipientEmail">
-          <FieldLabel htmlFor="recipientEmail" isRequired>{t('recipientEmailLabel')}</FieldLabel>
+          <FieldLabel htmlFor="recipientEmail" isRequired>
+            {t('recipientEmailLabel')}
+          </FieldLabel>
           <FieldControl asChild>
             <Input
               defaultValue={defaultValues.recipientEmail}
-              type="email"
+              error={fieldValidation.recipientEmail === false}
               id="recipientEmail"
               name="recipientEmail"
-              required
               onChange={handleInputValidation}
               onInvalid={handleInputValidation}
-              error={fieldValidation.recipientEmail === false}
+              required
+              type="email"
             />
           </FieldControl>
           <FieldMessage
@@ -212,17 +230,19 @@ export default function GiftCertificatePurchaseForm() {
           </FieldMessage>
         </Field>
         <Field className="relative space-y-2 pb-7" name="recipientName">
-          <FieldLabel htmlFor="recipientName" isRequired>{t('recipientNameLabel')}</FieldLabel>
+          <FieldLabel htmlFor="recipientName" isRequired>
+            {t('recipientNameLabel')}
+          </FieldLabel>
           <FieldControl asChild>
             <Input
               defaultValue={defaultValues.recipientName}
-              type="text"
+              error={fieldValidation.recipientName === false}
               id="recipientName"
               name="recipientName"
-              required
               onChange={handleInputValidation}
               onInvalid={handleInputValidation}
-              error={fieldValidation.recipientName === false}
+              required
+              type="text"
             />
           </FieldControl>
           <FieldMessage
@@ -232,17 +252,10 @@ export default function GiftCertificatePurchaseForm() {
             {t('nameValidationMessage')}
           </FieldMessage>
         </Field>
-        <Field
-          className="relative col-span-full max-w-full space-y-2 pb-5"
-          name="message"
-        >
+        <Field className="relative col-span-full max-w-full space-y-2 pb-5" name="message">
           <FieldLabel htmlFor="message">{t('messageLabel')}</FieldLabel>
           <FieldControl asChild>
-            <TextArea
-              defaultValue={defaultValues.message}
-              id="message"
-              name="message"
-            />
+            <TextArea defaultValue={defaultValues.message} id="message" name="message" />
           </FieldControl>
         </Field>
         <Submit />

--- a/core/app/[locale]/(default)/gift-certificates/_components/purchase-form.tsx
+++ b/core/app/[locale]/(default)/gift-certificates/_components/purchase-form.tsx
@@ -1,0 +1,252 @@
+'use client'
+
+import { useTranslations } from 'next-intl';
+import { useRef, useState } from 'react';
+import { useFormStatus } from 'react-dom';
+
+import { Button } from '~/components/ui/button';
+import {
+  Field,
+  FieldControl,
+  FieldLabel,
+  FieldMessage,
+  Form,
+  FormSubmit,
+  Input,
+  TextArea,
+  Select,
+} from '~/components/ui/form';
+import { Message } from '~/components/ui/message';
+
+import { addGiftCertificateToCart } from '../_actions/add-to-cart';
+
+const GIFT_CERTIFICATE_THEMES = ['GENERAL', 'BIRTHDAY', 'BOY', 'CELEBRATION', 'CHRISTMAS', 'GIRL', 'NONE'];
+
+const defaultValues = {
+  theme: "GENERAL",
+  amount: 25.00,
+  senderName: 'Nate Stewart',
+  senderEmail: 'nate.stewart@bigcommerce.com',
+  recipientName: 'Nathan Booker',
+  recipientEmail: 'nathan.booker@bigcommerce.com',
+  message: 'Hey, sorry I missed your birthday (again). No one is perfect, although I fully expect you to hold it against me. Anyway, let\'s get to work 🚀',
+}
+
+interface FormStatus {
+  status: 'success' | 'error';
+  message: string;
+}
+
+interface FieldValidation {
+  [key: string]: boolean;
+}
+
+const Submit = () => {
+  const { pending } = useFormStatus();
+  const t = useTranslations('GiftCertificate.Purchase');
+
+  return (
+    <FormSubmit asChild>
+      <Button type="submit" className="w-full" disabled={pending}>
+        {pending ? t('buttonPendingText') : t('buttonSubmitText')}
+      </Button>
+    </FormSubmit>
+  );
+};
+
+export default function GiftCertificatePurchaseForm() {
+  const form = useRef<HTMLFormElement>(null);
+  const [formStatus, setFormStatus] = useState<FormStatus | null>(null);
+  const [fieldValidation, setFieldValidation] = useState<FieldValidation>({});
+
+  const t = useTranslations('GiftCertificate.Purchase');
+
+  const onSubmit = async (formData: FormData) => {
+    const response = await addGiftCertificateToCart(formData);
+
+    if (response.status === 'success') {
+      form.current?.reset();
+      setFormStatus({
+        status: 'success',
+        message: t('success'),
+      });
+    } else {
+      setFormStatus({ status: 'error', message: response.error ?? t('error') });
+    }
+  };
+
+  const handleInputValidation = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, validity } = e.target;
+    const isValid = !validity.valueMissing && !validity.typeMismatch;
+
+    setFieldValidation(prev => ({
+      ...prev,
+      [name]: isValid,
+    }));
+  };
+
+  return (
+    <>
+      <div className="mx-auto mb-10 mt-8 lg:w-2/3">
+        <h2 className="text-2xl font-bold mb-4">{t('heading')}</h2>
+      </div>
+      {formStatus && (
+        <Message className="mx-auto lg:w-[830px]" variant={formStatus.status}>
+          <p>{formStatus.message}</p>
+        </Message>
+      )}
+      <Form
+        action={onSubmit}
+        className="mx-auto mb-10 mt-8 grid grid-cols-1 gap-y-6 lg:w-2/3 lg:grid-cols-2 lg:gap-x-6 lg:gap-y-2"
+        ref={form}
+      >
+        <Field className="relative space-y-2 pb-7" name="theme">
+          <FieldLabel htmlFor="theme" isRequired>{t('themeLabel')}</FieldLabel>
+          <FieldControl asChild>
+            <Select
+              name="theme"
+              options={GIFT_CERTIFICATE_THEMES.map((theme) => ({
+                value: theme, label: theme.charAt(0).toUpperCase() + theme.substring(1).toLowerCase()
+              }))}
+              defaultValue={defaultValues.theme}
+              required
+            />
+          </FieldControl>
+        </Field>
+        <Field className="relative space-y-2 pb-7" name="amount">
+          <FieldLabel htmlFor="amount" isRequired>{t('amountLabel')}</FieldLabel>
+          <FieldControl asChild>
+            <Input
+              defaultValue={defaultValues.amount}
+              type="number"
+              id="amount"
+              name="amount"
+              min="1"
+              step="0.01"
+              required
+              onChange={handleInputValidation}
+              onInvalid={handleInputValidation}
+              error={fieldValidation.amount === false}
+            />
+          </FieldControl>
+          <FieldMessage
+            className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-error"
+            match="valueMissing"
+          >
+            {t('amountValidationMessage')}
+          </FieldMessage>
+        </Field>
+        <Field className="relative space-y-2 pb-7" name="senderEmail">
+          <FieldLabel htmlFor="senderEmail" isRequired>{t('senderEmailLabel')}</FieldLabel>
+          <FieldControl asChild>
+            <Input
+              defaultValue={defaultValues.senderEmail}
+              type="email"
+              id="senderEmail"
+              name="senderEmail"
+              required
+              onChange={handleInputValidation}
+              onInvalid={handleInputValidation}
+              error={fieldValidation.senderEmail === false}
+            />
+          </FieldControl>
+          <FieldMessage
+            className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-error"
+            match="valueMissing"
+          >
+            {t('emailValidationMessage')}
+          </FieldMessage>
+          <FieldMessage
+            className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-error"
+            match="typeMismatch"
+          >
+            {t('emailValidationMessage')}
+          </FieldMessage>
+        </Field>
+        <Field className="relative space-y-2 pb-7" name="senderName">
+          <FieldLabel htmlFor="senderName" isRequired>{t('senderNameLabel')}</FieldLabel>
+          <FieldControl asChild>
+            <Input
+              defaultValue={defaultValues.senderName}
+              type="text"
+              id="senderName"
+              name="senderName"
+              required
+              onChange={handleInputValidation}
+              onInvalid={handleInputValidation}
+              error={fieldValidation.senderName === false}
+            />
+          </FieldControl>
+          <FieldMessage
+            className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-error"
+            match="valueMissing"
+          >
+            {t('nameValidationMessage')}
+          </FieldMessage>
+        </Field>
+        <Field className="relative space-y-2 pb-7" name="recipientEmail">
+          <FieldLabel htmlFor="recipientEmail" isRequired>{t('recipientEmailLabel')}</FieldLabel>
+          <FieldControl asChild>
+            <Input
+              defaultValue={defaultValues.recipientEmail}
+              type="email"
+              id="recipientEmail"
+              name="recipientEmail"
+              required
+              onChange={handleInputValidation}
+              onInvalid={handleInputValidation}
+              error={fieldValidation.recipientEmail === false}
+            />
+          </FieldControl>
+          <FieldMessage
+            className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-error"
+            match="valueMissing"
+          >
+            {t('emailValidationMessage')}
+          </FieldMessage>
+          <FieldMessage
+            className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-error"
+            match="typeMismatch"
+          >
+            {t('emailValidationMessage')}
+          </FieldMessage>
+        </Field>
+        <Field className="relative space-y-2 pb-7" name="recipientName">
+          <FieldLabel htmlFor="recipientName" isRequired>{t('recipientNameLabel')}</FieldLabel>
+          <FieldControl asChild>
+            <Input
+              defaultValue={defaultValues.recipientName}
+              type="text"
+              id="recipientName"
+              name="recipientName"
+              required
+              onChange={handleInputValidation}
+              onInvalid={handleInputValidation}
+              error={fieldValidation.recipientName === false}
+            />
+          </FieldControl>
+          <FieldMessage
+            className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-error"
+            match="valueMissing"
+          >
+            {t('nameValidationMessage')}
+          </FieldMessage>
+        </Field>
+        <Field
+          className="relative col-span-full max-w-full space-y-2 pb-5"
+          name="message"
+        >
+          <FieldLabel htmlFor="message">{t('messageLabel')}</FieldLabel>
+          <FieldControl asChild>
+            <TextArea
+              defaultValue={defaultValues.message}
+              id="message"
+              name="message"
+            />
+          </FieldControl>
+        </Field>
+        <Submit />
+      </Form>
+    </>
+  );
+}

--- a/core/app/[locale]/(default)/gift-certificates/_components/redeem-details.tsx
+++ b/core/app/[locale]/(default)/gift-certificates/_components/redeem-details.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { useTranslations } from 'next-intl';
+
+export default function RedeemGiftCertificateDetails() {
+  const t = useTranslations('GiftCertificate.Redeem');
+
+  return (
+    <div className="text-base mx-auto mb-10 mt-8 lg:w-2/3">
+      <h2 className="text-2xl font-bold mb-4">Redeem Gift Certificate</h2>
+      <p className="text-lg mb-4 text-gray-600">{t('instructionIntro')}</p>
+      <ul className="space-y-3 list-disc pl-5 text-gray-700">
+        {t('instructionOne') ? <li>{t('instructionOne')}</li> : ''}
+        {t('instructionTwo') ? <li>{t('instructionTwo')}</li> : ''}
+        {t('instructionThree') ? <li>{t('instructionThree')}</li> : ''}
+        {t('instructionFour') ? <li>{t('instructionFour')}</li> : ''}
+      </ul>
+    </div>
+  )
+}

--- a/core/app/[locale]/(default)/gift-certificates/_components/redeem-details.tsx
+++ b/core/app/[locale]/(default)/gift-certificates/_components/redeem-details.tsx
@@ -1,4 +1,4 @@
-'use client'
+'use client';
 
 import { useTranslations } from 'next-intl';
 
@@ -6,15 +6,15 @@ export default function RedeemGiftCertificateDetails() {
   const t = useTranslations('GiftCertificate.Redeem');
 
   return (
-    <div className="text-base mx-auto mb-10 mt-8 lg:w-2/3">
-      <h2 className="text-2xl font-bold mb-4">Redeem Gift Certificate</h2>
-      <p className="text-lg mb-4 text-gray-600">{t('instructionIntro')}</p>
-      <ul className="space-y-3 list-disc pl-5 text-gray-700">
+    <div className="mx-auto mb-10 mt-8 text-base lg:w-2/3">
+      <h2 className="mb-4 text-2xl font-bold">Redeem Gift Certificate</h2>
+      <p className="mb-4 text-lg text-gray-600">{t('instructionIntro')}</p>
+      <ul className="list-disc space-y-3 pl-5 text-gray-700">
         {t('instructionOne') ? <li>{t('instructionOne')}</li> : ''}
         {t('instructionTwo') ? <li>{t('instructionTwo')}</li> : ''}
         {t('instructionThree') ? <li>{t('instructionThree')}</li> : ''}
         {t('instructionFour') ? <li>{t('instructionFour')}</li> : ''}
       </ul>
     </div>
-  )
+  );
 }

--- a/core/app/[locale]/(default)/gift-certificates/_mutations/create-cart-with-gift-certificate.tsx
+++ b/core/app/[locale]/(default)/gift-certificates/_mutations/create-cart-with-gift-certificate.tsx
@@ -1,5 +1,4 @@
 import { getSessionCustomerId } from '~/auth';
-
 import { client } from '~/client';
 import { graphql, VariablesOf } from '~/client/graphql';
 
@@ -26,7 +25,7 @@ export const createCartWithGiftCertificate = async (giftCertificates: GiftCertif
     document: CreateCartMutation,
     variables: {
       createCartInput: {
-        giftCertificates: giftCertificates
+        giftCertificates,
       },
     },
     customerId,

--- a/core/app/[locale]/(default)/gift-certificates/_mutations/create-cart-with-gift-certificate.tsx
+++ b/core/app/[locale]/(default)/gift-certificates/_mutations/create-cart-with-gift-certificate.tsx
@@ -1,0 +1,37 @@
+import { getSessionCustomerId } from '~/auth';
+
+import { client } from '~/client';
+import { graphql, VariablesOf } from '~/client/graphql';
+
+const CreateCartMutation = graphql(`
+  mutation CreateCartMutation($createCartInput: CreateCartInput!) {
+    cart {
+      createCart(input: $createCartInput) {
+        cart {
+          entityId
+        }
+      }
+    }
+  }
+`);
+
+type Variables = VariablesOf<typeof CreateCartMutation>;
+type CreateCartInput = Variables['createCartInput'];
+type GiftCertificates = CreateCartInput['giftCertificates'];
+
+export const createCartWithGiftCertificate = async (giftCertificates: GiftCertificates) => {
+  const customerId = await getSessionCustomerId();
+
+  const response = await client.fetch({
+    document: CreateCartMutation,
+    variables: {
+      createCartInput: {
+        giftCertificates: giftCertificates
+      },
+    },
+    customerId,
+    fetchOptions: { cache: 'no-store' },
+  });
+
+  return response.data.cart.createCart?.cart;
+};

--- a/core/app/[locale]/(default)/gift-certificates/page.tsx
+++ b/core/app/[locale]/(default)/gift-certificates/page.tsx
@@ -1,5 +1,6 @@
 import { getTranslations } from 'next-intl/server';
-import GiftCertificateTabs from './_components/gift-certificate-tabs'
+
+import GiftCertificateTabs from './_components/gift-certificate-tabs';
 
 export async function generateMetadata() {
   const t = await getTranslations('GiftCertificate');
@@ -9,9 +10,7 @@ export async function generateMetadata() {
   };
 }
 
-export default async function GiftCertificateBalancePage() {
-  const t = await getTranslations('GiftCertificate');
-
+export default function GiftCertificateBalancePage() {
   return (
     <div>
       <div className="pb-12">

--- a/core/app/[locale]/(default)/gift-certificates/page.tsx
+++ b/core/app/[locale]/(default)/gift-certificates/page.tsx
@@ -1,0 +1,24 @@
+import { getTranslations } from 'next-intl/server';
+import GiftCertificateTabs from './_components/gift-certificate-tabs'
+
+export async function generateMetadata() {
+  const t = await getTranslations('GiftCertificate');
+
+  return {
+    title: t('title'),
+  };
+}
+
+export default async function GiftCertificateBalancePage() {
+  const t = await getTranslations('GiftCertificate');
+
+  return (
+    <div>
+      <div className="pb-12">
+        <GiftCertificateTabs />
+      </div>
+    </div>
+  );
+}
+
+export const runtime = 'edge';

--- a/core/components/ui/tabs/tabs.tsx
+++ b/core/components/ui/tabs/tabs.tsx
@@ -20,7 +20,7 @@ export function Tabs({ className, defaultValue, label, tabs, ...props }: Props) 
     <TabsPrimitive.Root activationMode="manual" defaultValue={defaultValue} {...props}>
       <TabsPrimitive.List
         aria-label={label}
-        className="mb-8 flex list-none items-start overflow-x-auto text-base"
+        className={`mb-8 flex list-none items-start overflow-x-auto text-base ${className}`}
       >
         {tabs.map((tab) => (
           <TabsPrimitive.Trigger

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -484,5 +484,57 @@
         "postalCode": "Enter a zip / postcode"
       }
     }
+  },
+  "GiftCertificate": {
+    "title": "Gift Certificates",
+    "Tabs": {
+      "label": "Gift Certificate Assistance",
+      "purchase": "Purchase Gift Certificate",
+      "check": "Check Balance",
+      "redeem": "Redeem Gift Certificate"
+    },
+    "Purchase": {
+      "heading": "Purchase a Gift Certificate",
+      "themeLabel": "Theme",
+      "amountLabel": "Amount",
+      "senderEmailLabel": "Your Email",
+      "senderNameLabel": "Your Name",
+      "recipientEmailLabel": "Recipient's Email",
+      "recipientNameLabel": "Recipient's Name",
+      "messageLabel": "Message",
+      "submitFormText": "Add Gift Certificate to Cart",
+      "buttonSubmitText": "Add Gift Certificate to Cart",
+      "buttonPendingText": "Adding...",
+      "success": "Gift Certificate added to cart.",
+      "amountValidationMessage": "An amount is required",
+      "emailValidationMessage": "Enter a valid email such as name@domain.com",
+      "nameValidationMessage": "Please enter a name"
+    },
+    "Check": {
+      "heading": "Check Your Gift Certificate Balance",
+      "balanceResult": "Balance: {balance}",
+      "placeholder": "Enter gift certificate code",
+      "buttonSubmitText": "Check Balance",
+      "buttonPendingText": "Checking..."
+    },
+    "Redeem": {
+      "heading": "Redeem Gift Certificate",
+      "instructionIntro": "To redeem a gift certificate, follow the simple steps below:",
+      "instructionOne": "Find your unique gift certificate code (e.g. Z50-Y6K-COS-402), normally recieved as an email attachment.",
+      "instructionTwo": "Browse this store and add what you'd like to purchase to your cart.",
+      "instructionThree": "When checking out, submit your code in the 'Coupon / Gift Certificate' box.",
+      "instructionFour": ""
+    },
+    "Actions": {
+      "Lookup": {
+        "noCode": "Please enter a gift certificate code.",
+        "notFound": "Gift certificate not found. Please check the code and try again.",
+        "error": "An error occured while up the gift certificate. Please try again."
+      },
+      "AddToCart": {
+        "certificateName": "{amount} Gift Certificate",
+        "error": "Failed to add gift certificate to cart."
+      }
+    }
   }
 }


### PR DESCRIPTION
## What/Why?

Adds a gift certificate page with purchase, check, and redeem tab similar to what Cornerstone has.

Uses our REST API for checking the certificate balance, which requires an additional `GIFT_CERTIFICATE_V3_API_TOKEN` env var. Suggest creating a read-only token if you go this route. Adding a gift certificate to a cart uses GraphQL.

The route is at `/gift-certificates`.

### Here's a demo:

https://github.com/user-attachments/assets/c7458958-e89e-4b31-8b29-d06c623676e7

Under the hood it supports localization using our existing standards within Catalyst.

## Backstory

I've been looking for something tangible to test v0.dev with and this fit the bill! It ended up doing a pretty good job out of the box, with my first prompt that asked for a gift certificate balance checker using the BigCommerce API.

### Initial v0 prompt and result
<img width="1508" alt="Screenshot 2024-10-21 at 2 22 17 AM" src="https://github.com/user-attachments/assets/31da9545-8edf-4e0d-81c2-443cc31107e2">

Ended up having to switch out the components since it defaults to shadcn components, fix the Gift Certificate API request that was using an invalid route, and manually polish areas to follow our standards. Like using our GraphQL client.

Overall it's a good pairing experience, especially when thinking through app router / RSCs.

## Testing

🎥 See video ^