### PR TITLE
fix: trigger server render on sort

### DIFF
--- a/core/vibes/soul/sections/products-list-section/sorting.tsx
+++ b/core/vibes/soul/sections/products-list-section/sorting.tsx
@@ -26,7 +26,10 @@ export function Sorting({ label = 'Sort', options, paramName }: Props) {
 }
 
 function SortingInner({ label = 'Sort', options, paramName = 'sort', defaultValue = '' }: Props) {
-  const [param, setParam] = useQueryState(paramName, parseAsString.withDefault(defaultValue));
+  const [param, setParam] = useQueryState(
+    paramName,
+    parseAsString.withDefault(defaultValue).withOptions({ shallow: false }),
+  );
   const resolved = options instanceof Promise ? use(options) : options;
 
   return (


### PR DESCRIPTION
## What/Why?
Add `useOptions({shallow: false})` to trigger server rerender.

## Testing
Locally sorting works.