### PR TITLE
Option to provide non translated strings in a fallback locale

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,8 @@ TURBO_REMOTE_CACHE_SIGNATURE_KEY=
 # https://nextjs.org/docs/app/building-your-application/caching#data-cache
 # This sets a sensible revalidation target for cached requests
 DEFAULT_REVALIDATE_TARGET=3600
+
+# Default locale fallback to use when a string is not found in the current locale.
+# This should be a valid locale code, such as `en` or `it`.
+# If not set, the default locale is `en`.
+LOCALE_FALLBACK=

--- a/core/i18n/request.ts
+++ b/core/i18n/request.ts
@@ -1,7 +1,9 @@
 import { notFound } from 'next/navigation';
 import { getRequestConfig } from 'next-intl/server';
 
-import { locales } from './routing';
+import { fallbackLocale, locales } from './routing';
+
+import deepmerge from 'deepmerge';
 
 export default getRequestConfig(async ({ requestLocale }) => {
   const locale = await requestLocale;
@@ -11,7 +13,12 @@ export default getRequestConfig(async ({ requestLocale }) => {
   }
 
   return {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-    messages: (await import(`../messages/${locale}.json`)).default,
+    locale,
+    messages: deepmerge(
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-member-access
+      (await import(`../messages/${fallbackLocale}.json`)).default,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-member-access
+      (await import(`../messages/${locale}.json`)).default,
+    ),
   };
 });

--- a/core/i18n/routing.ts
+++ b/core/i18n/routing.ts
@@ -7,6 +7,7 @@ const localeNodes = buildConfig.get('locales');
 
 export const locales = localeNodes.map((locale) => locale.code);
 export const defaultLocale = localeNodes.find((locale) => locale.isDefault)?.code ?? 'en';
+export const fallbackLocale = process.env.LOCALE_FALLBACK ?? 'en';
 
 interface LocaleEntry {
   id: string;

--- a/core/package.json
+++ b/core/package.json
@@ -35,6 +35,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "content-security-policy-builder": "^2.2.0",
+    "deepmerge": "^4.3.1",
     "embla-carousel-react": "8.3.1",
     "focus-trap-react": "^10.3.1",
     "gql.tada": "^1.8.10",


### PR DESCRIPTION
## What/Why?
If a new string is added, the translation must be available in any language. If not, the dotted path notation will be displayed in its place. I introduced the capability of using a fallback language for the missing strings.

## Testing
- Add a new string to the `messages/en.json` file
- Reference the string from any component
- Switch to a locale different from `en`
- The string should appear in English
- Add the string to the correct locale
- The string should appear in the correct locale