### PR TITLE
refactor(makeswift): userland RSC `Page` component etc.

### DIFF
--- a/core/lib/makeswift/client.ts
+++ b/core/lib/makeswift/client.ts
@@ -1,7 +1,11 @@
 import { Makeswift } from '@makeswift/runtime/next';
+import { getSiteVersion } from '@makeswift/runtime/next/server';
 import { strict } from 'assert';
+import { getLocale } from 'next-intl/server';
 
-import { runtime } from '~/lib/makeswift/runtime';
+import { defaultLocale } from '~/i18n/routing';
+
+import { runtime } from './runtime';
 
 strict(process.env.MAKESWIFT_SITE_API_KEY, 'MAKESWIFT_SITE_API_KEY is required');
 
@@ -9,3 +13,22 @@ export const client = new Makeswift(process.env.MAKESWIFT_SITE_API_KEY, {
   runtime,
   apiOrigin: process.env.MAKESWIFT_API_ORIGIN,
 });
+
+export const getPageSnapshot = async ({ path, locale }: { path: string; locale: string }) =>
+  await client.getPageSnapshot(path, {
+    siteVersion: await getSiteVersion(),
+    locale: normalizeLocale(locale),
+  });
+
+export const getComponentSnapshot = async (snapshotId: string) => {
+  const locale = await getLocale();
+
+  return await client.getComponentSnapshot(snapshotId, {
+    siteVersion: await getSiteVersion(),
+    locale: normalizeLocale(locale),
+  });
+};
+
+function normalizeLocale(locale: string): string | undefined {
+  return locale === defaultLocale ? undefined : locale;
+}

--- a/core/lib/makeswift/index.ts
+++ b/core/lib/makeswift/index.ts
@@ -1,0 +1,2 @@
+export { Page } from './page';
+export { client } from './client';

--- a/core/lib/makeswift/page.tsx
+++ b/core/lib/makeswift/page.tsx
@@ -1,0 +1,12 @@
+import { Page as MakeswiftPage } from '@makeswift/runtime/next';
+import { notFound } from 'next/navigation';
+
+import { getPageSnapshot } from './client';
+
+export async function Page({ path, locale }: { path: string; locale: string }) {
+  const snapshot = await getPageSnapshot({ path, locale });
+
+  if (snapshot == null) return notFound();
+
+  return <MakeswiftPage snapshot={snapshot} />;
+}

--- a/core/package.json
+++ b/core/package.json
@@ -17,7 +17,7 @@
     "@conform-to/react": "^1.2.2",
     "@conform-to/zod": "^1.2.2",
     "@icons-pack/react-simple-icons": "^10.2.0",
-    "@makeswift/runtime": "0.0.0-snapshot-20241213071732",
+    "@makeswift/runtime": "0.0.0-snapshot-20241217195602",
     "@radix-ui/react-accordion": "^1.2.1",
     "@radix-ui/react-alert-dialog": "^1.1.2",
     "@radix-ui/react-checkbox": "^1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^10.2.0
         version: 10.2.0(react@19.0.0)
       '@makeswift/runtime':
-        specifier: 0.0.0-snapshot-20241213071732
-        version: 0.0.0-snapshot-20241213071732(@types/react-dom@19.0.1)(@types/react@19.0.1)(next@15.0.4-canary.18(@playwright/test@1.49.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: 0.0.0-snapshot-20241217195602
+        version: 0.0.0-snapshot-20241217195602(@types/react-dom@19.0.1)(@types/react@19.0.1)(next@15.0.4-canary.18(@playwright/test@1.49.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-accordion':
         specifier: ^1.2.1
         version: 1.2.1(@types/react-dom@19.0.1)(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -1361,19 +1361,19 @@ packages:
     resolution: {integrity: sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==}
     engines: {node: '>=8'}
 
-  '@makeswift/controls@0.1.5':
-    resolution: {integrity: sha512-3+3cPc4tYj0q/XwUc+0pAZBnme0DS3EnncDU/v6FdHUNFwuWKafBoZ+0z+6chMbh0QNl5Qr3W4Htq+YdId8fsg==}
+  '@makeswift/controls@0.0.0-snapshot-20241217195602':
+    resolution: {integrity: sha512-Q1Y+kSsa09+7eys8zScPMnb70YH9aiI7ZGTFF6HTXJL/+xtKATCsUFNmCPiN/Er+2Ms+K+gefBE68YIZSJdVQw==}
 
   '@makeswift/next-plugin@0.3.0':
     resolution: {integrity: sha512-pGe0D6KrVxZcyaM8hFCIK806yNV6YJtRcjjD+2Wpn5qkFStIMTlACkGRVHVLftFyfi8/E3lGkbR05Jo3aTecwQ==}
     peerDependencies:
       next: ^13.4.0 || ^14.0.0
 
-  '@makeswift/prop-controllers@0.3.6':
-    resolution: {integrity: sha512-pEro/ziA+jw/fXYAGEAi375VGnZQCKJZTwVuuaUj63eXgFQWBjsgZFV1v77wfsv27xyLPXHecm2QEjq0BRmhBw==}
+  '@makeswift/prop-controllers@0.0.0-snapshot-20241217195602':
+    resolution: {integrity: sha512-w0ZicsgyGqlXntpdo0LqRrXE3iP/3vs/inWx3lv+7XYOn/p+nIYPbGLXZCf/4IEJzLmOdE14vOGH3f/uxhN40A==}
 
-  '@makeswift/runtime@0.0.0-snapshot-20241213071732':
-    resolution: {integrity: sha512-jWJkk8ID9osNwkCreUmF53C2tH6x2aWaKeE1LWom06o/OyizOniYkbCCiM97z+DUGAX9dasy+DHL7KOyxcCpKg==}
+  '@makeswift/runtime@0.0.0-snapshot-20241217195602':
+    resolution: {integrity: sha512-4CvJWFjkk2bes1+CzuDnWsFcKTpYY/RQz2ROkd+T1E5SofGbalN1iGEcpS+nHHYcnGF2rb+Vt6jRbZqt8XlrMw==}
     peerDependencies:
       '@types/react': ^18.0.0
       '@types/react-dom': ^18.0.0
@@ -7056,7 +7056,7 @@ snapshots:
     dependencies:
       '@lukeed/csprng': 1.1.0
 
-  '@makeswift/controls@0.1.5':
+  '@makeswift/controls@0.0.0-snapshot-20241217195602':
     dependencies:
       color: 3.2.1
       css-box-model: 1.2.1
@@ -7072,13 +7072,13 @@ snapshots:
       next: 15.0.4-canary.18(@playwright/test@1.49.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       semver: 7.6.3
 
-  '@makeswift/prop-controllers@0.3.6':
+  '@makeswift/prop-controllers@0.0.0-snapshot-20241217195602':
     dependencies:
-      '@makeswift/controls': 0.1.5
+      '@makeswift/controls': 0.0.0-snapshot-20241217195602
       ts-pattern: 5.5.0
       zod: 3.23.8
 
-  '@makeswift/runtime@0.0.0-snapshot-20241213071732(@types/react-dom@19.0.1)(@types/react@19.0.1)(next@15.0.4-canary.18(@playwright/test@1.49.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@makeswift/runtime@0.0.0-snapshot-20241217195602(@types/react-dom@19.0.1)(@types/react@19.0.1)(next@15.0.4-canary.18(@playwright/test@1.49.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@emotion/cache': 11.14.0
       '@emotion/css': 11.13.5
@@ -7086,9 +7086,9 @@ snapshots:
       '@emotion/server': 11.11.0(@emotion/css@11.13.5)
       '@emotion/sheet': 1.4.0
       '@emotion/utils': 1.4.2
-      '@makeswift/controls': 0.1.5
+      '@makeswift/controls': 0.0.0-snapshot-20241217195602
       '@makeswift/next-plugin': 0.3.0(next@15.0.4-canary.18(@playwright/test@1.49.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
-      '@makeswift/prop-controllers': 0.3.6
+      '@makeswift/prop-controllers': 0.0.0-snapshot-20241217195602
       '@popmotion/popcorn': 0.4.4
       '@redux-devtools/extension': 3.3.0(redux@4.2.1)
       '@types/is-hotkey': 0.1.10


### PR DESCRIPTION
## What/Why?

Implements "userland" RSC `Page` component and related API abstractions as discussed [here](https://makeswifthq.slack.com/archives/C014SCS4G75/p1734553802046819?thread_ts=1734538843.665429&cid=C014SCS4G75) and [here](https://makeswifthq.slack.com/archives/C080BNSNEG7/p1734401070722499?thread_ts=1734384162.728269&cid=C080BNSNEG7).


## Testing

https://github.com/user-attachments/assets/fcb2c2a1-ccee-46aa-95ce-31baeec92343


