### PR TITLE
chore(core): use next canary and enable ppr

### DIFF
--- a/core/app/[locale]/(default)/account/(tabs)/addresses/_actions/delete-address.ts
+++ b/core/app/[locale]/(default)/account/(tabs)/addresses/_actions/delete-address.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { revalidatePath } from 'next/cache';
+import { expirePath } from 'next/cache';
 import { getTranslations } from 'next-intl/server';
 
 import { getSessionCustomerAccessToken } from '~/auth';
@@ -50,7 +50,7 @@ export const deleteAddress = async (addressId: number): Promise<State> => {
 
     const result = response.data.customer.deleteCustomerAddress;
 
-    revalidatePath('/account/addresses', 'page');
+    expirePath('/account/addresses', 'page');
 
     if (result.errors.length === 0) {
       return { status: 'success', message: t('success') };

--- a/core/app/[locale]/(default)/account/(tabs)/addresses/add/_actions/add-address.ts
+++ b/core/app/[locale]/(default)/account/(tabs)/addresses/add/_actions/add-address.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { revalidatePath } from 'next/cache';
+import { expirePath } from 'next/cache';
 import { getTranslations } from 'next-intl/server';
 
 import { getSessionCustomerAccessToken } from '~/auth';
@@ -80,7 +80,7 @@ export const addAddress = async ({
 
     const result = response.data.customer.addCustomerAddress;
 
-    revalidatePath('/account/addresses', 'page');
+    expirePath('/account/addresses', 'page');
 
     if (result.errors.length === 0) {
       return { status: 'success', message: t('success') };

--- a/core/app/[locale]/(default)/account/(tabs)/addresses/edit/[slug]/_actions/update-address.ts
+++ b/core/app/[locale]/(default)/account/(tabs)/addresses/edit/[slug]/_actions/update-address.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { revalidatePath } from 'next/cache';
+import { expirePath } from 'next/cache';
 import { getTranslations } from 'next-intl/server';
 
 import { getSessionCustomerAccessToken } from '~/auth';
@@ -88,7 +88,7 @@ export const updateAddress = async ({
 
     const result = response.data.customer.updateCustomerAddress;
 
-    revalidatePath('/account/addresses', 'page');
+    expirePath('/account/addresses', 'page');
 
     if (result.errors.length === 0) {
       return { status: 'success', message: t('success') };

--- a/core/app/[locale]/(default)/account/(tabs)/settings/_actions/update-customer.ts
+++ b/core/app/[locale]/(default)/account/(tabs)/settings/_actions/update-customer.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { revalidatePath } from 'next/cache';
+import { expirePath } from 'next/cache';
 import { getTranslations } from 'next-intl/server';
 
 import { getSessionCustomerAccessToken } from '~/auth';
@@ -88,7 +88,7 @@ export const updateCustomer = async ({ formData, reCaptchaToken }: UpdateCustome
     },
   });
 
-  revalidatePath('/account/settings', 'page');
+  expirePath('/account/settings', 'page');
 
   const result = response.data.customer.updateCustomer;
 

--- a/core/app/[locale]/(default)/cart/_actions/remove-item.ts
+++ b/core/app/[locale]/(default)/cart/_actions/remove-item.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { revalidateTag } from 'next/cache';
+import { expireTag } from 'next/cache';
 import { cookies } from 'next/headers';
 
 import { getSessionCustomerAccessToken } from '~/auth';
@@ -61,7 +61,7 @@ export async function removeItem({
       cookieStore.delete('cartId');
     }
 
-    revalidateTag(TAGS.cart);
+    expireTag(TAGS.cart);
 
     return { status: 'success', data: cart };
   } catch (error: unknown) {

--- a/core/app/[locale]/(default)/cart/_components/coupon-code/apply-coupon-code.ts
+++ b/core/app/[locale]/(default)/cart/_components/coupon-code/apply-coupon-code.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { revalidateTag } from 'next/cache';
+import { expireTag } from 'next/cache';
 import { z } from 'zod';
 
 import { getSessionCustomerAccessToken } from '~/auth';
@@ -54,7 +54,7 @@ export const applyCouponCode = async (formData: FormData) => {
       return { status: 'error', error: 'Coupon code is invalid.' };
     }
 
-    revalidateTag(TAGS.checkout);
+    expireTag(TAGS.checkout);
 
     return { status: 'success', data: checkout };
   } catch (error: unknown) {

--- a/core/app/[locale]/(default)/cart/_components/coupon-code/remove-coupon-code.ts
+++ b/core/app/[locale]/(default)/cart/_components/coupon-code/remove-coupon-code.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { revalidateTag } from 'next/cache';
+import { expireTag } from 'next/cache';
 import { z } from 'zod';
 
 import { getSessionCustomerAccessToken } from '~/auth';
@@ -54,7 +54,7 @@ export const removeCouponCode = async (formData: FormData) => {
       return { status: 'error', error: 'Error ocurred removing coupon.' };
     }
 
-    revalidateTag(TAGS.checkout);
+    expireTag(TAGS.checkout);
 
     return { status: 'success', data: checkout };
   } catch (error: unknown) {

--- a/core/app/[locale]/(default)/cart/_components/item-quantity/update-item-quantity.ts
+++ b/core/app/[locale]/(default)/cart/_components/item-quantity/update-item-quantity.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { revalidatePath } from 'next/cache';
+import { expirePath } from 'next/cache';
 import { cookies } from 'next/headers';
 
 import { getSessionCustomerAccessToken } from '~/auth';
@@ -83,7 +83,7 @@ export async function updateItemQuantity({
       return { status: 'error', error: 'Failed to change product quantity in Cart' };
     }
 
-    revalidatePath('/cart');
+    expirePath('/cart');
 
     return { status: 'success', data: cart };
   } catch (error: unknown) {

--- a/core/app/[locale]/(default)/cart/_components/shipping-info/submit-shipping-info.ts
+++ b/core/app/[locale]/(default)/cart/_components/shipping-info/submit-shipping-info.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { revalidateTag } from 'next/cache';
+import { expireTag } from 'next/cache';
 import { z } from 'zod';
 
 import { getSessionCustomerAccessToken } from '~/auth';
@@ -119,7 +119,7 @@ export const submitShippingInfo = async (
       return { status: 'error', error: 'Failed to submit shipping info.' };
     }
 
-    revalidateTag(TAGS.checkout);
+    expireTag(TAGS.checkout);
 
     return { status: 'success', data: result };
   } catch (error: unknown) {

--- a/core/app/[locale]/(default)/cart/_components/shipping-options/submit-shipping-costs.ts
+++ b/core/app/[locale]/(default)/cart/_components/shipping-options/submit-shipping-costs.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { revalidateTag } from 'next/cache';
+import { expireTag } from 'next/cache';
 import { z } from 'zod';
 
 import { getSessionCustomerAccessToken } from '~/auth';
@@ -57,7 +57,7 @@ export const submitShippingCosts = async (
       return { status: 'error', error: 'Failed to submit shipping cost.' };
     }
 
-    revalidateTag(TAGS.checkout);
+    expireTag(TAGS.checkout);
 
     return { status: 'success', data: shippingCost };
   } catch (error: unknown) {

--- a/core/app/[locale]/(default)/compare/_actions/add-to-cart.ts
+++ b/core/app/[locale]/(default)/compare/_actions/add-to-cart.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { revalidateTag } from 'next/cache';
+import { expireTag } from 'next/cache';
 import { cookies } from 'next/headers';
 
 import { addCartLineItem } from '~/client/mutations/add-cart-line-item';
@@ -33,7 +33,7 @@ export const addToCart = async (data: FormData) => {
         return { status: 'error', error: 'Failed to add product to cart.' };
       }
 
-      revalidateTag(TAGS.cart);
+      expireTag(TAGS.cart);
 
       return { status: 'success', data: cart };
     }
@@ -53,7 +53,7 @@ export const addToCart = async (data: FormData) => {
       path: '/',
     });
 
-    revalidateTag(TAGS.cart);
+    expireTag(TAGS.cart);
 
     return { status: 'success', data: cart };
   } catch (error: unknown) {

--- a/core/app/[locale]/(default)/layout.tsx
+++ b/core/app/[locale]/(default)/layout.tsx
@@ -30,3 +30,5 @@ export default async function DefaultLayout({ params, children }: Props) {
     </>
   );
 }
+
+export const experimental_ppr = true;

--- a/core/app/[locale]/(default)/product/[slug]/_components/product-form/_actions/add-to-cart.ts
+++ b/core/app/[locale]/(default)/product/[slug]/_components/product-form/_actions/add-to-cart.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
-import { revalidateTag } from 'next/cache';
+import { expireTag } from 'next/cache';
 import { cookies } from 'next/headers';
 
 import { FragmentOf, graphql } from '~/client/graphql';
@@ -152,7 +152,7 @@ export async function handleAddToCart(
         return { status: 'error', error: 'Failed to add product to cart.' };
       }
 
-      revalidateTag(TAGS.cart);
+      expireTag(TAGS.cart);
 
       return { status: 'success', data: cart };
     }
@@ -179,7 +179,7 @@ export async function handleAddToCart(
       path: '/',
     });
 
-    revalidateTag(TAGS.cart);
+    expireTag(TAGS.cart);
 
     return { status: 'success', data: cart };
   } catch (error: unknown) {

--- a/core/components/product-card/add-to-cart/form/_actions/add-to-cart.ts
+++ b/core/components/product-card/add-to-cart/form/_actions/add-to-cart.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { revalidateTag } from 'next/cache';
+import { expireTag } from 'next/cache';
 import { cookies } from 'next/headers';
 
 import { addCartLineItem } from '~/client/mutations/add-cart-line-item';
@@ -32,7 +32,7 @@ export const addToCart = async (data: FormData) => {
         return { status: 'error', error: 'Failed to add product to cart.' };
       }
 
-      revalidateTag(TAGS.cart);
+      expireTag(TAGS.cart);
 
       return { status: 'success', data: cart };
     }
@@ -52,7 +52,7 @@ export const addToCart = async (data: FormData) => {
       path: '/',
     });
 
-    revalidateTag(TAGS.cart);
+    expireTag(TAGS.cart);
 
     return { status: 'success', data: cart };
   } catch (error: unknown) {

--- a/core/next.config.ts
+++ b/core/next.config.ts
@@ -28,6 +28,7 @@ export default async (): Promise<NextConfig> => {
     reactStrictMode: true,
     experimental: {
       optimizePackageImports: ['@icons-pack/react-simple-icons'],
+      ppr: 'incremental',
     },
     typescript: {
       ignoreBuildErrors: !!process.env.CI,

--- a/core/package.json
+++ b/core/package.json
@@ -42,7 +42,7 @@
     "lodash.debounce": "^4.0.8",
     "lru-cache": "^11.0.2",
     "lucide-react": "^0.456.0",
-    "next": "15.0.3",
+    "next": "15.0.4-canary.18",
     "next-auth": "5.0.0-beta.25",
     "next-intl": "^3.25.1",
     "react": "19.0.0-rc-5c56b873-20241107",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,13 +80,13 @@ importers:
         version: 1.34.3
       '@vercel/analytics':
         specifier: ^1.4.0
-        version: 1.4.0(next@15.0.3(@playwright/test@1.48.2)(react-dom@19.0.0-rc-5c56b873-20241107(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107)(svelte@5.1.15)
+        version: 1.4.0(next@15.0.4-canary.18(@playwright/test@1.48.2)(react-dom@19.0.0-rc-5c56b873-20241107(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107)(svelte@5.1.15)
       '@vercel/kv':
         specifier: ^3.0.0
         version: 3.0.0
       '@vercel/speed-insights':
         specifier: ^1.1.0
-        version: 1.1.0(next@15.0.3(@playwright/test@1.48.2)(react-dom@19.0.0-rc-5c56b873-20241107(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107)(svelte@5.1.15)
+        version: 1.1.0(next@15.0.4-canary.18(@playwright/test@1.48.2)(react-dom@19.0.0-rc-5c56b873-20241107(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107)(svelte@5.1.15)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
@@ -118,14 +118,14 @@ importers:
         specifier: ^0.456.0
         version: 0.456.0(react@19.0.0-rc-5c56b873-20241107)
       next:
-        specifier: 15.0.3
-        version: 15.0.3(@playwright/test@1.48.2)(react-dom@19.0.0-rc-5c56b873-20241107(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107)
+        specifier: 15.0.4-canary.18
+        version: 15.0.4-canary.18(@playwright/test@1.48.2)(react-dom@19.0.0-rc-5c56b873-20241107(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107)
       next-auth:
         specifier: 5.0.0-beta.25
-        version: 5.0.0-beta.25(next@15.0.3(@playwright/test@1.48.2)(react-dom@19.0.0-rc-5c56b873-20241107(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107))(nodemailer@6.9.16)(react@19.0.0-rc-5c56b873-20241107)
+        version: 5.0.0-beta.25(next@15.0.4-canary.18(@playwright/test@1.48.2)(react-dom@19.0.0-rc-5c56b873-20241107(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107))(nodemailer@6.9.16)(react@19.0.0-rc-5c56b873-20241107)
       next-intl:
         specifier: ^3.25.1
-        version: 3.25.1(next@15.0.3(@playwright/test@1.48.2)(react-dom@19.0.0-rc-5c56b873-20241107(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107)
+        version: 3.25.1(next@15.0.4-canary.18(@playwright/test@1.48.2)(react-dom@19.0.0-rc-5c56b873-20241107(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107)
       react:
         specifier: 19.0.0-rc-5c56b873-20241107
         version: 19.0.0-rc-5c56b873-20241107
@@ -1276,56 +1276,56 @@ packages:
   '@next/bundle-analyzer@15.0.3':
     resolution: {integrity: sha512-x7ZNvpoQPO0C5ZG//qVp21Qs3v6+C8LBJmdu9DKj4/NmjlnwoQ7dqRZ/nKZcwVhkFT7BHf+Qd5FaeHq9IDJvDQ==}
 
-  '@next/env@15.0.3':
-    resolution: {integrity: sha512-t9Xy32pjNOvVn2AS+Utt6VmyrshbpfUMhIjFO60gI58deSo/KgLOp31XZ4O+kY/Is8WAGYwA5gR7kOb1eORDBA==}
+  '@next/env@15.0.4-canary.18':
+    resolution: {integrity: sha512-iMvlOu17qnXruB7jBg9L7PD1ohRcsDtfOQu1cOV6I9+fkerAzQOSRz4otKB9z+M1C4JROKw8YQXxd10sfORvQQ==}
 
   '@next/eslint-plugin-next@15.0.3':
     resolution: {integrity: sha512-3Ln/nHq2V+v8uIaxCR6YfYo7ceRgZNXfTd3yW1ukTaFbO+/I8jNakrjYWODvG9BuR2v5kgVtH/C8r0i11quOgw==}
 
-  '@next/swc-darwin-arm64@15.0.3':
-    resolution: {integrity: sha512-s3Q/NOorCsLYdCKvQlWU+a+GeAd3C8Rb3L1YnetsgwXzhc3UTWrtQpB/3eCjFOdGUj5QmXfRak12uocd1ZiiQw==}
+  '@next/swc-darwin-arm64@15.0.4-canary.18':
+    resolution: {integrity: sha512-UkVlc57+Avzln6a/JHvpDaHUd67xrZyH+FtoJpRTtAhfnsAiqXEKvklMarfRhI3H/3ZzVWS/kvHmMRNEmREC0w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.0.3':
-    resolution: {integrity: sha512-Zxl/TwyXVZPCFSf0u2BNj5sE0F2uR6iSKxWpq4Wlk/Sv9Ob6YCKByQTkV2y6BCic+fkabp9190hyrDdPA/dNrw==}
+  '@next/swc-darwin-x64@15.0.4-canary.18':
+    resolution: {integrity: sha512-gFtNOZyBJ+VJzH99o1X5iySBp5OBhBvn7hmwm3glpexI+WdHjsu3gqeX0W01EFAJHfkZryF3eLQ9WzDykafNZg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@15.0.3':
-    resolution: {integrity: sha512-T5+gg2EwpsY3OoaLxUIofmMb7ohAUlcNZW0fPQ6YAutaWJaxt1Z1h+8zdl4FRIOr5ABAAhXtBcpkZNwUcKI2fw==}
+  '@next/swc-linux-arm64-gnu@15.0.4-canary.18':
+    resolution: {integrity: sha512-eD0z3mEqQcgb3swew+DaH1qTRALApwI7JShXRbs4pQoIw5NC3iFCqat/EnNdnuGnHz6m/B+pMOGlGzJDAKF+yw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@15.0.3':
-    resolution: {integrity: sha512-WkAk6R60mwDjH4lG/JBpb2xHl2/0Vj0ZRu1TIzWuOYfQ9tt9NFsIinI1Epma77JVgy81F32X/AeD+B2cBu/YQA==}
+  '@next/swc-linux-arm64-musl@15.0.4-canary.18':
+    resolution: {integrity: sha512-/Monhk57eg4pwUGjhVdzaWBjn98xgLZ2UzbCJgz+/V1bEbQ2cdsiAY2396vDJN6xL6QC1T44jQWnnRmxDoIwCg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@15.0.3':
-    resolution: {integrity: sha512-gWL/Cta1aPVqIGgDb6nxkqy06DkwJ9gAnKORdHWX1QBbSZZB+biFYPFti8aKIQL7otCE1pjyPaXpFzGeG2OS2w==}
+  '@next/swc-linux-x64-gnu@15.0.4-canary.18':
+    resolution: {integrity: sha512-C2MeKImORC9hta3Mu3EN/BoCP5b8LhqlqibH0d7/fIGl0kwGEWFtY6GNkLfkjheznbyi+IrTC0whw0IuP1zq2w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@15.0.3':
-    resolution: {integrity: sha512-QQEMwFd8r7C0GxQS62Zcdy6GKx999I/rTO2ubdXEe+MlZk9ZiinsrjwoiBL5/57tfyjikgh6GOU2WRQVUej3UA==}
+  '@next/swc-linux-x64-musl@15.0.4-canary.18':
+    resolution: {integrity: sha512-u8aVGeYbVqAXiW5HhFnoxjTA4hBedId8ySxiMuPZkwLZSunKN4k7UVL1CuU6WLhw4pKN4A5awtVO2polQJBkhQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@15.0.3':
-    resolution: {integrity: sha512-9TEp47AAd/ms9fPNgtgnT7F3M1Hf7koIYYWCMQ9neOwjbVWJsHZxrFbI3iEDJ8rf1TDGpmHbKxXf2IFpAvheIQ==}
+  '@next/swc-win32-arm64-msvc@15.0.4-canary.18':
+    resolution: {integrity: sha512-rdwne0Bmw/6Lxug6XlsyMCeM+rF2aN5SM1mcanQAjCFL/UWCOtzf4aXt6DDu5cKKNik6jtWJ/9KzcvM3aYytDQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.0.3':
-    resolution: {integrity: sha512-VNAz+HN4OGgvZs6MOoVfnn41kBzT+M+tB+OK4cww6DNyWS6wKaDpaAm/qLeOUbnMh0oVx1+mg0uoYARF69dJyA==}
+  '@next/swc-win32-x64-msvc@15.0.4-canary.18':
+    resolution: {integrity: sha512-8bvtOx955ulXPtYJ55rsyLdaDJUQdRwTOU+vnbbixRe/ski2vxM2j9Qbv9aVSBaxUCSBSbIxH2I7s+JmBRyhHA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -4335,16 +4335,16 @@ packages:
       next: ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0
 
-  next@15.0.3:
-    resolution: {integrity: sha512-ontCbCRKJUIoivAdGB34yCaOcPgYXr9AAkV/IwqFfWWTXEPUgLYkSkqBhIk9KK7gGmgjc64B+RdoeIDM13Irnw==}
+  next@15.0.4-canary.18:
+    resolution: {integrity: sha512-nsEmZn47CSIRPMzZxwT4U8oDZppSgxnW2vfLRnZC1F1ZyLOxiBdmqA/25w5aQ5nkBLpjAbOLMpPOq9TKgQpjyA==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
       '@playwright/test': ^1.41.2
       babel-plugin-react-compiler: '*'
-      react: ^18.2.0 || 19.0.0-rc-66855b96-20241106
-      react-dom: ^18.2.0 || 19.0.0-rc-66855b96-20241106
+      react: ^18.2.0 || 19.0.0-rc-380f5d67-20241113
+      react-dom: ^18.2.0 || 19.0.0-rc-380f5d67-20241113
       sass: ^1.3.0
     peerDependenciesMeta:
       '@opentelemetry/api':
@@ -6765,34 +6765,34 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@next/env@15.0.3': {}
+  '@next/env@15.0.4-canary.18': {}
 
   '@next/eslint-plugin-next@15.0.3':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@15.0.3':
+  '@next/swc-darwin-arm64@15.0.4-canary.18':
     optional: true
 
-  '@next/swc-darwin-x64@15.0.3':
+  '@next/swc-darwin-x64@15.0.4-canary.18':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.0.3':
+  '@next/swc-linux-arm64-gnu@15.0.4-canary.18':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.0.3':
+  '@next/swc-linux-arm64-musl@15.0.4-canary.18':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.0.3':
+  '@next/swc-linux-x64-gnu@15.0.4-canary.18':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.0.3':
+  '@next/swc-linux-x64-musl@15.0.4-canary.18':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.0.3':
+  '@next/swc-win32-arm64-msvc@15.0.4-canary.18':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.0.3':
+  '@next/swc-win32-x64-msvc@15.0.4-canary.18':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -7757,9 +7757,9 @@ snapshots:
     dependencies:
       crypto-js: 4.2.0
 
-  '@vercel/analytics@1.4.0(next@15.0.3(@playwright/test@1.48.2)(react-dom@19.0.0-rc-5c56b873-20241107(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107)(svelte@5.1.15)':
+  '@vercel/analytics@1.4.0(next@15.0.4-canary.18(@playwright/test@1.48.2)(react-dom@19.0.0-rc-5c56b873-20241107(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107)(svelte@5.1.15)':
     optionalDependencies:
-      next: 15.0.3(@playwright/test@1.48.2)(react-dom@19.0.0-rc-5c56b873-20241107(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107)
+      next: 15.0.4-canary.18(@playwright/test@1.48.2)(react-dom@19.0.0-rc-5c56b873-20241107(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107)
       react: 19.0.0-rc-5c56b873-20241107
       svelte: 5.1.15
 
@@ -7767,9 +7767,9 @@ snapshots:
     dependencies:
       '@upstash/redis': 1.34.3
 
-  '@vercel/speed-insights@1.1.0(next@15.0.3(@playwright/test@1.48.2)(react-dom@19.0.0-rc-5c56b873-20241107(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107)(svelte@5.1.15)':
+  '@vercel/speed-insights@1.1.0(next@15.0.4-canary.18(@playwright/test@1.48.2)(react-dom@19.0.0-rc-5c56b873-20241107(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107)(svelte@5.1.15)':
     optionalDependencies:
-      next: 15.0.3(@playwright/test@1.48.2)(react-dom@19.0.0-rc-5c56b873-20241107(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107)
+      next: 15.0.4-canary.18(@playwright/test@1.48.2)(react-dom@19.0.0-rc-5c56b873-20241107(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107)
       react: 19.0.0-rc-5c56b873-20241107
       svelte: 5.1.15
 
@@ -10246,42 +10246,42 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next-auth@5.0.0-beta.25(next@15.0.3(@playwright/test@1.48.2)(react-dom@19.0.0-rc-5c56b873-20241107(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107))(nodemailer@6.9.16)(react@19.0.0-rc-5c56b873-20241107):
+  next-auth@5.0.0-beta.25(next@15.0.4-canary.18(@playwright/test@1.48.2)(react-dom@19.0.0-rc-5c56b873-20241107(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107))(nodemailer@6.9.16)(react@19.0.0-rc-5c56b873-20241107):
     dependencies:
       '@auth/core': 0.37.2(nodemailer@6.9.16)
-      next: 15.0.3(@playwright/test@1.48.2)(react-dom@19.0.0-rc-5c56b873-20241107(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107)
+      next: 15.0.4-canary.18(@playwright/test@1.48.2)(react-dom@19.0.0-rc-5c56b873-20241107(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107)
       react: 19.0.0-rc-5c56b873-20241107
     optionalDependencies:
       nodemailer: 6.9.16
 
-  next-intl@3.25.1(next@15.0.3(@playwright/test@1.48.2)(react-dom@19.0.0-rc-5c56b873-20241107(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107):
+  next-intl@3.25.1(next@15.0.4-canary.18(@playwright/test@1.48.2)(react-dom@19.0.0-rc-5c56b873-20241107(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107):
     dependencies:
       '@formatjs/intl-localematcher': 0.5.7
       negotiator: 1.0.0
-      next: 15.0.3(@playwright/test@1.48.2)(react-dom@19.0.0-rc-5c56b873-20241107(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107)
+      next: 15.0.4-canary.18(@playwright/test@1.48.2)(react-dom@19.0.0-rc-5c56b873-20241107(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107)
       react: 19.0.0-rc-5c56b873-20241107
       use-intl: 3.25.1(react@19.0.0-rc-5c56b873-20241107)
 
-  next@15.0.3(@playwright/test@1.48.2)(react-dom@19.0.0-rc-5c56b873-20241107(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107):
+  next@15.0.4-canary.18(@playwright/test@1.48.2)(react-dom@19.0.0-rc-5c56b873-20241107(react@19.0.0-rc-5c56b873-20241107))(react@19.0.0-rc-5c56b873-20241107):
     dependencies:
-      '@next/env': 15.0.3
+      '@next/env': 15.0.4-canary.18
       '@swc/counter': 0.1.3
       '@swc/helpers': 0.5.13
       busboy: 1.6.0
-      caniuse-lite: 1.0.30001649
+      caniuse-lite: 1.0.30001680
       postcss: 8.4.31
       react: 19.0.0-rc-5c56b873-20241107
       react-dom: 19.0.0-rc-5c56b873-20241107(react@19.0.0-rc-5c56b873-20241107)
       styled-jsx: 5.1.6(react@19.0.0-rc-5c56b873-20241107)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.0.3
-      '@next/swc-darwin-x64': 15.0.3
-      '@next/swc-linux-arm64-gnu': 15.0.3
-      '@next/swc-linux-arm64-musl': 15.0.3
-      '@next/swc-linux-x64-gnu': 15.0.3
-      '@next/swc-linux-x64-musl': 15.0.3
-      '@next/swc-win32-arm64-msvc': 15.0.3
-      '@next/swc-win32-x64-msvc': 15.0.3
+      '@next/swc-darwin-arm64': 15.0.4-canary.18
+      '@next/swc-darwin-x64': 15.0.4-canary.18
+      '@next/swc-linux-arm64-gnu': 15.0.4-canary.18
+      '@next/swc-linux-arm64-musl': 15.0.4-canary.18
+      '@next/swc-linux-x64-gnu': 15.0.4-canary.18
+      '@next/swc-linux-x64-musl': 15.0.4-canary.18
+      '@next/swc-win32-arm64-msvc': 15.0.4-canary.18
+      '@next/swc-win32-x64-msvc': 15.0.4-canary.18
       '@playwright/test': 1.48.2
       sharp: 0.33.5
     transitivePeerDependencies:


### PR DESCRIPTION
## What/Why?
+ Bumps next to canary
+ Enables PPR
+ Use new `expirePath`/`expireTag` functions.

We will need PPR in Header to properly render cart count.

## Testing
Locally PPR is enabled in static sites.