### PR TITLE
fix(core): update inventory logic for out-of-stock again

### DIFF
--- a/core/components/add-to-cart-button/fragment.ts
+++ b/core/components/add-to-cart-button/fragment.ts
@@ -3,7 +3,6 @@ import { graphql } from '~/client/graphql';
 export const AddToCartButtonFragment = graphql(`
   fragment AddToCartButtonFragment on Product {
     inventory {
-      hasVariantInventory
       isInStock
     }
     availabilityV2 {

--- a/core/components/add-to-cart-button/index.tsx
+++ b/core/components/add-to-cart-button/index.tsx
@@ -20,11 +20,6 @@ export const AddToCartButton = ({
 }) => {
   const t = useTranslations('Components.AddToCartButton');
 
-  const noParentOrVariantStock =
-    !product.inventory.isInStock ||
-    !product.inventory.hasVariantInventory ||
-    product.availabilityV2.status === 'Unavailable';
-
   const buttonText = () => {
     if (product.availabilityV2.status === 'Unavailable') {
       return t('unavailable');
@@ -34,7 +29,7 @@ export const AddToCartButton = ({
       return t('preorder');
     }
 
-    if (noParentOrVariantStock) {
+    if (!product.inventory.isInStock) {
       return t('outOfStock');
     }
 
@@ -44,7 +39,7 @@ export const AddToCartButton = ({
   return (
     <Button
       className={className}
-      disabled={noParentOrVariantStock}
+      disabled={!product.inventory.isInStock}
       loading={loading}
       loadingText={t('processing')}
       type="submit"


### PR DESCRIPTION
## What/Why?
Fixes it again... The PLP page was showing out of stock options even though they were in stock.

## Testing
![Screenshot 2024-12-10 at 16 27 53](https://github.com/user-attachments/assets/10bf5f65-467f-41d9-96aa-927352690994)
![Screenshot 2024-12-10 at 16 28 02](https://github.com/user-attachments/assets/2774d7fa-d83e-4695-8626-6d740757efd0)
![Screenshot 2024-12-10 at 16 28 06](https://github.com/user-attachments/assets/53118b05-f369-46bb-85db-82f45a1583ec)
