### PR TITLE
fix: bump VIBES components and pass in accessibility props in Home

### DIFF
--- a/core/app/[locale]/(default)/page.tsx
+++ b/core/app/[locale]/(default)/page.tsx
@@ -96,6 +96,8 @@ export default async function Home({ params }: Props) {
         description={t('NewestProducts.description')}
         emptyStateSubtitle={t('NewestProducts.emptyStateSubtitle')}
         emptyStateTitle={t('NewestProducts.emptyStateTitle')}
+        nextLabel={t('NewestProducts.nextProducts')}
+        previousLabel={t('NewestProducts.previousProducts')}
         products={getNewestProducts()}
         title={t('NewestProducts.title')}
       />

--- a/core/components/footer/footer.tsx
+++ b/core/components/footer/footer.tsx
@@ -7,6 +7,7 @@ import {
   SiX,
   SiYoutube,
 } from '@icons-pack/react-simple-icons';
+import { useTranslations } from 'next-intl';
 import { cache, JSX } from 'react';
 
 import { Footer as FooterSection } from '@/vibes/soul/sections/footer';
@@ -132,11 +133,15 @@ const getSocialMediaLinks = async () => {
 };
 
 export const Footer = () => {
+  const t = useTranslations('Components.Footer');
+
   return (
     <FooterSection
       contactInformation={getContactInformation()}
       copyright={getCopyright()}
       logo={getLogo()}
+      logoHref="/"
+      logoLabel={t('home')}
       paymentIcons={paymentIcons}
       sections={getSections()}
       socialMediaLinks={getSocialMediaLinks()}

--- a/core/components/header/index.tsx
+++ b/core/components/header/index.tsx
@@ -58,13 +58,15 @@ export const Header = async () => {
     <HeaderSection
       navigation={{
         accountHref: '/login',
-        accountLabel: t('Icons.Account'),
+        accountLabel: t('Icons.account'),
         cartHref: '/cart',
-        cartLabel: t('Icons.Cart'),
+        cartLabel: t('Icons.cart'),
         searchHref: '/search',
-        searchLabel: t('Icons.Search'),
+        searchLabel: t('Icons.search'),
         links: getLinks(),
         logo: getLogo(),
+        mobileMenuTriggerLabel: t('toggleNavigation'),
+        logoLabel: t('home'),
       }}
     />
   );

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -34,7 +34,9 @@
       "description": "Our latest products are here. Check out what's new in store.",
       "cta": "See all",
       "emptyStateTitle": "No products found",
-      "emptyStateSubtitle": "Please try again later."
+      "emptyStateSubtitle": "Please try again later.",
+      "previousProducts": "Previous products",
+      "nextProducts": "Next products"
     },
     "BestSellingProducts": {
       "title": "Our best sellers",
@@ -494,10 +496,12 @@
   },
   "Components": {
     "Header": {
+      "home": "Home",
+      "toggleNavigation": "Toggle navigation",
       "Icons": {
-        "Account": "Profile",
-        "Cart": "Cart",
-        "Search": "Search"
+        "account": "Profile",
+        "cart": "Cart",
+        "search": "Search"
       },
       "Account": {
         "account": "Account",
@@ -535,6 +539,7 @@
       }
     },
     "Footer": {
+      "home": "Home",
       "socialMediaLinks": "Social media links"
     },
     "Subscribe": {

--- a/core/vibes/soul/primitives/carousel/index.tsx
+++ b/core/vibes/soul/primitives/carousel/index.tsx
@@ -15,6 +15,7 @@ interface CarouselProps extends React.ComponentPropsWithoutRef<'div'> {
   opts?: CarouselOptions;
   plugins?: CarouselPlugin;
   setApi?: (api: CarouselApi) => void;
+  carouselScrollbarLabel?: string;
 }
 
 type CarouselContextProps = {
@@ -132,7 +133,12 @@ function CarouselItem({ className, ...rest }: React.HTMLAttributes<HTMLDivElemen
   );
 }
 
-function CarouselButtons({ className, ...rest }: React.HTMLAttributes<HTMLDivElement>) {
+function CarouselButtons({
+  className,
+  previousLabel = 'Previous',
+  nextLabel = 'Next',
+  ...rest
+}: React.HTMLAttributes<HTMLDivElement> & { previousLabel?: string; nextLabel?: string }) {
   const { scrollPrev, scrollNext, canScrollPrev, canScrollNext } = useCarousel();
 
   return (
@@ -141,6 +147,7 @@ function CarouselButtons({ className, ...rest }: React.HTMLAttributes<HTMLDivEle
         className="rounded-lg ring-primary transition-colors duration-300 focus-visible:outline-0 focus-visible:ring-2 disabled:pointer-events-none disabled:text-contrast-300"
         disabled={!canScrollPrev}
         onClick={scrollPrev}
+        title={previousLabel}
       >
         <ArrowLeft strokeWidth={1.5} />
       </button>
@@ -148,6 +155,7 @@ function CarouselButtons({ className, ...rest }: React.HTMLAttributes<HTMLDivEle
         className="rounded-lg ring-primary transition-colors duration-300 focus-visible:outline-0 focus-visible:ring-2 disabled:pointer-events-none disabled:text-contrast-300"
         disabled={!canScrollNext}
         onClick={scrollNext}
+        title={nextLabel}
       >
         <ArrowRight strokeWidth={1.5} />
       </button>
@@ -155,7 +163,10 @@ function CarouselButtons({ className, ...rest }: React.HTMLAttributes<HTMLDivEle
   );
 }
 
-function CarouselScrollbar({ className }: React.HTMLAttributes<HTMLDivElement>) {
+function CarouselScrollbar({
+  className,
+  label = 'Carousel scrollbar',
+}: React.HTMLAttributes<HTMLDivElement> & { label?: string }) {
   const { api } = useCarousel();
   const [progress, setProgress] = useState(0);
   const [scrollbarPosition, setScrollbarPosition] = useState({ width: 0, left: 0 });
@@ -203,10 +214,12 @@ function CarouselScrollbar({ className }: React.HTMLAttributes<HTMLDivElement>) 
 
     api.on('select', onScroll);
     api.on('scroll', onScroll);
+    api.on('reInit', onScroll);
 
     return () => {
       api.off('select', onScroll);
       api.off('scroll', onScroll);
+      api.off('reInit', onScroll);
     };
   }, [api]);
 
@@ -215,6 +228,10 @@ function CarouselScrollbar({ className }: React.HTMLAttributes<HTMLDivElement>) 
       className={clsx('relative flex h-6 w-full max-w-56 items-center overflow-hidden', className)}
     >
       <input
+        aria-label={label}
+        aria-orientation="horizontal"
+        aria-valuenow={progress}
+        aria-valuetext={`${Math.round(progress)}%`}
         className="absolute h-full w-full cursor-pointer appearance-none bg-transparent opacity-0"
         max={100}
         min={0}

--- a/core/vibes/soul/primitives/navigation/index.tsx
+++ b/core/vibes/soul/primitives/navigation/index.tsx
@@ -88,6 +88,7 @@ interface Props<S extends SearchResult> {
   localeAction?: LocaleAction;
   logo?: Streamable<string | { src: string; alt: string } | null>;
   logoHref?: string;
+  logoLabel?: string;
   searchHref: string;
   searchParamName?: string;
   searchAction?: SearchAction<S>;
@@ -98,6 +99,7 @@ interface Props<S extends SearchResult> {
   cartLabel?: string;
   accountLabel?: string;
   searchLabel?: string;
+  mobileMenuTriggerLabel?: string;
 }
 
 const HamburgerMenuButton = forwardRef<
@@ -169,6 +171,7 @@ export const Navigation = forwardRef(function Navigation<S extends SearchResult>
     links: streamableLinks,
     logo: streamableLogo,
     logoHref = '/',
+    logoLabel = 'Home',
     activeLocaleId,
     localeAction,
     locales,
@@ -182,6 +185,7 @@ export const Navigation = forwardRef(function Navigation<S extends SearchResult>
     cartLabel = 'Cart',
     accountLabel = 'Profile',
     searchLabel = 'Search',
+    mobileMenuTriggerLabel = 'Toggle navigation',
   }: Props<S>,
   ref: Ref<HTMLDivElement>,
 ) {
@@ -228,6 +232,7 @@ export const Navigation = forwardRef(function Navigation<S extends SearchResult>
           <Popover.Anchor className="absolute left-0 right-0 top-full" />
           <Popover.Trigger asChild>
             <HamburgerMenuButton
+              aria-label={mobileMenuTriggerLabel}
               className="mr-3 @4xl:hidden"
               onClick={() => setIsMobileMenuOpen((prev) => !prev)}
               open={isMobileMenuOpen}
@@ -296,6 +301,7 @@ export const Navigation = forwardRef(function Navigation<S extends SearchResult>
         </Popover.Root>
         <div className="flex flex-1 items-center self-stretch py-2">
           <Link
+            aria-label={logoLabel}
             className="relative flex size-full max-w-[80%] items-center outline-0 ring-primary ring-offset-4 focus-visible:ring-2 @4xl:max-w-[50%]"
             href={logoHref}
           >

--- a/core/vibes/soul/primitives/product-card/index.tsx
+++ b/core/vibes/soul/primitives/product-card/index.tsx
@@ -34,6 +34,7 @@ export function ProductCard({
   return (
     <div className={className}>
       <Link
+        aria-label={title}
         className="group flex cursor-pointer flex-col gap-2 rounded-xl ring-primary ring-offset-4 focus-visible:outline-0 focus-visible:ring-2 @md:rounded-2xl"
         href={href}
         id={id}

--- a/core/vibes/soul/primitives/products-carousel/index.tsx
+++ b/core/vibes/soul/primitives/products-carousel/index.tsx
@@ -21,6 +21,9 @@ interface Props {
   className?: string;
   emptyStateTitle?: string;
   emptyStateSubtitle?: string;
+  scrollbarLabel?: string;
+  previousLabel?: string;
+  nextLabel?: string;
 }
 
 export function ProductsCarousel({
@@ -28,6 +31,9 @@ export function ProductsCarousel({
   className,
   emptyStateTitle,
   emptyStateSubtitle,
+  scrollbarLabel,
+  previousLabel,
+  nextLabel,
 }: Props) {
   return (
     <Stream fallback={<ProductsCarouselSkeleton pending />} value={streamableProducts}>
@@ -54,8 +60,8 @@ export function ProductsCarousel({
               ))}
             </CarouselContent>
             <div className="flex w-full items-center justify-between">
-              <CarouselScrollbar />
-              <CarouselButtons />
+              <CarouselScrollbar label={scrollbarLabel} />
+              <CarouselButtons nextLabel={nextLabel} previousLabel={previousLabel} />
             </div>
           </Carousel>
         );
@@ -85,10 +91,7 @@ export function ProductsCarouselSkeleton({
           </CarouselItem>
         ))}
       </CarouselContent>
-      <div className="flex w-full items-center justify-between">
-        <CarouselScrollbar />
-        <CarouselButtons />
-      </div>
+      <div className="h-6 w-56 animate-pulse bg-contrast-100" />
     </Carousel>
   );
 }

--- a/core/vibes/soul/sections/featured-products-carousel/index.tsx
+++ b/core/vibes/soul/sections/featured-products-carousel/index.tsx
@@ -14,6 +14,9 @@ interface Props {
   products: Streamable<CarouselProduct[]>;
   emptyStateTitle?: string;
   emptyStateSubtitle?: string;
+  scrollbarLabel?: string;
+  previousLabel?: string;
+  nextLabel?: string;
 }
 
 export function FeaturedProductsCarousel({
@@ -23,6 +26,9 @@ export function FeaturedProductsCarousel({
   products,
   emptyStateTitle,
   emptyStateSubtitle,
+  scrollbarLabel,
+  previousLabel,
+  nextLabel,
 }: Props) {
   return (
     <section className="group/pending overflow-hidden @container">
@@ -45,7 +51,10 @@ export function FeaturedProductsCarousel({
           <ProductsCarousel
             emptyStateSubtitle={emptyStateSubtitle}
             emptyStateTitle={emptyStateTitle}
+            nextLabel={nextLabel}
+            previousLabel={previousLabel}
             products={products}
+            scrollbarLabel={scrollbarLabel}
           />
         </div>
       </div>

--- a/core/vibes/soul/sections/footer/index.tsx
+++ b/core/vibes/soul/sections/footer/index.tsx
@@ -38,6 +38,8 @@ interface Props {
   paymentIcons?: Streamable<ReactNode[] | null>;
   socialMediaLinks?: Streamable<SocialMediaLink[] | null>;
   className?: string;
+  logoHref?: string;
+  logoLabel?: string;
 }
 
 export const Footer = forwardRef(function Footer(
@@ -48,7 +50,9 @@ export const Footer = forwardRef(function Footer(
     paymentIcons: streamablePaymentIcons,
     socialMediaLinks: streamableSocialMediaLinks,
     copyright: streamableCopyright,
-    className = '',
+    className,
+    logoHref = '#',
+    logoLabel = 'Home',
   }: Props,
   ref: Ref<HTMLDivElement>,
 ) {
@@ -76,8 +80,9 @@ export const Footer = forwardRef(function Footer(
                 if (logo != null && typeof logo === 'string') {
                   return (
                     <Link
+                      aria-label={logoLabel}
                       className="relative mb-2 inline-block h-10 w-full max-w-56 rounded-lg ring-primary focus-visible:outline-0 focus-visible:ring-2"
-                      href="#"
+                      href={logoHref}
                     >
                       <span className="whitespace-nowrap font-heading text-2xl font-semibold">
                         {logo}
@@ -89,8 +94,9 @@ export const Footer = forwardRef(function Footer(
                 if (logo != null && typeof logo === 'object' && logo.src !== '') {
                   return (
                     <Link
+                      aria-label={logoLabel}
                       className="relative mb-2 inline-block h-10 w-full max-w-56 rounded-lg ring-primary focus-visible:outline-0 focus-visible:ring-2"
-                      href="#"
+                      href={logoHref}
                     >
                       <Image
                         alt={logo.alt}


### PR DESCRIPTION
## What/Why?
This should clear all accessibility warnings in the homepage except the contrasting colors.

## Testing
![Screenshot 2024-12-11 at 8 39 58 AM](https://github.com/user-attachments/assets/d256c869-15cc-454d-b2d8-7a496e722ae0)
