### PR TITLE
feat(core): add images for order items

### DIFF
--- a/.changeset/chilled-fans-count.md
+++ b/.changeset/chilled-fans-count.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+add images for order items


### PR DESCRIPTION
## What/Why?
The PR brings images for items in Orders. 

## Testing
locally

https://github.com/user-attachments/assets/be0dbdf4-7f6d-42fa-a7aa-c7c6cdb46004

