### PR TITLE
Assign cart to customer as part of login mutation

### DIFF
--- a/.changeset/proud-taxis-smoke.md
+++ b/.changeset/proud-taxis-smoke.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Assign cart to customer as part of initial login mutation


### PR DESCRIPTION
## What/Why?
Use the new enhancement to the `login()` mutation to assign the guest cart to the customer at the moment of login, which avoids an extra GQL request for this and simplifies the code.

A similar enhancement is coming soon to logout but will be a separate PR.

## Testing
Preview deployment

https://github.com/user-attachments/assets/b3b9fa00-0eac-448e-807f-8616e3c5624f

