### PR TITLE
fix: PDP 404

### DIFF
--- a/core/middlewares/with-routes.ts
+++ b/core/middlewares/with-routes.ts
@@ -315,11 +315,12 @@ export const withRoutes: MiddlewareFactory = () => {
         break;
       }
 
-      // Disable static caching on the product page because the page is editable with Makeswift
-      // case 'Product': {
-      //   url = `/${locale}/product/${node.entityId}${postfix}`;
-      //   break;
-      // }
+      case 'Product': {
+        // Disable static caching on the product page because the page is editable with Makeswift
+        // url = `/${locale}/product/${node.entityId}${postfix}`;
+        url = `/${locale}/product/${node.entityId}`;
+        break;
+      }
 
       case 'NormalPage': {
         url = `/${locale}/webpages/normal/${node.id}`;


### PR DESCRIPTION
## What/Why?
This error was introduced when we tried to fix a stale issue when publishing changes. Instead of just removing the `postfix`, we commented out the whole block that handles PDP.

## Testing
Run locally, go to PDP.

<img width="1583" alt="image" src="https://github.com/user-attachments/assets/e64d59a7-faeb-4a54-bc08-14c162097e5b">
