### PR TITLE
fix(core): fix validation message for email on account settings page

### DIFF
--- a/.changeset/sweet-dragons-stare.md
+++ b/.changeset/sweet-dragons-stare.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+fix validation message for email on account settings page

--- a/core/app/[locale]/(default)/account/(tabs)/settings/_components/text-field.tsx
+++ b/core/app/[locale]/(default)/account/(tabs)/settings/_components/text-field.tsx
@@ -49,12 +49,20 @@ export const TextField = ({
         />
       </FieldControl>
       {isRequired && (
-        <FieldMessage
-          className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-error"
-          match="valueMissing"
-        >
-          {t(fieldNameById ?? 'empty')}
-        </FieldMessage>
+        <>
+          <FieldMessage
+            className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-error"
+            match="valueMissing"
+          >
+            {t(fieldNameById ?? 'empty')}
+          </FieldMessage>
+          <FieldMessage
+            className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-error"
+            match="typeMismatch"
+          >
+            {t(fieldNameById)}
+          </FieldMessage>
+        </>
       )}
     </Field>
   );


### PR DESCRIPTION
## What/Why?
This PR adds validation message after an incorrectly entered email

## Testing
locally

**before:**

https://github.com/user-attachments/assets/1f9c0884-2e8e-4782-bc82-99561c7883ba

**after:**

https://github.com/user-attachments/assets/4119afd9-9ce0-4762-a14b-5bcb58fffaf3
