### PR TITLE
feat: add BlogPostContent to blog/[id] page

### DIFF
--- a/core/app/[locale]/(default)/blog/[blogId]/page.tsx
+++ b/core/app/[locale]/(default)/blog/[blogId]/page.tsx
@@ -2,11 +2,8 @@ import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { getFormatter } from 'next-intl/server';
 
-import { Image } from '~/components/image';
-import { Link } from '~/components/link';
-import { Tag } from '~/components/ui/tag';
+import { BlogPostContent } from '@/vibes/soul/sections/blog-post-content';
 
-import { SharingLinks } from './_components/sharing-links';
 import { getBlogPageData } from './page-data';
 
 interface Props {
@@ -47,49 +44,36 @@ export default async function Blog({ params }: Props) {
   }
 
   return (
-    <div className="mx-auto max-w-4xl">
-      <h1 className="mb-2 text-3xl font-black lg:text-5xl">{blogPost.name}</h1>
-
-      <div className="mb-8 flex">
-        <small className="mb-0 text-base text-gray-500">
-          {format.dateTime(new Date(blogPost.publishedDate.utc))}
-        </small>
-
-        {Boolean(blogPost.author) && (
-          <small className="text-base text-gray-500">, by {blogPost.author}</small>
-        )}
-      </div>
-
-      {blogPost.thumbnailImage ? (
-        <div className="mb-6 flex h-40 sm:h-80 lg:h-96">
-          <Image
-            alt={blogPost.thumbnailImage.altText}
-            className="h-full w-full object-cover object-center"
-            height={900}
-            src={blogPost.thumbnailImage.url}
-            width={900}
-          />
-        </div>
-      ) : (
-        <div className="mb-6 flex h-40 justify-between bg-primary/10 p-4 sm:h-80 lg:h-96">
-          <h3 className="mb-0 flex-none basis-1/2 self-start text-3xl font-bold text-primary">
-            {blogPost.name}
-          </h3>
-          <small className="mb-0 flex-none self-end text-xl font-bold text-primary">
-            {format.dateTime(new Date(blogPost.publishedDate.utc))}
-          </small>
-        </div>
-      )}
-
-      <div className="mb-10 text-base" dangerouslySetInnerHTML={{ __html: blogPost.htmlBody }} />
-      <div className="mb-10 flex">
-        {blogPost.tags.map((tag) => (
-          <Link className="me-3 block cursor-pointer" href={`/blog/tag/${tag}`} key={tag}>
-            <Tag content={tag} />
-          </Link>
-        ))}
-      </div>
-      <SharingLinks data={data} />
-    </div>
+    <BlogPostContent
+      author={blogPost.author ?? undefined}
+      breadcrumbs={[
+        {
+          label: 'Home',
+          href: '/',
+        },
+        {
+          label: 'Blog',
+          href: '/blog',
+        },
+        {
+          label: blogPost.name,
+          href: '#',
+        },
+      ]}
+      content={blogPost.htmlBody}
+      date={format.dateTime(new Date(blogPost.publishedDate.utc))}
+      image={
+        blogPost.thumbnailImage
+          ? { alt: blogPost.thumbnailImage.altText, src: blogPost.thumbnailImage.url }
+          : undefined
+      }
+      tags={blogPost.tags.map((tag) => ({
+        label: tag,
+        link: {
+          href: `/blog/tag/${tag}`,
+        },
+      }))}
+      title={blogPost.name}
+    />
   );
 }

--- a/core/vibes/soul/sections/blog-post-content/blog-post-content.tsx
+++ b/core/vibes/soul/sections/blog-post-content/blog-post-content.tsx
@@ -1,0 +1,88 @@
+import { clsx } from 'clsx';
+
+import { Image } from '~/components/image';
+
+import { Breadcrumb, Breadcrumbs } from '../../primitives/breadcrumbs';
+import { ButtonLink } from '../../primitives/button-link';
+
+interface Tag {
+  label: string;
+  link: {
+    href: string;
+    target?: string;
+  };
+}
+
+interface Image {
+  src: string;
+  alt: string;
+}
+
+interface Props {
+  title: string;
+  author?: string;
+  date: string;
+  tags?: Tag[];
+  content: string;
+  image?: Image;
+  className?: string;
+  breadcrumbs?: Breadcrumb[];
+}
+
+export const BlogPostContent = function BlogPostContent({
+  title,
+  author,
+  date,
+  tags,
+  content,
+  image,
+  className = '',
+  breadcrumbs,
+}: Props) {
+  return (
+    <section className={clsx('@container', className)}>
+      <div className="mx-auto max-w-screen-2xl px-4 py-10 @xl:px-6 @xl:py-14 @4xl:px-8 @4xl:py-20">
+        <header className="mx-auto w-full max-w-4xl pb-8 @2xl:pb-12 @4xl:pb-16">
+          {breadcrumbs && <Breadcrumbs breadcrumbs={breadcrumbs} />}
+
+          <h1 className="mb-4 mt-8 font-heading text-4xl font-medium leading-none @xl:text-5xl @4xl:text-6xl">
+            {title}
+          </h1>
+          <p>
+            {date}{' '}
+            {Boolean(author) && (
+              <>
+                <span className="px-1">•</span> {author}
+              </>
+            )}
+          </p>
+
+          {(tags?.length ?? 0) > 0 && (
+            <div className="-ml-1 mt-4 flex flex-wrap gap-1.5 @xl:mt-6">
+              {tags?.map((tag, index) => (
+                <ButtonLink href={tag.link.href} key={index} size="small" variant="tertiary">
+                  {tag.label}
+                </ButtonLink>
+              ))}
+            </div>
+          )}
+        </header>
+
+        {image?.src != null && image.src !== '' && (
+          <Image
+            alt={image.alt}
+            className="mb-8 aspect-video w-full rounded-2xl bg-contrast-100 object-cover @2xl:mb-12 @4xl:mb-16"
+            height={780}
+            src={image.src}
+            width={1280}
+          />
+        )}
+
+        <article
+          className="prose mx-auto w-full max-w-4xl space-y-4 [&_h2]:font-heading [&_h2]:text-3xl [&_h2]:font-normal [&_h2]:leading-none [&_h2]:@xl:text-4xl [&_img]:mx-auto [&_img]:max-h-[600px] [&_img]:w-fit [&_img]:rounded-2xl [&_img]:object-cover"
+          dangerouslySetInnerHTML={{ __html: content }}
+        />
+      </div>
+    </section>
+  );
+};

--- a/core/vibes/soul/sections/blog-post-content/index.ts
+++ b/core/vibes/soul/sections/blog-post-content/index.ts
@@ -1,0 +1,1 @@
+export * from './blog-post-content';


### PR DESCRIPTION
## What/Why?
- Add `blog-post-content` vibes component into catalyst
- Use `BlogPostContent` component on the blog post page (`/blog/[blogId]`)

## Testing

1. Ensure blog post content displays as expected
2. Ensure author can be blang
3. Ensure breadcrumbs link to the correct URL
4. Ensure blog tags link to the correct URL

https://github.com/user-attachments/assets/d7e5bf30-4100-4baa-9c6e-ff774b631c1d


