### PR TITLE
fix: invalid use of `useFormState`

### DIFF
--- a/core/vibes/soul/sections/account-settings-section/change-password-form.tsx
+++ b/core/vibes/soul/sections/account-settings-section/change-password-form.tsx
@@ -3,7 +3,7 @@
 import { getFormProps, getInputProps, SubmissionResult, useForm } from '@conform-to/react';
 import { getZodConstraint, parseWithZod } from '@conform-to/zod';
 import { useEffect } from 'react';
-import { useFormState as useActionState } from 'react-dom';
+import { useFormState, useFormStatus } from 'react-dom';
 
 import { Input } from '@/vibes/soul/form/input';
 import { Button } from '@/vibes/soul/primitives/button';
@@ -29,7 +29,7 @@ export function ChangePasswordForm({
   confirmPasswordLabel = 'Confirm password',
   submitLabel = 'Update',
 }: Props) {
-  const [lastResult, formAction, isPending] = useActionState(action, null);
+  const [lastResult, formAction] = useFormState(action, null);
   const [form, fields] = useForm({
     constraint: getZodConstraint(changePasswordSchema),
     shouldValidate: 'onBlur',
@@ -66,9 +66,17 @@ export function ChangePasswordForm({
         key={fields.confirmPassword.id}
         label={confirmPasswordLabel}
       />
-      <Button loading={isPending} size="small" type="submit" variant="secondary">
-        {submitLabel}
-      </Button>
+      <SubmitButton>{submitLabel}</SubmitButton>
     </form>
+  );
+}
+
+function SubmitButton({ children }: { children: React.ReactNode }) {
+  const { pending } = useFormStatus();
+
+  return (
+    <Button loading={pending} size="small" type="submit" variant="secondary">
+      {children}
+    </Button>
   );
 }

--- a/core/vibes/soul/sections/account-settings-section/update-account-form.tsx
+++ b/core/vibes/soul/sections/account-settings-section/update-account-form.tsx
@@ -3,7 +3,7 @@
 import { getFormProps, getInputProps, SubmissionResult, useForm } from '@conform-to/react';
 import { getZodConstraint, parseWithZod } from '@conform-to/zod';
 import { useEffect } from 'react';
-import { useFormState as useActionState } from 'react-dom';
+import { useFormState, useFormStatus } from 'react-dom';
 
 import { Input } from '@/vibes/soul/form/input';
 import { Button } from '@/vibes/soul/primitives/button';
@@ -29,7 +29,7 @@ export function UpdateAccountForm({
   emailLabel = 'Email',
   submitLabel = 'Update',
 }: Props) {
-  const [lastResult, formAction, isPending] = useActionState(action, null);
+  const [lastResult, formAction] = useFormState(action, null);
   const [form, fields] = useForm({
     constraint: getZodConstraint(updateAccountSchema),
     shouldValidate: 'onBlur',
@@ -67,9 +67,17 @@ export function UpdateAccountForm({
         key={fields.email.id}
         label={emailLabel}
       />
-      <Button loading={isPending} size="small" type="submit" variant="secondary">
-        {submitLabel}
-      </Button>
+      <SubmitButton>{submitLabel}</SubmitButton>
     </form>
+  );
+}
+
+function SubmitButton({ children }: { children: React.ReactNode }) {
+  const { pending } = useFormStatus();
+
+  return (
+    <Button loading={pending} size="small" type="submit" variant="secondary">
+      {children}
+    </Button>
   );
 }

--- a/core/vibes/soul/sections/address-list-section/index.tsx
+++ b/core/vibes/soul/sections/address-list-section/index.tsx
@@ -3,7 +3,7 @@
 import { getFormProps, getInputProps, SubmissionResult, useForm } from '@conform-to/react';
 import { getZodConstraint, parseWithZod } from '@conform-to/zod';
 import { startTransition, useEffect, useOptimistic, useState } from 'react';
-import { useFormState as useActionState } from 'react-dom';
+import { useFormState, useFormStatus } from 'react-dom';
 import { z } from 'zod';
 
 import { Input } from '@/vibes/soul/form/input';
@@ -70,7 +70,7 @@ export function AddressListSection<A extends Address>({
   countryLabel,
   postalCodeLabel,
 }: Props<A>) {
-  const [state, formAction, isPending] = useActionState(addressAction, {
+  const [state, formAction] = useFormState(addressAction, {
     addresses,
     defaultAddressId,
     lastResult: null,
@@ -125,14 +125,7 @@ export function AddressListSection<A extends Address>({
   return (
     <div>
       <div className="flex items-center justify-between">
-        <h1 className="text-4xl">
-          {title}
-          {isPending && (
-            <span className="ml-2">
-              <Spinner />
-            </span>
-          )}
-        </h1>
+        <Title>{title}</Title>
         {!showNewAddressForm && (
           <Button onClick={() => setShowNewAddressForm(true)} size="small">
             {showAddFormLabel}
@@ -264,6 +257,21 @@ export function AddressListSection<A extends Address>({
         ))}
       </div>
     </div>
+  );
+}
+
+function Title({ children }: { children: React.ReactNode }) {
+  const { pending } = useFormStatus();
+
+  return (
+    <h1 className="text-4xl">
+      {children}
+      {pending && (
+        <span className="ml-2">
+          <Spinner />
+        </span>
+      )}
+    </h1>
   );
 }
 

--- a/core/vibes/soul/sections/cart/index.tsx
+++ b/core/vibes/soul/sections/cart/index.tsx
@@ -5,7 +5,7 @@ import { parseWithZod } from '@conform-to/zod';
 import clsx from 'clsx';
 import { ArrowRight, Minus, Plus, Trash2 } from 'lucide-react';
 import { startTransition, Suspense, use, useEffect, useOptimistic } from 'react';
-import { useFormState as useActionState } from 'react-dom';
+import { useFormState, useFormStatus } from 'react-dom';
 
 import { Button } from '@/vibes/soul/primitives/button';
 import { ButtonLink } from '@/vibes/soul/primitives/button-link';
@@ -116,7 +116,7 @@ function CartInner<LineItem extends CartLineItem>({
 }: CartProps<LineItem>) {
   const resolvedLineItems = lineItems instanceof Promise ? use(lineItems) : lineItems;
 
-  const [state, formAction, isPending] = useActionState(lineItemAction, {
+  const [state, formAction] = useFormState(lineItemAction, {
     lineItems: resolvedLineItems,
     lastResult: null,
   });
@@ -202,7 +202,7 @@ function CartInner<LineItem extends CartLineItem>({
               </tfoot>
             )}
           </table>
-          <CheckoutButton action={checkoutAction} className="mt-10 w-full" disabled={isPending}>
+          <CheckoutButton action={checkoutAction} className="mt-10 w-full">
             {summary.ctaLabel}
             <ArrowRight size={20} strokeWidth={1} />
           </CheckoutButton>
@@ -357,7 +357,7 @@ function CheckoutButton({
 }: { action: Action<SubmissionResult | null, FormData> } & React.ComponentPropsWithoutRef<
   typeof Button
 >) {
-  const [lastResult, formAction, isPending] = useActionState(action, null);
+  const [lastResult, formAction] = useFormState(action, null);
 
   useEffect(() => {
     if (lastResult?.error) {
@@ -367,9 +367,15 @@ function CheckoutButton({
 
   return (
     <form action={formAction}>
-      <Button {...rest} loading={isPending} type="submit" />
+      <SubmitButton {...rest} />
     </form>
   );
+}
+
+function SubmitButton(props: React.ComponentPropsWithoutRef<typeof Button>) {
+  const { pending } = useFormStatus();
+
+  return <Button {...props} loading={pending} disabled={pending} type="submit" />;
 }
 
 export function CartEmptyState({ title, subtitle, cta }: CartEmptyState) {

--- a/core/vibes/soul/sections/forgot-password-section/forgot-password-form.tsx
+++ b/core/vibes/soul/sections/forgot-password-section/forgot-password-form.tsx
@@ -3,7 +3,7 @@
 import { getFormProps, getInputProps, SubmissionResult, useForm } from '@conform-to/react';
 import { getZodConstraint, parseWithZod } from '@conform-to/zod';
 import { useEffect } from 'react';
-import { useFormState as useActionState } from 'react-dom';
+import { useFormState, useFormStatus } from 'react-dom';
 
 import { Input } from '@/vibes/soul/form/input';
 import { Button } from '@/vibes/soul/primitives/button';
@@ -25,7 +25,7 @@ export function ForgotPasswordForm({
   emailLabel = 'Email',
   submitLabel = 'Reset password',
 }: Props) {
-  const [lastResult, formAction, isPending] = useActionState(action, null);
+  const [lastResult, formAction] = useFormState(action, null);
   const [form, fields] = useForm({
     constraint: getZodConstraint(schema),
     shouldValidate: 'onBlur',
@@ -47,9 +47,17 @@ export function ForgotPasswordForm({
         key={fields.email.id}
         label={emailLabel}
       />
-      <Button className="mt-auto w-full" loading={isPending} type="submit" variant="secondary">
-        {submitLabel}
-      </Button>
+      <SubmitButton>{submitLabel}</SubmitButton>
     </form>
+  );
+}
+
+function SubmitButton({ children }: { children: React.ReactNode }) {
+  const { pending } = useFormStatus();
+
+  return (
+    <Button className="mt-auto w-full" loading={pending} type="submit" variant="secondary">
+      {children}
+    </Button>
   );
 }

--- a/core/vibes/soul/sections/product-detail/product-detail-form.tsx
+++ b/core/vibes/soul/sections/product-detail/product-detail-form.tsx
@@ -11,7 +11,7 @@ import {
 import { getZodConstraint, parseWithZod } from '@conform-to/zod';
 import { parseAsString, useQueryState, useQueryStates } from 'nuqs';
 import { useCallback } from 'react';
-import { useFormState as useActionState } from 'react-dom';
+import { useFormState, useFormStatus } from 'react-dom';
 import { z } from 'zod';
 
 import { ButtonRadioGroup } from '@/vibes/soul/form/button-radio-group';
@@ -66,7 +66,7 @@ export function ProductDetailForm<F extends Field>({
     }),
     { quantity: 1 },
   );
-  const [{ lastResult }, formAction, isPending] = useActionState(action, {
+  const [{ lastResult }, formAction] = useFormState(action, {
     fields,
     lastResult: null,
   });
@@ -111,13 +111,21 @@ export function ProductDetailForm<F extends Field>({
               required
               value={quantityControl.value}
             />
-            <Button className="w-auto @xl:w-56" size="medium" type="submit" loading={isPending}>
-              {ctaLabel}
-            </Button>
+            <SubmitButton>{ctaLabel}</SubmitButton>
           </div>
         </div>
       </form>
     </FormProvider>
+  );
+}
+
+function SubmitButton({ children }: { children: React.ReactNode }) {
+  const { pending } = useFormStatus();
+
+  return (
+    <Button className="w-auto @xl:w-56" loading={pending} size="medium" type="submit">
+      {children}
+    </Button>
   );
 }
 

--- a/core/vibes/soul/sections/sign-in-section/sign-in-form.tsx
+++ b/core/vibes/soul/sections/sign-in-section/sign-in-form.tsx
@@ -3,7 +3,7 @@
 import { getFormProps, getInputProps, SubmissionResult, useForm } from '@conform-to/react';
 import { getZodConstraint, parseWithZod } from '@conform-to/zod';
 import { useEffect } from 'react';
-import { useFormState as useActionState } from 'react-dom';
+import { useFormState, useFormStatus } from 'react-dom';
 
 import { Input } from '@/vibes/soul/form/input';
 import { Button } from '@/vibes/soul/primitives/button';
@@ -27,7 +27,7 @@ export function SignInForm({
   passwordLabel = 'Password',
   submitLabel = 'Sign in',
 }: Props) {
-  const [lastResult, formAction, isPending] = useActionState(action, null);
+  const [lastResult, formAction] = useFormState(action, null);
   const [form, fields] = useForm({
     defaultValue: { email: '', password: '' },
     constraint: getZodConstraint(schema),
@@ -57,9 +57,17 @@ export function SignInForm({
         key={fields.password.id}
         label={passwordLabel}
       />
-      <Button className="mt-auto w-full" loading={isPending} type="submit" variant="secondary">
-        {submitLabel}
-      </Button>
+      <SubmitButton>{submitLabel}</SubmitButton>
     </form>
+  );
+}
+
+function SubmitButton({ children }: { children: React.ReactNode }) {
+  const { pending } = useFormStatus();
+
+  return (
+    <Button className="mt-auto w-full" loading={pending} type="submit" variant="secondary">
+      {children}
+    </Button>
   );
 }

--- a/core/vibes/soul/sections/sign-up-section/sign-up-form.tsx
+++ b/core/vibes/soul/sections/sign-up-section/sign-up-form.tsx
@@ -3,7 +3,7 @@
 import { getFormProps, getInputProps, SubmissionResult, useForm } from '@conform-to/react';
 import { getZodConstraint, parseWithZod } from '@conform-to/zod';
 import { useEffect } from 'react';
-import { useFormState as useActionState } from 'react-dom';
+import { useFormState, useFormStatus } from 'react-dom';
 
 import { Input } from '@/vibes/soul/form/input';
 import { Button } from '@/vibes/soul/primitives/button';
@@ -33,7 +33,7 @@ export function SignUpForm({
   confirmPasswordLabel = 'Confirm password',
   submitLabel = 'Sign up',
 }: Props) {
-  const [lastResult, formAction, isPending] = useActionState(action, null);
+  const [lastResult, formAction] = useFormState(action, null);
   const [form, fields] = useForm({
     constraint: getZodConstraint(schema),
     shouldValidate: 'onBlur',
@@ -84,9 +84,17 @@ export function SignUpForm({
         key={fields.confirmPassword.id}
         label={confirmPasswordLabel}
       />
-      <Button className="mt-auto w-full" loading={isPending} type="submit" variant="secondary">
-        {submitLabel}
-      </Button>
+      <SubmitButton>{submitLabel}</SubmitButton>
     </form>
+  );
+}
+
+function SubmitButton({ children }: { children: React.ReactNode }) {
+  const { pending } = useFormStatus();
+
+  return (
+    <Button className="mt-auto w-full" loading={pending} type="submit" variant="secondary">
+      {children}
+    </Button>
   );
 }


### PR DESCRIPTION
## What/Why?
VIBES uses `useActionState` for forms which is only supported in React 19 RC. In Catalyst we were using `useFormState` as a drop-in replacement for `useActionState`. Unfortunately, the third tuple item returned by `useActionState`, `isPending`, isn't returned by `useFormState`. This PR addresses that by using `useFormStatus` for the pending state.

## Testing
### Before

https://github.com/user-attachments/assets/7039aa59-ece6-4c0f-8361-d842735aebfa

### After

https://github.com/user-attachments/assets/f9a4cf64-de91-4c27-859a-952cecd224bb

