### PR TITLE
test(core): fix playwright tests again...

### DIFF
--- a/core/components/search-form/index.tsx
+++ b/core/components/search-form/index.tsx
@@ -16,7 +16,7 @@ export const SearchForm = ({ initialTerm = '' }: Props) => {
     <div className="flex flex-col gap-8 py-16">
       {initialTerm ? (
         <h3 className="text-3xl font-black lg:text-4xl">
-          {t('noSearchResults', { term: `"${initialTerm}"` })}
+          {t('noSearchResults', { term: initialTerm })}
         </h3>
       ) : (
         <h3 className="text-3xl font-black lg:text-4xl">{t('searchProducts')}</h3>

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -458,7 +458,7 @@
         "products": "Products",
         "categories": "Categories",
         "brands": "Brands",
-        "noSearchResults": "Sorry, no results for {term}.",
+        "noSearchResults": "Sorry, no results for \"{term}\".",
         "searchPlaceholder": "Search...",
         "clearSearch": "Clear search",
         "processing": "Processing..."
@@ -479,7 +479,7 @@
       "searchProducts": "Search for products",
       "searchPlaceholder": "Search...",
       "search": "Search",
-      "noSearchResults": "Sorry, no results for {term}.",
+      "noSearchResults": "Sorry, no results for \"{term}\".",
       "checkSpelling": "Please check the spelling or try another search."
     },
     "AddToCartButton": {

--- a/core/tests/ui/e2e/search.spec.ts
+++ b/core/tests/ui/e2e/search.spec.ts
@@ -80,5 +80,5 @@ test('Search not found', async ({ page }) => {
 
   await searchBox.fill('flora & fauna');
 
-  await expect(page.getByText('No products matched with "flora & fauna"')).toBeVisible();
+  await expect(page.getByText('Sorry, no results for "flora & fauna".')).toBeVisible();
 });


### PR DESCRIPTION
## What/Why?
Ensure the "No search results" test works correctly after translation strings were updated.

## Testing
One flakey test, but works correctly:
![Screenshot 2024-12-02 at 11 11 21](https://github.com/user-attachments/assets/e9521c6c-8f9b-4e97-b87e-f6d5c201d61f)
