### PR TITLE
feat: add pagination and breadcrumbs to /blog and /blog/tag/[tagId]

### DIFF
--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -14,6 +14,7 @@ import { getFilterParsers } from '@/vibes/soul/sections/products-list-section/fi
 import { Filter } from '@/vibes/soul/sections/products-list-section/filters-panel';
 import { Option as SortOption } from '@/vibes/soul/sections/products-list-section/sorting';
 import { facetsTransformer } from '~/data-transformers/facets-transformer';
+import { pageInfoTransformer } from '~/data-transformers/page-info-transformer';
 import { pricesTransformer } from '~/data-transformers/prices-transformer';
 
 import { fetchFacetedSearch } from '../../fetch-faceted-search';
@@ -162,7 +163,7 @@ async function getSortOptions(): Promise<SortOption[]> {
 async function getPaginationInfo(
   categoryId: number,
   searchParamsPromise: Promise<SearchParams>,
-): Promise<CursorPaginationInfo | null> {
+): Promise<CursorPaginationInfo> {
   const searchParams = await searchParamsPromise;
   const searchParamsCache = await createFiltersSearchParamCache(categoryId);
   const parsedSearchParams = searchParamsCache.parse(searchParams);
@@ -171,16 +172,8 @@ async function getPaginationInfo(
     ...parsedSearchParams,
     category: categoryId,
   });
-  const { hasNextPage, hasPreviousPage, endCursor, startCursor } = search.products.pageInfo;
 
-  return hasNextPage || hasPreviousPage
-    ? {
-        startCursorParamName: 'before',
-        endCursorParamName: 'after',
-        endCursor: hasNextPage ? endCursor : null,
-        startCursor: hasPreviousPage ? startCursor : null,
-      }
-    : null;
+  return pageInfoTransformer(search.products.pageInfo);
 }
 
 async function getFilterLabel(): Promise<string> {

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -47,7 +47,7 @@ async function getCategory(categoryId: number) {
   return category;
 }
 
-async function getBreadcrumbs(categoryId: number): Promise<Breadcrumb[] | null> {
+async function getBreadcrumbs(categoryId: number): Promise<Breadcrumb[]> {
   const category = await getCategory(categoryId);
 
   return removeEdgesAndNodes(category.breadcrumbs).map(({ name, path }) => ({

--- a/core/app/[locale]/(default)/blog/page.tsx
+++ b/core/app/[locale]/(default)/blog/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
 import { FeaturedBlogPostList } from '@/vibes/soul/sections/featured-blog-post-list';
+import { pageInfoTransformer } from '~/data-transformers/page-info-transformer';
 
 import { getBlog, getBlogMetaData, getBlogPosts } from './page-data';
 
@@ -24,6 +25,13 @@ async function listBlogPosts(searchParamsPromise: Promise<SearchParams>) {
   return posts;
 }
 
+async function getPaginationInfo(searchParamsPromise: Promise<SearchParams>) {
+  const searchParams = await searchParamsPromise;
+  const blogPosts = await getBlogPosts(searchParams);
+
+  return pageInfoTransformer(blogPosts?.pageInfo);
+}
+
 export default async function Blog(props: Props) {
   const blog = await getBlog();
 
@@ -33,8 +41,18 @@ export default async function Blog(props: Props) {
 
   return (
     <FeaturedBlogPostList
-      cta={{ href: '#', label: 'View All' }}
+      breadcrumbs={[
+        {
+          label: 'Home',
+          href: '/',
+        },
+        {
+          label: 'Blog',
+          href: '#',
+        },
+      ]}
       description={blog.description}
+      paginationInfo={getPaginationInfo(props.searchParams)}
       posts={listBlogPosts(props.searchParams)}
       title={blog.name}
     />

--- a/core/app/[locale]/(default)/blog/page.tsx
+++ b/core/app/[locale]/(default)/blog/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
 import { FeaturedBlogPostList } from '@/vibes/soul/sections/featured-blog-post-list';
-import { pageInfoTransformer } from '~/data-transformers/page-info-transformer';
+import { defaultPageInfo, pageInfoTransformer } from '~/data-transformers/page-info-transformer';
 
 import { getBlog, getBlogMetaData, getBlogPosts } from './page-data';
 
@@ -29,7 +29,7 @@ async function getPaginationInfo(searchParamsPromise: Promise<SearchParams>) {
   const searchParams = await searchParamsPromise;
   const blogPosts = await getBlogPosts(searchParams);
 
-  return pageInfoTransformer(blogPosts?.pageInfo);
+  return pageInfoTransformer(blogPosts?.pageInfo ?? defaultPageInfo);
 }
 
 export default async function Blog(props: Props) {

--- a/core/app/[locale]/(default)/blog/tag/[tagId]/page.tsx
+++ b/core/app/[locale]/(default)/blog/tag/[tagId]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
 import { FeaturedBlogPostList } from '@/vibes/soul/sections/featured-blog-post-list';
-import { pageInfoTransformer } from '~/data-transformers/page-info-transformer';
+import { defaultPageInfo, pageInfoTransformer } from '~/data-transformers/page-info-transformer';
 
 import { getBlog, getBlogMetaData, getBlogPosts } from '../../page-data';
 
@@ -31,7 +31,7 @@ async function getPaginationInfo(props: Props) {
   const searchParams = await props.searchParams;
   const blogPosts = await getBlogPosts({ tagId, ...searchParams });
 
-  return pageInfoTransformer(blogPosts?.pageInfo);
+  return pageInfoTransformer(blogPosts?.pageInfo ?? defaultPageInfo);
 }
 
 export default async function Tag(props: Props) {

--- a/core/data-transformers/page-info-transformer.ts
+++ b/core/data-transformers/page-info-transformer.ts
@@ -1,23 +1,22 @@
+import { ResultOf } from 'gql.tada';
+
 import { CursorPaginationInfo } from '@/vibes/soul/primitives/cursor-pagination';
+import { PaginationFragment } from '~/client/fragments/pagination';
 
-interface PageInfo {
-  hasNextPage: boolean;
-  hasPreviousPage: boolean;
-  startCursor: string | null;
-  endCursor: string | null;
-}
+export const defaultPageInfo = {
+  hasNextPage: false,
+  hasPreviousPage: false,
+  startCursor: null,
+  endCursor: null,
+};
 
-/**
- * Utility function to convert GraphQL PageInfo object into CursorPaginationInfo
- *
- * @param {PageInfo | undefined} pageInfo - The PageInfo object to transform
- * @returns {CursorPaginationInfo}
- */
-export function pageInfoTransformer(pageInfo: PageInfo | undefined): CursorPaginationInfo {
+export function pageInfoTransformer(
+  pageInfo: ResultOf<typeof PaginationFragment>,
+): CursorPaginationInfo {
   return {
     startCursorParamName: 'before',
-    startCursor: pageInfo?.hasPreviousPage ? pageInfo.startCursor : null,
+    startCursor: pageInfo.startCursor,
     endCursorParamName: 'after',
-    endCursor: pageInfo?.hasNextPage ? pageInfo.endCursor : null,
+    endCursor: pageInfo.endCursor,
   };
 }

--- a/core/data-transformers/page-info-transformer.ts
+++ b/core/data-transformers/page-info-transformer.ts
@@ -1,0 +1,23 @@
+import { CursorPaginationInfo } from '@/vibes/soul/primitives/cursor-pagination';
+
+interface PageInfo {
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+  endCursor: string | null;
+}
+
+/**
+ * Utility function to convert GraphQL PageInfo object into CursorPaginationInfo
+ *
+ * @param {PageInfo | undefined} pageInfo - The PageInfo object to transform
+ * @returns {CursorPaginationInfo}
+ */
+export function pageInfoTransformer(pageInfo: PageInfo | undefined): CursorPaginationInfo {
+  return {
+    startCursorParamName: 'before',
+    startCursor: pageInfo?.hasPreviousPage ? pageInfo.startCursor : null,
+    endCursorParamName: 'after',
+    endCursor: pageInfo?.hasNextPage ? pageInfo.endCursor : null,
+  };
+}

--- a/core/vibes/soul/primitives/breadcrumbs/index.tsx
+++ b/core/vibes/soul/primitives/breadcrumbs/index.tsx
@@ -1,7 +1,7 @@
 import { clsx } from 'clsx';
 import { ChevronRight } from 'lucide-react';
 
-import { Stream, Streamable, useStreamable } from '@/vibes/soul/lib/streamable';
+import { Stream, Streamable } from '@/vibes/soul/lib/streamable';
 import { AnimatedLink } from '@/vibes/soul/primitives/animated-link';
 
 export interface Breadcrumb {
@@ -13,51 +13,43 @@ export interface BreadcrumbsProps {
   className?: string;
 }
 
-export function Breadcrumbs(props: BreadcrumbsProps) {
+export function Breadcrumbs({ breadcrumbs: streamableBreadcrumbs, className }: BreadcrumbsProps) {
   return (
-    <Stream fallback={<BreadcrumbsSkeleton />} value={props.breadcrumbs}>
-      {(breadcrumbs) => (
-        <BreadcrumbsResolved breadcrumbs={breadcrumbs} className={props.className} />
-      )}
+    <Stream fallback={<BreadcrumbsSkeleton />} value={streamableBreadcrumbs}>
+      {(breadcrumbs) =>
+        breadcrumbs.length === 0 ? (
+          <div className={clsx('min-h-[1lh]', className)} />
+        ) : (
+          <nav aria-label="breadcrumb" className={clsx(className)}>
+            <ol className="flex flex-wrap items-center gap-x-1.5 text-sm @xl:text-base">
+              {breadcrumbs.map(({ label, href }, idx) => {
+                if (idx < breadcrumbs.length - 1) {
+                  return (
+                    <li className="inline-flex items-center gap-x-1.5" key={idx}>
+                      <AnimatedLink label={label} link={{ href }} />
+                      <ChevronRight
+                        aria-hidden="true"
+                        className="text-contrast-500"
+                        size={20}
+                        strokeWidth={1}
+                      />
+                    </li>
+                  );
+                }
+
+                return (
+                  <li className="inline-flex items-center text-contrast-500" key={idx}>
+                    <span aria-current="page" aria-disabled="true" role="link">
+                      {label}
+                    </span>
+                  </li>
+                );
+              })}
+            </ol>
+          </nav>
+        )
+      }
     </Stream>
-  );
-}
-
-function BreadcrumbsResolved({ breadcrumbs: streamableBreadcrumbs, className }: BreadcrumbsProps) {
-  const breadcrumbs = useStreamable(streamableBreadcrumbs);
-
-  if (breadcrumbs.length === 0) {
-    return <div className={clsx('min-h-[1lh]', className)} />;
-  }
-
-  return (
-    <nav aria-label="breadcrumb" className={clsx(className)}>
-      <ol className="flex flex-wrap items-center gap-x-1.5 text-sm @xl:text-base">
-        {breadcrumbs.map(({ label, href }, idx) => {
-          if (idx < breadcrumbs.length - 1) {
-            return (
-              <li className="inline-flex items-center gap-x-1.5" key={idx}>
-                <AnimatedLink label={label} link={{ href }} />
-                <ChevronRight
-                  aria-hidden="true"
-                  className="text-contrast-500"
-                  size={20}
-                  strokeWidth={1}
-                />
-              </li>
-            );
-          }
-
-          return (
-            <li className="inline-flex items-center text-contrast-500" key={idx}>
-              <span aria-current="page" aria-disabled="true" role="link">
-                {label}
-              </span>
-            </li>
-          );
-        })}
-      </ol>
-    </nav>
   );
 }
 

--- a/core/vibes/soul/primitives/breadcrumbs/index.tsx
+++ b/core/vibes/soul/primitives/breadcrumbs/index.tsx
@@ -1,19 +1,31 @@
 import { clsx } from 'clsx';
 import { ChevronRight } from 'lucide-react';
 
+import { Stream, Streamable, useStreamable } from '@/vibes/soul/lib/streamable';
 import { AnimatedLink } from '@/vibes/soul/primitives/animated-link';
 
 export interface Breadcrumb {
   label: string;
   href: string;
 }
-
 export interface BreadcrumbsProps {
-  breadcrumbs: Breadcrumb[];
+  breadcrumbs: Streamable<Breadcrumb[]>;
   className?: string;
 }
 
-export function Breadcrumbs({ breadcrumbs, className }: BreadcrumbsProps) {
+export function Breadcrumbs(props: BreadcrumbsProps) {
+  return (
+    <Stream fallback={<BreadcrumbsSkeleton />} value={props.breadcrumbs}>
+      {(breadcrumbs) => (
+        <BreadcrumbsResolved breadcrumbs={breadcrumbs} className={props.className} />
+      )}
+    </Stream>
+  );
+}
+
+function BreadcrumbsResolved({ breadcrumbs: streamableBreadcrumbs, className }: BreadcrumbsProps) {
+  const breadcrumbs = useStreamable(streamableBreadcrumbs);
+
   if (breadcrumbs.length === 0) {
     return <div className={clsx('min-h-[1lh]', className)} />;
   }

--- a/core/vibes/soul/sections/featured-blog-post-list/index.tsx
+++ b/core/vibes/soul/sections/featured-blog-post-list/index.tsx
@@ -1,6 +1,6 @@
-import { Stream, Streamable } from '@/vibes/soul/lib/streamable';
+import { Streamable } from '@/vibes/soul/lib/streamable';
 import { BlogPost } from '@/vibes/soul/primitives/blog-post-card';
-import { Breadcrumb, Breadcrumbs, BreadcrumbsSkeleton } from '@/vibes/soul/primitives/breadcrumbs';
+import { Breadcrumb, Breadcrumbs } from '@/vibes/soul/primitives/breadcrumbs';
 import { CursorPagination, CursorPaginationInfo } from '@/vibes/soul/primitives/cursor-pagination';
 import { BlogPostList } from '@/vibes/soul/sections/blog-post-list';
 
@@ -17,16 +17,12 @@ export function FeaturedBlogPostList({
   description,
   posts,
   paginationInfo,
-  breadcrumbs: streamableBreadcrumbs,
+  breadcrumbs,
 }: Props) {
   return (
     <section className="@container">
       <div className="mx-auto max-w-screen-2xl px-4 py-10 @xl:px-6 @xl:py-14 @4xl:px-8 @4xl:py-20">
-        {streamableBreadcrumbs && (
-          <Stream fallback={<BreadcrumbsSkeleton />} value={streamableBreadcrumbs}>
-            {(breadcrumbs) => <Breadcrumbs breadcrumbs={breadcrumbs} />}
-          </Stream>
-        )}
+        {breadcrumbs && <Breadcrumbs breadcrumbs={breadcrumbs} />}
 
         <div className="pt-6">
           <h1 className="mb-3 font-heading text-4xl font-medium leading-none text-foreground @xl:text-5xl @4xl:text-6xl">

--- a/core/vibes/soul/sections/featured-blog-post-list/index.tsx
+++ b/core/vibes/soul/sections/featured-blog-post-list/index.tsx
@@ -1,39 +1,46 @@
-import { Streamable } from '@/vibes/soul/lib/streamable';
+import { Stream, Streamable } from '@/vibes/soul/lib/streamable';
 import { BlogPost } from '@/vibes/soul/primitives/blog-post-card';
-import { ButtonLink } from '@/vibes/soul/primitives/button-link';
+import { Breadcrumb, Breadcrumbs, BreadcrumbsSkeleton } from '@/vibes/soul/primitives/breadcrumbs';
+import { CursorPagination, CursorPaginationInfo } from '@/vibes/soul/primitives/cursor-pagination';
 import { BlogPostList } from '@/vibes/soul/sections/blog-post-list';
-
-interface Link {
-  label: string;
-  href: string;
-}
 
 interface Props {
   title: string;
   description?: string;
-  cta?: Link;
   posts: Streamable<BlogPost[]>;
+  paginationInfo?: Streamable<CursorPaginationInfo>;
+  breadcrumbs?: Streamable<Breadcrumb[]>;
 }
 
-export function FeaturedBlogPostList({ title, description, cta, posts }: Props) {
+export function FeaturedBlogPostList({
+  title,
+  description,
+  posts,
+  paginationInfo,
+  breadcrumbs: streamableBreadcrumbs,
+}: Props) {
   return (
     <section className="@container">
       <div className="mx-auto max-w-screen-2xl px-4 py-10 @xl:px-6 @xl:py-14 @4xl:px-8 @4xl:py-20">
-        <h1 className="mb-3 font-heading text-4xl font-medium leading-none text-foreground @xl:text-5xl @4xl:text-6xl">
-          {title}
-        </h1>
-
-        {description != null && description !== '' && (
-          <p className="max-w-lg text-lg text-contrast-500">{description}</p>
+        {streamableBreadcrumbs && (
+          <Stream fallback={<BreadcrumbsSkeleton />} value={streamableBreadcrumbs}>
+            {(breadcrumbs) => <Breadcrumbs breadcrumbs={breadcrumbs} />}
+          </Stream>
         )}
 
-        <BlogPostList className="mb-8 mt-8 @4xl:mb-10 @4xl:mt-10" posts={posts} />
+        <div className="pt-6">
+          <h1 className="mb-3 font-heading text-4xl font-medium leading-none text-foreground @xl:text-5xl @4xl:text-6xl">
+            {title}
+          </h1>
 
-        {cta != null && cta.href !== '' && cta.label !== '' && (
-          <ButtonLink href={cta.href} size="medium" variant="tertiary">
-            {cta.label}
-          </ButtonLink>
-        )}
+          {description != null && description !== '' && (
+            <p className="max-w-lg text-lg text-contrast-500">{description}</p>
+          )}
+
+          <BlogPostList className="mb-8 mt-8 @4xl:mb-10 @4xl:mt-10" posts={posts} />
+
+          {paginationInfo && <CursorPagination info={paginationInfo} />}
+        </div>
       </div>
     </section>
   );

--- a/core/vibes/soul/sections/product-detail/index.tsx
+++ b/core/vibes/soul/sections/product-detail/index.tsx
@@ -1,5 +1,5 @@
 import { Stream, Streamable } from '@/vibes/soul/lib/streamable';
-import { Breadcrumb, Breadcrumbs, BreadcrumbsSkeleton } from '@/vibes/soul/primitives/breadcrumbs';
+import { Breadcrumb, Breadcrumbs } from '@/vibes/soul/primitives/breadcrumbs';
 import { Price, PriceLabel } from '@/vibes/soul/primitives/price-label';
 import { Rating } from '@/vibes/soul/primitives/rating';
 import { ProductGallery } from '@/vibes/soul/sections/product-detail/product-gallery';
@@ -36,7 +36,7 @@ export function ProductDetail<F extends Field>({
   product: streamableProduct,
   action,
   fields: streamableFields,
-  breadcrumbs: streamableBreadcrumbs,
+  breadcrumbs,
   quantityLabel,
   incrementLabel,
   decrementLabel,
@@ -47,11 +47,7 @@ export function ProductDetail<F extends Field>({
   return (
     <section className="@container">
       <div className="mx-auto w-full max-w-screen-lg px-4 py-10 @xl:px-6 @xl:py-14 @4xl:px-8 @4xl:py-20">
-        <Stream fallback={<BreadcrumbsSkeleton className="mb-6" />} value={streamableBreadcrumbs}>
-          {(breadcrumbs) =>
-            breadcrumbs && <Breadcrumbs breadcrumbs={breadcrumbs} className="mb-6" />
-          }
-        </Stream>
+        {breadcrumbs && <Breadcrumbs breadcrumbs={breadcrumbs} className="mb-6" />}
 
         <Stream fallback={<ProductDetailSkeleton />} value={streamableProduct}>
           {(product) =>

--- a/core/vibes/soul/sections/products-list-section/filters-panel.tsx
+++ b/core/vibes/soul/sections/products-list-section/filters-panel.tsx
@@ -57,7 +57,7 @@ interface Props {
   className?: string;
   filters: Filter[] | Promise<Filter[]>;
   resetFiltersLabel?: string;
-  paginationInfo?: Streamable<CursorPaginationInfo | null>;
+  paginationInfo?: Streamable<CursorPaginationInfo>;
 }
 
 function getParamCountLabel(params: Record<string, string | null | string[]>, key: string) {

--- a/core/vibes/soul/sections/products-list-section/index.tsx
+++ b/core/vibes/soul/sections/products-list-section/index.tsx
@@ -1,8 +1,8 @@
 import { Sliders } from 'lucide-react';
 import { Suspense } from 'react';
 
-import { Streamable } from '@/vibes/soul/lib/streamable';
-import { Breadcrumb, Breadcrumbs } from '@/vibes/soul/primitives/breadcrumbs';
+import { Stream, Streamable } from '@/vibes/soul/lib/streamable';
+import { Breadcrumb, Breadcrumbs, BreadcrumbsSkeleton } from '@/vibes/soul/primitives/breadcrumbs';
 import { Button } from '@/vibes/soul/primitives/button';
 import { CursorPagination, CursorPaginationInfo } from '@/vibes/soul/primitives/cursor-pagination';
 import { ListProduct, ProductsList } from '@/vibes/soul/primitives/products-list';
@@ -36,7 +36,7 @@ interface Props {
 }
 
 export function ProductsListSection({
-  breadcrumbs,
+  breadcrumbs: streamableBreadcrumbs,
   title = 'Products',
   totalCount,
   products,
@@ -61,8 +61,11 @@ export function ProductsListSection({
       <div className="@container">
         <div className="mx-auto max-w-screen-2xl px-4 py-10 @xl:px-6 @xl:py-14 @4xl:px-8 @4xl:py-12">
           <div>
-            {breadcrumbs && <Breadcrumbs breadcrumbs={breadcrumbs} />}
-
+            <Stream fallback={<BreadcrumbsSkeleton />} value={streamableBreadcrumbs}>
+              {(breadcrumbs) =>
+                breadcrumbs && breadcrumbs.length > 1 && <Breadcrumbs breadcrumbs={breadcrumbs} />
+              }
+            </Stream>
             <div className="flex flex-wrap items-center justify-between gap-4 pb-8 pt-6 text-foreground">
               <h1 className="flex items-center gap-2 font-heading text-3xl font-medium leading-none @lg:text-4xl @2xl:text-5xl">
                 <Suspense

--- a/core/vibes/soul/sections/products-list-section/index.tsx
+++ b/core/vibes/soul/sections/products-list-section/index.tsx
@@ -4,11 +4,7 @@ import { Suspense } from 'react';
 import { Stream, Streamable } from '@/vibes/soul/lib/streamable';
 import { Breadcrumb, Breadcrumbs, BreadcrumbsSkeleton } from '@/vibes/soul/primitives/breadcrumbs';
 import { Button } from '@/vibes/soul/primitives/button';
-import {
-  CursorPagination,
-  CursorPaginationInfo,
-  CursorPaginationSkeleton,
-} from '@/vibes/soul/primitives/cursor-pagination';
+import { CursorPagination, CursorPaginationInfo } from '@/vibes/soul/primitives/cursor-pagination';
 import { ListProduct, ProductsList } from '@/vibes/soul/primitives/products-list';
 import * as SidePanel from '@/vibes/soul/primitives/side-panel';
 
@@ -25,7 +21,7 @@ interface Props {
   filters: Streamable<Filter[]>;
   sortOptions: Streamable<SortOption[]>;
   compareProducts?: Streamable<ListProduct[] | null>;
-  paginationInfo?: Streamable<CursorPaginationInfo | null>;
+  paginationInfo?: Streamable<CursorPaginationInfo>;
   compareAction?: React.ComponentProps<'form'>['action'];
   compareLabel?: string;
   filterLabel?: string;
@@ -66,9 +62,7 @@ export function ProductsListSection({
         <div className="mx-auto max-w-screen-2xl px-4 py-10 @xl:px-6 @xl:py-14 @4xl:px-8 @4xl:py-12">
           <div>
             <Stream fallback={<BreadcrumbsSkeleton />} value={streamableBreadcrumbs}>
-              {(breadcrumbs) =>
-                breadcrumbs && breadcrumbs.length > 1 && <Breadcrumbs breadcrumbs={breadcrumbs} />
-              }
+              {(breadcrumbs) => breadcrumbs && <Breadcrumbs breadcrumbs={breadcrumbs} />}
             </Stream>
             <div className="flex flex-wrap items-center justify-between gap-4 pb-8 pt-6 text-foreground">
               <h1 className="flex items-center gap-2 font-heading text-3xl font-medium leading-none @lg:text-4xl @2xl:text-5xl">
@@ -140,9 +134,8 @@ export function ProductsListSection({
                 products={products}
                 showCompare
               />
-              <Stream fallback={<CursorPaginationSkeleton />} value={paginationInfo}>
-                {(info) => info && <CursorPagination info={info} />}
-              </Stream>
+
+              {paginationInfo && <CursorPagination info={paginationInfo} />}
             </ProductListContainer>
           </div>
         </div>

--- a/core/vibes/soul/sections/products-list-section/index.tsx
+++ b/core/vibes/soul/sections/products-list-section/index.tsx
@@ -1,8 +1,8 @@
 import { Sliders } from 'lucide-react';
 import { Suspense } from 'react';
 
-import { Stream, Streamable } from '@/vibes/soul/lib/streamable';
-import { Breadcrumb, Breadcrumbs, BreadcrumbsSkeleton } from '@/vibes/soul/primitives/breadcrumbs';
+import { Streamable } from '@/vibes/soul/lib/streamable';
+import { Breadcrumb, Breadcrumbs } from '@/vibes/soul/primitives/breadcrumbs';
 import { Button } from '@/vibes/soul/primitives/button';
 import { CursorPagination, CursorPaginationInfo } from '@/vibes/soul/primitives/cursor-pagination';
 import { ListProduct, ProductsList } from '@/vibes/soul/primitives/products-list';
@@ -14,7 +14,7 @@ import { ProductListContainer } from './product-list-container';
 import { Sorting, Option as SortOption } from './sorting';
 
 interface Props {
-  breadcrumbs?: Streamable<Breadcrumb[] | null>;
+  breadcrumbs?: Streamable<Breadcrumb[]>;
   title?: Streamable<string | null>;
   totalCount: Streamable<number>;
   products: Streamable<ListProduct[]>;
@@ -36,7 +36,7 @@ interface Props {
 }
 
 export function ProductsListSection({
-  breadcrumbs: streamableBreadcrumbs,
+  breadcrumbs,
   title = 'Products',
   totalCount,
   products,
@@ -61,9 +61,8 @@ export function ProductsListSection({
       <div className="@container">
         <div className="mx-auto max-w-screen-2xl px-4 py-10 @xl:px-6 @xl:py-14 @4xl:px-8 @4xl:py-12">
           <div>
-            <Stream fallback={<BreadcrumbsSkeleton />} value={streamableBreadcrumbs}>
-              {(breadcrumbs) => breadcrumbs && <Breadcrumbs breadcrumbs={breadcrumbs} />}
-            </Stream>
+            {breadcrumbs && <Breadcrumbs breadcrumbs={breadcrumbs} />}
+
             <div className="flex flex-wrap items-center justify-between gap-4 pb-8 pt-6 text-foreground">
               <h1 className="flex items-center gap-2 font-heading text-3xl font-medium leading-none @lg:text-4xl @2xl:text-5xl">
                 <Suspense


### PR DESCRIPTION
## What/Why?
- Added breadcrumbs to `/blog` and `/blog/tag/[tagId]` routes - when testing yesterday I realized that there was not an easy way to navigate after filtering for a blog tag
- Added `CursorPagination` to `FeaturedBlogPostList`
- Refactored `CursorPagination` component and its uses, as I noticed we were using `suspense`, even though the component already uses suspense internally. 
- Created utility function to transform GraphQL pagination info into the `CursorPaginationInfo` type

## Testing


https://github.com/user-attachments/assets/2224741c-2d9e-4d0a-8771-ed82bcab5694

