### PR TITLE
fix: ensure page info transformer returns null if no previous/next page

### DIFF
--- a/core/data-transformers/page-info-transformer.ts
+++ b/core/data-transformers/page-info-transformer.ts
@@ -15,8 +15,8 @@ export function pageInfoTransformer(
 ): CursorPaginationInfo {
   return {
     startCursorParamName: 'before',
-    startCursor: pageInfo.startCursor,
+    startCursor: pageInfo.hasPreviousPage ? pageInfo.startCursor : null,
     endCursorParamName: 'after',
-    endCursor: pageInfo.endCursor,
+    endCursor: pageInfo.hasNextPage ? pageInfo.endCursor : null,
   };
 }


### PR DESCRIPTION
## What/Why?
In my last PR, I realized there was a small oversight. We should return `null` for startCursor/endCursor if there is no previous or next page.

## Testing
Confirmed cursor pagination is fixed

![image](https://github.com/user-attachments/assets/98353045-439d-4ba8-81d6-2e800e019ea5)
