### PR TITLE
test(core): Add wishlist related tests

### DIFF
--- a/core/tests/ui/e2e/account.spec.ts
+++ b/core/tests/ui/e2e/account.spec.ts
@@ -50,23 +50,3 @@ test('Account dropdown is visible in header', async ({ page, account }) => {
 
   await customer.logout();
 });
-
-test('Add and remove new wishlist', async ({ page, account }) => {
-  const customer = await account.create();
-
-  await customer.login();
-
-  await page.goto('/account/wishlists');
-  await page.getByRole('heading', { name: 'Wishlists' }).waitFor();
-
-  await page.getByRole('button', { name: 'New wishlist' }).click();
-  await page.getByLabel('Wishlist name').fill('test');
-  await page.getByRole('button', { name: 'Create' }).click();
-  await expect(page.getByText('Your wishlist test was created successfully')).toBeVisible();
-  await expect(page.getByRole('heading', { name: 'test' })).toBeVisible();
-
-  await page.getByRole('button', { name: 'Delete' }).click();
-  await page.getByRole('button', { name: /Delete/ }).click();
-  await expect(page.getByText('Your wishlist test was deleted successfully')).toBeVisible();
-  await expect(page.getByRole('heading', { name: 'test' })).toBeHidden();
-});

--- a/core/tests/ui/e2e/wishlist.spec.ts
+++ b/core/tests/ui/e2e/wishlist.spec.ts
@@ -9,6 +9,22 @@ test('Guest user is redirected to login upon adding product to wishlist', async 
   await expect(page).toHaveURL(/login/);
 });
 
+test('Favorites wishlist present by default and cannot be deleted', async ({ page, account }) => {
+  const customer = await account.create();
+
+  await customer.login();
+
+  await page.goto('/account/wishlists/');
+
+  await expect(page.getByText('Favorites')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Delete' })).toBeHidden();
+
+  await page.getByRole('link', { name: 'Favorites' }).click();
+  await page.getByRole('heading', { name: 'Favorites' }).waitFor();
+
+  // Need to check there is no Wishlist Actions to edit/delete wishlist
+});
+
 test('Add product to Favorites wishlist from PDP', async ({ page, account }) => {
   const customer = await account.create();
 

--- a/core/tests/ui/e2e/wishlist.spec.ts
+++ b/core/tests/ui/e2e/wishlist.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from '~/tests/fixtures';
+
+test('Guest user is redirected to login upon adding product to wishlist', async ({ page }) => {
+  await page.goto('/laundry-detergent/');
+  await page.getByRole('heading', { level: 1, name: '[Sample] Laundry Detergent' }).waitFor();
+
+  await page.getByRole('link', { name: 'Save to wishlist' }).click();
+
+  await expect(page).toHaveURL(/login/);
+});
+
+test('Add product to Favorites wishlist from PDP', async ({ page, account }) => {
+  const customer = await account.create();
+
+  await customer.login();
+
+  await page.goto('/laundry-detergent/');
+  await page.getByRole('heading', { level: 1, name: '[Sample] Laundry Detergent' }).waitFor();
+  await page.getByRole('button', { name: 'Save to wishlist' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Add to list' })).toBeVisible();
+  await expect(page.getByText('Select from available lists:')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Save' })).toBeDisabled();
+
+  await page.getByLabel('Favorites').click();
+  await page.getByRole('button', { name: 'Save' }).click();
+  await page.getByRole('button', { name: 'Close' }).click();
+
+  await expect(page.getByRole('button', { name: 'Saved' })).toBeVisible();
+
+  await page.goto('/account/wishlists/');
+  await expect(page.getByText('[Sample] Laundry Detergent')).toBeVisible();
+});
+
+test('Add new wishlist from drawer', async ({ page, account }) => {
+  const customer = await account.create();
+
+  await customer.login();
+
+  await page.goto('/laundry-detergent/');
+  await page.getByRole('heading', { level: 1, name: '[Sample] Laundry Detergent' }).waitFor();
+  await page.getByRole('button', { name: 'Save to wishlist' }).click();
+  await page.getByRole('button', { name: 'New list' }).click();
+  await page.getByLabel('Wishlist name').fill('Birthday');
+  await page.getByRole('button', { name: 'Create' }).click();
+
+  await expect(page.getByText('Your wishlist Birthday was created successfully')).toBeVisible();
+
+  await page.goto('/account/wishlists/');
+  await expect(page.getByText('Birthday')).toBeVisible();
+});
+
+test('Add and remove new wishlist', async ({ page, account }) => {
+  const customer = await account.create();
+
+  await customer.login();
+
+  await page.goto('/account/wishlists');
+  await page.getByRole('heading', { name: 'Wishlists' }).waitFor();
+
+  await page.getByRole('button', { name: 'New wishlist' }).click();
+  await page.getByLabel('Wishlist name').fill('Anniversary');
+  await page.getByRole('button', { name: 'Create' }).click();
+  await expect(page.getByText('Your wishlist Anniversary was created successfully')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Anniversary' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Delete' }).click();
+  await page.getByRole('button', { name: /Delete/ }).click();
+  await expect(page.getByText('Your wishlist Anniversary was deleted successfully')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'test' })).toBeHidden();
+});

--- a/core/tests/ui/e2e/wishlist.spec.ts
+++ b/core/tests/ui/e2e/wishlist.spec.ts
@@ -22,7 +22,7 @@ test('Favorites wishlist present by default and cannot be deleted', async ({ pag
   await page.getByRole('link', { name: 'Favorites' }).click();
   await page.getByRole('heading', { name: 'Favorites' }).waitFor();
 
-  // Need to check there is no Wishlist Actions to edit/delete wishlist
+  // Need to check there is no Wishlist Actions to edit/delete wishlist after fixing SD-10825
 });
 
 test('Add product to Favorites wishlist from PDP', async ({ page, account }) => {

--- a/core/tests/ui/e2e/wishlist.spec.ts
+++ b/core/tests/ui/e2e/wishlist.spec.ts
@@ -22,7 +22,7 @@ test('Favorites wishlist present by default and cannot be deleted', async ({ pag
   await page.getByRole('link', { name: 'Favorites' }).click();
   await page.getByRole('heading', { name: 'Favorites' }).waitFor();
 
-  // Need to check there is no Wishlist Actions to edit/delete wishlist after fixing SD-10825
+  // Need to check there is no Wishlist Actions to edit/delete wishlist after fixing related issue
 });
 
 test('Add product to Favorites wishlist from PDP', async ({ page, account }) => {

--- a/core/tests/ui/e2e/wishlist.spec.ts
+++ b/core/tests/ui/e2e/wishlist.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '~/tests/fixtures';
 
-test('Guest user is redirected to login upon adding product to wishlist', async ({ page }) => {
+test('Guest user is required to register to create a wishlist', async ({ page }) => {
   await page.goto('/laundry-detergent/');
   await page.getByRole('heading', { level: 1, name: '[Sample] Laundry Detergent' }).waitFor();
 
@@ -19,10 +19,7 @@ test('Favorites wishlist present by default and cannot be deleted', async ({ pag
   await expect(page.getByText('Favorites')).toBeVisible();
   await expect(page.getByRole('button', { name: 'Delete' })).toBeHidden();
 
-  await page.getByRole('link', { name: 'Favorites' }).click();
-  await page.getByRole('heading', { name: 'Favorites' }).waitFor();
-
-  // Need to check there is no Wishlist Actions to edit/delete wishlist after fixing related issue
+  // Need to check there is no Wishlist Actions to edit/delete wishlist on details page after fixing related issue
 });
 
 test('Add product to Favorites wishlist from PDP', async ({ page, account }) => {


### PR DESCRIPTION
## What/Why?
- moved add/delete wishlist test from account.spec.ts to separate file wishlist.spec.ts
- test with adding product to wishlist
- test with creating new wishlist from drawer
- test to make sure guest user cannot use wishlist
- test to verify Favorites wishlist is default and cannot be deleted

## Testing
See regression test run in CI (there is separate ticket to fix button test in visual regression)