### PR TITLE
feat(core): remove recaptcha fields in the account area

### DIFF
--- a/.changeset/modern-garlics-sparkle.md
+++ b/.changeset/modern-garlics-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Removed ReCaptcha validation when you are logged in and making account changes. We have already validated a customer is human at the loggin screen.

--- a/core/app/[locale]/(default)/account/addresses/_actions/delete-address.ts
+++ b/core/app/[locale]/(default)/account/addresses/_actions/delete-address.ts
@@ -10,12 +10,9 @@ import { graphql } from '~/client/graphql';
 import { State } from '../../settings/change-password/_actions/change-password';
 
 const DeleteCustomerAddressMutation = graphql(`
-  mutation DeleteCustomerAddressMutation(
-    $reCaptcha: ReCaptchaV2Input
-    $input: DeleteCustomerAddressInput!
-  ) {
+  mutation DeleteCustomerAddressMutation($input: DeleteCustomerAddressInput!) {
     customer {
-      deleteCustomerAddress(reCaptchaV2: $reCaptcha, input: $input) {
+      deleteCustomerAddress(input: $input) {
         errors {
           __typename
           ... on CustomerAddressDeletionError {

--- a/core/app/[locale]/(default)/account/addresses/add/_actions/add-address.ts
+++ b/core/app/[locale]/(default)/account/addresses/add/_actions/add-address.ts
@@ -9,12 +9,9 @@ import { graphql, VariablesOf } from '~/client/graphql';
 import { parseAccountFormData } from '~/components/form-fields/shared/parse-fields';
 
 const AddCustomerAddressMutation = graphql(`
-  mutation AddCustomerAddressMutation(
-    $input: AddCustomerAddressInput!
-    $reCaptchaV2: ReCaptchaV2Input
-  ) {
+  mutation AddCustomerAddressMutation($input: AddCustomerAddressInput!) {
     customer {
-      addCustomerAddress(input: $input, reCaptchaV2: $reCaptchaV2) {
+      addCustomerAddress(input: $input) {
         errors {
           ... on CustomerAddressCreationError {
             message
@@ -48,13 +45,7 @@ const isAddCustomerAddressInput = (data: unknown): data is AddCustomerAddressInp
   return false;
 };
 
-export const addAddress = async ({
-  formData,
-  reCaptchaToken,
-}: {
-  formData: FormData;
-  reCaptchaToken?: string;
-}) => {
+export const addAddress = async (formData: FormData) => {
   const t = await getTranslations('Account.Addresses.Add.Form');
   const customerAccessToken = await getSessionCustomerAccessToken();
 
@@ -74,7 +65,6 @@ export const addAddress = async ({
       fetchOptions: { cache: 'no-store' },
       variables: {
         input: parsed,
-        ...(reCaptchaToken && { reCaptchaV2: { token: reCaptchaToken } }),
       },
     });
 

--- a/core/app/[locale]/(default)/account/addresses/add/_components/add-address-form.tsx
+++ b/core/app/[locale]/(default)/account/addresses/add/_components/add-address-form.tsx
@@ -3,7 +3,6 @@
 import { useTranslations } from 'next-intl';
 import { MouseEvent, useEffect, useRef, useState } from 'react';
 import { useFormStatus } from 'react-dom';
-import ReCaptcha from 'react-google-recaptcha';
 
 import {
   Checkboxes,
@@ -32,7 +31,7 @@ import {
 } from '~/components/form-fields/shared/field-handlers';
 import { Link } from '~/components/link';
 import { Button } from '~/components/ui/button';
-import { Field, Form, FormSubmit } from '~/components/ui/form';
+import { Form, FormSubmit } from '~/components/ui/form';
 import { Message } from '~/components/ui/message';
 import { useRouter } from '~/i18n/routing';
 
@@ -89,26 +88,14 @@ interface AddAddressProps {
     code: CountryCode;
     states: CountryStates;
   };
-  reCaptchaSettings?: {
-    isEnabledOnStorefront: boolean;
-    siteKey: string;
-  };
 }
 
-export const AddAddressForm = ({
-  addressFields,
-  countries,
-  defaultCountry,
-  reCaptchaSettings,
-}: AddAddressProps) => {
+export const AddAddressForm = ({ addressFields, countries, defaultCountry }: AddAddressProps) => {
   const form = useRef<HTMLFormElement>(null);
   const [formStatus, setFormStatus] = useState<FormStatus | null>(null);
 
-  const reCaptchaRef = useRef<ReCaptcha>(null);
   const router = useRouter();
   const t = useTranslations('Account.Addresses.Add.Form');
-  const [reCaptchaToken, setReCaptchaToken] = useState('');
-  const [isReCaptchaValid, setReCaptchaValid] = useState(true);
 
   const [textInputValid, setTextInputValid] = useState<Record<string, boolean>>({});
   const [numbersInputValid, setNumbersInputValid] = useState<Record<string, boolean>>({});
@@ -162,26 +149,8 @@ export const AddAddressForm = ({
     }
   };
 
-  const onReCaptchaChange = (token: string | null) => {
-    if (!token) {
-      setReCaptchaValid(false);
-
-      return;
-    }
-
-    setReCaptchaToken(token);
-    setReCaptchaValid(true);
-  };
   const onSubmit = async (formData: FormData) => {
-    if (reCaptchaSettings?.isEnabledOnStorefront && !reCaptchaToken) {
-      setReCaptchaValid(false);
-
-      return;
-    }
-
-    setReCaptchaValid(true);
-
-    const submit = await addAddress({ formData, reCaptchaToken });
+    const submit = await addAddress(formData);
 
     if (submit.status === 'success') {
       setAccountState({
@@ -359,21 +328,6 @@ export const AddAddressForm = ({
                 return null;
             }
           })}
-
-          {reCaptchaSettings?.isEnabledOnStorefront && (
-            <Field className="relative col-span-full max-w-full space-y-2 pb-7" name="ReCAPTCHA">
-              <ReCaptcha
-                onChange={onReCaptchaChange}
-                ref={reCaptchaRef}
-                sitekey={reCaptchaSettings.siteKey}
-              />
-              {!isReCaptchaValid && (
-                <span className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-error">
-                  {t('recaptchaText')}
-                </span>
-              )}
-            </Field>
-          )}
         </div>
 
         <div className="mt-8 flex flex-col justify-stretch gap-2 md:flex-row md:justify-start md:gap-6">

--- a/core/app/[locale]/(default)/account/addresses/add/page.tsx
+++ b/core/app/[locale]/(default)/account/addresses/add/page.tsx
@@ -4,7 +4,6 @@ import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
 import { graphql, ResultOf } from '~/client/graphql';
 import { FormFieldsFragment } from '~/components/form-fields/fragment';
-import { bypassReCaptcha } from '~/lib/bypass-recaptcha';
 
 import { AddAddressForm } from './_components/add-address-form';
 
@@ -19,10 +18,6 @@ const CustomerNewAdressQuery = graphql(
         settings {
           contact {
             country
-          }
-          reCaptcha {
-            isEnabledOnStorefront
-            siteKey
           }
           formFields {
             shippingAddress(filters: $shippingFilters, sortBy: $shippingSorting) {
@@ -90,8 +85,6 @@ export default async function AddPage() {
     statesOrProvinces: defaultCountryStates = FALLBACK_COUNTRY.states,
   } = countries?.find(({ name: country }) => country === defaultCountry) || {};
 
-  const recaptchaSettings = await bypassReCaptcha(data.site.settings?.reCaptcha);
-
   return (
     <div className="mx-auto mb-14 lg:w-2/3">
       <h1 className="mb-8 text-3xl font-black lg:text-4xl">{t('heading')}</h1>
@@ -99,7 +92,6 @@ export default async function AddPage() {
         addressFields={addressFields}
         countries={countries || []}
         defaultCountry={{ id: entityId, code, states: defaultCountryStates }}
-        reCaptchaSettings={recaptchaSettings}
       />
     </div>
   );

--- a/core/app/[locale]/(default)/account/addresses/edit/[slug]/_actions/update-address.ts
+++ b/core/app/[locale]/(default)/account/addresses/edit/[slug]/_actions/update-address.ts
@@ -9,12 +9,9 @@ import { graphql, VariablesOf } from '~/client/graphql';
 import { parseAccountFormData } from '~/components/form-fields/shared/parse-fields';
 
 const UpdateCustomerAddressMutation = graphql(`
-  mutation UpdateCustomerAddressMutation(
-    $input: UpdateCustomerAddressInput!
-    $reCaptchaV2: ReCaptchaV2Input
-  ) {
+  mutation UpdateCustomerAddressMutation($input: UpdateCustomerAddressInput!) {
     customer {
-      updateCustomerAddress(input: $input, reCaptchaV2: $reCaptchaV2) {
+      updateCustomerAddress(input: $input) {
         errors {
           __typename
           ... on AddressDoesNotExistError {
@@ -54,15 +51,7 @@ const isUpdateCustomerAddressInput = (
   return false;
 };
 
-export const updateAddress = async ({
-  addressId,
-  formData,
-  reCaptchaToken,
-}: {
-  addressId: number;
-  formData: FormData;
-  reCaptchaToken?: string;
-}) => {
+export const updateAddress = async (formData: FormData, addressId: number) => {
   const t = await getTranslations('Account.Addresses.Edit.Form');
   const customerAccessToken = await getSessionCustomerAccessToken();
 
@@ -85,7 +74,6 @@ export const updateAddress = async ({
           addressEntityId: addressId,
           data: parsed,
         },
-        ...(reCaptchaToken && { reCaptchaV2: { token: reCaptchaToken } }),
       },
     });
 

--- a/core/app/[locale]/(default)/account/addresses/edit/[slug]/_components/edit-address-form.tsx
+++ b/core/app/[locale]/(default)/account/addresses/edit/[slug]/_components/edit-address-form.tsx
@@ -3,7 +3,6 @@
 import { useTranslations } from 'next-intl';
 import { MouseEvent, useEffect, useRef, useState } from 'react';
 import { useFormStatus } from 'react-dom';
-import ReCaptcha from 'react-google-recaptcha';
 
 import {
   Checkboxes,
@@ -33,7 +32,7 @@ import {
 } from '~/components/form-fields/shared/field-handlers';
 import { Link } from '~/components/link';
 import { Button } from '~/components/ui/button';
-import { Field, Form, FormSubmit } from '~/components/ui/form';
+import { Form, FormSubmit } from '~/components/ui/form';
 import { Message } from '~/components/ui/message';
 import { useRouter } from '~/i18n/routing';
 
@@ -105,10 +104,6 @@ interface EditAddressProps {
   addressFields: AddressFields;
   countries: Countries;
   isAddressRemovable: boolean;
-  reCaptchaSettings?: {
-    isEnabledOnStorefront: boolean;
-    siteKey: string;
-  };
 }
 
 export const EditAddressForm = ({
@@ -116,16 +111,12 @@ export const EditAddressForm = ({
   addressFields,
   countries,
   isAddressRemovable,
-  reCaptchaSettings,
 }: EditAddressProps) => {
   const form = useRef<HTMLFormElement>(null);
   const [formStatus, setFormStatus] = useState<FormStatus | null>(null);
   const t = useTranslations('Account.Addresses.Edit.Form');
 
-  const reCaptchaRef = useRef<ReCaptcha>(null);
   const router = useRouter();
-  const [reCaptchaToken, setReCaptchaToken] = useState('');
-  const [isReCaptchaValid, setReCaptchaValid] = useState(true);
   const { setAccountState } = useAccountStatusContext();
 
   useEffect(() => {
@@ -166,17 +157,6 @@ export const EditAddressForm = ({
     multiTextValid,
   );
 
-  const onReCaptchaChange = (token: string | null) => {
-    if (!token) {
-      setReCaptchaValid(false);
-
-      return;
-    }
-
-    setReCaptchaToken(token);
-    setReCaptchaValid(true);
-  };
-
   const validatePicklistFields = createPreSubmitPicklistValidationHandler(
     addressFields,
     setPicklistValid,
@@ -197,15 +177,7 @@ export const EditAddressForm = ({
   };
 
   const onSubmit = async (formData: FormData) => {
-    if (reCaptchaSettings?.isEnabledOnStorefront && !reCaptchaToken) {
-      setReCaptchaValid(false);
-
-      return;
-    }
-
-    setReCaptchaValid(true);
-
-    const submit = await updateAddress({ addressId: address.entityId, formData });
+    const submit = await updateAddress(formData, address.entityId);
 
     if (submit.status === 'success') {
       setAccountState({
@@ -425,21 +397,6 @@ export const EditAddressForm = ({
                 return null;
             }
           })}
-
-          {reCaptchaSettings?.isEnabledOnStorefront && (
-            <Field className="relative col-span-full max-w-full space-y-2 pb-7" name="ReCAPTCHA">
-              <ReCaptcha
-                onChange={onReCaptchaChange}
-                ref={reCaptchaRef}
-                sitekey={reCaptchaSettings.siteKey}
-              />
-              {!isReCaptchaValid && (
-                <span className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-error">
-                  {t('recaptchaText')}
-                </span>
-              )}
-            </Field>
-          )}
         </div>
 
         <div className="mt-8 flex flex-col justify-stretch gap-2 md:flex-row md:justify-between md:gap-0">

--- a/core/app/[locale]/(default)/account/addresses/edit/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/account/addresses/edit/[slug]/page.tsx
@@ -8,7 +8,6 @@ import { FormFieldValuesFragment } from '~/client/fragments/form-fields-values';
 import { PaginationFragment } from '~/client/fragments/pagination';
 import { graphql, ResultOf } from '~/client/graphql';
 import { FormFieldsFragment } from '~/components/form-fields/fragment';
-import { bypassReCaptcha } from '~/lib/bypass-recaptcha';
 
 import { EditAddressForm } from './_components/edit-address-form';
 
@@ -56,10 +55,6 @@ const CustomerEditAddressQuery = graphql(
         settings {
           contact {
             country
-          }
-          reCaptcha {
-            isEnabledOnStorefront
-            siteKey
           }
           formFields {
             shippingAddress(filters: $shippingFilters, sortBy: $shippingSorting) {
@@ -131,8 +126,6 @@ export default async function Edit({ params }: Props) {
     return notFound();
   }
 
-  const reCaptchaSettings = await bypassReCaptcha(data.site.settings?.reCaptcha);
-
   return (
     <div className="mx-auto mb-14 lg:w-2/3">
       <h1 className="mb-8 text-3xl font-black lg:text-4xl">{t('heading')}</h1>
@@ -141,7 +134,6 @@ export default async function Edit({ params }: Props) {
         addressFields={addressFields}
         countries={countries || []}
         isAddressRemovable={addresses.length > 1}
-        reCaptchaSettings={reCaptchaSettings}
       />
     </div>
   );

--- a/core/app/[locale]/(default)/account/settings/_actions/update-customer.ts
+++ b/core/app/[locale]/(default)/account/settings/_actions/update-customer.ts
@@ -9,9 +9,9 @@ import { graphql, VariablesOf } from '~/client/graphql';
 import { parseAccountFormData } from '~/components/form-fields/shared/parse-fields';
 
 const UpdateCustomerMutation = graphql(`
-  mutation UpdateCustomerMutation($input: UpdateCustomerInput!, $reCaptchaV2: ReCaptchaV2Input) {
+  mutation UpdateCustomerMutation($input: UpdateCustomerInput!) {
     customer {
-      updateCustomer(input: $input, reCaptchaV2: $reCaptchaV2) {
+      updateCustomer(input: $input) {
         customer {
           firstName
           lastName
@@ -58,16 +58,9 @@ const isUpdateCustomerInput = (data: unknown): data is AddCustomerAddressInput =
   return false;
 };
 
-interface UpdateCustomerForm {
-  formData: FormData;
-  reCaptchaToken?: string;
-}
-
-export const updateCustomer = async ({ formData, reCaptchaToken }: UpdateCustomerForm) => {
+export const updateCustomer = async (formData: FormData) => {
   const t = await getTranslations('Account.Settings.UpdateCustomer');
   const customerAccessToken = await getSessionCustomerAccessToken();
-
-  formData.delete('g-recaptcha-response');
 
   const parsed = parseAccountFormData(formData);
 
@@ -84,7 +77,6 @@ export const updateCustomer = async ({ formData, reCaptchaToken }: UpdateCustome
     fetchOptions: { cache: 'no-store' },
     variables: {
       input: parsed,
-      ...(reCaptchaToken && { reCaptchaV2: { token: reCaptchaToken } }),
     },
   });
 

--- a/core/app/[locale]/(default)/account/settings/_components/update-settings-form.tsx
+++ b/core/app/[locale]/(default)/account/settings/_components/update-settings-form.tsx
@@ -3,7 +3,6 @@
 import { useTranslations } from 'next-intl';
 import { ChangeEvent, MouseEvent, useRef, useState } from 'react';
 import { useFormStatus } from 'react-dom';
-import ReCaptcha from 'react-google-recaptcha';
 
 import { ExistingResultType } from '~/client/util';
 import {
@@ -30,7 +29,7 @@ import {
 } from '~/components/form-fields/shared/field-handlers';
 import { Link } from '~/components/link';
 import { Button } from '~/components/ui/button';
-import { Field, Form, FormSubmit } from '~/components/ui/form';
+import { Form, FormSubmit } from '~/components/ui/form';
 import { Message } from '~/components/ui/message';
 
 import { AccountState as FormStatus } from '../../_components/account-status-provider';
@@ -48,10 +47,6 @@ interface FormProps {
   addressFields: AddressFields;
   customerInfo: CustomerInfo;
   customerFields: CustomerFields;
-  reCaptchaSettings?: {
-    isEnabledOnStorefront: boolean;
-    siteKey: string;
-  };
 }
 
 interface SumbitMessages {
@@ -92,12 +87,7 @@ const SubmitButton = ({ messages }: SumbitMessages) => {
   );
 };
 
-export const UpdateSettingsForm = ({
-  addressFields,
-  customerFields,
-  customerInfo,
-  reCaptchaSettings,
-}: FormProps) => {
+export const UpdateSettingsForm = ({ addressFields, customerFields, customerInfo }: FormProps) => {
   const form = useRef<HTMLFormElement>(null);
   const [formStatus, setFormStatus] = useState<FormStatus | null>(null);
 
@@ -109,10 +99,6 @@ export const UpdateSettingsForm = ({
   const [checkboxesValid, setCheckboxesValid] = useState<Record<string, boolean>>({});
   const [datesValid, setDatesValid] = useState<Record<string, boolean>>({});
   const [passwordValid, setPasswordValid] = useState<Record<string, boolean>>({});
-
-  const reCaptchaRef = useRef<ReCaptcha>(null);
-  const [reCaptchaToken, setReCaptchaToken] = useState('');
-  const [isReCaptchaValid, setReCaptchaValid] = useState(true);
 
   const t = useTranslations('Account.Settings');
 
@@ -162,27 +148,8 @@ export const UpdateSettingsForm = ({
     }
   };
 
-  const onReCaptchaChange = (token: string | null) => {
-    if (!token) {
-      setReCaptchaValid(false);
-
-      return;
-    }
-
-    setReCaptchaToken(token);
-    setReCaptchaValid(true);
-  };
-
   const onSubmit = async (formData: FormData) => {
-    if (reCaptchaSettings?.isEnabledOnStorefront && !reCaptchaToken) {
-      setReCaptchaValid(false);
-
-      return;
-    }
-
-    setReCaptchaValid(true);
-
-    const submit = await updateCustomer({ formData, reCaptchaToken });
+    const submit = await updateCustomer(formData);
 
     if (submit.status === 'success') {
       setFormStatus({
@@ -403,21 +370,6 @@ export const UpdateSettingsForm = ({
                   return null;
               }
             })}
-
-          {reCaptchaSettings?.isEnabledOnStorefront && (
-            <Field className="relative col-span-full max-w-full space-y-2 pb-7" name="ReCAPTCHA">
-              <ReCaptcha
-                onChange={onReCaptchaChange}
-                ref={reCaptchaRef}
-                sitekey={reCaptchaSettings.siteKey}
-              />
-              {!isReCaptchaValid && (
-                <span className="absolute inset-x-0 bottom-0 inline-flex w-full text-xs font-normal text-error">
-                  {t('recaptchaText')}
-                </span>
-              )}
-            </Field>
-          )}
           <div className="mt-8 flex flex-col items-center md:flex-row md:flex-wrap md:justify-start lg:col-span-2">
             <FormSubmit asChild>
               <SubmitButton messages={{ submit: t('submit'), submitting: t('submitting') }} />

--- a/core/app/[locale]/(default)/account/settings/page-data.tsx
+++ b/core/app/[locale]/(default)/account/settings/page-data.tsx
@@ -7,7 +7,6 @@ import { FormFieldValuesFragment } from '~/client/fragments/form-fields-values';
 import { PaginationFragment } from '~/client/fragments/pagination';
 import { graphql, VariablesOf } from '~/client/graphql';
 import { FormFieldsFragment } from '~/components/form-fields/fragment';
-import { bypassReCaptcha } from '~/lib/bypass-recaptcha';
 
 const CustomerSettingsQuery = graphql(
   `
@@ -65,10 +64,6 @@ const CustomerSettingsQuery = graphql(
               ...FormFieldsFragment
             }
           }
-          reCaptcha {
-            isEnabledOnStorefront
-            siteKey
-          }
         }
       }
     }
@@ -109,8 +104,6 @@ export const getCustomerSettingsQuery = cache(async ({ address, customer }: Prop
   const customerFields = response.data.site.settings?.formFields.customer;
   const customerInfo = response.data.customer;
 
-  const reCaptchaSettings = await bypassReCaptcha(response.data.site.settings?.reCaptcha);
-
   if (!addressFields || !customerFields || !customerInfo) {
     return null;
   }
@@ -119,7 +112,6 @@ export const getCustomerSettingsQuery = cache(async ({ address, customer }: Prop
     addressFields,
     customerFields,
     customerInfo,
-    reCaptchaSettings,
   };
 });
 

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -189,7 +189,6 @@
         "title": "Add address",
         "heading": "New address",
         "Form": {
-          "recaptchaText": "Pass ReCAPTCHA check",
           "submit": "Add new address",
           "submitting": "Saving address...",
           "cancel": "Cancel",
@@ -204,7 +203,6 @@
         "title": "Edit address",
         "heading": "Edit address",
         "Form": {
-          "recaptchaText": "Pass ReCAPTCHA check",
           "submit": "Edit address",
           "submitting": "Updating address...",
           "cancel": "Cancel",
@@ -228,7 +226,6 @@
       "title": "Account settings",
       "emptyTextValidatoinMessage": "This field can not be empty",
       "cancel": "Cancel",
-      "recaptchaText": "Pass ReCAPTCHA check",
       "changePassword": "Change password",
       "submit": "Update settings",
       "submitting": "Update settings...",


### PR DESCRIPTION
## What/Why?
Removes the ReCaptcha validation from actions related to your account. ReCaptcha was needed for BigCommerce headless stores using client-side tokens, however we are using server side auth so it's no longer needed for pages that a customer is logged in for.

## Testing
![Screenshot 2024-12-10 at 10 49 48](https://github.com/user-attachments/assets/feb1e2b7-d7e7-4013-a73f-5d5dadd83838)
![Screenshot 2024-12-10 at 10 49 57](https://github.com/user-attachments/assets/8bb7b944-4a1a-42f7-b1ce-e541baaab075)
![Screenshot 2024-12-10 at 10 50 04](https://github.com/user-attachments/assets/5fdf3530-4d92-4c0e-868a-5f5a31933f6c)
![Screenshot 2024-12-10 at 10 50 10](https://github.com/user-attachments/assets/dd64bfe5-84be-48df-8c0a-0384bad13ac2)
