### PR TITLE
feat(cli): fix event name and provide additional properties

### DIFF
--- a/.changeset/tricky-trainers-greet.md
+++ b/.changeset/tricky-trainers-greet.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": minor
+---
+
+Ensures a command is always passed as an event name and provides a allowlist of args to pass as additional properties to the event.

--- a/packages/create-catalyst/src/hooks/telemetry.ts
+++ b/packages/create-catalyst/src/hooks/telemetry.ts
@@ -4,13 +4,59 @@ import { Telemetry } from '../utils/telemetry/telemetry';
 
 const telemetry = new Telemetry();
 
-export const telemetryPreHook = async (command: Command) => {
-  // If the binary is ran without a command, the command.args will be an empty array.
-  // When running `npm create @bigcommerce/catalyst`, npm runs the binary with no args passed,
-  // but the program defaults to the `create` command.
-  const [commandName = 'create'] = command.args;
+const allowlistArguments = ['--gh-ref', '--repository', '--project-name'];
 
-  await telemetry.track(commandName, {});
+function parseArguments(args: string[]) {
+  return args.reduce<Record<string, string>>((result, arg, index, array) => {
+    if (arg.includes('=')) {
+      const [key, value] = arg.split('=');
+
+      if (allowlistArguments.includes(key)) {
+        return {
+          ...result,
+          [key]: value,
+        };
+      }
+    }
+
+    if (allowlistArguments.includes(arg)) {
+      const nextValue =
+        array[index + 1] && !array[index + 1].startsWith('--') ? array[index + 1] : null;
+
+      if (nextValue && !nextValue.includes('--')) {
+        return {
+          ...result,
+          [arg]: nextValue,
+        };
+      }
+    }
+
+    return result;
+  }, {});
+}
+
+export const telemetryPreHook = async (command: Command) => {
+  // @ts-expect-error _name is a private property
+  const availableCommands = command.commands.map((cmd) => cmd._name); // eslint-disable-line @typescript-eslint/no-unsafe-return, no-underscore-dangle
+
+  const [commandName = 'create', ...args] = command.args;
+
+  // When running `npm create @bigcommerce/catalyst`, the command defaults to
+  // the `create` command but commander doesn't pass it as part of the arguments.
+  //  We need to handle this case separately.
+  if (!availableCommands.includes(commandName)) {
+    // Return the await to get a proper stack trace.
+    // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+    return await telemetry.track('create', {
+      ...parseArguments(args),
+    });
+  }
+
+  // Return the await to get a proper stack trace.
+  // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+  return await telemetry.track(commandName, {
+    ...parseArguments(args),
+  });
 };
 
 export const telemetryPostHook = async () => {


### PR DESCRIPTION
## What/Why?
We were getting some events with arguments. This fixes the telemetry to only send events if the command is one of the available commands. Also added a function to filter out an allowlist of args to pass as properties on the event.

## Testing
![Screenshot 2024-10-28 at 16 01 14](https://github.com/user-attachments/assets/15a820fb-ef1f-4159-b0c2-6c5decbb858e)
