### PR TITLE
fix: PDP was ignoring TS

### DIFF
--- a/core/app/[locale]/(default)/product/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/page.tsx
@@ -154,8 +154,16 @@ export default async function Product({ params: { locale, slug }, searchParams }
 
   return (
     <>
-      {/* @ts-expect-error: TODO(jorgemoya): fix this issue */}
-      <ProductDetail product={formattedProduct} />
+      {/* TODO(jorgemoya): pass appropriate fields and action */}
+      <ProductDetail
+        action={async (state) => {
+          'use server';
+
+          return await Promise.resolve(state);
+        }}
+        fields={[]}
+        product={formattedProduct}
+      />
 
       <ProductDescription
         accordions={accordions}


### PR DESCRIPTION
## What/Why?
A `@ts-expect-error` was resulting in a 500 when rendering PDPs. This PR fixes that issue.

## Testing
Since `@ts-expect-error` was removed we're now respecting TS types.