### PR TITLE
feat: update button props and css variables

### DIFF
--- a/core/app/globals.css
+++ b/core/app/globals.css
@@ -3,30 +3,62 @@
 @tailwind utilities;
 
 :root {
-    --primary: 96 100% 68%;
-    --accent: 96 100% 88%;
-    --background: 0 0% 100%;
-    --foreground: 0 0% 7%;
-    --success: 116 78% 65%;
-    --error: 0 100% 60%;
-    --warning: 40 100% 60%;
-    --info: 220 70% 45%;
-    --contrast-100: 0 0% 93%;
-    --contrast-200: 0 0% 82%;
-    --contrast-300: 0 0% 70%;
-    --contrast-400: 0 0% 54%;
-    --contrast-500: 0 0% 34%;
-    --font-variation-settings-body: "slnt" 0;
-    --font-variation-settings-heading: "slnt" 0;
-    --font-size-xs: 0.75rem;
-    --font-size-sm: 0.875rem;
-    --font-size-base: 1rem;
-    --font-size-lg: 1.125rem;
-    --font-size-xl: 1.25rem;
-    --font-size-2xl: 1.5rem;
-    --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-    --shadow-base: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-    --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-    --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
-    --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
-  }
+  --primary: 96 100% 68%;
+  --accent: 96 100% 88%;
+  --background: 0 0% 100%;
+  --foreground: 0 0% 7%;
+  --success: 116 78% 65%;
+  --error: 0 100% 60%;
+  --warning: 40 100% 60%;
+  --info: 220 70% 45%;
+  --contrast-100: 0 0% 93%;
+  --contrast-200: 0 0% 82%;
+  --contrast-300: 0 0% 70%;
+  --contrast-400: 0 0% 54%;
+  --contrast-500: 0 0% 34%;
+  --font-variation-settings-body: 'slnt' 0;
+  --font-variation-settings-heading: 'slnt' 0;
+  --font-size-xs: 0.75rem;
+  --font-size-sm: 0.875rem;
+  --font-size-base: 1rem;
+  --font-size-lg: 1.125rem;
+  --font-size-xl: 1.25rem;
+  --font-size-2xl: 1.5rem;
+  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  --shadow-base: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
+  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+
+  /* Button */
+
+  --button-font-family: var(--font-family-body);
+
+  --button-primary-background: hsl(var(--primary));
+  --button-primary-background-hover: color-mix(in oklab, hsl(var(--primary)), white 75%);
+  --button-primary-foreground: hsl(var(--foreground));
+  --button-primary-foreground-hover: hsl(var(--foreground));
+  --button-primary-border: hsl(var(--primary));
+  --button-primary-focus: hsl(var(--foreground));
+
+  --button-secondary-background: hsl(var(--foreground));
+  --button-secondary-background-hover: hsl(var(--background));
+  --button-secondary-foreground: hsl(var(--background));
+  --button-secondary-foreground-hover: hsl(var(--foreground));
+  --button-secondary-border: hsl(var(--foreground));
+  --button-secondary-focus: hsl(var(--foreground));
+
+  --button-tertiary-background: hsl(var(--background));
+  --button-tertiary-background-hover: hsl(var(--contrast-100));
+  --button-tertiary-foreground: hsl(var(--foreground));
+  --button-tertiary-foreground-hover: hsl(var(--foreground));
+  --button-tertiary-border: hsl(var(--contrast-200));
+  --button-tertiary-focus: hsl(var(--foreground));
+
+  --button-ghost-background: transparent;
+  --button-ghost-background-hover: hsl(var(--foreground) / 5%);
+  --button-ghost-foreground: hsl(var(--foreground));
+  --button-ghost-foreground-hover: hsl(var(--foreground));
+  --button-ghost-border: transparent;
+  --button-ghost-focus: hsl(var(--foreground));
+}

--- a/core/vibes/soul/primitives/alert/index.tsx
+++ b/core/vibes/soul/primitives/alert/index.tsx
@@ -50,7 +50,13 @@ export function Alert({
           </Button>
         )}
 
-        <Button aria-label={dismissLabel} onClick={onDismiss} size="icon-small" variant="ghost">
+        <Button
+          aria-label={dismissLabel}
+          onClick={onDismiss}
+          shape="circle"
+          size="x-small"
+          variant="ghost"
+        >
           <X size={20} strokeWidth={1} />
         </Button>
       </div>

--- a/core/vibes/soul/primitives/button-link/index.tsx
+++ b/core/vibes/soul/primitives/button-link/index.tsx
@@ -4,13 +4,15 @@ import { Link } from '~/components/link';
 
 export type Props = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
   variant?: 'primary' | 'secondary' | 'tertiary' | 'ghost';
-  size?: 'large' | 'medium' | 'small' | 'x-small' | 'icon' | 'icon-small';
+  size?: 'large' | 'medium' | 'small' | 'x-small';
+  shape?: 'pill' | 'rounded' | 'square' | 'circle';
   href: string;
 };
 
 export function ButtonLink({
   variant = 'primary',
   size = 'large',
+  shape = 'pill',
   href,
   className,
   children,
@@ -20,25 +22,36 @@ export function ButtonLink({
     <Link
       {...props}
       className={clsx(
-        'relative z-0 inline-flex h-fit select-none items-center justify-center overflow-hidden rounded-full border text-center font-semibold leading-normal after:absolute after:inset-0 after:-z-10 after:-translate-x-[105%] after:rounded-full after:transition-[opacity,transform] after:duration-300 after:[animation-timing-function:cubic-bezier(0,0.25,0,1)] hover:after:translate-x-0 focus-visible:outline-none focus-visible:ring-2',
+        'relative z-0 inline-flex h-fit select-none items-center justify-center overflow-hidden border text-center font-[family-name:var(--button-font-family)] font-semibold leading-normal after:absolute after:inset-0 after:-z-10 after:-translate-x-[105%] after:transition-[opacity,transform] after:duration-300 after:[animation-timing-function:cubic-bezier(0,0.25,0,1)] hover:after:translate-x-0 focus-visible:outline-none focus-visible:ring-2',
         {
           primary:
-            'border-primary bg-primary text-foreground ring-foreground after:bg-background/40',
+            'border-[var(--button-primary-border)] bg-[var(--button-primary-background)] text-[var(--button-primary-foreground)] ring-[var(--button-primary-focus)] after:bg-[var(--button-primary-background-hover)]',
           secondary:
-            'border-foreground bg-foreground text-background ring-primary after:bg-background',
+            'border-[var(--button-secondary-border)] bg-[var(--button-secondary-background)] text-[var(--button-secondary-foreground)] ring-[var(--button-secondary-focus)] after:bg-[var(--button-secondary-background-hover)]',
           tertiary:
-            'border-contrast-200 bg-background text-foreground ring-primary after:bg-contrast-100',
+            'border-[var(--button-tertiary-border)] bg-[var(--button-tertiary-background)] text-[var(--button-tertiary-foreground)] ring-[var(--button-tertiary-focus)] after:bg-[var(--button-tertiary-background-hover)]',
           ghost:
-            'border-transparent bg-transparent text-foreground ring-primary after:bg-foreground/5',
+            'border-[var(--button-ghost-border)] bg-[var(--button-ghost-background)] text-[var(--button-ghost-foreground)] ring-[var(--button-ghost-focus)] after:bg-[var(--button-ghost-background-hover)]',
         }[variant],
         {
-          'icon-small': 'min-h-8 p-1.5 text-xs',
-          icon: 'min-h-10 p-2.5 text-sm',
-          'x-small': 'min-h-8 gap-x-2 px-3 py-1.5 text-xs',
-          small: 'min-h-10 gap-x-2 px-4 py-2.5 text-sm',
-          medium: 'min-h-12 gap-x-2.5 px-5 py-3 text-base',
-          large: 'min-h-14 gap-x-3 px-6 py-4 text-base',
+          'x-small': 'min-h-8 text-xs',
+          small: 'min-h-10 text-sm',
+          medium: 'min-h-12 text-base',
+          large: 'min-h-14 text-base',
         }[size],
+        shape !== 'circle' &&
+          {
+            'x-small': 'gap-x-2 px-3 py-1.5',
+            small: 'gap-x-2 px-4 py-2.5',
+            medium: 'gap-x-2.5 px-5 py-3',
+            large: 'gap-x-3 px-6 py-4',
+          }[size],
+        {
+          pill: 'rounded-full after:rounded-full',
+          rounded: 'rounded-lg after:rounded-lg',
+          square: 'rounded-none after:rounded-none',
+          circle: 'aspect-square rounded-full after:rounded-full',
+        }[shape],
         className,
       )}
       href={href}

--- a/core/vibes/soul/primitives/button/index.tsx
+++ b/core/vibes/soul/primitives/button/index.tsx
@@ -3,7 +3,8 @@ import { Loader2 } from 'lucide-react';
 
 export type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   variant?: 'primary' | 'secondary' | 'tertiary' | 'ghost';
-  size?: 'large' | 'medium' | 'small' | 'x-small' | 'icon' | 'icon-small';
+  size?: 'large' | 'medium' | 'small' | 'x-small';
+  shape?: 'pill' | 'rounded' | 'square' | 'circle';
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
   loading?: boolean;
   type?: 'button' | 'submit' | 'reset';
@@ -12,6 +13,7 @@ export type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
 export function Button({
   variant = 'primary',
   size = 'large',
+  shape = 'pill',
   onClick,
   loading = false,
   disabled = false,
@@ -24,17 +26,23 @@ export function Button({
     <button
       aria-busy={loading}
       className={clsx(
-        'relative z-0 h-fit overflow-hidden rounded-full border font-semibold leading-normal after:absolute after:inset-0 after:-z-10 after:-translate-x-[105%] after:rounded-full after:transition-[opacity,transform] after:duration-300 after:[animation-timing-function:cubic-bezier(0,0.25,0,1)] focus-visible:outline-none focus-visible:ring-2',
+        'relative z-0 inline-flex h-fit select-none items-center justify-center overflow-hidden border text-center font-[family-name:var(--button-font-family)] font-semibold leading-normal after:absolute after:inset-0 after:-z-10 after:-translate-x-[105%] after:transition-[opacity,transform] after:duration-300 after:[animation-timing-function:cubic-bezier(0,0.25,0,1)] hover:after:translate-x-0 focus-visible:outline-none focus-visible:ring-2',
         {
           primary:
-            'border-primary bg-primary text-foreground ring-foreground after:bg-background/40',
+            'border-[var(--button-primary-border)] bg-[var(--button-primary-background)] text-[var(--button-primary-foreground)] ring-[var(--button-primary-focus)] after:bg-[var(--button-primary-background-hover)]',
           secondary:
-            'border-foreground bg-foreground text-background ring-primary after:bg-background',
+            'border-[var(--button-secondary-border)] bg-[var(--button-secondary-background)] text-[var(--button-secondary-foreground)] ring-[var(--button-secondary-focus)] after:bg-[var(--button-secondary-background-hover)]',
           tertiary:
-            'border-contrast-200 bg-background text-foreground ring-primary after:bg-contrast-100',
+            'border-[var(--button-tertiary-border)] bg-[var(--button-tertiary-background)] text-[var(--button-tertiary-foreground)] ring-[var(--button-tertiary-focus)] after:bg-[var(--button-tertiary-background-hover)]',
           ghost:
-            'border-transparent bg-transparent text-foreground ring-primary after:bg-foreground/5',
+            'border-[var(--button-ghost-border)] bg-[var(--button-ghost-background)] text-[var(--button-ghost-foreground)] ring-[var(--button-ghost-focus)] after:bg-[var(--button-ghost-background-hover)]',
         }[variant],
+        {
+          pill: 'rounded-full after:rounded-full',
+          rounded: 'rounded-lg after:rounded-lg',
+          square: 'rounded-none after:rounded-none',
+          circle: 'rounded-full after:rounded-full',
+        }[shape],
         !loading && !disabled && 'hover:after:translate-x-0',
         disabled && 'cursor-not-allowed opacity-30',
         className,
@@ -47,14 +55,20 @@ export function Button({
         className={clsx(
           'inline-flex items-center justify-center transition-all duration-300 ease-in-out',
           loading ? '-translate-y-10 opacity-0' : 'translate-y-0 opacity-100',
+          shape === 'circle' && 'aspect-square',
           {
-            'icon-small': 'min-h-8 p-1.5 text-xs',
-            icon: 'min-h-10 p-2.5 text-sm',
-            'x-small': 'min-h-8 gap-x-2 px-3 py-1.5 text-xs',
-            small: 'min-h-10 gap-x-2 px-4 py-2.5 text-sm',
-            medium: 'min-h-12 gap-x-2.5 px-5 py-3 text-base',
-            large: 'min-h-14 gap-x-3 px-6 py-4 text-base',
+            'x-small': 'min-h-8 text-xs',
+            small: 'min-h-10 text-sm',
+            medium: 'min-h-12 text-base',
+            large: 'min-h-14 text-base',
           }[size],
+          shape !== 'circle' &&
+            {
+              'x-small': 'gap-x-2 px-3 py-1.5',
+              small: 'gap-x-2 px-4 py-2.5',
+              medium: 'gap-x-2.5 px-5 py-3',
+              large: 'gap-x-3 px-6 py-4',
+            }[size],
           variant === 'secondary' && 'mix-blend-difference',
         )}
       >

--- a/core/vibes/soul/primitives/inline-email-form/index.tsx
+++ b/core/vibes/soul/primitives/inline-email-form/index.tsx
@@ -61,7 +61,8 @@ export function InlineEmailForm({
           <Button
             aria-label={submitLabel}
             loading={isPending}
-            size="icon"
+            size="small"
+            shape="circle"
             type="submit"
             variant="secondary"
           >

--- a/core/vibes/soul/primitives/navigation/index.tsx
+++ b/core/vibes/soul/primitives/navigation/index.tsx
@@ -591,7 +591,13 @@ function SubmitButton({ loading, submitLabel }: { loading: boolean; submitLabel:
   const { pending } = useFormStatus();
 
   return (
-    <Button loading={pending || loading} size="icon" type="submit" variant="secondary">
+    <Button
+      loading={pending || loading}
+      shape="circle"
+      size="small"
+      type="submit"
+      variant="secondary"
+    >
       <ArrowRight aria-label={submitLabel} size={20} strokeWidth={1.5} />
     </Button>
   );


### PR DESCRIPTION
## What/Why?
To improve the theming experience we are introducing component based CSS variables for colors, font family etc. 

This PR adds a `shape` prop to the `Button` and `ButtonLink` and updates the idea of an `icon` size to a combination of a `size` and `shape` rather than being a special type of `size`.

I also add CSS variables to control the colors of all variations of the button at a global level. This will be hooked into via the `Theme` component to allow visual editing in Makeswift.

## Testing

Verified all live usages of the `Button` and `Button` link have no visual regression.

https://github.com/user-attachments/assets/5397b468-948f-4a6a-bf8f-c8facefd090e