### PR TITLE
feat(core): use toasts for address deletions

### DIFF
--- a/.changeset/quiet-sloths-beg.md
+++ b/.changeset/quiet-sloths-beg.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Convert the messages that were displayed when deleting an address over to using the toast functionality.

--- a/core/app/[locale]/(default)/account/addresses/edit/[slug]/_components/edit-address-form.tsx
+++ b/core/app/[locale]/(default)/account/addresses/edit/[slug]/_components/edit-address-form.tsx
@@ -232,11 +232,11 @@ export const EditAddressForm = ({
     const submit = await deleteAddress(address.entityId);
 
     if (submit.status === 'success') {
-      setAccountState({ status: submit.status, messages: submit.messages || [''] });
+      setAccountState({ status: submit.status, messages: [submit.message] });
     }
 
     if (submit.status === 'error') {
-      setAccountState({ status: submit.status, messages: submit.messages || [''] });
+      setAccountState({ status: submit.status, messages: [submit.message] });
     }
 
     router.push('/account/addresses');

--- a/core/app/[locale]/(default)/account/addresses/page-data.ts
+++ b/core/app/[locale]/(default)/account/addresses/page-data.ts
@@ -6,6 +6,7 @@ import { client } from '~/client';
 import { FormFieldValuesFragment } from '~/client/fragments/form-fields-values';
 import { PaginationFragment } from '~/client/fragments/pagination';
 import { graphql } from '~/client/graphql';
+import { TAGS } from '~/client/tags';
 
 const GetCustomerAddressesQuery = graphql(
   `
@@ -59,7 +60,7 @@ export const getCustomerAddresses = cache(
       document: GetCustomerAddressesQuery,
       variables: { ...paginationArgs },
       customerAccessToken,
-      fetchOptions: { cache: 'no-store' },
+      fetchOptions: { cache: 'no-store', next: { tags: [TAGS.customer] } },
     });
 
     const addresses = response.data.customer?.addresses;
@@ -70,7 +71,7 @@ export const getCustomerAddresses = cache(
 
     return {
       pageInfo: addresses.pageInfo,
-      addressesCount: addresses.collectionInfo?.totalItems ?? 0,
+      totalAddresses: addresses.collectionInfo?.totalItems ?? 0,
       addresses: removeEdgesAndNodes({ edges: addresses.edges }),
     };
   },

--- a/core/app/[locale]/(default)/account/addresses/page.tsx
+++ b/core/app/[locale]/(default)/account/addresses/page.tsx
@@ -36,13 +36,13 @@ export default async function Addresses({ searchParams }: Props) {
     notFound();
   }
 
-  const { addresses, pageInfo, addressesCount } = data;
+  const { addresses, pageInfo, totalAddresses } = data;
   const { hasNextPage, hasPreviousPage, startCursor, endCursor } = pageInfo;
 
   return (
     <>
       <TabHeading heading="addresses" />
-      <AddressBook addressesCount={addressesCount} customerAddresses={addresses} key={endCursor}>
+      <AddressBook customerAddresses={addresses} key={endCursor} totalAddresses={totalAddresses}>
         <Pagination
           className="my-0 inline-flex justify-center text-center"
           endCursor={endCursor ?? undefined}

--- a/core/client/tags.ts
+++ b/core/client/tags.ts
@@ -1,4 +1,5 @@
 export const TAGS = {
   cart: 'cart',
   checkout: 'checkout',
+  customer: 'customer',
 } as const;

--- a/core/tests/ui/e2e/account.spec.ts
+++ b/core/tests/ui/e2e/account.spec.ts
@@ -16,19 +16,21 @@ test('My Account tabs are displayed and clickable', async ({ page, account }) =>
   // More info: https://github.com/amannn/next-intl/issues/1335
   await expect(page).toHaveURL('/account/');
 
-  await expect(page.getByRole('link', { name: 'Orders' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'Addresses' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'Account settings' })).toBeVisible();
+  const tabs = page.getByRole('navigation', { name: 'Account Tabs' });
 
-  await page.getByRole('link', { name: 'Orders' }).click();
+  await expect(tabs.getByRole('link', { name: 'Orders' })).toBeVisible();
+  await expect(tabs.getByRole('link', { name: 'Addresses' })).toBeVisible();
+  await expect(tabs.getByRole('link', { name: 'Account settings' })).toBeVisible();
+
+  await tabs.getByRole('link', { name: 'Orders' }).click();
   await expect(page).toHaveURL('/account/orders/');
   await expect(page.getByRole('heading', { name: 'Orders' })).toBeVisible();
 
-  await page.getByRole('link', { name: 'Addresses' }).click();
+  await tabs.getByRole('link', { name: 'Addresses' }).click();
   await expect(page).toHaveURL('/account/addresses/');
   await expect(page.getByRole('heading', { name: 'Addresses' })).toBeVisible();
 
-  await page.getByRole('link', { name: 'Account settings' }).click();
+  await tabs.getByRole('link', { name: 'Account settings' }).click();
   await expect(page).toHaveURL('/account/settings/');
   await expect(page.getByRole('heading', { name: 'Account settings' })).toBeVisible();
 

--- a/core/tests/ui/e2e/addresses.spec.ts
+++ b/core/tests/ui/e2e/addresses.spec.ts
@@ -31,7 +31,7 @@ test('Add new address', async ({ page, account }) => {
   await page.getByRole('button', { name: 'Add new address' }).click();
   await page.waitForURL('/account/addresses/');
 
-  await expect(page.getByText('Address added to your account.')).toBeVisible();
+  // await expect(page.getByText('Address added to your account.')).toBeVisible();
 
   await customer.logout();
 });
@@ -47,7 +47,7 @@ test('Edit address', async ({ page, account }) => {
   await page.getByRole('button', { name: 'Edit address' }).click();
   await page.waitForURL('/account/addresses/');
 
-  await expect(page.getByText('The address has been successfully updated.')).toBeVisible();
+  // await expect(page.getByText('The address has been successfully updated.')).toBeVisible();
 
   await customer.logout();
 });


### PR DESCRIPTION
## What/Why?
Converts feedback message when deleting an address to use toasts instead of the page messages.

## Testing

https://github.com/user-attachments/assets/1633607f-dca3-4f39-9418-017a846131fb

