### PR TITLE
feat: allow project creation without prompts if given valid config values

### DIFF
--- a/.changeset/good-dragons-sing.md
+++ b/.changeset/good-dragons-sing.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": minor
+---
+
+Introduce an additional project creation scenario in which projects can be created without prompts if the CLI is provided with a valid `--store-hash`, `--channel-id`, and `--storefront-token`

--- a/packages/create-catalyst/src/commands/create.ts
+++ b/packages/create-catalyst/src/commands/create.ts
@@ -111,15 +111,38 @@ export const create = new Command('create')
       });
     }
 
+    if (!projectName) throw new Error('Something went wrong, projectName is not defined');
+    if (!projectDir) throw new Error('Something went wrong, projectDir is not defined');
+
+    if (storeHash && channelId && storefrontToken) {
+      console.log(`\nCreating '${projectName}' at '${projectDir}'\n`);
+
+      cloneCatalyst({ repository, projectName, projectDir, ghRef });
+
+      writeEnv(projectDir, {
+        channelId: channelId.toString(),
+        storeHash,
+        storefrontToken,
+        arbitraryEnv: options.env,
+      });
+
+      await installDependencies(projectDir);
+
+      console.log(
+        `\n${chalk.green('Success!')} Created '${projectName}' at '${projectDir}'\n`,
+        '\nNext steps:\n',
+        chalk.yellow(`\ncd ${projectName} && pnpm run dev\n`),
+      );
+
+      process.exit(0);
+    }
+
     if (!options.storeHash || !options.accessToken) {
       const credentials = await login(bigcommerceAuthUrl);
 
       storeHash = credentials.storeHash;
       accessToken = credentials.accessToken;
     }
-
-    if (!projectName) throw new Error('Something went wrong, projectName is not defined');
-    if (!projectDir) throw new Error('Something went wrong, projectDir is not defined');
 
     if (!storeHash || !accessToken) {
       console.log(`\nCreating '${projectName}' at '${projectDir}'\n`);


### PR DESCRIPTION
## What/Why?
If a user provides `--store-hash`, `--channel-id`, and `--storefront-token`, there is no need to prompt the user to log into a store because they already have a store they want to connect to, a channel they want to link, and a valid auth token to interact with the GQL API for that channel.

## Testing
I would post a video but it would expose SF tokens - this was tested locally and ran without errors and without affecting other CLI flag combinations.