### PR TITLE
Chore: Update FeateredImage CTA href

### DIFF
--- a/core/app/[locale]/(default)/page.tsx
+++ b/core/app/[locale]/(default)/page.tsx
@@ -68,7 +68,7 @@ export default async function Home({ params: { locale } }: Props) {
       <FeaturedProductsCarousel products={newestProducts} title={t('Carousel.title')} />
 
       <FeaturedImage
-        cta={{ href: '/products', label: t('FeaturedImage.cta') }}
+        cta={{ href: '/shop-all', label: t('FeaturedImage.cta') }}
         description="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt."
         image={{
           src: image.src,

--- a/core/app/[locale]/(default)/page.tsx
+++ b/core/app/[locale]/(default)/page.tsx
@@ -68,7 +68,7 @@ export default async function Home({ params: { locale } }: Props) {
       <FeaturedProductsCarousel products={newestProducts} title={t('Carousel.title')} />
 
       <FeaturedImage
-        cta={{ href: '/#', label: t('FeaturedImage.cta') }}
+        cta={{ href: '/products', label: t('FeaturedImage.cta') }}
         description="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt."
         image={{
           src: image.src,


### PR DESCRIPTION
## What/Why?
The cta button on the featured image of the homepage was linking back to the home page. Now, it links to `/shop-all`. 

## Testing
Go to home page, scroll down to the featured image and click the `Shop Now` button.

![CleanShot 2024-11-07 at 13 26 17@2x](https://github.com/user-attachments/assets/e07a5e31-ba32-4ad5-8d1f-eb8d9a536f23)
