### PR TITLE
fix(core): improve error message on reset password page

### DIFF
--- a/.changeset/eighty-tomatoes-give.md
+++ b/.changeset/eighty-tomatoes-give.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+improve error message on reset password page

--- a/core/app/[locale]/(default)/(auth)/login/forgot-password/_components/reset-password-form/index.tsx
+++ b/core/app/[locale]/(default)/(auth)/login/forgot-password/_components/reset-password-form/index.tsx
@@ -122,7 +122,7 @@ export const ResetPasswordForm = ({ reCaptchaSettings }: Props) => {
   return (
     <>
       {formStatus?.status === 'error' && (
-        <Message className="mb-8 w-full" variant={formStatus.status}>
+        <Message className="mb-8 w-full whitespace-pre" variant={formStatus.status}>
           <p>{formStatus.message}</p>
         </Message>
       )}


### PR DESCRIPTION
## What/Why?
This PR improves validation error on Reset Password form for User. Previously Zod Error was an array of data that was quite hard to read through so we've transformed it into a message where User can read about invalid field and reason for appeared error.

## Testing
locally
<img width="1006" alt="error_message" src="https://github.com/user-attachments/assets/0e5004fe-de9a-4b75-a05d-fdcf5e42b1de">



https://github.com/user-attachments/assets/d25bc125-a6cf-4aeb-9aee-7537c0bf521c


https://github.com/user-attachments/assets/908c6ded-b637-4125-a782-fdd1b5fa43e8

