### PR TITLE
chore(core): bump next-intl

### DIFF
--- a/.changeset/silent-rats-hear.md
+++ b/.changeset/silent-rats-hear.md
@@ -1,0 +1,9 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Bump `next-intl` which includes [some minor changes and updated APIs]((https://next-intl-docs.vercel.app/blog/next-intl-3-22)):
+
++ Use new `createNavigation` api.
++ Pass `locale` to redirects.
++ `setRequestLocale` is no longer unstable.

--- a/core/app/[locale]/(default)/(auth)/change-password/page.tsx
+++ b/core/app/[locale]/(default)/(auth)/change-password/page.tsx
@@ -1,4 +1,4 @@
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import { getTranslations } from 'next-intl/server';
 
 import { redirect } from '~/i18n/routing';
@@ -22,12 +22,13 @@ interface Props {
 
 export default function ChangePassword({ searchParams }: Props) {
   const t = useTranslations('ChangePassword');
+  const locale = useLocale();
 
   const customerId = searchParams.c;
   const customerToken = searchParams.t;
 
   if (!customerId || !customerToken) {
-    redirect('/login');
+    redirect({ href: '/login', locale });
   }
 
   if (customerId && customerToken) {

--- a/core/app/[locale]/(default)/(auth)/login/_actions/login.ts
+++ b/core/app/[locale]/(default)/(auth)/login/_actions/login.ts
@@ -1,12 +1,15 @@
 'use server';
 
 import { isRedirectError } from 'next/dist/client/components/redirect';
+import { getLocale } from 'next-intl/server';
 
 import { Credentials, signIn } from '~/auth';
 import { redirect } from '~/i18n/routing';
 
 export const login = async (_previousState: unknown, formData: FormData) => {
   try {
+    const locale = await getLocale();
+
     const credentials = Credentials.parse({
       email: formData.get('email'),
       password: formData.get('password'),
@@ -19,7 +22,7 @@ export const login = async (_previousState: unknown, formData: FormData) => {
       redirect: false,
     });
 
-    redirect('/account');
+    redirect({ href: '/account', locale });
   } catch (error: unknown) {
     // We need to throw this error to trigger the redirect as Next.js uses error boundaries to redirect.
     if (isRedirectError(error)) {

--- a/core/app/[locale]/(default)/(auth)/login/page.tsx
+++ b/core/app/[locale]/(default)/(auth)/login/page.tsx
@@ -1,5 +1,5 @@
 import { useTranslations } from 'next-intl';
-import { getTranslations, unstable_setRequestLocale } from 'next-intl/server';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { Link } from '~/components/link';
 import { Button } from '~/components/ui/button';
@@ -20,7 +20,7 @@ interface Props {
 }
 
 export default function Login({ params: { locale } }: Props) {
-  unstable_setRequestLocale(locale);
+  setRequestLocale(locale);
 
   const t = useTranslations('Login');
 

--- a/core/app/[locale]/(default)/(auth)/register/_actions/login.ts
+++ b/core/app/[locale]/(default)/(auth)/register/_actions/login.ts
@@ -1,11 +1,14 @@
 'use server';
 
 import { isRedirectError } from 'next/dist/client/components/redirect';
+import { getLocale } from 'next-intl/server';
 
 import { Credentials, signIn } from '~/auth';
 import { redirect } from '~/i18n/routing';
 
 export const login = async (formData: FormData) => {
+  const locale = await getLocale();
+
   try {
     const credentials = Credentials.parse({
       email: formData.get('customer-email'),
@@ -19,7 +22,7 @@ export const login = async (formData: FormData) => {
       redirect: false,
     });
 
-    redirect('/account');
+    redirect({ href: '/account', locale });
   } catch (error: unknown) {
     if (isRedirectError(error)) {
       throw error;

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import { getTranslations, unstable_setRequestLocale } from 'next-intl/server';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { ProductCard } from '~/components/product-card';
 import { Pagination } from '~/components/ui/pagination';
@@ -40,7 +40,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 }
 
 export default async function Brand({ params: { slug, locale }, searchParams }: Props) {
-  unstable_setRequestLocale(locale);
+  setRequestLocale(locale);
 
   const t = await getTranslations('Brand');
 

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import { getTranslations, unstable_setRequestLocale } from 'next-intl/server';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { Breadcrumbs } from '~/components/breadcrumbs';
 import { ProductCard } from '~/components/product-card';
@@ -48,7 +48,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 }
 
 export default async function Category({ params: { locale, slug }, searchParams }: Props) {
-  unstable_setRequestLocale(locale);
+  setRequestLocale(locale);
 
   const t = await getTranslations('Category');
 

--- a/core/app/[locale]/(default)/account/(tabs)/layout.tsx
+++ b/core/app/[locale]/(default)/account/(tabs)/layout.tsx
@@ -1,5 +1,5 @@
 import { useTranslations } from 'next-intl';
-import { unstable_setRequestLocale } from 'next-intl/server';
+import { setRequestLocale } from 'next-intl/server';
 import { PropsWithChildren } from 'react';
 
 import { Link } from '~/components/link';
@@ -15,7 +15,7 @@ interface Props extends PropsWithChildren {
 }
 
 export default function AccountTabLayout({ children, params: { locale } }: Props) {
-  unstable_setRequestLocale(locale);
+  setRequestLocale(locale);
 
   const t = useTranslations('Account.Home');
 

--- a/core/app/[locale]/(default)/account/(tabs)/settings/change-password/page.tsx
+++ b/core/app/[locale]/(default)/account/(tabs)/settings/change-password/page.tsx
@@ -1,4 +1,4 @@
-import { getTranslations, unstable_setRequestLocale } from 'next-intl/server';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { locales, LocaleType } from '~/i18n/routing';
 
@@ -19,7 +19,7 @@ interface Props {
 }
 
 export default function ChangePassword({ params: { locale } }: Props) {
-  unstable_setRequestLocale(locale);
+  setRequestLocale(locale);
 
   return (
     <>

--- a/core/app/[locale]/(default)/account/layout.tsx
+++ b/core/app/[locale]/(default)/account/layout.tsx
@@ -1,13 +1,15 @@
+import { getLocale } from 'next-intl/server';
 import { PropsWithChildren } from 'react';
 
 import { auth } from '~/auth';
 import { redirect } from '~/i18n/routing';
 
 export default async function AccountLayout({ children }: PropsWithChildren) {
+  const locale = await getLocale();
   const session = await auth();
 
   if (!session) {
-    redirect('/login');
+    redirect({ href: '/login', locale });
   }
 
   return children;

--- a/core/app/[locale]/(default)/cart/_actions/redirect-to-checkout.ts
+++ b/core/app/[locale]/(default)/cart/_actions/redirect-to-checkout.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import { getLocale } from 'next-intl/server';
 import { z } from 'zod';
 
 import { getSessionCustomerId } from '~/auth';
@@ -20,6 +21,7 @@ const CheckoutRedirectMutation = graphql(`
 `);
 
 export const redirectToCheckout = async (formData: FormData) => {
+  const locale = await getLocale();
   const cartId = z.string().parse(formData.get('cartId'));
   const customerId = await getSessionCustomerId();
 
@@ -36,5 +38,5 @@ export const redirectToCheckout = async (formData: FormData) => {
     throw new Error('Invalid checkout url.');
   }
 
-  redirect(url);
+  redirect({ href: url, locale });
 };

--- a/core/app/[locale]/(default)/layout.tsx
+++ b/core/app/[locale]/(default)/layout.tsx
@@ -1,4 +1,4 @@
-import { unstable_setRequestLocale } from 'next-intl/server';
+import { setRequestLocale } from 'next-intl/server';
 import { PropsWithChildren, Suspense } from 'react';
 
 import { Footer } from '~/components/footer/footer';
@@ -11,7 +11,7 @@ interface Props extends PropsWithChildren {
 }
 
 export default function DefaultLayout({ children, params: { locale } }: Props) {
-  unstable_setRequestLocale(locale);
+  setRequestLocale(locale);
 
   return (
     <>

--- a/core/app/[locale]/(default)/page.tsx
+++ b/core/app/[locale]/(default)/page.tsx
@@ -1,5 +1,5 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
-import { getTranslations, unstable_setRequestLocale } from 'next-intl/server';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { getSessionCustomerId } from '~/auth';
 import { client } from '~/client';
@@ -41,7 +41,7 @@ interface Props {
 }
 
 export default async function Home({ params: { locale } }: Props) {
-  unstable_setRequestLocale(locale);
+  setRequestLocale(locale);
 
   const t = await getTranslations('Home');
 

--- a/core/app/[locale]/(default)/product/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import { getTranslations, unstable_setRequestLocale } from 'next-intl/server';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { Suspense } from 'react';
 
 import { Breadcrumbs } from '~/components/breadcrumbs';
@@ -69,7 +69,7 @@ export async function generateMetadata({ params, searchParams }: Props): Promise
 }
 
 export default async function Product({ params: { locale, slug }, searchParams }: Props) {
-  unstable_setRequestLocale(locale);
+  setRequestLocale(locale);
 
   const t = await getTranslations('Product');
 

--- a/core/app/[locale]/layout.tsx
+++ b/core/app/[locale]/layout.tsx
@@ -3,7 +3,7 @@ import { SpeedInsights } from '@vercel/speed-insights/next';
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import { NextIntlClientProvider, useMessages } from 'next-intl';
-import { unstable_setRequestLocale } from 'next-intl/server';
+import { setRequestLocale } from 'next-intl/server';
 import { PropsWithChildren } from 'react';
 
 import '../globals.css';
@@ -82,8 +82,8 @@ interface Props extends PropsWithChildren {
 
 export default function RootLayout({ children, params: { locale } }: Props) {
   // need to call this method everywhere where static rendering is enabled
-  // https://next-intl-docs.vercel.app/docs/getting-started/app-router#add-unstable_setrequestlocale-to-all-layouts-and-pages
-  unstable_setRequestLocale(locale);
+  // https://next-intl-docs.vercel.app/docs/getting-started/app-router#add-setRequestLocale-to-all-layouts-and-pages
+  setRequestLocale(locale);
 
   const messages = useMessages();
 

--- a/core/app/[locale]/maintenance/page.tsx
+++ b/core/app/[locale]/maintenance/page.tsx
@@ -1,5 +1,5 @@
 import { Phone } from 'lucide-react';
-import { getTranslations, unstable_setRequestLocale } from 'next-intl/server';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { ReactNode } from 'react';
 
 import { client } from '~/client';
@@ -42,7 +42,7 @@ interface Props {
 }
 
 export default async function Maintenance({ params: { locale } }: Props) {
-  unstable_setRequestLocale(locale);
+  setRequestLocale(locale);
 
   const t = await getTranslations('Maintenance');
 

--- a/core/app/[locale]/store-selector/page.tsx
+++ b/core/app/[locale]/store-selector/page.tsx
@@ -1,4 +1,4 @@
-import { getTranslations, unstable_setRequestLocale } from 'next-intl/server';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
@@ -35,7 +35,7 @@ interface Props {
 }
 
 export default async function StoreSelector({ params: { locale: selectedLocale } }: Props) {
-  unstable_setRequestLocale(selectedLocale);
+  setRequestLocale(selectedLocale);
 
   const t = await getTranslations('StoreSelector');
 

--- a/core/app/admin/route.ts
+++ b/core/app/admin/route.ts
@@ -1,3 +1,5 @@
+import { useLocale } from 'next-intl';
+
 import { redirect } from '~/i18n/routing';
 
 const canonicalDomain: string = process.env.BIGCOMMERCE_GRAPHQL_API_DOMAIN ?? 'mybigcommerce.com';
@@ -5,16 +7,19 @@ const BIGCOMMERCE_STORE_HASH = process.env.BIGCOMMERCE_STORE_HASH;
 const ENABLE_ADMIN_ROUTE = process.env.ENABLE_ADMIN_ROUTE;
 
 export const GET = () => {
+  const locale = useLocale();
+
   // This route should not work unless explicitly enabled
   if (ENABLE_ADMIN_ROUTE !== 'true') {
-    return redirect('/');
+    return redirect({ href: '/', locale });
   }
 
-  return redirect(
-    BIGCOMMERCE_STORE_HASH
+  return redirect({
+    href: BIGCOMMERCE_STORE_HASH
       ? `https://store-${BIGCOMMERCE_STORE_HASH}.${canonicalDomain}/admin`
       : 'https://login.bigcommerce.com',
-  );
+    locale,
+  });
 };
 
 export const runtime = 'edge';

--- a/core/app/admin/route.ts
+++ b/core/app/admin/route.ts
@@ -1,24 +1,20 @@
-import { useLocale } from 'next-intl';
-
-import { redirect } from '~/i18n/routing';
+import { defaultLocale, redirect } from '~/i18n/routing';
 
 const canonicalDomain: string = process.env.BIGCOMMERCE_GRAPHQL_API_DOMAIN ?? 'mybigcommerce.com';
 const BIGCOMMERCE_STORE_HASH = process.env.BIGCOMMERCE_STORE_HASH;
 const ENABLE_ADMIN_ROUTE = process.env.ENABLE_ADMIN_ROUTE;
 
 export const GET = () => {
-  const locale = useLocale();
-
   // This route should not work unless explicitly enabled
   if (ENABLE_ADMIN_ROUTE !== 'true') {
-    return redirect({ href: '/', locale });
+    return redirect({ href: '/', locale: defaultLocale });
   }
 
   return redirect({
     href: BIGCOMMERCE_STORE_HASH
       ? `https://store-${BIGCOMMERCE_STORE_HASH}.${canonicalDomain}/admin`
       : 'https://login.bigcommerce.com',
-    locale,
+    locale: defaultLocale,
   });
 };
 

--- a/core/app/sitemap.xml/route.ts
+++ b/core/app/sitemap.xml/route.ts
@@ -3,10 +3,12 @@
  * Proxy to the existing BigCommerce sitemap index on the canonical URL
  */
 
+import { getChannelIdFromLocale } from '~/channels.config';
 import { client } from '~/client';
+import { defaultLocale } from '~/i18n/routing';
 
 export const GET = async () => {
-  const sitemapIndex = await client.fetchSitemapIndex();
+  const sitemapIndex = await client.fetchSitemapIndex(getChannelIdFromLocale(defaultLocale));
 
   return new Response(sitemapIndex, {
     headers: {

--- a/core/app/xmlsitemap.php/route.ts
+++ b/core/app/xmlsitemap.php/route.ts
@@ -1,7 +1,5 @@
 /* eslint-disable check-file/folder-naming-convention */
-import { useLocale } from 'next-intl';
-
-import { permanentRedirect } from '~/i18n/routing';
+import { defaultLocale, permanentRedirect } from '~/i18n/routing';
 
 /*
  * This route is used to redirect the legacy Stencil sitemap that lives on /xmlsitemap.php
@@ -11,9 +9,7 @@ import { permanentRedirect } from '~/i18n/routing';
  */
 
 export const GET = () => {
-  const locale = useLocale();
-
-  permanentRedirect({ href: '/sitemap.xml', locale });
+  permanentRedirect({ href: '/sitemap.xml', locale: defaultLocale });
 };
 
 export const runtime = 'edge';

--- a/core/app/xmlsitemap.php/route.ts
+++ b/core/app/xmlsitemap.php/route.ts
@@ -1,4 +1,6 @@
 /* eslint-disable check-file/folder-naming-convention */
+import { useLocale } from 'next-intl';
+
 import { permanentRedirect } from '~/i18n/routing';
 
 /*
@@ -8,6 +10,10 @@ import { permanentRedirect } from '~/i18n/routing';
  * on /xmlsitemap.php
  */
 
-export const GET = () => permanentRedirect('/sitemap.xml');
+export const GET = () => {
+  const locale = useLocale();
+
+  permanentRedirect({ href: '/sitemap.xml', locale });
+};
 
 export const runtime = 'edge';

--- a/core/client/index.ts
+++ b/core/client/index.ts
@@ -23,7 +23,7 @@ export const client = createClient({
      * - Requests in middlewares
      * - Requests in `generateStaticParams`
      * - Request in api routes
-     * - Requests in static sites without `unstable_setRequestLocale`
+     * - Requests in static sites without `setRequestLocale`
      *
      * We use the default channelId as a fallback, but it is not ideal in some scenarios.
      *  */

--- a/core/components/header/_actions/logout.ts
+++ b/core/components/header/_actions/logout.ts
@@ -1,10 +1,14 @@
 'use server';
 
+import { getLocale } from 'next-intl/server';
+
 import { signOut } from '~/auth';
 import { redirect } from '~/i18n/routing';
 
 export const logout = async () => {
+  const locale = await getLocale();
+
   await signOut({ redirect: false });
 
-  redirect('/login');
+  redirect({ href: '/login', locale });
 };

--- a/core/components/ui/compare-drawer/compare-drawer.tsx
+++ b/core/components/ui/compare-drawer/compare-drawer.tsx
@@ -1,6 +1,6 @@
 import * as AccordionPrimitive from '@radix-ui/react-accordion';
 import { ChevronDown, X } from 'lucide-react';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 
 import { BcImage } from '~/components/bc-image';
 import { Link as CustomLink } from '~/components/link';
@@ -12,13 +12,17 @@ import { type Product, useCompareDrawerContext } from './context';
 
 const CompareLink = ({ products }: { products: Product[] }) => {
   const t = useTranslations('Components.Compare');
+  const locale = useLocale();
 
   return (
     <Button
       asChild
       className="me-4 h-12 w-auto grow whitespace-nowrap px-8 hover:text-white md:grow-0"
     >
-      <CustomLink href={`/compare?ids=${products.map(({ id }) => id).join(',')}`}>
+      <CustomLink
+        href={{ pathname: '/compare', query: { ids: products.map(({ id }) => id).join(',') } }}
+        locale={locale}
+      >
         {t('compareButton', { products: products.length })}
       </CustomLink>
     </Button>

--- a/core/i18n/routing.ts
+++ b/core/i18n/routing.ts
@@ -1,5 +1,5 @@
-import { createSharedPathnamesNavigation } from 'next-intl/navigation';
-import { defineRouting, LocalePrefix } from 'next-intl/routing';
+import { createNavigation } from 'next-intl/navigation';
+import { defineRouting } from 'next-intl/routing';
 
 // Enable locales by including them here.
 // List includes locales with existing messages support.
@@ -70,16 +70,14 @@ enum LocalePrefixes {
   ASNEEDED = 'as-needed', // removes prefix on default locale
 }
 
-export const localePrefix: LocalePrefix = LocalePrefixes.ASNEEDED;
+export const localePrefix = LocalePrefixes.ASNEEDED;
 
 export const defaultLocale = 'en';
 
 export const routing = defineRouting({
   locales,
   defaultLocale,
-  localePrefix: {
-    mode: localePrefix,
-  },
+  localePrefix,
 });
 
 // Lightweight wrappers around Next.js' navigation APIs
@@ -87,4 +85,4 @@ export const routing = defineRouting({
 // Redirect will append locale prefix even when in default locale
 // More info: https://github.com/amannn/next-intl/issues/1335
 export const { Link, redirect, usePathname, useRouter, permanentRedirect } =
-  createSharedPathnamesNavigation(routing);
+  createNavigation(routing);

--- a/core/package.json
+++ b/core/package.json
@@ -44,7 +44,7 @@
     "lucide-react": "^0.452.0",
     "next": "14.2.15",
     "next-auth": "5.0.0-beta.22",
-    "next-intl": "^3.21.1",
+    "next-intl": "^3.22.0",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.0",
     "react-dom": "^18.3.1",

--- a/core/tests/fixtures/utils/account/account.ts
+++ b/core/tests/fixtures/utils/account/account.ts
@@ -17,7 +17,7 @@ export class Account {
     await this.page.getByRole('button', { name: 'Log in' }).click();
     // Prepending locale to URL as a workaround for issue in next-intl
     // More info: https://github.com/amannn/next-intl/issues/1335
-    await this.page.waitForURL('/en/account/');
+    await this.page.waitForURL('/account/');
   }
 
   async logout() {

--- a/core/tests/ui/e2e/account.spec.ts
+++ b/core/tests/ui/e2e/account.spec.ts
@@ -14,7 +14,7 @@ test('My Account tabs are displayed and clickable', async ({ page, account }) =>
 
   // Prepending locale to URL as a workaround for issue in next-intl
   // More info: https://github.com/amannn/next-intl/issues/1335
-  await expect(page).toHaveURL('/en/account/');
+  await expect(page).toHaveURL('/account/');
   await expect(page.getByRole('link', { name: 'Addresses' })).toBeVisible();
   await expect(page.getByRole('link', { name: 'Account settings' })).toBeVisible();
 

--- a/core/tests/ui/e2e/login.spec.ts
+++ b/core/tests/ui/e2e/login.spec.ts
@@ -12,7 +12,7 @@ test('Account login and logout', async ({ page, account }) => {
   await page.getByLabel('Password').fill(customer.password);
   await page.getByRole('button', { name: 'Log in' }).click();
 
-  await page.waitForURL('/en/account/');
+  await page.waitForURL('/account/');
 
   await expect(page.getByRole('heading', { name: 'My Account' })).toBeVisible();
 
@@ -20,7 +20,7 @@ test('Account login and logout', async ({ page, account }) => {
 
   // Prepending locale to URL as a workaround for issue in next-intl
   // More info: https://github.com/amannn/next-intl/issues/1335
-  await page.waitForURL('/en/login/');
+  await page.waitForURL('/login/');
 
   await expect(page.getByRole('heading', { name: 'Log in' })).toBeVisible();
 });

--- a/core/tests/ui/e2e/register.spec.ts
+++ b/core/tests/ui/e2e/register.spec.ts
@@ -22,7 +22,7 @@ test('Account register', async ({ page }) => {
 
   await page.getByRole('button', { name: 'Create account' }).click();
 
-  await expect(page).toHaveURL('/en/account/');
+  await expect(page).toHaveURL('/account/');
   await expect(page.getByText('Your account has been successfully created')).toBeVisible();
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,8 +120,8 @@ importers:
         specifier: 5.0.0-beta.22
         version: 5.0.0-beta.22(next@14.2.15(@playwright/test@1.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nodemailer@6.9.15)(react@18.3.1)
       next-intl:
-        specifier: ^3.21.1
-        version: 3.21.1(next@14.2.15(@playwright/test@1.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        specifier: ^3.22.0
+        version: 3.22.0(next@14.2.15(@playwright/test@1.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -252,7 +252,7 @@ importers:
     devDependencies:
       '@bigcommerce/eslint-config':
         specifier: ^2.9.1
-        version: 2.9.1(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0(@types/node@20.16.11))(typescript@5.6.3)
+        version: 2.9.1(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0)(typescript@5.6.3)
       '@bigcommerce/eslint-config-catalyst':
         specifier: workspace:^
         version: link:../eslint-config-catalyst
@@ -328,7 +328,7 @@ importers:
     devDependencies:
       '@bigcommerce/eslint-config':
         specifier: ^2.9.1
-        version: 2.9.1(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0(@types/node@20.16.11))(typescript@5.6.3)
+        version: 2.9.1(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0)(typescript@5.6.3)
       '@bigcommerce/eslint-config-catalyst':
         specifier: workspace:^
         version: link:../eslint-config-catalyst
@@ -4155,8 +4155,8 @@ packages:
       nodemailer:
         optional: true
 
-  next-intl@3.21.1:
-    resolution: {integrity: sha512-hQm4Wgq5i1lfOHAWmXBVl5d2/XAeddcjsrUmjotXEESzPSvW5j2t0Pr8AV8WorTILgqU748aXuenBhz5P78tdw==}
+  next-intl@3.22.0:
+    resolution: {integrity: sha512-Agyr8iHFdIBzTmJ7+ZWBQf/XQJvePVwrbdxVWh/U3/NigyIu0YnE7YtLpGVhaoM7xE56bdcOtyvkZa8O+sLeZg==}
     peerDependencies:
       next: ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -5312,8 +5312,8 @@ packages:
       '@types/react':
         optional: true
 
-  use-intl@3.21.1:
-    resolution: {integrity: sha512-52kYgcydYkG9SX0ZZGt7W6WD2Va01hwe15bDgkXuaTdSxrF9fDu6hHTV5DxIuSmSSf/FEcBo/nodpw3ZhY31Lw==}
+  use-intl@3.22.0:
+    resolution: {integrity: sha512-SoiPcyLJODhenrbDkcYJuOImgrBFN7Z8keLSHe7ffsNkIJtjdjet/RmqAv5Ym9TVxPpCs+fH2cl1J3YzFJSkWw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
 
@@ -5722,37 +5722,6 @@ snapshots:
       to-fast-properties: 2.0.0
 
   '@bcoe/v8-coverage@0.2.3': {}
-
-  '@bigcommerce/eslint-config@2.9.1(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0(@types/node@20.16.11))(typescript@5.6.3)':
-    dependencies:
-      '@bigcommerce/eslint-plugin': 1.3.1(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)
-      '@rushstack/eslint-patch': 1.10.4
-      '@stylistic/eslint-plugin': 2.7.2(eslint@8.57.1)(typescript@5.6.3)
-      '@typescript-eslint/eslint-plugin': 8.4.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)
-      '@typescript-eslint/parser': 8.4.0(eslint@8.57.1)(typescript@5.6.3)
-      eslint: 8.57.1
-      eslint-config-prettier: 9.1.0(eslint@8.57.1)
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-import@2.30.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-gettext: 1.2.0
-      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-import@2.30.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-jest: 28.8.3(@typescript-eslint/eslint-plugin@8.4.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(jest@29.7.0)(typescript@5.6.3)
-      eslint-plugin-jest-formatting: 3.1.0(eslint@8.57.1)
-      eslint-plugin-jsdoc: 50.2.2(eslint@8.57.1)
-      eslint-plugin-jsx-a11y: 6.10.0(eslint@8.57.1)
-      eslint-plugin-prettier: 5.2.1(@types/eslint@9.6.1)(eslint-config-prettier@9.1.0(eslint@8.57.1))(eslint@8.57.1)(prettier@3.3.3)
-      eslint-plugin-react: 7.35.2(eslint@8.57.1)
-      eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
-      eslint-plugin-switch-case: 1.1.2
-      prettier: 3.3.3
-    optionalDependencies:
-      typescript: 5.6.3
-    transitivePeerDependencies:
-      - '@types/eslint'
-      - eslint-import-resolver-node
-      - eslint-import-resolver-webpack
-      - eslint-plugin-import-x
-      - jest
-      - supports-color
 
   '@bigcommerce/eslint-config@2.9.1(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0)(typescript@5.6.3)':
     dependencies:
@@ -8432,7 +8401,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-import@2.30.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.0(eslint@8.57.1)
       eslint-plugin-react: 7.35.2(eslint@8.57.1)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
@@ -8467,26 +8436,7 @@ snapshots:
       is-bun-module: 1.1.0
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-import@2.30.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
-    transitivePeerDependencies:
-      - '@typescript-eslint/parser'
-      - eslint-import-resolver-node
-      - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-import@2.30.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.3.6
-      enhanced-resolve: 5.17.1
-      eslint: 8.57.1
-      eslint-module-utils: 2.9.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-import@2.30.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
-      fast-glob: 3.3.2
-      get-tsconfig: 4.8.0
-      is-bun-module: 1.1.0
-      is-glob: 4.0.3
-    optionalDependencies:
-      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-import@2.30.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
@@ -8523,17 +8473,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.9.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-import@2.30.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.4.0(eslint@8.57.1)(typescript@5.6.3)
-      eslint: 8.57.1
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-import@2.30.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1)
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-module-utils@2.9.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-import@2.30.0)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
@@ -8555,34 +8494,6 @@ snapshots:
     dependencies:
       gettext-parser: 4.2.0
 
-  eslint-plugin-import@2.30.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-import@2.30.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.8
-      array.prototype.findlastindex: 1.2.5
-      array.prototype.flat: 1.3.2
-      array.prototype.flatmap: 1.3.2
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 8.57.1
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.9.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-import@2.30.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
-      hasown: 2.0.2
-      is-core-module: 2.15.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.0
-      semver: 6.3.1
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.4.0(eslint@8.57.1)(typescript@5.6.3)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
   eslint-plugin-import@2.30.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
@@ -8594,7 +8505,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.9.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-import@2.30.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.9.0(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.4.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0)(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -9963,13 +9874,13 @@ snapshots:
     optionalDependencies:
       nodemailer: 6.9.15
 
-  next-intl@3.21.1(next@14.2.15(@playwright/test@1.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
+  next-intl@3.22.0(next@14.2.15(@playwright/test@1.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
     dependencies:
       '@formatjs/intl-localematcher': 0.5.4
       negotiator: 0.6.3
       next: 14.2.15(@playwright/test@1.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
-      use-intl: 3.21.1(react@18.3.1)
+      use-intl: 3.22.0(react@18.3.1)
 
   next@14.2.15(@playwright/test@1.48.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -11117,7 +11028,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
 
-  use-intl@3.21.1(react@18.3.1):
+  use-intl@3.22.0(react@18.3.1):
     dependencies:
       '@formatjs/fast-memoize': 2.2.0
       intl-messageformat: 10.5.14


### PR DESCRIPTION
## What/Why?
+ Bump `next-intl`.
+ Use new `createNavigation` api.
+ Pass `locale` to `redirects`.
+ `setRequestLocale` is no longer unstable.
+ Fixes https://github.com/amannn/next-intl/issues/1335

## Testing
Locally, redirecting on default locale will not append the default locale, just like Links.
Updated tests to match this behavior.