### PR TITLE
fix(core): improve behaviour for change password page for logged in user

### DIFF
--- a/.changeset/metal-dragons-decide.md
+++ b/.changeset/metal-dragons-decide.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+improve behaviour for change password page for logged in user

--- a/core/app/[locale]/(default)/account/(tabs)/settings/change-password/page.tsx
+++ b/core/app/[locale]/(default)/account/(tabs)/settings/change-password/page.tsx
@@ -1,6 +1,6 @@
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 
-import { locales, LocaleType } from '~/i18n/routing';
+import { LocaleType } from '~/i18n/routing';
 
 import { TabHeading } from '../../_components/tab-heading';
 
@@ -31,8 +31,4 @@ export default function ChangePassword({ params: { locale } }: Props) {
   );
 }
 
-export function generateStaticParams() {
-  return locales.map((locale) => ({ locale }));
-}
-
-export const dynamic = 'force-static';
+export const runtime = 'edge';


### PR DESCRIPTION
## What/Why?
This PR improves change password page behaviour.  Previously if  logged in User tried to reach change password page by url,  it was blocked by error.

## Testing
locally

https://github.com/user-attachments/assets/57c07f2f-0ee4-4b87-9c85-18611515db7c


https://github.com/user-attachments/assets/8a9204b1-e230-46ed-8c65-1d136103bd99

