### PR TITLE
fix: properly handle empty array URL search params

### DIFF
--- a/.changeset/honest-ways-tell.md
+++ b/.changeset/honest-ways-tell.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Ignore empty strings when parsing array URL search parameters in faceted search.

--- a/core/app/[locale]/(default)/(faceted)/fetch-faceted-search.ts
+++ b/core/app/[locale]/(default)/(faceted)/fetch-faceted-search.ts
@@ -236,7 +236,7 @@ const SearchParamToArray = SearchParamSchema.transform((value) => {
     return value;
   }
 
-  if (typeof value === 'string') {
+  if (typeof value === 'string' && value !== '') {
     return [value];
   }
 


### PR DESCRIPTION
## What/Why?
The previous implementation would treat an empty string as a valid value, resulting in `['']` as the parsed array, which when mapped and coerced with `Number` to get an entity ID would result in `[0]`.

This gave some weird results, e.g., when visiting `/shop-all?brand=`.

The entity ID `0` was being passed to the `searchProducts` mutation resulting in products that _didn't_ have a brand in the results, instead of all products since a brand wasn't specified.

The current change now treats this as an empty array, which I believe is the appropriate behavior.

Notably, this behavior was not occurring in production deployments.

## Testing

https://github.com/user-attachments/assets/fc22f48d-33aa-46ee-94b7-e5a212ac5e45

