### PR TITLE
Replace built-in image, hide body overflow-x, update labels, fix sticky layout

### DIFF
--- a/core/app/globals.css
+++ b/core/app/globals.css
@@ -30,3 +30,7 @@
   --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
   --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
 }
+
+body {
+  overflow-x: hidden;
+}

--- a/core/lib/makeswift/components.ts
+++ b/core/lib/makeswift/components.ts
@@ -13,6 +13,7 @@ import '~/makeswift/components/products-carousel/products-carousel.makeswift';
 import '~/makeswift/components/products-list/products-list.makeswift';
 // import '~/makeswift/components/inline-email-form/inline-email-form.makeswift';
 import '~/makeswift/components/icon/icon.makeswift';
+import '~/makeswift/components/image/image.makeswift';
 
 import '~/makeswift/components/slideshow/slideshow.makeswift';
 import '~/makeswift/components/featured-image/featured-image.makeswift';

--- a/core/makeswift/components/image/image.makeswift.tsx
+++ b/core/makeswift/components/image/image.makeswift.tsx
@@ -1,0 +1,76 @@
+import { MakeswiftComponentType } from '@makeswift/runtime';
+import {
+  Checkbox,
+  Image as ImageControl,
+  Link as LinkControl,
+  Style,
+  TextInput,
+} from '@makeswift/runtime/controls';
+import { ComponentPropsWithoutRef } from 'react';
+
+import { BcImage as Image } from '~/components/bc-image';
+import { Link } from '~/components/link';
+import { runtime } from '~/lib/makeswift/runtime';
+
+runtime.registerComponent(
+  function MSImage({
+    className,
+    image,
+    link,
+    ...rest
+  }: Omit<ComponentPropsWithoutRef<typeof Image>, 'src'> & {
+    image?: { url: string; dimensions: { width: number; height: number } };
+    link: { href: string; target?: string };
+  }) {
+    const imageElement = image ? (
+      <Image
+        {...rest}
+        className={className}
+        height={image.dimensions.height}
+        src={image.url}
+        width={image.dimensions.width}
+      />
+    ) : (
+      <Image
+        {...rest}
+        className={className}
+        height={240}
+        src="data:image/svg+xml,%3Csvg width='360' height='240' viewBox='0 0 360 240' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cg clip-path='url(%23clip0)'%3E%3Cpath d='M0 0H360V240H0V0Z' fill='%23A1A8C2' fill-opacity='0.18'/%3E%3Cpath d='M260 59C260 78.33 244.33 94 225 94C205.67 94 190 78.33 190 59C190 39.67 205.67 24 225 24C244.33 24 260 39.67 260 59Z' fill='%23A1A8C2' fill-opacity='0.25'/%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M319 250H417L291.485 124.485C286.799 119.799 279.201 119.799 274.515 124.485L234 165L319 250Z' fill='%23A1A8C2' fill-opacity='0.25'/%3E%3Cpath d='M311 250L-89 250L102.515 58.4853C107.201 53.799 114.799 53.799 119.485 58.4853L311 250Z' fill='%23A1A8C2' fill-opacity='0.25'/%3E%3C/g%3E%3Cdefs%3E%3CclipPath id='clip0'%3E%3Cpath d='M0 0H360V240H0V0Z' fill='white'/%3E%3C/clipPath%3E%3C/defs%3E%3C/svg%3E%0A"
+        width={360}
+      />
+    );
+
+    console.log({
+      link,
+    });
+
+    return link.href === '#' ? (
+      imageElement
+    ) : (
+      <Link className={className} href={link.href} target={link.target}>
+        {imageElement}
+      </Link>
+    );
+  },
+  {
+    type: MakeswiftComponentType.Image,
+    label: 'Image',
+    props: {
+      className: Style({
+        properties: [Style.Width, Style.Margin, Style.Border, Style.BorderRadius],
+      }),
+      image: ImageControl({
+        format: ImageControl.Format.WithDimensions,
+      }),
+      alt: TextInput({
+        label: 'Alt text',
+        defaultValue: 'A caption about your image',
+      }),
+      link: LinkControl(),
+      priority: Checkbox({
+        label: 'Priority',
+        defaultValue: true,
+      }),
+    },
+  },
+);

--- a/core/makeswift/components/products-carousel/products-carousel.makeswift.tsx
+++ b/core/makeswift/components/products-carousel/products-carousel.makeswift.tsx
@@ -148,7 +148,7 @@ runtime.registerComponent(
   },
   {
     type: 'primitive-products-carousel',
-    label: 'Primitives / Products Carousel',
+    label: 'Catalog / Products Carousel',
     icon: 'carousel',
     props: {
       className: Style(),

--- a/core/makeswift/components/products-list/products-list.makeswift.tsx
+++ b/core/makeswift/components/products-list/products-list.makeswift.tsx
@@ -147,7 +147,7 @@ runtime.registerComponent(
   },
   {
     type: 'primitive-products-list',
-    label: 'Primitives / Products List',
+    label: 'Catalog / Products List',
     icon: 'gallery',
     props: {
       className: Style(),

--- a/core/makeswift/components/sticky-sidebar-layout/sticky-sidebar-layout.makeswift.tsx
+++ b/core/makeswift/components/sticky-sidebar-layout/sticky-sidebar-layout.makeswift.tsx
@@ -23,8 +23,8 @@ runtime.registerComponent(StickySidebarLayout, {
     sidebarPosition: Select({
       label: 'Sidebar Position',
       options: [
-        { value: 'left', label: 'Left' },
-        { value: 'right', label: 'Right' },
+        { value: 'left', label: 'Before' },
+        { value: 'right', label: 'After' },
       ],
       defaultValue: 'left',
     }),

--- a/core/vibes/soul/primitives/price-label/index.tsx
+++ b/core/vibes/soul/primitives/price-label/index.tsx
@@ -36,7 +36,7 @@ export function PriceLabel({ className, price }: Props) {
       return (
         <span className={clsx('block font-semibold', className)}>
           <span className="font-normal text-contrast-400 line-through">{price.previousValue}</span>{' '}
-          <span className="text-error">{price.currentValue}</span>
+          <span className="text-accent">{price.currentValue}</span>
         </span>
       );
 

--- a/core/vibes/soul/sections/sticky-sidebar-layout/index.tsx
+++ b/core/vibes/soul/sections/sticky-sidebar-layout/index.tsx
@@ -19,7 +19,7 @@ export function StickySidebarLayout({
     <section className={clsx('@container', className)}>
       <div
         className={clsx(
-          'mx-auto flex flex-col items-stretch gap-x-16 gap-y-10 px-4 py-10 @xl:px-6 @xl:py-14 @4xl:flex-row @4xl:px-8 @4xl:py-20',
+          'mx-auto flex flex-col items-stretch px-4 py-10 @xl:px-6 @xl:py-14 @4xl:flex-row @4xl:px-8 @4xl:py-20',
           {
             lg: 'max-w-screen-lg',
             xl: 'max-w-screen-xl',
@@ -30,7 +30,7 @@ export function StickySidebarLayout({
         <div
           className={clsx(
             'shrink-0',
-            sidebarPosition === 'right' ? 'order-2' : 'order-1',
+            sidebarPosition === 'right' ? 'order-2 pt-5 @4xl:pl-8' : 'order-1 pb-5 @4xl:pr-8',
             {
               '1/3': '@4xl:w-1/3',
               '1/2': '@4xl:w-1/2',
@@ -45,7 +45,8 @@ export function StickySidebarLayout({
         </div>
         <div
           className={clsx(
-            sidebarPosition === 'right' ? 'order-1' : 'order-2',
+            'flex-1',
+            sidebarPosition === 'right' ? 'order-1 pb-5 @4xl:pr-8' : 'order-2 pt-5 @4xl:pl-8',
             {
               '1/3': '@4xl:w-2/3',
               '1/2': '@4xl:w-1/2',


### PR DESCRIPTION
- Replaced built-in Makeswift image with `BcImage`.
- Added `overflow-x: hidden` to body.
- Replaced `gap` with `padding` in the `StickyLayout` component. Gap seems to affect the `max-width` calculation of child elements. Further investigation is required, but using padding fixes the overflow issues.
- Put all Makeswift components that fetch from the product catalog under the `Catalog` label group.