### PR TITLE
feat(cli): add identify on init

### DIFF
--- a/.changeset/warm-rivers-breathe.md
+++ b/.changeset/warm-rivers-breathe.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": patch
+---
+
+Adds a identify call on init.

--- a/packages/create-catalyst/src/commands/init.ts
+++ b/packages/create-catalyst/src/commands/init.ts
@@ -6,7 +6,10 @@ import * as z from 'zod';
 import { Https } from '../utils/https';
 import { login } from '../utils/login';
 import { parse } from '../utils/parse';
+import { Telemetry } from '../utils/telemetry/telemetry';
 import { writeEnv } from '../utils/write-env';
+
+const telemetry = new Telemetry();
 
 export const init = new Command('init')
   .description('Connect a BigCommerce store with an existing Catalyst project')
@@ -49,6 +52,8 @@ export const init = new Command('init')
 
       process.exit(1);
     }
+
+    await telemetry.identify(storeHash);
 
     const bc = new Https({ bigCommerceApiUrl, storeHash, accessToken });
     const sampleDataApi = new Https({


### PR DESCRIPTION
## What/Why?
Adds a missing `.identify` call when using the `init` command.
