### PR TITLE
fix: run root lint task with env

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "dev": "dotenv -e .env.local -- turbo run dev",
     "build": "dotenv -e .env.local -- turbo run build",
-    "lint": "turbo lint",
+    "lint": "dotenv -e .env.local -- turbo lint",
     "typecheck": "turbo typecheck"
   },
   "devDependencies": {


### PR DESCRIPTION
## What/Why?
Some users get the following error when trying to run `pnpm run lint`:
```
/Users/user.name/catalyst/packages/client/dist/index.js:153
      throw new Error("Client configuration must include a channelId.");
            ^

Error: Client configuration must include a channelId.
    at new Client (/Users/user.name/catalyst/packages/client/dist/index.js:153:13)
    ...
```

This PR adds `env` awareness to tasks run from root which should fix the issue

## Testing
Locally