### PR TITLE
Add Makeswift plugin into Next.js config

### DIFF
--- a/core/next.config.ts
+++ b/core/next.config.ts
@@ -1,5 +1,6 @@
 import bundleAnalyzer from '@next/bundle-analyzer';
 import type { NextConfig } from 'next';
+import createWithMakeswift from '@makeswift/runtime/next/plugin';
 import createNextIntlPlugin from 'next-intl/plugin';
 import { optimize } from 'webpack';
 
@@ -8,6 +9,7 @@ import { client } from './client';
 import { graphql } from './client/graphql';
 import { cspHeader } from './lib/content-security-policy';
 
+const withMakeswift = createWithMakeswift({ previewMode: false });
 const withNextIntl = createNextIntlPlugin();
 
 const LocaleQuery = graphql(`
@@ -78,6 +80,9 @@ export default async (): Promise<NextConfig> => {
 
   // Apply withNextIntl to the config
   nextConfig = withNextIntl(nextConfig);
+
+  // Apply withMakeswift to the config
+  nextConfig = withMakeswift(nextConfig);
 
   if (process.env.ANALYZE === 'true') {
     const withBundleAnalyzer = bundleAnalyzer();


### PR DESCRIPTION
## What/Why?
Re-add required Makeswift plugin into the next.config.ts configuration, to avoid errors with disallowed image hosts for Makeswift-provided images.

