### PR TITLE
chore(cli): noop commit to rebuild CLI

### DIFF
--- a/.changeset/quiet-ligers-try.md
+++ b/.changeset/quiet-ligers-try.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": patch
+---
+
+Noop commit to rebuild CLI.


### PR DESCRIPTION
## What/Why?
Trying to rerelease the CLI in order to build the env var into the CLI.

## Testing
![Screenshot 2024-10-17 at 14 58 42](https://github.com/user-attachments/assets/f3f4c55a-fcb3-4394-9560-cdb9bfb63468)
