### PR TITLE
fix(core): wishlist book item image missed in some products

### DIFF
--- a/.changeset/silent-keys-pump.md
+++ b/.changeset/silent-keys-pump.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+fix for wishlist book item image missed in some products

--- a/core/app/[locale]/(default)/account/(tabs)/wishlists/_components/wishlist-book.tsx
+++ b/core/app/[locale]/(default)/account/(tabs)/wishlists/_components/wishlist-book.tsx
@@ -120,7 +120,7 @@ const Wishlist = ({ setWishlistBook, wishlist }: WishlistProps) => {
             <ul className="flex gap-4 [&>*:nth-child(n+2)]:hidden md:[&>*:nth-child(n+2)]:list-item md:[&>*:nth-child(n+4)]:hidden lg:[&>*:nth-child(n+4)]:list-item lg:[&>*:nth-child(n+5)]:hidden xl:[&>*:nth-child(n+5)]:list-item lg:[&>*:nth-child(n+7)]:hidden">
               {items.slice(0, VisibleWishlistItemsPerDevice.xl).map((item) => {
                 const { entityId: productId, product } = item;
-                const defaultImage = product.images.find(({ isDefault }) => isDefault);
+
                 const showPriceRange =
                   product.prices?.priceRange.min.value !== product.prices?.priceRange.max.value;
 
@@ -128,12 +128,12 @@ const Wishlist = ({ setWishlistBook, wishlist }: WishlistProps) => {
                   <li className="w-32 sm:w-40 md:w-36" key={productId}>
                     <Link className="mb-2 flex" href={product.path}>
                       <div className="flex h-32 w-full sm:h-40 md:h-36">
-                        {defaultImage ? (
+                        {product.defaultImage ? (
                           <BcImage
-                            alt={defaultImage.altText}
+                            alt={product.defaultImage.altText}
                             className="object-contain"
                             height={300}
-                            src={defaultImage.url}
+                            src={product.defaultImage.url}
                             width={300}
                           />
                         ) : (


### PR DESCRIPTION
## What/Why?
As product `defaultImage` now available in wishlist connection we can use it to display in the card

<img width="1703" alt="wishlist-item-without-image" src="https://github.com/user-attachments/assets/1068e32c-9065-41da-9561-e754a7439228">

<img width="1295" alt="wishlist-item-with-image" src="https://github.com/user-attachments/assets/98e4c513-98f1-4daf-8e40-b104da8ba915">

## Testing
Locally