### PR TITLE
feat: add height prop to Logo

### DIFF
--- a/core/vibes/soul/primitives/logo/index.tsx
+++ b/core/vibes/soul/primitives/logo/index.tsx
@@ -10,6 +10,7 @@ interface Props {
   label?: string;
   href: string;
   width: number;
+  height: number;
 }
 
 // eslint-disable-next-line valid-jsdoc
@@ -25,7 +26,7 @@ interface Props {
  * }
  * ```
  */
-export function Logo({ className, logo: streamableLogo, href, width, label }: Props) {
+export function Logo({ className, logo: streamableLogo, href, width, height, label }: Props) {
   return (
     <Stream
       fallback={<div className="h-6 w-16 animate-pulse rounded-md bg-contrast-100" />}
@@ -35,11 +36,11 @@ export function Logo({ className, logo: streamableLogo, href, width, label }: Pr
         <Link
           aria-label={label}
           className={clsx(
-            'relative h-full items-center outline-0 ring-[var(--logo-focus,hsl(var(--primary)))] ring-offset-4 focus-visible:ring-2',
+            'relative outline-0 ring-[var(--logo-focus,hsl(var(--primary)))] ring-offset-4 focus-visible:ring-2',
             className,
           )}
           href={href}
-          style={typeof logo === 'string' ? {} : { width }}
+          style={typeof logo === 'string' ? {} : { width, height }}
         >
           {typeof logo === 'object' && logo !== null && logo.src !== '' ? (
             <Image

--- a/core/vibes/soul/primitives/navigation/index.tsx
+++ b/core/vibes/soul/primitives/navigation/index.tsx
@@ -94,10 +94,12 @@ interface Props<S extends SearchResult> {
   localeAction?: LocaleAction;
   logo?: Streamable<string | { src: string; alt: string } | null>;
   logoWidth?: number;
+  logoHeight?: number;
   logoHref?: string;
   logoLabel?: string;
   mobileLogo?: Streamable<string | { src: string; alt: string } | null>;
   mobileLogoWidth?: number;
+  mobileLogoHeight?: number;
   searchHref: string;
   searchParamName?: string;
   searchAction?: SearchAction<S>;
@@ -255,8 +257,10 @@ export const Navigation = forwardRef(function Navigation<S extends SearchResult>
     logoHref = '/',
     logoLabel = 'Home',
     logoWidth = 200,
+    logoHeight = 40,
     mobileLogo: streamableMobileLogo,
     mobileLogoWidth = 100,
+    mobileLogoHeight = 40,
     linksPosition = 'center',
     activeLocaleId,
     localeAction,
@@ -304,7 +308,7 @@ export const Navigation = forwardRef(function Navigation<S extends SearchResult>
     >
       <div
         className={clsx(
-          'flex h-14 items-center justify-between gap-1 bg-[var(--nav-background,hsl(var(--background)))] pl-3 pr-2 transition-shadow @4xl:rounded-2xl @4xl:px-2 @4xl:pl-6 @4xl:pr-2.5',
+          'flex items-center justify-between gap-1 bg-[var(--nav-background,hsl(var(--background)))] py-2 pl-3 pr-2 transition-shadow @4xl:rounded-2xl @4xl:px-2 @4xl:pl-6 @4xl:pr-2.5',
           isFloating
             ? 'shadow-xl ring-1 ring-[var(--nav-floating-border,hsl(var(--foreground)/10%))]'
             : 'shadow-none ring-0',
@@ -386,6 +390,7 @@ export const Navigation = forwardRef(function Navigation<S extends SearchResult>
         >
           <Logo
             className={clsx(streamableMobileLogo != null ? 'hidden @4xl:flex' : 'flex')}
+            height={logoHeight}
             href={logoHref}
             label={logoLabel}
             logo={streamableLogo}
@@ -394,6 +399,7 @@ export const Navigation = forwardRef(function Navigation<S extends SearchResult>
           {streamableMobileLogo != null && (
             <Logo
               className="flex @4xl:hidden"
+              height={mobileLogoHeight}
               href={logoHref}
               label={logoLabel}
               logo={streamableMobileLogo}
@@ -405,7 +411,7 @@ export const Navigation = forwardRef(function Navigation<S extends SearchResult>
         {/* Top Level Nav Links */}
         <ul
           className={clsx(
-            'hidden @4xl:flex @4xl:flex-1',
+            'hidden gap-1 @4xl:flex @4xl:flex-1',
             {
               left: '@4xl:justify-start',
               center: '@4xl:justify-center',
@@ -437,7 +443,7 @@ export const Navigation = forwardRef(function Navigation<S extends SearchResult>
                 <NavigationMenu.Item key={i} value={i.toString()}>
                   <NavigationMenu.Trigger asChild>
                     <Link
-                      className="mx-0.5 my-2.5 hidden items-center whitespace-nowrap rounded-xl bg-[var(--nav-link-background,transparent)] p-2.5 font-[family-name:var(--nav-link-font-family,var(--font-family-body))] text-sm font-medium text-[var(--nav-link-text,hsl(var(--foreground)))] ring-[var(--nav-focus,hsl(var(--primary)))] transition-colors duration-200 hover:bg-[var(--nav-link-background-hover,hsl(var(--contrast-100)))] hover:text-[var(--nav-link-text-hover,hsl(var(--foreground)))] focus-visible:outline-0 focus-visible:ring-2 @4xl:inline-flex"
+                      className="hidden items-center whitespace-nowrap rounded-xl bg-[var(--nav-link-background,transparent)] p-2.5 font-[family-name:var(--nav-link-font-family,var(--font-family-body))] text-sm font-medium text-[var(--nav-link-text,hsl(var(--foreground)))] ring-[var(--nav-focus,hsl(var(--primary)))] transition-colors duration-200 hover:bg-[var(--nav-link-background-hover,hsl(var(--contrast-100)))] hover:text-[var(--nav-link-text-hover,hsl(var(--foreground)))] focus-visible:outline-0 focus-visible:ring-2 @4xl:inline-flex"
                       href={item.href}
                     >
                       {item.label}

--- a/core/vibes/soul/sections/footer/index.tsx
+++ b/core/vibes/soul/sections/footer/index.tsx
@@ -43,6 +43,7 @@ interface Props {
   logoHref?: string;
   logoLabel?: string;
   logoWidth?: number;
+  logoHeight?: number;
 }
 
 /**
@@ -79,6 +80,7 @@ export const Footer = forwardRef(function Footer(
     logoHref = '#',
     logoLabel = 'Home',
     logoWidth = 200,
+    logoHeight = 40,
   }: Props,
   ref: Ref<HTMLDivElement>,
 ) {
@@ -92,9 +94,15 @@ export const Footer = forwardRef(function Footer(
     >
       <div className="mx-auto max-w-screen-2xl px-4 py-6 @xl:px-6 @xl:py-10 @4xl:px-8 @4xl:py-12">
         <div className="flex flex-col justify-between gap-x-8 gap-y-12 @3xl:flex-row">
-          <div className="@3xl:w-1/3">
+          <div className="flex flex-col @3xl:w-1/3">
             {/* Logo Information */}
-            <Logo href={logoHref} label={logoLabel} logo={logo} width={logoWidth} />
+            <Logo
+              height={logoHeight}
+              href={logoHref}
+              label={logoLabel}
+              logo={logo}
+              width={logoWidth}
+            />
 
             {/* Contact Information */}
             <Stream


### PR DESCRIPTION
## What/Why?
TLDR; Added a `height` prop to the `Logo` primitive and corresponding props to the `Navigation` and `Footer`. 

Previously, the logo height in the `Navigation` was being driven by a hardcoded height of `h-14` on the root element, and then `h-full` on the `Logo`. In the footer can't make this assumption which reveals we shouldn't be assuming there will always be an inferable height for the logo. Instead, I've decided to add a `height` prop to the logo and refactored the `Navigation` component to always include `8px` of padding to the y-axis so that users can better control the aspect ratio and size of their logo. I also added this to the `Footer` for the same reasons.

@fikrikarim we'll need to add these properties to the `Site Header` and `Site Footer` Makeswift components too.

## Testing
![CleanShot 2024-12-23 at 15 23 46@2x](https://github.com/user-attachments/assets/e6fcc3f9-c24f-4742-bc60-07d80005e2bd)
![CleanShot 2024-12-23 at 15 24 03@2x](https://github.com/user-attachments/assets/598bfb83-8285-46f1-8f29-b56e91a6b2c8)
![CleanShot 2024-12-23 at 15 30 32@2x](https://github.com/user-attachments/assets/d3cd01a1-8a8c-4c6e-8a9e-646f5337d789)
![CleanShot 2024-12-23 at 15 31 09@2x](https://github.com/user-attachments/assets/5f8008ff-29cb-45dc-ba16-34db4ea9b8c0)