### PR TITLE
fix: disambiguate checkout ref to prefer branch over local file name

### DIFF
--- a/.changeset/silent-mayflies-accept.md
+++ b/.changeset/silent-mayflies-accept.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": patch
+---
+
+fix: disambiguate checkout ref to prefer branch over local file name

--- a/packages/create-catalyst/src/utils/checkout-ref.ts
+++ b/packages/create-catalyst/src/utils/checkout-ref.ts
@@ -5,7 +5,7 @@ import { isExecException } from './is-exec-exception';
 export function checkoutRef(repoDir: string, ref: string): void {
   try {
     // Attempt to checkout the specified ref
-    execSync(`git checkout ${ref}`, {
+    execSync(`git checkout -- ${ref}`, {
       cwd: repoDir,
       stdio: 'inherit',
       encoding: 'utf8',


### PR DESCRIPTION
## What/Why?
The following command:
```
pnpm create @bigcommerce/catalyst@latest --gh-ref integrations/makeswift
```

Results in the following output:

```
◢ @bigcommerce/create-catalyst v0.16.0

✔ What is the name of your project? tmp-catalyst
✔ Would you like to connect to a BigCommerce store? No

Creating 'tmp-catalyst' at '/Users/chris.nanninga/Documents/Code/tmp-catalyst'

Cloning bigcommerce/catalyst using SSH...

Cloning into 'tmp-catalyst'...
remote: Enumerating objects: 24154, done.
remote: Counting objects: 100% (2109/2109), done.
remote: Compressing objects: 100% (1107/1107), done.
remote: Total 24154 (delta 1077), reused 1718 (delta 831), pack-reused 22045 (from 1)
Receiving objects: 100% (24154/24154), 39.57 MiB | 9.31 MiB/s, done.
Resolving deltas: 100% (14099/14099), done.

Renaming remote references: 100% (103/103), done.

fatal: 'integrations/makeswift' could be both a local file and a tracking branch.
Please use -- (and optionally --no-guess) to disambiguate
Error checking out ref 'integrations/makeswift': 
Error checking out ref 'integrations/makeswift': Command failed: git checkout integrations/makeswift
Unknown error occurred while checking out ref 'integrations/makeswift'.
```

To always have Git prioritize branches over local file names in cases like this, I am switching to use the `--` separator.

Open to alternative suggestions!

## Testing
Locally