### PR TITLE
fix(core): fix warning for using the same keys on items

### DIFF
--- a/.changeset/chilly-trains-sort.md
+++ b/.changeset/chilly-trains-sort.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+fix warning for using the same keys on items

--- a/core/components/ui/footer/footer.tsx
+++ b/core/components/ui/footer/footer.tsx
@@ -107,8 +107,8 @@ const Footer = ({
         {Boolean(socialMediaLinks) && (
           <nav aria-label="Social media links" className="block">
             <ul className="flex gap-6">
-              {socialMediaLinks?.map((link) => (
-                <li key={link.href}>
+              {socialMediaLinks?.map((link, index) => (
+                <li key={index}>
                   <CustomLink className="inline-block" href={link.href} target="_blank">
                     {link.icon}
                   </CustomLink>


### PR DESCRIPTION
## What/Why?
This PR just removes annoyance for warning not using unique keys in components.
```
Warning: Encountered two children with the  same key
```
We have collection items  with identical keys in `<Footer/>` so updating keys in one of them removes the warning.

## Testing
locally

<img width="1512" alt="warning_before" src="https://github.com/user-attachments/assets/063fda46-f2b6-4c6b-a555-fa7b19bbb9cc">

<img width="1512" alt="warning_after" src="https://github.com/user-attachments/assets/7e99d0b3-02bf-4545-8780-129041dffb23">
