### PR TITLE
test(core): add order details test

### DIFF
--- a/core/tests/fixtures/utils/order/index.ts
+++ b/core/tests/fixtures/utils/order/index.ts
@@ -10,8 +10,8 @@ export class OrderFactory {
 
   constructor(private readonly page: Page) {}
 
-  async create(customerId: number, productId: number) {
-    const orderData = await createOrder(customerId, productId);
+  async create(productId: number, customerId: number) {
+    const orderData = await createOrder(productId, customerId);
 
     const order = new Order(
       this.page,

--- a/core/tests/ui/e2e/order-details.spec.ts
+++ b/core/tests/ui/e2e/order-details.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '~/tests/fixtures';
+
+test('Order contains all necessary info and sections on Order Details page', async ({ page, account, order }) => {
+  const customer = await account.create();
+
+  await customer.login();
+
+  const orderDetails = await order.create(98, customer.id);
+
+  await page.goto('/account/orders/');
+  await expect(page.getByRole('link', { name: `Order # ${orderDetails.id}` })).toBeVisible();
+
+  await page.getByRole('link', { name: 'View Details' }).click();
+  await page.waitForURL(`/account/order/${orderDetails.id}/`);
+
+  await expect(page.getByRole('heading', { name: `Order #${orderDetails.id}` })).toBeVisible();
+  await expect(page.getByText('Order contents')).toBeVisible();
+  await expect(page.getByText('Order Summary')).toBeVisible();
+  await expect(page.getByText('Shipping', { exact: true })).toBeVisible();
+});

--- a/core/tests/ui/e2e/order.spec.ts
+++ b/core/tests/ui/e2e/order.spec.ts
@@ -31,7 +31,7 @@ test('Order details are visible on Orders page', async ({ page, account, order }
 
   await customer.login();
 
-  const orderDetails = await order.create(94, customer.id);
+  const orderDetails = await order.create(98, customer.id);
 
   await page.goto('/account/orders/');
 
@@ -44,5 +44,5 @@ test('Order details are visible on Orders page', async ({ page, account, order }
   await expect(page.getByText('Total')).toBeVisible();
   await expect(page.getByText(formattedTotal).first()).toBeVisible();
   await expect(page.getByText(orderDetails.status)).toBeVisible();
-  await expect(page.getByRole('link', { name: '[Sample] Oak Cheese Grater' })).toBeVisible();
+  await expect(page.getByRole('link', { name: '[Sample] Laundry Detergent' })).toBeVisible();
 });


### PR DESCRIPTION
## What/Why?
This Pr adds test for Order page to validate that  necessary sections are presented on the page.

## Testing
locally

![Screenshot 2024-12-04 at 14 30 25](https://github.com/user-attachments/assets/4d56fcca-e3af-4393-84c1-8c1d75eec967)
![Screenshot 2024-12-04 at 14 29 33](https://github.com/user-attachments/assets/ced88c76-e0ad-4ad6-88ec-52401fe9a86b)
