### PR TITLE
fix(cli): add default command name on pre-hook

### DIFF
--- a/.changeset/breezy-numbers-divide.md
+++ b/.changeset/breezy-numbers-divide.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": patch
+---
+
+Default to the `create` command when running the preCommand hook.

--- a/packages/create-catalyst/src/hooks/telemetry.ts
+++ b/packages/create-catalyst/src/hooks/telemetry.ts
@@ -5,7 +5,10 @@ import { Telemetry } from '../utils/telemetry/telemetry';
 const telemetry = new Telemetry();
 
 export const telemetryPreHook = async (command: Command) => {
-  const [commandName] = command.args;
+  // If the binary is ran without a command, the command.args will be an empty array.
+  // When running `npm create @bigcommerce/catalyst`, npm runs the binary with no args passed,
+  // but the program defaults to the `create` command.
+  const [commandName = 'create'] = command.args;
 
   await telemetry.track(commandName, {});
 };


### PR DESCRIPTION
## What/Why?
![Screenshot 2024-10-21 at 11 14 30](https://github.com/user-attachments/assets/537a21a1-2ece-4b40-947e-c553ced06835)

We were getting an issue where the `commandName` was empty, which happens when we run `./bin/index.cjs` without an argument. 

## Testing
![Screenshot 2024-10-21 at 12 03 32](https://github.com/user-attachments/assets/54a39e4a-e755-4146-8a84-3c2e3d263224)
