### PR TITLE
feat: add empty state to BlogPostList

### DIFF
--- a/core/app/[locale]/(default)/blog/page.tsx
+++ b/core/app/[locale]/(default)/blog/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
+import { getTranslations } from 'next-intl/server';
 import { SearchParams } from 'nuqs';
 import { createSearchParamsCache, parseAsInteger, parseAsString } from 'nuqs/server';
 
@@ -34,6 +35,18 @@ async function listBlogPosts(searchParamsPromise: Promise<SearchParams>) {
   return posts;
 }
 
+async function getEmptyStateTitle(): Promise<string | null> {
+  const t = await getTranslations('Blog.Empty');
+
+  return t('title');
+}
+
+async function getEmptyStateSubtitle(): Promise<string | null> {
+  const t = await getTranslations('Blog.Empty');
+
+  return t('subtitle');
+}
+
 async function getPaginationInfo(searchParamsPromise: Promise<SearchParams>) {
   const searchParamsParsed = searchParamsCache.parse(await searchParamsPromise);
   const blogPosts = await getBlogPosts(searchParamsParsed);
@@ -66,7 +79,10 @@ export default async function Blog(props: Props) {
         ...tagCrumb,
       ]}
       description={blog.description}
+      emptyStateSubtitle={getEmptyStateSubtitle()}
+      emptyStateTitle={getEmptyStateTitle()}
       paginationInfo={getPaginationInfo(props.searchParams)}
+      placeholderCount={6}
       posts={listBlogPosts(props.searchParams)}
       title={blog.name}
     />

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -311,6 +311,10 @@
   },
   "Blog": {
     "title": "Blog",
+    "Empty": {
+      "title": "No blog posts found",
+      "subtitle": "Check back later for more content"
+    },
     "SharingLinks": {
       "share": "Share",
       "email": "Email",

--- a/core/vibes/soul/sections/blog-post-list/index.tsx
+++ b/core/vibes/soul/sections/blog-post-list/index.tsx
@@ -10,20 +10,88 @@ import {
 interface Props {
   posts: Streamable<BlogPost[]>;
   className?: string;
+  emptyStateSubtitle?: Streamable<string | null>;
+  emptyStateTitle?: Streamable<string | null>;
+  placeholderCount?: number;
 }
 
-export function BlogPostList({ posts: streamablePosts, className = '' }: Props) {
+export function BlogPostList({
+  posts: streamablePosts,
+  className = '',
+  emptyStateTitle,
+  emptyStateSubtitle,
+  placeholderCount = 6,
+}: Props) {
+  return (
+    <Stream
+      fallback={<BlogPostListSkeleton className={className} placeholderCount={placeholderCount} />}
+      value={streamablePosts}
+    >
+      {(posts) => {
+        if (posts.length === 0) {
+          return (
+            <BlogPostListEmptyState
+              className={className}
+              emptyStateSubtitle={emptyStateSubtitle}
+              emptyStateTitle={emptyStateTitle}
+              placeholderCount={placeholderCount}
+            />
+          );
+        }
+
+        return (
+          <div className={clsx('@container', className)}>
+            <div className="mx-auto grid grid-cols-1 gap-x-5 gap-y-8 @md:grid-cols-2 @xl:gap-y-10 @3xl:grid-cols-3 @6xl:grid-cols-4">
+              {posts.map((post) => (
+                <BlogPostCard key={post.id} {...post} />
+              ))}
+            </div>
+          </div>
+        );
+      }}
+    </Stream>
+  );
+}
+
+export function BlogPostListSkeleton({
+  className,
+  placeholderCount = 6,
+}: Pick<Props, 'className' | 'placeholderCount'>) {
   return (
     <div className={clsx('@container', className)}>
       <div className="mx-auto grid grid-cols-1 gap-x-5 gap-y-8 @md:grid-cols-2 @xl:gap-y-10 @3xl:grid-cols-3 @6xl:grid-cols-4">
-        <Stream
-          fallback={Array.from({ length: 5 }).map((_, index) => (
-            <BlogPostCardSkeleton key={index} />
-          ))}
-          value={streamablePosts}
-        >
-          {(posts) => posts.map((post) => <BlogPostCard key={post.id} {...post} />)}
-        </Stream>
+        {Array.from({ length: placeholderCount }).map((_, index) => (
+          <BlogPostCardSkeleton key={index} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function BlogPostListEmptyState({
+  className,
+  placeholderCount = 6,
+  emptyStateTitle,
+  emptyStateSubtitle,
+}: Omit<Props, 'posts'>) {
+  return (
+    <div className={clsx('relative w-full @container', className)}>
+      <div
+        className={clsx(
+          'mx-auto grid grid-cols-1 gap-x-4 gap-y-6 [mask-image:linear-gradient(to_bottom,_black_0%,_transparent_90%)] @sm:grid-cols-2 @2xl:grid-cols-3 @2xl:gap-x-5 @2xl:gap-y-8 @5xl:grid-cols-4 @7xl:grid-cols-5',
+        )}
+      >
+        {Array.from({ length: placeholderCount }).map((_, index) => (
+          <BlogPostCardSkeleton key={index} />
+        ))}
+      </div>
+      <div className="absolute inset-0 mx-auto px-3 py-16 pb-3 @4xl:px-10 @4xl:pb-10 @4xl:pt-28">
+        <div className="mx-auto max-w-xl space-y-2 text-center @4xl:space-y-3">
+          <h3 className="@4x:leading-none font-heading text-2xl leading-tight text-foreground @4xl:text-4xl">
+            {emptyStateTitle}
+          </h3>
+          <p className="text-sm text-contrast-500 @4xl:text-lg">{emptyStateSubtitle}</p>
+        </div>
       </div>
     </div>
   );

--- a/core/vibes/soul/sections/featured-blog-post-list/index.tsx
+++ b/core/vibes/soul/sections/featured-blog-post-list/index.tsx
@@ -10,6 +10,9 @@ interface Props {
   posts: Streamable<BlogPost[]>;
   paginationInfo?: Streamable<CursorPaginationInfo>;
   breadcrumbs?: Streamable<Breadcrumb[]>;
+  emptyStateSubtitle?: Streamable<string | null>;
+  emptyStateTitle?: Streamable<string | null>;
+  placeholderCount?: number;
 }
 
 export function FeaturedBlogPostList({
@@ -18,6 +21,9 @@ export function FeaturedBlogPostList({
   posts,
   paginationInfo,
   breadcrumbs,
+  emptyStateSubtitle,
+  emptyStateTitle,
+  placeholderCount,
 }: Props) {
   return (
     <section className="@container">
@@ -33,7 +39,13 @@ export function FeaturedBlogPostList({
             <p className="max-w-lg text-lg text-contrast-500">{description}</p>
           )}
 
-          <BlogPostList className="mb-8 mt-8 @4xl:mb-10 @4xl:mt-10" posts={posts} />
+          <BlogPostList
+            className="mb-8 mt-8 @4xl:mb-10 @4xl:mt-10"
+            emptyStateSubtitle={emptyStateSubtitle}
+            emptyStateTitle={emptyStateTitle}
+            placeholderCount={placeholderCount}
+            posts={posts}
+          />
 
           {paginationInfo && <CursorPagination info={paginationInfo} />}
         </div>


### PR DESCRIPTION
## What/Why?
- Sync BlogPostList with `vibes` changes for empty blog post state
- Implement it in the `/blog` route

## Testing

![image](https://github.com/user-attachments/assets/d250b253-5df5-4a0c-a97b-3e06891573d9)

![image](https://github.com/user-attachments/assets/ce55a27b-f466-435c-960a-db113b5d83f3)

![image](https://github.com/user-attachments/assets/6765d92b-013d-46d7-ba7a-a7ccadaa6d2c)
