### PR TITLE
FEAT: added reset branch to ref command

### DIFF
--- a/packages/create-catalyst/src/commands/create.ts
+++ b/packages/create-catalyst/src/commands/create.ts
@@ -68,6 +68,7 @@ export const create = new Command('create')
     const sampleDataApiUrl = parse(options.sampleDataApiUrl, URLSchema);
     const bigcommerceApiUrl = parse(`https://api.${options.bigcommerceHostname}`, URLSchema);
     const bigcommerceAuthUrl = parse(`https://login.${options.bigcommerceHostname}`, URLSchema);
+    const resetMain = options.resetMain;
 
     let projectName;
     let projectDir;
@@ -75,7 +76,6 @@ export const create = new Command('create')
     let accessToken = options.accessToken;
     let channelId;
     let storefrontToken = options.storefrontToken;
-    let resetMain = options.resetMain;
 
     if (options.channelId) {
       channelId = parseInt(options.channelId, 10);

--- a/packages/create-catalyst/src/commands/create.ts
+++ b/packages/create-catalyst/src/commands/create.ts
@@ -32,6 +32,7 @@ export const create = new Command('create')
   .option('--channel-id <id>', 'BigCommerce channel ID')
   .option('--storefront-token <token>', 'BigCommerce storefront token')
   .option('--gh-ref <ref>', 'Clone a specific ref from the source repository')
+  .option('--reset-main', 'Reset the main branch to the gh-ref')
   .option('--repository <repository>', 'GitHub repository to clone from', 'bigcommerce/catalyst')
   .option('--env <vars...>', 'Arbitrary environment variables to set in .env.local')
   .addOption(
@@ -74,6 +75,7 @@ export const create = new Command('create')
     let accessToken = options.accessToken;
     let channelId;
     let storefrontToken = options.storefrontToken;
+    let resetMain = options.resetMain;
 
     if (options.channelId) {
       channelId = parseInt(options.channelId, 10);
@@ -123,7 +125,7 @@ export const create = new Command('create')
     if (storeHash && channelId && storefrontToken) {
       console.log(`\nCreating '${projectName}' at '${projectDir}'\n`);
 
-      cloneCatalyst({ repository, projectName, projectDir, ghRef });
+      cloneCatalyst({ repository, projectName, projectDir, ghRef, resetMain });
 
       writeEnv(projectDir, {
         channelId: channelId.toString(),
@@ -153,7 +155,7 @@ export const create = new Command('create')
     if (!storeHash || !accessToken) {
       console.log(`\nCreating '${projectName}' at '${projectDir}'\n`);
 
-      cloneCatalyst({ repository, projectName, projectDir, ghRef });
+      cloneCatalyst({ repository, projectName, projectDir, ghRef, resetMain });
 
       await installDependencies(projectDir);
 
@@ -254,7 +256,7 @@ export const create = new Command('create')
 
     console.log(`\nCreating '${projectName}' at '${projectDir}'\n`);
 
-    cloneCatalyst({ repository, projectName, projectDir, ghRef });
+    cloneCatalyst({ repository, projectName, projectDir, ghRef, resetMain });
 
     writeEnv(projectDir, {
       channelId: channelId.toString(),

--- a/packages/create-catalyst/src/utils/checkout-ref.ts
+++ b/packages/create-catalyst/src/utils/checkout-ref.ts
@@ -2,7 +2,7 @@ import { execSync } from 'node:child_process';
 
 import { isExecException } from './is-exec-exception';
 
-export function checkoutRef(repoDir: string, ref: string): boolean {
+export function checkoutRef(repoDir: string, ref: string): void {
   try {
     // Attempt to checkout the specified ref
     execSync(`git checkout ${ref}`, {
@@ -10,34 +10,30 @@ export function checkoutRef(repoDir: string, ref: string): boolean {
       stdio: 'inherit',
       encoding: 'utf8',
     });
-    console.log(`Checked out ref ${ref} successfully.`);
 
-    return true;
+    console.log(`Checked out ref ${ref} successfully.`);
   } catch (error: unknown) {
     // Handle the error safely according to ESLint rules
     if (isExecException(error)) {
       const stderr = error.stderr ? error.stderr.toString() : '';
-
       // Check if the error message indicates that the ref was not found
       if (
         stderr.includes(`fatal: reference is not a tree: ${ref}`) ||
         stderr.includes(`fatal: ambiguous argument '${ref}'`) ||
         stderr.includes(`unknown revision or path not in the working tree`)
       ) {
-        console.error(`Ref '${ref}' not found in the repository.`);
+        throw new Error(`Ref '${ref}' not found in the repository.`);
       } else {
-        console.error(`Error checking out ref '${ref}':`, stderr.trim());
+        throw new Error(`Error checking out ref '${ref}': ${stderr.trim()}`);
       }
     }
 
     if (error instanceof Error) {
       // General error handling
-      console.error(`Error checking out ref '${ref}':`, error.message);
+      throw new Error(`Error checking out ref '${ref}': ${error.message}`);
     }
 
     // Unknown error type
-    console.error(`Unknown error occurred while checking out ref '${ref}'.`);
-
-    return false;
+    throw new Error(`Unknown error occurred while checking out ref '${ref}'.`);
   }
 }

--- a/packages/create-catalyst/src/utils/checkout-ref.ts
+++ b/packages/create-catalyst/src/utils/checkout-ref.ts
@@ -2,7 +2,7 @@ import { execSync } from 'node:child_process';
 
 import { isExecException } from './is-exec-exception';
 
-export function checkoutRef(repoDir: string, ref: string): void {
+export function checkoutRef(repoDir: string, ref: string): boolean {
   try {
     // Attempt to checkout the specified ref
     execSync(`git checkout ${ref}`, {
@@ -11,6 +11,7 @@ export function checkoutRef(repoDir: string, ref: string): void {
       encoding: 'utf8',
     });
     console.log(`Checked out ref ${ref} successfully.`);
+    return true;
   } catch (error: unknown) {
     // Handle the error safely according to ESLint rules
     if (isExecException(error)) {
@@ -35,5 +36,6 @@ export function checkoutRef(repoDir: string, ref: string): void {
 
     // Unknown error type
     console.error(`Unknown error occurred while checking out ref '${ref}'.`);
+    return false;
   }
 }

--- a/packages/create-catalyst/src/utils/checkout-ref.ts
+++ b/packages/create-catalyst/src/utils/checkout-ref.ts
@@ -10,30 +10,30 @@ export function checkoutRef(repoDir: string, ref: string): void {
       stdio: 'inherit',
       encoding: 'utf8',
     });
-
     console.log(`Checked out ref ${ref} successfully.`);
   } catch (error: unknown) {
     // Handle the error safely according to ESLint rules
     if (isExecException(error)) {
       const stderr = error.stderr ? error.stderr.toString() : '';
+
       // Check if the error message indicates that the ref was not found
       if (
         stderr.includes(`fatal: reference is not a tree: ${ref}`) ||
         stderr.includes(`fatal: ambiguous argument '${ref}'`) ||
         stderr.includes(`unknown revision or path not in the working tree`)
       ) {
-        throw new Error(`Ref '${ref}' not found in the repository.`);
+        console.error(`Ref '${ref}' not found in the repository.`);
       } else {
-        throw new Error(`Error checking out ref '${ref}': ${stderr.trim()}`);
+        console.error(`Error checking out ref '${ref}':`, stderr.trim());
       }
     }
 
     if (error instanceof Error) {
       // General error handling
-      throw new Error(`Error checking out ref '${ref}': ${error.message}`);
+      console.error(`Error checking out ref '${ref}':`, error.message);
     }
 
     // Unknown error type
-    throw new Error(`Unknown error occurred while checking out ref '${ref}'.`);
+    console.error(`Unknown error occurred while checking out ref '${ref}'.`);
   }
 }

--- a/packages/create-catalyst/src/utils/checkout-ref.ts
+++ b/packages/create-catalyst/src/utils/checkout-ref.ts
@@ -11,6 +11,7 @@ export function checkoutRef(repoDir: string, ref: string): boolean {
       encoding: 'utf8',
     });
     console.log(`Checked out ref ${ref} successfully.`);
+
     return true;
   } catch (error: unknown) {
     // Handle the error safely according to ESLint rules
@@ -36,6 +37,7 @@ export function checkoutRef(repoDir: string, ref: string): boolean {
 
     // Unknown error type
     console.error(`Unknown error occurred while checking out ref '${ref}'.`);
+
     return false;
   }
 }

--- a/packages/create-catalyst/src/utils/clone-catalyst.ts
+++ b/packages/create-catalyst/src/utils/clone-catalyst.ts
@@ -33,9 +33,10 @@ export const cloneCatalyst = ({
 
   if (ghRef) {
     if (resetMain) {
-      return resetBranchToRef(projectDir, 'main', ghRef);
+      resetBranchToRef(projectDir, 'main', ghRef);
+      return;
     }
-    
+
     checkoutRef(projectDir, ghRef);
 
     console.log();

--- a/packages/create-catalyst/src/utils/clone-catalyst.ts
+++ b/packages/create-catalyst/src/utils/clone-catalyst.ts
@@ -33,10 +33,10 @@ export const cloneCatalyst = ({
 
   if (ghRef) {
     if (resetMain) {
-      resetBranchToRef(projectDir, 'main', ghRef);
-    } else {
-      checkoutRef(projectDir, ghRef);
+      return resetBranchToRef(projectDir, 'main', ghRef);
     }
+    
+    checkoutRef(projectDir, ghRef);
 
     console.log();
   }

--- a/packages/create-catalyst/src/utils/clone-catalyst.ts
+++ b/packages/create-catalyst/src/utils/clone-catalyst.ts
@@ -37,6 +37,7 @@ export const cloneCatalyst = ({
     } else {
       checkoutRef(projectDir, ghRef);
     }
+
     console.log();
   }
 };

--- a/packages/create-catalyst/src/utils/clone-catalyst.ts
+++ b/packages/create-catalyst/src/utils/clone-catalyst.ts
@@ -33,27 +33,17 @@ export const cloneCatalyst = ({
 
   if (ghRef) {
     if (resetMain) {
-      try {
-        resetBranchToRef(projectDir, 'main', ghRef);
-      } catch (error: unknown) {
-        if (error instanceof Error) {
-          console.error(error.message);
-        } else {
-          console.error('Unknown error occurred while resetting branch to ref');
-        }
-      }
+      checkoutRef(projectDir, 'main');
+
+      resetBranchToRef(projectDir, ghRef);
+
+      console.log(`Reset main to ${ghRef} successfully.`);
+      console.log();
+
       return;
     }
 
-    try {
-      checkoutRef(projectDir, ghRef);
-    } catch (error: unknown) {
-      if (error instanceof Error) {
-        console.error(error.message);
-      } else {
-        console.error('Unknown error occurred while checking out ref');
-      }
-    }
+    checkoutRef(projectDir, ghRef);
 
     console.log();
   }

--- a/packages/create-catalyst/src/utils/clone-catalyst.ts
+++ b/packages/create-catalyst/src/utils/clone-catalyst.ts
@@ -2,17 +2,20 @@ import { execSync } from 'child_process';
 
 import { checkoutRef } from './checkout-ref';
 import { hasGitHubSSH } from './has-github-ssh';
+import { resetBranchToRef } from './reset-branch-to-ref';
 
 export const cloneCatalyst = ({
   repository,
   projectName,
   projectDir,
   ghRef,
+  resetMain = false,
 }: {
   repository: string;
   projectName: string;
   projectDir: string;
   ghRef?: string;
+  resetMain?: boolean;
 }) => {
   const useSSH = hasGitHubSSH();
 
@@ -29,7 +32,11 @@ export const cloneCatalyst = ({
   console.log();
 
   if (ghRef) {
-    checkoutRef(projectDir, ghRef);
+    if (resetMain) {
+      resetBranchToRef(projectDir, 'main', ghRef);
+    } else {
+      checkoutRef(projectDir, ghRef);
+    }
     console.log();
   }
 };

--- a/packages/create-catalyst/src/utils/clone-catalyst.ts
+++ b/packages/create-catalyst/src/utils/clone-catalyst.ts
@@ -33,11 +33,27 @@ export const cloneCatalyst = ({
 
   if (ghRef) {
     if (resetMain) {
-      resetBranchToRef(projectDir, 'main', ghRef);
+      try {
+        resetBranchToRef(projectDir, 'main', ghRef);
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          console.error(error.message);
+        } else {
+          console.error('Unknown error occurred while resetting branch to ref');
+        }
+      }
       return;
     }
 
-    checkoutRef(projectDir, ghRef);
+    try {
+      checkoutRef(projectDir, ghRef);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        console.error(error.message);
+      } else {
+        console.error('Unknown error occurred while checking out ref');
+      }
+    }
 
     console.log();
   }

--- a/packages/create-catalyst/src/utils/reset-branch-to-ref.ts
+++ b/packages/create-catalyst/src/utils/reset-branch-to-ref.ts
@@ -6,31 +6,37 @@ import { isExecException } from './is-exec-exception';
 export function resetBranchToRef(repoDir: string, targetBranch: string, ref: string): void {
   try {
     // Checkout the target branch
-    const checkoutSuccess = checkoutRef(repoDir, targetBranch);
+    checkoutRef(repoDir, targetBranch);
 
     // Reset current branch to the specified ref
-    if (checkoutSuccess) {
-      execSync(`git reset --hard ${ref}`, {
-        cwd: repoDir,
-        stdio: 'inherit',
-        encoding: 'utf8',
-      });
-      console.log(`Reset ${targetBranch} to ${ref} successfully.`);
-    }
+    execSync(`git reset --hard ${ref}`, {
+      cwd: repoDir,
+      stdio: 'inherit',
+      encoding: 'utf8',
+    });
+    console.log(`Reset ${targetBranch} to ${ref} successfully.`);
   } catch (error: unknown) {
     // Handle the error safely according to ESLint rules
     if (isExecException(error)) {
       const stderr = error.stderr ? error.stderr.toString() : '';
-
-      console.error(`Error resetting ${targetBranch} branch to ref '${ref}':`, stderr.trim());
+      // Check if the error message indicates that the ref was not found
+      if (
+        stderr.includes(`fatal: reference is not a tree: ${ref}`) ||
+        stderr.includes(`fatal: ambiguous argument '${ref}'`) ||
+        stderr.includes(`unknown revision or path not in the working tree`)
+      ) {
+        throw new Error(`Ref '${ref}' not found in the repository.`);
+      } else {
+        throw new Error(`Error resetting ${targetBranch} branch to ref '${ref}': ${stderr.trim()}`);
+      }
     }
 
     if (error instanceof Error) {
       // General error handling
-      console.error(`Error resetting ${targetBranch} branch to ref '${ref}':`, error.message);
+      throw new Error(`Error resetting ${targetBranch} branch to ref '${ref}': ${error.message}`);
     }
 
     // Unknown error type
-    console.error(`Unknown error occurred while resetting ${targetBranch} branch to '${ref}'.`);
+    throw new Error(`Unknown error occurred while resetting ${targetBranch} branch to '${ref}'.`);
   }
 }

--- a/packages/create-catalyst/src/utils/reset-branch-to-ref.ts
+++ b/packages/create-catalyst/src/utils/reset-branch-to-ref.ts
@@ -1,0 +1,36 @@
+import { execSync } from 'node:child_process';
+
+import { isExecException } from './is-exec-exception';
+import { checkoutRef } from './checkout-ref';
+
+export function resetBranchToRef(repoDir: string, targetBranch: string, ref: string): void {
+  try {
+    // Checkout the target branch
+    const checkoutSuccess = checkoutRef(repoDir, targetBranch);
+
+    // Reset current branch to the specified ref
+    if (checkoutSuccess) {
+      execSync(`git reset --hard ${ref}`, {
+        cwd: repoDir,
+        stdio: 'inherit',
+        encoding: 'utf8',
+      });
+      console.log(`Reset ${targetBranch} to ${ref} successfully.`);
+    }
+  } catch (error: unknown) {
+    // Handle the error safely according to ESLint rules
+    if (isExecException(error)) {
+      const stderr = error.stderr ? error.stderr.toString() : '';
+
+      console.error(`Error resetting ${targetBranch} branch to ref '${ref}':`, stderr.trim());
+    }
+
+    if (error instanceof Error) {
+      // General error handling
+      console.error(`Error resetting ${targetBranch} branch to ref '${ref}':`, error.message);
+    }
+
+    // Unknown error type
+    console.error(`Unknown error occurred while resetting ${targetBranch} branch to '${ref}'.`);
+  }
+}

--- a/packages/create-catalyst/src/utils/reset-branch-to-ref.ts
+++ b/packages/create-catalyst/src/utils/reset-branch-to-ref.ts
@@ -1,7 +1,7 @@
 import { execSync } from 'node:child_process';
 
-import { isExecException } from './is-exec-exception';
 import { checkoutRef } from './checkout-ref';
+import { isExecException } from './is-exec-exception';
 
 export function resetBranchToRef(repoDir: string, targetBranch: string, ref: string): void {
   try {

--- a/packages/create-catalyst/src/utils/reset-branch-to-ref.ts
+++ b/packages/create-catalyst/src/utils/reset-branch-to-ref.ts
@@ -1,42 +1,9 @@
 import { execSync } from 'node:child_process';
 
-import { checkoutRef } from './checkout-ref';
-import { isExecException } from './is-exec-exception';
-
-export function resetBranchToRef(repoDir: string, targetBranch: string, ref: string): void {
-  try {
-    // Checkout the target branch
-    checkoutRef(repoDir, targetBranch);
-
-    // Reset current branch to the specified ref
-    execSync(`git reset --hard ${ref}`, {
-      cwd: repoDir,
-      stdio: 'inherit',
-      encoding: 'utf8',
-    });
-    console.log(`Reset ${targetBranch} to ${ref} successfully.`);
-  } catch (error: unknown) {
-    // Handle the error safely according to ESLint rules
-    if (isExecException(error)) {
-      const stderr = error.stderr ? error.stderr.toString() : '';
-      // Check if the error message indicates that the ref was not found
-      if (
-        stderr.includes(`fatal: reference is not a tree: ${ref}`) ||
-        stderr.includes(`fatal: ambiguous argument '${ref}'`) ||
-        stderr.includes(`unknown revision or path not in the working tree`)
-      ) {
-        throw new Error(`Ref '${ref}' not found in the repository.`);
-      } else {
-        throw new Error(`Error resetting ${targetBranch} branch to ref '${ref}': ${stderr.trim()}`);
-      }
-    }
-
-    if (error instanceof Error) {
-      // General error handling
-      throw new Error(`Error resetting ${targetBranch} branch to ref '${ref}': ${error.message}`);
-    }
-
-    // Unknown error type
-    throw new Error(`Unknown error occurred while resetting ${targetBranch} branch to '${ref}'.`);
-  }
+export function resetBranchToRef(projectDir: string, ghRef: string): void {
+  execSync(`git reset --hard ${ghRef}`, {
+    cwd: projectDir,
+    stdio: 'inherit',
+    encoding: 'utf8',
+  });
 }


### PR DESCRIPTION
## What/Why?
When moving from OCC to development, users should have the ability to check out a ref that is then set to the `main` branch so they can continue smoothly in their development journey. This will put them in a state where they have the exact code they originally deployed in OCC but will be set to the `main` branch.

- create `reset-main` boolean option for CLI
- create new resetBranchToRef to be called if `ghRef` and `resetMain` are present
- update checkoutRef to return a boolean status to determine whether or not it was run successfully


## Testing
- test existing OCC generated command in isolation - should work as expected
- test existing OCC generated command  with `--reset-main` flag with the end result of being in the `main` branch with code matching the `gh-ref` provided