### PR TITLE
fix: replace /account with /login in Header

### DIFF
--- a/core/components/header/index.tsx
+++ b/core/components/header/index.tsx
@@ -162,7 +162,7 @@ export const Header = async () => {
   return (
     <HeaderSection
       navigation={{
-        accountHref: '/account',
+        accountHref: '/login',
         activeLocaleId: locale,
         cartHref: '/cart',
         links,


### PR DESCRIPTION
## What/Why?
For some reason, the redirect from `/account` to `/login` is very slow. The opposite is not true, so this replaces the link for now.

## Testing
Locally, way faster to redirect from `/login` to `/account` if authenticated.