### PR TITLE
fix: mark bindings that use `swr` to fetch data with `use client`

### DIFF
--- a/core/makeswift/components/featured-products-carousel/featured-products-carousel.makeswift.tsx
+++ b/core/makeswift/components/featured-products-carousel/featured-products-carousel.makeswift.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import useSWR from 'swr';
 
 import { FeaturedProductsCarousel } from '@/vibes/soul/sections/featured-products-carousel';

--- a/core/makeswift/components/featured-products-list/featured-products-list.makeswift.tsx
+++ b/core/makeswift/components/featured-products-list/featured-products-list.makeswift.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import useSWR from 'swr';
 
 import { FeaturedProductsList } from '@/vibes/soul/sections/featured-products-list';

--- a/core/makeswift/components/product-card/product-card.makeswift.tsx
+++ b/core/makeswift/components/product-card/product-card.makeswift.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Checkbox, Combobox, Style } from '@makeswift/runtime/controls';
 import useSWR from 'swr';
 

--- a/core/makeswift/components/products-carousel/products-carousel.makeswift.tsx
+++ b/core/makeswift/components/products-carousel/products-carousel.makeswift.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
 import {
   Combobox,

--- a/core/makeswift/components/products-list/products-list.makeswift.tsx
+++ b/core/makeswift/components/products-list/products-list.makeswift.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
 import {
   Checkbox,


### PR DESCRIPTION
## What/Why?

Resolves `Attempted import error: 'swr' does not contain a default export (imported as 'useSWR')` runtime error,`useSWR` cannot be used on the server: https://github.com/vercel/swr/issues/2694
