### PR TITLE
refactor: move app fonts from root layout to their own file

### DIFF
--- a/core/app/[locale]/layout.tsx
+++ b/core/app/[locale]/layout.tsx
@@ -2,7 +2,6 @@ import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import { clsx } from 'clsx';
 import type { Metadata } from 'next';
-import { DM_Serif_Text, Inter, Roboto_Mono } from 'next/font/google';
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages, setRequestLocale } from 'next-intl/server';
 import { NuqsAdapter } from 'nuqs/adapters/next/app';
@@ -10,31 +9,13 @@ import { PropsWithChildren } from 'react';
 
 import '../globals.css';
 
+import { fonts } from '~/app/fonts';
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
 
 import { Notifications } from '../notifications';
 import { Providers } from '../providers';
-
-const inter = Inter({
-  display: 'swap',
-  subsets: ['latin'],
-  variable: '--font-family-body',
-});
-
-const dm_serif_text = DM_Serif_Text({
-  display: 'swap',
-  subsets: ['latin'],
-  weight: '400',
-  variable: '--font-family-heading',
-});
-
-const roboto_mono = Roboto_Mono({
-  subsets: ['latin'],
-  display: 'swap',
-  variable: '--font-family-mono',
-});
 
 const RootLayoutMetadataQuery = graphql(`
   query RootLayoutMetadataQuery {
@@ -109,10 +90,7 @@ export default async function RootLayout({ params, children }: Props) {
   const messages = await getMessages();
 
   return (
-    <html
-      className={clsx(inter.variable, dm_serif_text.variable, roboto_mono.variable)}
-      lang={locale}
-    >
+    <html className={clsx(fonts.map((f) => f.variable))} lang={locale}>
       <body>
         <Notifications />
         <NextIntlClientProvider locale={locale} messages={messages}>

--- a/core/app/fonts.ts
+++ b/core/app/fonts.ts
@@ -1,0 +1,22 @@
+import { DM_Serif_Text, Inter, Roboto_Mono } from 'next/font/google';
+
+const inter = Inter({
+  display: 'swap',
+  subsets: ['latin'],
+  variable: '--font-family-body',
+});
+
+const dmSerifText = DM_Serif_Text({
+  display: 'swap',
+  subsets: ['latin'],
+  weight: '400',
+  variable: '--font-family-heading',
+});
+
+const robotoMono = Roboto_Mono({
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--font-family-mono',
+});
+
+export const fonts = [inter, dmSerifText, robotoMono];


### PR DESCRIPTION
## What/Why?

We want to be able to import the fonts elsewhere, plus this arrangement matches Next.js examples as well: https://nextjs.org/docs/pages/building-your-application/optimizing/fonts#using-multiple-fonts

There are no semantic changes in this PR.

## Testing

<img width="1184" alt="Screenshot 2024-12-23 at 8 10 46 PM" src="https://github.com/user-attachments/assets/27c0ce3f-5085-4863-b18a-ee71d37a3736" />


https://github.com/user-attachments/assets/bf2831ec-cb79-48c3-be69-ed52ac5bba80


