### PR TITLE
REFERENCE: Add v3 scripts server component into root layout

### DIFF
--- a/core/app/[locale]/_components/bigcommerce-scripts.tsx
+++ b/core/app/[locale]/_components/bigcommerce-scripts.tsx
@@ -1,0 +1,59 @@
+import Script from 'next/script'
+
+type BigCommerceScript = {
+  id: string;
+  html: string;
+  loadStrategy: 'beforeInteractive' | 'afterInteractive' | 'lazyOnload';
+}
+
+async function fetchBigCommerceScripts(): Promise<BigCommerceScript[]> {
+  const response = await fetch(`https://api.bigcommerce.com/stores/${process.env.BIGCOMMERCE_STORE_HASH}/v3/content/scripts?channel_id:in=${process.env.BIGCOMMERCE_CHANNEL_ID}`, {
+    headers: {
+      'X-Auth-Token': process.env.BIGCOMMERCE_CONTENT_V3_API_TOKEN as string,
+      'Content-Type': 'application/json',
+    },
+    next: { revalidate: 3600 } // revalidate every hour
+  })
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch BigCommerce scripts')
+  }
+
+  const data = await response.json()
+
+  // Filter and process scripts to only include those with HTML content
+  return data.data
+  .filter((script: any) => script.kind === 'script_tag' && script.html)
+  .map((script: any) => {
+    const html = script.html
+
+    // The html below is being stripped of it's first and last tags, 
+    // since BigCommerce scripts require a wrapping tag while next/script does not.
+    return {
+      id: script.uuid,
+      html: html.slice(
+        html.indexOf('>') + 1,
+        html.lastIndexOf('<')
+      ),
+      loadStrategy: script.load_method === 'default' ? 'afterInteractive' : 
+                    script.load_method === 'async' ? 'lazyOnload' : 'beforeInteractive'
+    }
+  })
+}
+
+export default async function BigCommerceScripts() {
+  const scripts = await fetchBigCommerceScripts()
+
+  return (
+    <>
+      {scripts.map((script) => (
+        <Script
+          key={script.id}
+          id={script.id}
+          dangerouslySetInnerHTML={{ __html: script.html }}
+          strategy={script.loadStrategy}
+        />
+      ))}
+    </>
+  )
+}

--- a/core/app/[locale]/layout.tsx
+++ b/core/app/[locale]/layout.tsx
@@ -14,6 +14,7 @@ import { revalidate } from '~/client/revalidate-target';
 
 import { Notifications } from '../notifications';
 import { Providers } from '../providers';
+import BigCommerceScripts from './_components/bigcommerce-scripts';
 
 const inter = Inter({
   subsets: ['latin'],
@@ -95,6 +96,7 @@ export default function RootLayout({ children, params: { locale } }: Props) {
           <Providers>{children}</Providers>
         </NextIntlClientProvider>
         <VercelComponents />
+        <BigCommerceScripts />
       </body>
     </html>
   );


### PR DESCRIPTION
## What/Why?
This is an example of using the v3 Scripts API to render scripts in Catalyst that are written in by an app.

## Testing
<img width="1510" alt="Screenshot 2024-11-04 at 2 25 49 AM" src="https://github.com/user-attachments/assets/7a67bbc9-4f14-4456-bb40-db0797ecd689">
