### PR TITLE
fix: remove makeswift featured image section

### DIFF
--- a/core/lib/makeswift/components.ts
+++ b/core/lib/makeswift/components.ts
@@ -14,9 +14,8 @@ import '~/makeswift/components/products-list/products-list.makeswift';
 // import '~/makeswift/components/inline-email-form/inline-email-form.makeswift';
 import '~/makeswift/components/icon/icon.makeswift';
 import '~/makeswift/components/image/image.makeswift';
-
 import '~/makeswift/components/slideshow/slideshow.makeswift';
-import '~/makeswift/components/featured-image/featured-image.makeswift';
+// import '~/makeswift/components/featured-image/featured-image.makeswift';
 import '~/makeswift/components/sticky-sidebar-layout/sticky-sidebar-layout.makeswift';
 import '~/makeswift/components/section-layout/section-layout.makeswift';
 import '~/makeswift/components/css-theme/register';


### PR DESCRIPTION
Removing the FeaturedImageSection registration because we want all of those sections to be built visually in Makeswift.