### PR TITLE
test(core): Add change password test as a logged in user

### DIFF
--- a/core/tests/ui/e2e/change-password.spec.ts
+++ b/core/tests/ui/e2e/change-password.spec.ts
@@ -5,7 +5,7 @@ import { expect, test } from '~/tests/fixtures';
 // Prefix is added to ensure that the password requirements are met
 const password = faker.internet.password({ pattern: /[a-zA-Z0-9]/, prefix: '1At', length: 10 });
 
-test('Change password', async ({ page }) => {
+test('Cannot change password with invalid reset token and customerId', async ({ page }) => {
   await page.goto('/change-password?c=123&t=test123');
 
   await page.getByRole('heading', { name: 'Change password' }).waitFor();
@@ -18,4 +18,31 @@ test('Change password', async ({ page }) => {
   await expect(page.getByRole('region')).toHaveText(
     'Invalid password reset token or customerEntityId.',
   );
+});
+
+test('Change password from Account Settings and log in', async ({ page, account }) => {
+  const customer = await account.create();
+
+  await customer.login();
+
+  await page.goto('/account/settings/');
+  await page.getByRole('link', { name: 'Change password' }).click();
+  await page.getByLabel('Current passwordRequired', { exact: true }).fill(customer.password);
+  await page.getByLabel('New passwordRequired', { exact: true }).fill(`${customer.password}1`);
+  await page.getByLabel('Confirm passwordRequired', { exact: true }).fill(`${customer.password}1`);
+
+  await page.getByRole('button', { name: 'Change password' }).click();
+
+  await expect(page.getByRole('region')).toHaveText(
+    'Your password has been successfully updated. Please log in using your new credentials.',
+  );
+
+  await page.goto('/account/');
+  await page.getByRole('heading', { name: 'Log In' }).waitFor();
+
+  await page.getByLabel('Email').fill(customer.email);
+  await page.getByLabel('Password').fill(`${customer.password}1`);
+  await page.getByRole('button', { name: 'Log in' }).click();
+
+  await expect(page).toHaveURL('/account/');
 });


### PR DESCRIPTION
## What/Why?
Added a test for changing password via Account settings as a logged in user and log in with a new password afterwards 

## Testing
See regression suite test run in CI