### PR TITLE
fix(core): update styles for reset password validation

### DIFF
--- a/.changeset/shy-ads-buy.md
+++ b/.changeset/shy-ads-buy.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+update styles for reset password validation

--- a/core/app/[locale]/(default)/(auth)/change-password/_components/change-password-form.tsx
+++ b/core/app/[locale]/(default)/(auth)/change-password/_components/change-password-form.tsx
@@ -127,7 +127,7 @@ export const ChangePasswordForm = ({ customerId, customerToken }: Props) => {
             />
           </FieldControl>
           <FieldMessage
-            className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs text-gray-500"
+            className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs text-error"
             match={(value: string) => value !== newPassword}
           >
             {t('confirmPasswordValidationMessage')}

--- a/core/app/[locale]/(default)/(auth)/login/forgot-password/_components/reset-password-form/index.tsx
+++ b/core/app/[locale]/(default)/(auth)/login/forgot-password/_components/reset-password-form/index.tsx
@@ -80,7 +80,7 @@ export const ResetPasswordForm = ({ reCaptchaSettings }: Props) => {
   };
 
   const handleEmailValidation = (e: ChangeEvent<HTMLInputElement>) => {
-    const validationStatus = e.target.validity.valueMissing;
+    const validationStatus = e.target.validity.valueMissing || e.target.validity.typeMismatch;
 
     setIsEmailValid(!validationStatus);
   };
@@ -144,8 +144,14 @@ export const ResetPasswordForm = ({ reCaptchaSettings }: Props) => {
             />
           </FieldControl>
           <FieldMessage
-            className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs text-gray-500"
+            className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs text-error"
             match="valueMissing"
+          >
+            {t('emailValidationMessage')}
+          </FieldMessage>
+          <FieldMessage
+            className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs text-error"
+            match="typeMismatch"
           >
             {t('emailValidationMessage')}
           </FieldMessage>
@@ -162,7 +168,7 @@ export const ResetPasswordForm = ({ reCaptchaSettings }: Props) => {
               sitekey={reCaptchaSettings.siteKey}
             />
             {!isReCaptchaValid && (
-              <span className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-red-200">
+              <span className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs text-error">
                 {t('recaptchaText')}
               </span>
             )}


### PR DESCRIPTION
## What/Why?
The PR improves styles for reset password page like:

- fix invalid email validation
- update colour & size for validation errors
- fix ReCaptcha colour

## Testing
locally

https://github.com/user-attachments/assets/e82af807-ba97-429a-8b9b-02f9035dc16e


<img width="1108" alt="change_password_before" src="https://github.com/user-attachments/assets/f720af8e-b521-4ad3-b8ae-38ccac8dcdce">

<img width="1105" alt="change_password_after" src="https://github.com/user-attachments/assets/7b0f5618-6d40-4f9d-92a1-ed33289b866f">


