### PR TITLE
fix: section max width

### DIFF
--- a/core/vibes/soul/sections/sticky-sidebar-layout/index.tsx
+++ b/core/vibes/soul/sections/sticky-sidebar-layout/index.tsx
@@ -1,5 +1,6 @@
 import { clsx } from 'clsx';
 
+// eslint-disable-next-line valid-jsdoc
 /**
  * This component supports various CSS variables for theming. Here's a comprehensive list, along
  * with their default values:
@@ -34,10 +35,10 @@ export function StickySidebarLayout({
         className={clsx(
           'mx-auto flex flex-col items-stretch gap-x-16 gap-y-10 px-4 py-10 @xl:px-6 @xl:py-14 @4xl:flex-row @4xl:px-8 @4xl:py-20',
           {
-            md: 'max-w-screen-[var(--section-max-width-md,768px)]',
-            lg: 'max-w-screen-[var(--section-max-width-lg,1024px)]',
-            xl: 'max-w-screen-[var(--section-max-width-xl,1280px)]',
-            '2xl': 'max-w-screen-[var(--section-max-width-2xl,1536px)]',
+            md: 'max-w-[var(--section-max-width-md,768px)]',
+            lg: 'max-w-[var(--section-max-width-lg,1024px)]',
+            xl: 'max-w-[var(--section-max-width-xl,1280px)]',
+            '2xl': 'max-w-[var(--section-max-width-2xl,1536px)]',
           }[containerSize],
         )}
       >


### PR DESCRIPTION
## What/Why?
Fix max widths not being applied to sticky sidebar sections

## Testing
![CleanShot 2024-12-19 at 14 59 19@2x](https://github.com/user-attachments/assets/3bfeb238-6e86-46f9-a115-0468d08094e5)
