### PR TITLE
fix(core): update inventory logic for out-of-stock

### DIFF
--- a/.changeset/silent-snails-sparkle.md
+++ b/.changeset/silent-snails-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Fixes the inventory handling to handle some options being out of stock.

--- a/core/components/add-to-cart-button/index.tsx
+++ b/core/components/add-to-cart-button/index.tsx
@@ -21,10 +21,9 @@ export const AddToCartButton = ({
   const t = useTranslations('Components.AddToCartButton');
 
   const noParentOrVariantStock =
-    !product.inventory.isInStock && !product.inventory.hasVariantInventory;
-
-  const isProductDisabled =
-    product.availabilityV2.status === 'Unavailable' || noParentOrVariantStock;
+    !product.inventory.isInStock ||
+    !product.inventory.hasVariantInventory ||
+    product.availabilityV2.status === 'Unavailable';
 
   const buttonText = () => {
     if (product.availabilityV2.status === 'Unavailable') {
@@ -45,7 +44,7 @@ export const AddToCartButton = ({
   return (
     <Button
       className={className}
-      disabled={isProductDisabled}
+      disabled={noParentOrVariantStock}
       loading={loading}
       loadingText={t('processing')}
       type="submit"


### PR DESCRIPTION
## What/Why?
The product options didn't have any inventory but other variants had stock. This fixes the logic to check for everything correctly.

## Testing
![Screenshot 2024-12-10 at 11 40 57](https://github.com/user-attachments/assets/5af9264e-9ba8-43f6-91cb-e42ac9341c85)
![Screenshot 2024-12-10 at 11 41 51](https://github.com/user-attachments/assets/73aac41d-b6bf-4d81-bbaa-c584caf24c8b)
