### PR TITLE
feat: add FeaturedBlogPostList to /blog

### DIFF
--- a/core/app/[locale]/(default)/blog/tag/[tagId]/page.tsx
+++ b/core/app/[locale]/(default)/blog/tag/[tagId]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from 'next/navigation';
 import { BlogPostCard } from '~/components/blog-post-card';
 import { Pagination } from '~/components/ui/pagination';
 
-import { getBlogPosts } from '../../page-data';
+import { getBlog, getBlogPosts } from '../../page-data';
 
 interface Props {
   params: Promise<{
@@ -15,16 +15,16 @@ interface Props {
 export default async function Tag(props: Props) {
   const searchParams = await props.searchParams;
   const { tagId } = await props.params;
-
+  const blog = await getBlog();
   const blogPosts = await getBlogPosts({ tagId, ...searchParams });
 
-  if (!blogPosts) {
+  if (!blog || !blogPosts) {
     return notFound();
   }
 
   return (
     <div className="mx-auto max-w-screen-xl">
-      <h1 className="mb-8 text-3xl font-black lg:text-5xl">{blogPosts.name}</h1>
+      <h1 className="mb-8 text-3xl font-black lg:text-5xl">{blog.name}</h1>
 
       <div className="grid grid-cols-1 gap-10 sm:grid-cols-2 lg:grid-cols-3 lg:gap-8">
         {blogPosts.posts.items.map((post) => {

--- a/core/vibes/soul/primitives/blog-post-card/index.tsx
+++ b/core/vibes/soul/primitives/blog-post-card/index.tsx
@@ -1,0 +1,87 @@
+import { clsx } from 'clsx';
+
+import { Image } from '~/components/image';
+import { Link } from '~/components/link';
+
+export interface BlogPost {
+  id: string;
+  author?: string | null;
+  content: string;
+  date: string;
+  image?: {
+    src: string;
+    alt: string;
+  };
+  href: string;
+  title: string;
+  className?: string;
+}
+
+export function BlogPostCard({ title, image, content, href, date, author, className }: BlogPost) {
+  return (
+    <Link
+      className={clsx(
+        'group max-w-full rounded-b-lg rounded-t-2xl text-foreground ring-primary ring-offset-4 @container focus:outline-0 focus-visible:ring-2',
+        className,
+      )}
+      href={href}
+    >
+      <div className="relative mb-4 aspect-[4/3] w-full overflow-hidden rounded-2xl bg-contrast-100">
+        {image?.src != null && image.src !== '' ? (
+          <Image
+            alt={image.alt}
+            className="object-cover transition-transform duration-500 ease-out group-hover:scale-110"
+            fill
+            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+            src={image.src}
+          />
+        ) : (
+          <div className="p-4 text-5xl font-bold leading-none tracking-tighter text-foreground/15">
+            {title}
+          </div>
+        )}
+      </div>
+
+      <div className="text-lg font-medium leading-snug">{title}</div>
+      <p className="mb-3 mt-1.5 line-clamp-3 text-sm font-normal text-contrast-400">{content}</p>
+      <div className="text-sm">
+        <time dateTime={date}>
+          {new Date(date).toLocaleDateString('en-US', {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+          })}
+        </time>
+        {date !== '' && author != null && author !== '' && (
+          <span className="after:mx-2 after:content-['•']" />
+        )}
+        {author != null && author !== '' && <span>{author}</span>}
+      </div>
+    </Link>
+  );
+}
+
+export function BlogPostCardSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={clsx('flex max-w-md animate-pulse flex-col gap-2 rounded-xl', className)}>
+      {/* Image */}
+      <div className="aspect-[4/3] overflow-hidden rounded-xl bg-contrast-100" />
+
+      {/* Title */}
+      <div className="h-4 w-24 rounded-lg bg-contrast-100" />
+
+      {/* Content */}
+      <div className="h-3 w-full rounded-lg bg-contrast-100" />
+      <div className="h-3 w-full rounded-lg bg-contrast-100" />
+      <div className="h-3 w-1/2 rounded-lg bg-contrast-100" />
+
+      <div className="flex flex-wrap items-center">
+        {/* Date */}
+        <div className="h-4 w-16 rounded-lg bg-contrast-100" />
+        <span className="after:mx-2 after:text-contrast-100 after:content-['•']" />
+        {/* Author */}
+        <div className="h-4 w-20 rounded-lg bg-contrast-100" />
+      </div>
+    </div>
+  );
+}

--- a/core/vibes/soul/sections/blog-post-content/blog-post-content.tsx
+++ b/core/vibes/soul/sections/blog-post-content/blog-post-content.tsx
@@ -29,7 +29,7 @@ interface Props {
   breadcrumbs?: Breadcrumb[];
 }
 
-export const BlogPostContent = function BlogPostContent({
+export function BlogPostContent({
   title,
   author,
   date,
@@ -85,4 +85,4 @@ export const BlogPostContent = function BlogPostContent({
       </div>
     </section>
   );
-};
+}

--- a/core/vibes/soul/sections/blog-post-list/index.tsx
+++ b/core/vibes/soul/sections/blog-post-list/index.tsx
@@ -1,0 +1,30 @@
+import { clsx } from 'clsx';
+
+import { Stream, Streamable } from '@/vibes/soul/lib/streamable';
+import {
+  BlogPost,
+  BlogPostCard,
+  BlogPostCardSkeleton,
+} from '@/vibes/soul/primitives/blog-post-card';
+
+interface Props {
+  posts: Streamable<BlogPost[]>;
+  className?: string;
+}
+
+export function BlogPostList({ posts: streamablePosts, className = '' }: Props) {
+  return (
+    <div className={clsx('@container', className)}>
+      <div className="mx-auto grid grid-cols-1 gap-x-5 gap-y-8 @md:grid-cols-2 @xl:gap-y-10 @3xl:grid-cols-3 @6xl:grid-cols-4">
+        <Stream
+          fallback={Array.from({ length: 5 }).map((_, index) => (
+            <BlogPostCardSkeleton key={index} />
+          ))}
+          value={streamablePosts}
+        >
+          {(posts) => posts.map((post) => <BlogPostCard key={post.id} {...post} />)}
+        </Stream>
+      </div>
+    </div>
+  );
+}

--- a/core/vibes/soul/sections/featured-blog-post-list/index.tsx
+++ b/core/vibes/soul/sections/featured-blog-post-list/index.tsx
@@ -1,0 +1,40 @@
+import { Streamable } from '@/vibes/soul/lib/streamable';
+import { BlogPost } from '@/vibes/soul/primitives/blog-post-card';
+import { ButtonLink } from '@/vibes/soul/primitives/button-link';
+import { BlogPostList } from '@/vibes/soul/sections/blog-post-list';
+
+interface Link {
+  label: string;
+  href: string;
+}
+
+interface Props {
+  title: string;
+  description?: string;
+  cta?: Link;
+  posts: Streamable<BlogPost[]>;
+}
+
+export function FeaturedBlogPostList({ title, description, cta, posts }: Props) {
+  return (
+    <section className="@container">
+      <div className="mx-auto max-w-screen-2xl px-4 py-10 @xl:px-6 @xl:py-14 @4xl:px-8 @4xl:py-20">
+        <h1 className="mb-3 font-heading text-4xl font-medium leading-none text-foreground @xl:text-5xl @4xl:text-6xl">
+          {title}
+        </h1>
+
+        {description != null && description !== '' && (
+          <p className="max-w-lg text-lg text-contrast-500">{description}</p>
+        )}
+
+        <BlogPostList className="mb-8 mt-8 @4xl:mb-10 @4xl:mt-10" posts={posts} />
+
+        {cta != null && cta.href !== '' && cta.label !== '' && (
+          <ButtonLink href={cta.href} size="medium" variant="tertiary">
+            {cta.label}
+          </ButtonLink>
+        )}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## What/Why?
- Use `FeaturedBlogPostList` component on `/blog` page
- Update code to use streamable props for blog posts
- Optimized page-data to separate blog info from blog posts. This is more efficient, since we don't need to fetch the blog name/description on every request.

## Testing
Blog functionality works as expected when using the `FeaturedBlogPostList` component

https://github.com/user-attachments/assets/8a7fbe48-874c-4e0f-8cde-7705f079e673

**Updated:**

`object-cover` ensures image is not stretched:
![image](https://github.com/user-attachments/assets/91721046-aa0a-429a-ae8e-ddbfa5ebeaa1)

