### PR TITLE
Hide some Makeswift builtins

### DIFF
--- a/core/lib/makeswift/components.ts
+++ b/core/lib/makeswift/components.ts
@@ -16,3 +16,41 @@ import '~/makeswift/components/inline-email-form/inline-email-form.makeswift';
 import '~/makeswift/components/slideshow/slideshow.makeswift';
 import '~/makeswift/components/featured-image/featured-image.makeswift';
 import '~/makeswift/components/sticky-sidebar-layout/sticky-sidebar-layout.makeswift';
+
+import { MakeswiftComponentType } from '@makeswift/runtime';
+
+import { runtime } from './runtime';
+
+// Hide some builtin Makeswift components
+
+// TODO(migueloller): Hiding builtins this way results in existing components being rendered without
+// the ability to edit them. We should find a way to hide them in the editor without affecting the
+// rendering of existing components.
+
+runtime.registerComponent(() => null, {
+  type: MakeswiftComponentType.Carousel,
+  label: 'Carousel (hidden)',
+  hidden: true,
+  props: {},
+});
+
+runtime.registerComponent(() => null, {
+  type: MakeswiftComponentType.Countdown,
+  label: 'Countdown (hidden)',
+  hidden: true,
+  props: {},
+});
+
+runtime.registerComponent(() => null, {
+  type: MakeswiftComponentType.Form,
+  label: 'Form (hidden)',
+  hidden: true,
+  props: {},
+});
+
+runtime.registerComponent(() => null, {
+  type: MakeswiftComponentType.Navigation,
+  label: 'Navigation (hidden)',
+  hidden: true,
+  props: {},
+});

--- a/core/makeswift/components/button-link/button-link.makeswift.tsx
+++ b/core/makeswift/components/button-link/button-link.makeswift.tsx
@@ -1,3 +1,4 @@
+import { MakeswiftComponentType } from '@makeswift/runtime';
 import { Link, Select, Style, TextInput } from '@makeswift/runtime/controls';
 
 import { ButtonLink, Props } from '@/vibes/soul/primitives/button-link';
@@ -17,8 +18,8 @@ runtime.registerComponent(
     );
   },
   {
-    type: 'primitive-button',
-    label: 'Primitives / Button',
+    type: MakeswiftComponentType.Button,
+    label: 'Button',
     icon: 'button',
     props: {
       className: Style({ properties: [Style.Margin] }),


### PR DESCRIPTION
## What/Why?
We don't want the following builtins to appear in the Makeswift builder:
- Carousel
- Countdown
- Form
- Navigation

Also, we want the Button component to appear in the Makeswift toolbar instead of the menu

## Testing
### Before

![CleanShot 2024-11-08 at 15 17 59](https://github.com/user-attachments/assets/2113db51-6f24-4daa-b882-a0fa5db844ac)

### After

https://github.com/user-attachments/assets/1f3124d5-a213-4d6b-9e36-a3028b85f610
