### PR TITLE
docs: update ecommerce functionality documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ Catalyst has a production-ready business-to-consumer (B2C) ecommerce funnel, inc
 * Product detail pages (PDPs) which are dynamically created for each product and published to the Catalyst storefront channel
 * Shopping cart
 * Secure redirected headless checkout page, which can be themed to match the styling of the core Catalyst storefront
-* Order information for logged-in customers. This includes order history, order status, order details, tracking information, and tracking info and shipment addresses for each consignment
+* Accounts logged-in customers. This currently includes address management and customer account settings.
 
 
 ## Default state of Catalyst


### PR DESCRIPTION
## What/Why?
Updates the `Ecommerce functionality` section in the documentation to remove things related to order management as it's a WIP feature right now. Per https://github.com/bigcommerce/catalyst/issues/1515#issuecomment-2445674083 this can cause some confusion when scoping works for clients.

When the full account orders functionality is merged in, we can revert this PR.

Closes #1515

## Testing
N/A