### PR TITLE
Downgrade cart to guest cart on logout

### DIFF
--- a/.changeset/unlucky-suits-pretend.md
+++ b/.changeset/unlucky-suits-pretend.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Downgrade customer cart to guest cart automatically on logout

--- a/core/auth.ts
+++ b/core/auth.ts
@@ -24,8 +24,8 @@ const LoginMutation = graphql(`
 `);
 
 const LogoutMutation = graphql(`
-  mutation LogoutMutation {
-    logout {
+  mutation LogoutMutation($cartEntityId: String) {
+    logout(cartEntityId: $cartEntityId) {
       result
     }
   }
@@ -64,12 +64,14 @@ const config = {
   events: {
     async signOut(message) {
       const customerAccessToken = 'token' in message ? message.token?.customerAccessToken : null;
+      const cookieStore = await cookies();
+      const cartEntityId = cookieStore.get('cartId')?.value;
 
       if (customerAccessToken) {
         try {
           await client.fetch({
             document: LogoutMutation,
-            variables: {},
+            variables: { cartEntityId },
             customerAccessToken,
             fetchOptions: {
               cache: 'no-store',


### PR DESCRIPTION
## What/Why?
Opposite of https://github.com/bigcommerce/catalyst/pull/1765, downgrades customer cart to a guest cart whenever a shopper explicitly logs out.

Depends on new GQL capability that is not rolled out to 100% of stores yet, so `do not merge` label for now.

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->