### PR TITLE
Wire up plain text description and custom fields on compare

### DIFF
--- a/core/app/[locale]/(default)/compare/page.tsx
+++ b/core/app/[locale]/(default)/compare/page.tsx
@@ -60,7 +60,15 @@ const ComparePageQuery = graphql(
                   }
                 }
               }
-              description
+              plainTextDescription(characterLimit: 200)
+              customFields {
+                edges {
+                  node {
+                    name
+                    value
+                  }
+                }
+              }
               inventory {
                 aggregated {
                   availableToSell
@@ -110,6 +118,7 @@ export default async function Compare({ searchParams }: Props) {
   const products = removeEdgesAndNodes(data.site.products).map((product) => ({
     ...product,
     productOptions: removeEdgesAndNodes(product.productOptions),
+    customFields: removeEdgesAndNodes(product.customFields),
   }));
 
   const formattedProducts = products.map((product) => ({
@@ -120,8 +129,12 @@ export default async function Compare({ searchParams }: Props) {
       ? { src: product.defaultImage.url, alt: product.defaultImage.altText }
       : undefined,
     price: pricesTransformer(product.prices, format),
-    description: product.description,
+    description: product.plainTextDescription,
     rating: product.reviewSummary.averageRating,
+    customFields: product.customFields.map((field) => ({
+      name: field.name,
+      value: field.value,
+    })),
   }));
 
   // if (!products.length) {

--- a/core/vibes/soul/primitives/compare-card/index.tsx
+++ b/core/vibes/soul/primitives/compare-card/index.tsx
@@ -6,7 +6,7 @@ import { CardProduct, ProductCard } from '@/vibes/soul/primitives/product-card'
 
 import { Rating } from '../rating'
 
-export type CompareProduct = CardProduct & { description?: string }
+export type CompareProduct = CardProduct & { description?: string; customFields?: { name: string; value: string }[] }
 
 export type Props = {
   className?: string
@@ -15,6 +15,7 @@ export type Props = {
   addToCartLabel?: string
   descriptionLabel?: string
   ratingLabel?: string
+  otherDetailsLabel?: string
 }
 
 export function CompareCard({
@@ -24,6 +25,7 @@ export function CompareCard({
   addToCartLabel = 'Add to Cart',
   descriptionLabel = 'Description',
   ratingLabel = 'Rating',
+  otherDetailsLabel = 'Other Details',
 }: Props) {
   return (
     <div className={clsx('flex flex-col divide-y divide-contrast-100 @container', className)}>
@@ -39,11 +41,21 @@ export function CompareCard({
       </div>
       <div className="space-y-5 py-5">
         <h3 className="font-mono text-xs uppercase">{descriptionLabel}</h3>
-        <p>{product.description}</p>
+        <p className="text-sm">{product.description}</p>
       </div>
       <div className="space-y-5 py-5">
         <h3 className="font-mono text-xs uppercase">{ratingLabel}</h3>
         {product.rating != null && <Rating rating={product.rating} />}
+      </div>
+      <div className="space-y-5 py-5">
+        <h3 className="font-mono text-xs uppercase">{otherDetailsLabel}</h3>
+        {product.customFields?.map((field) => (
+          <div>
+            <p className="text-xs">
+              <strong>{field.name}</strong>: {field.value}
+            </p>
+          </div>
+        ))}
       </div>
     </div>
   )


### PR DESCRIPTION
## What/Why?
Use plaintextdescription and custom fields on compare page.

Need to look at styling next; this should be table-like.

## Testing
Reference:

https://cornerstone-light-demo.mybigcommerce.com/compare/111/110/109

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/179cfa35-9eb1-4057-bf8a-3b5d659f413a">
