### PR TITLE
fix: use grid for PDP specifications

### DIFF
--- a/core/app/[locale]/(default)/product/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/page.tsx
@@ -66,15 +66,17 @@ const getProduct = async (productPromise: ReturnType<typeof getProductData>) => 
           {
             title: t('specifications'),
             content: (
-              <div className="prose">
-                <ul className="flex flex-col gap-4">
+              <div className="prose @container">
+                <dl className="flex flex-col gap-4">
                   {specifications.map((field, index) => (
-                    <li className="flex gap-2" key={index}>
-                      <strong>{field.name}</strong>
-                      {field.value}
-                    </li>
+                    <div className="grid grid-cols-1 gap-2 @lg:grid-cols-2" key={index}>
+                      <dt>
+                        <strong>{field.name}</strong>
+                      </dt>
+                      <dd>{field.value}</dd>
+                    </div>
                   ))}
-                </ul>
+                </dl>
               </div>
             ),
           },

--- a/core/vibes/soul/sections/product-detail/index.tsx
+++ b/core/vibes/soul/sections/product-detail/index.tsx
@@ -62,7 +62,7 @@ export function ProductDetail<F extends Field>({
         <Stream fallback={<ProductDetailSkeleton />} value={streamableProduct}>
           {(product) =>
             product && (
-              <div className="grid grid-cols-1 items-stretch gap-x-6 gap-y-8 @2xl:grid-cols-2 @5xl:gap-x-12">
+              <div className="grid grid-cols-1 items-stretch gap-x-8 gap-y-8 @2xl:grid-cols-2 @5xl:gap-x-12">
                 <div className="hidden @2xl:block">
                   <Stream fallback={<ProductGallerySkeleton />} value={product.images}>
                     {(images) => <ProductGallery images={images} />}


### PR DESCRIPTION
## What/Why?
- Updated specifications to use CSS `grid`
- Replaced `ul` and `li` tags with `dl`, `dt` and `dd` tags. Grouped using `div` as per [spec](https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element) allows.
- Reduced column spacing on smaller screens for PDP gallery / details per @andrewreifman request.

## Testing

https://github.com/user-attachments/assets/e6822cf7-597f-49c1-9a26-1da612ce1860

