### PR TITLE
fix(core): improve account settings form

### DIFF
--- a/.changeset/fast-students-approve.md
+++ b/.changeset/fast-students-approve.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+remove unnecessary fields from account settings form and update confirmation message

--- a/core/app/[locale]/(default)/account/(tabs)/settings/_components/update-settings-form.tsx
+++ b/core/app/[locale]/(default)/account/(tabs)/settings/_components/update-settings-form.tsx
@@ -68,8 +68,6 @@ export enum FieldNameToFieldId {
   email = 1,
   firstName = 4,
   lastName,
-  company,
-  phone,
 }
 
 type FieldUnionType = keyof typeof FieldNameToFieldId;
@@ -192,10 +190,7 @@ export const UpdateSettingsForm = ({
     if (submit.status === 'success') {
       setFormStatus({
         status: 'success',
-        message: t('successMessage', {
-          firstName: submit.data?.firstName,
-          lastName: submit.data?.lastName,
-        }),
+        message: t('successMessage'),
       });
     }
 

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -204,7 +204,7 @@
       "changePassword": "Change password",
       "submit": "Update settings",
       "submitting": "Update settings...",
-      "successMessage": "Dear {firstName} {lastName}, you successfully updated your account data",
+      "successMessage": "Your account settings have been updated",
       "validationMessages": {
           "email": "Enter a valid email such as name@domain.com",
           "empty": "This field can not be empty",

--- a/core/tests/ui/e2e/account-settings.spec.ts
+++ b/core/tests/ui/e2e/account-settings.spec.ts
@@ -8,16 +8,12 @@ test('Update Account information', async ({ page, account }) => {
   await page.goto('/account/settings');
   await page.getByLabel('First NameRequired').fill('Updated');
   await page.getByLabel('Last NameRequired').fill('Name');
-  await page.getByLabel('Phone Number').fill('12345678');
-  await page.getByLabel('Company').fill('Corporation');
   await page.getByLabel('Email Address').fill('updated@email.com');
 
   await page.getByRole('button', { name: 'Update settings' }).click();
 
-  await expect(
-    page.getByText('Dear Updated Name, you successfully updated your account data'),
-  ).toBeVisible();
-  await expect(page.getByLabel('Company')).toHaveValue('Corporation');
-  await expect(page.getByLabel('Phone Number')).toHaveValue('12345678');
+  await expect(page.getByText('Your account settings have been updated')).toBeVisible();
+  await expect(page.getByLabel('First NameRequired')).toHaveValue('Updated');
+  await expect(page.getByLabel('Last NameRequired')).toHaveValue('Name');
   await expect(page.getByLabel('Email Address')).toHaveValue('updated@email.com');
 });


### PR DESCRIPTION
## What/Why?
This PR improves account settings form, namely it removes unnecessary fields.
Also this PR updates settings confirmation message.

## Testing
locally

**before**:

https://github.com/user-attachments/assets/ee8b85bd-34b9-4ef7-8303-95449c3d2ff0

**after**:

https://github.com/user-attachments/assets/ce4aa7dc-8152-41c3-8f3c-db12840ec726

**with custom field:**

https://github.com/user-attachments/assets/bf0e367b-d144-488b-89e6-c731d46fbb23
