### PR TITLE
fix(chore): Send slack notifications only for open pr

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -151,7 +151,7 @@ jobs:
 
       - name: Send slack notification
         uses: slackapi/slack-github-action@v1.26.0
-        if: ${{ steps.pr_details.outputs.draft != 'true' && failure() }}
+        if: ${{ steps.pr_details.outputs.draft != 'true' && steps.pr_details.outputs.pr && failure() }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
@@ -213,7 +213,7 @@ jobs:
 
       - name: Send slack notification
         uses: slackapi/slack-github-action@v1.26.0
-        if: ${{ steps.pr_details.outputs.draft != 'true' && failure() }}
+        if: ${{ steps.pr_details.outputs.draft != 'true' && steps.pr_details.outputs.pr && failure() }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:


### PR DESCRIPTION
## What/Why?
Do not send slack notifications if a pull request does not exist. This would cut down some of the noise and notify of changes that need attention.

## Testing
Part of CI 