### PR TITLE
chore: remove duplicate dep

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -15,9 +15,8 @@
   "dependencies": {
     "@bigcommerce/catalyst-client": "workspace:^",
     "@conform-to/react": "^1.2.2",
-    "@icons-pack/react-simple-icons": "^10.2.0",
-    "@conform-to/react": "^1.2.2",
     "@conform-to/zod": "^1.2.2",
+    "@icons-pack/react-simple-icons": "^10.2.0",
     "@radix-ui/react-accordion": "^1.2.1",
     "@radix-ui/react-alert-dialog": "^1.1.2",
     "@radix-ui/react-checkbox": "^1.1.2",


### PR DESCRIPTION
## What/Why?
`@conform-to/react` was listed twice as a dependency