### PR TITLE
feat: add banner id to site-header

### DIFF
--- a/core/lib/makeswift/components/site-header/site-header.client.tsx
+++ b/core/lib/makeswift/components/site-header/site-header.client.tsx
@@ -12,8 +12,6 @@ import {
 
 import { HeaderSection } from '@/vibes/soul/sections/header-section';
 
-const MAKESWIFT_SITE_BANNER_ID = 'MAKESWIFT_SITE_BANNER';
-
 type HeaderSectionProps = ComponentPropsWithoutRef<typeof HeaderSection>;
 
 type NavigationProps = HeaderSectionProps['navigation'];
@@ -43,6 +41,7 @@ export const PropsContextProvider = ({
 
 interface Props {
   banner?: {
+    id: string;
     show: boolean;
     allowClose: boolean;
     children?: ReactNode;
@@ -95,7 +94,7 @@ export const MakeswiftHeader = forwardRef(
     const combinedBanner = banner?.show
       ? {
           ...passedBanner,
-          id: passedBanner?.id ?? MAKESWIFT_SITE_BANNER_ID, // Update this when we allow users to add multiple MakeswiftHeader
+          id: banner.id,
           hideDismiss: !banner.allowClose,
           children: banner.children ?? passedBanner?.children,
         }

--- a/core/lib/makeswift/components/site-header/site-header.makeswift.tsx
+++ b/core/lib/makeswift/components/site-header/site-header.makeswift.tsx
@@ -23,6 +23,7 @@ runtime.registerComponent(MakeswiftHeader, {
   props: {
     banner: Shape({
       type: {
+        id: TextInput({ label: 'Banner ID', defaultValue: 'black_friday_2025' }),
         show: Checkbox({ label: 'Show banner', defaultValue: false }),
         allowClose: Checkbox({ label: 'Allow banner to close', defaultValue: true }),
         children: Slot(),


### PR DESCRIPTION
## What/Why?
Add `bannerId` to `site-header` to allow users to make a new banner. This is needed because we use the `bannerId` to determine whether users have dismissed the banner.

## Testing

https://github.com/user-attachments/assets/d54c8985-8300-479f-99c7-6c17a311ac5b

