### PR TITLE
Improve CLI user experience & create continuity between control panel and CLI

### DIFF
--- a/.changeset/large-planes-reflect.md
+++ b/.changeset/large-planes-reflect.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": minor
+---
+
+Update CLI to use new APIs for consistency with One-Click Catalyst in the control panel

--- a/packages/create-catalyst/package.json
+++ b/packages/create-catalyst/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@commander-js/extra-typings": "^12.1.0",
+    "@iarna/toml": "^2.2.5",
     "@inquirer/prompts": "^7.2.0",
     "@segment/analytics-node": "^2.2.0",
     "chalk": "^5.3.0",
@@ -29,6 +30,7 @@
     "giget": "^1.2.3",
     "lodash.kebabcase": "^4.1.1",
     "nypm": "^0.4.1",
+    "open": "^10.1.0",
     "ora": "^8.1.1",
     "semver": "^7.6.3",
     "std-env": "^3.8.0",

--- a/packages/create-catalyst/src/commands/create.ts
+++ b/packages/create-catalyst/src/commands/create.ts
@@ -267,7 +267,8 @@ export const create = new Command('create')
 
     let envVars: Record<string, string> = {};
 
-    if (!options.storeHash || !options.accessToken) {
+    // Skip login if we have all necessary credentials
+    if ((!storeHash || !accessToken) && (!channelId || !storefrontToken)) {
       const credentials = await login(`https://login.${options.bigcommerceHostname}`);
 
       storeHash = credentials.storeHash;

--- a/packages/create-catalyst/src/commands/create.ts
+++ b/packages/create-catalyst/src/commands/create.ts
@@ -246,6 +246,7 @@ export const create = new Command('create')
       .default('https://cxm-prd.bigcommerceapp.com')
       .hideHelp(),
   )
+  // eslint-disable-next-line complexity
   .action(async (options) => {
     const { ghRef, repository } = options;
 

--- a/packages/create-catalyst/src/commands/create.ts
+++ b/packages/create-catalyst/src/commands/create.ts
@@ -282,12 +282,34 @@ export const create = new Command('create')
 
       await installDependencies(projectDir);
 
+      // Add any CLI-provided env vars
+      if (options.env) {
+        const cliEnvVars = options.env.reduce<Record<string, string>>((acc, env) => {
+          const [key, value] = env.split('=');
+
+          if (key && value) {
+            acc[key] = value;
+          }
+
+          return acc;
+        }, {});
+
+        Object.assign(envVars, cliEnvVars);
+      }
+
+      // Write env vars even if we don't have store credentials
+      writeEnv(projectDir, envVars);
+
       console.log(
         [
           `\n${chalk.green('Success!')} Created '${projectName}' at '${projectDir}'\n`,
           `Next steps:`,
-          chalk.yellow(`\n- cd ${projectName} && cp .env.example .env.local`),
-          chalk.yellow(`\n- Populate .env.local with your BigCommerce API credentials\n`),
+          Object.keys(envVars).length > 0
+            ? chalk.yellow(`\n- cd ${projectName} && pnpm run dev\n`)
+            : [
+                chalk.yellow(`\n- cd ${projectName} && cp .env.example .env.local`),
+                chalk.yellow(`\n- Populate .env.local with your BigCommerce API credentials\n`),
+              ].join(''),
         ].join('\n'),
       );
 

--- a/packages/create-catalyst/src/commands/create.ts
+++ b/packages/create-catalyst/src/commands/create.ts
@@ -114,10 +114,22 @@ async function handleChannelSelection(bc: Https) {
   const existingChannel = await select({
     message: 'Which channel would you like to use?',
     choices: availableChannels.data
-      .sort(
-        (a: Channel, b: Channel) =>
-          channelSortOrder.indexOf(a.platform) - channelSortOrder.indexOf(b.platform),
-      )
+      .sort((a: Channel, b: Channel) => {
+        const aIndex = channelSortOrder.indexOf(a.platform);
+        const bIndex = channelSortOrder.indexOf(b.platform);
+
+        // If both platforms are not in the sort order, maintain their original order
+        if (aIndex === -1 && bIndex === -1) {
+          return 0;
+        }
+
+        // If one platform is not in the sort order, it should go to the end
+        if (aIndex === -1) return 1;
+        if (bIndex === -1) return -1;
+
+        // If both platforms are in the sort order, use their relative positions
+        return aIndex - bIndex;
+      })
       .map((ch: Channel) => ({
         name: ch.name,
         value: ch,

--- a/packages/create-catalyst/src/commands/create.ts
+++ b/packages/create-catalyst/src/commands/create.ts
@@ -245,7 +245,15 @@ export const create = new Command('create')
             message: 'What would you like to name your new channel?',
           });
 
-          const response = await cliApi.createChannel(newChannelName);
+          const shouldInstallSampleData = await select({
+            message: 'Would you like to install sample data?',
+            choices: [
+              { name: 'Yes', value: true },
+              { name: 'No', value: false },
+            ],
+          });
+
+          const response = await cliApi.createChannel(newChannelName, shouldInstallSampleData);
 
           if (!response.ok) {
             console.error(

--- a/packages/create-catalyst/src/commands/init.ts
+++ b/packages/create-catalyst/src/commands/init.ts
@@ -182,4 +182,8 @@ export const init = new Command('init')
     }
 
     writeEnv(projectDir, envVars);
+
+    console.log(chalk.green(`\n.env.local file created for channel ${existingChannel.name}!\n`));
+    console.log(chalk.green(`\nNext steps:\n`));
+    console.log(chalk.yellow(`\npnpm run dev\n`));
   });

--- a/packages/create-catalyst/src/utils/auth.ts
+++ b/packages/create-catalyst/src/utils/auth.ts
@@ -8,7 +8,7 @@ interface AuthConfig {
 
 export class Auth {
   private client: Https;
-  private readonly DEVICE_OAUTH_CLIENT_ID = 'acse0vvawm9r1n0evag4b8e1ea1fo90';
+  private readonly DEVICE_OAUTH_CLIENT_ID = 's1q4io7mah2lm1i6uwp9yl1eit80n3b';
 
   constructor({ baseUrl }: AuthConfig) {
     this.client = new Https({ baseUrl });

--- a/packages/create-catalyst/src/utils/auth.ts
+++ b/packages/create-catalyst/src/utils/auth.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+
 import { Https } from './https';
 import { parse } from './parse';
 
@@ -66,4 +67,4 @@ export class Auth {
 
     return parse(await response.json(), DeviceCodeSuccessSchema);
   }
-} 
+}

--- a/packages/create-catalyst/src/utils/auth.ts
+++ b/packages/create-catalyst/src/utils/auth.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod';
+import { Https } from './https';
+import { parse } from './parse';
+
+interface AuthConfig {
+  baseUrl: string;
+}
+
+export class Auth {
+  private client: Https;
+  private readonly DEVICE_OAUTH_CLIENT_ID = 'acse0vvawm9r1n0evag4b8e1ea1fo90';
+
+  constructor({ baseUrl }: AuthConfig) {
+    this.client = new Https({ baseUrl });
+  }
+
+  async getDeviceCode() {
+    const response = await this.client.fetch('/device/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        scopes: [
+          'store_channel_settings',
+          'store_sites',
+          'store_storefront_api',
+          'store_v2_content',
+          'store_v2_information',
+          'store_v2_products',
+          'store_cart',
+        ].join(' '),
+        client_id: this.DEVICE_OAUTH_CLIENT_ID,
+      }),
+    });
+
+    const DeviceCodeSchema = z.object({
+      device_code: z.string(),
+      user_code: z.string(),
+      verification_uri: z.string(),
+      expires_in: z.number(),
+      interval: z.number(),
+    });
+
+    return parse(await response.json(), DeviceCodeSchema);
+  }
+
+  async checkDeviceCode(deviceCode: string) {
+    const response = await this.client.fetch('/device/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        device_code: deviceCode,
+        client_id: this.DEVICE_OAUTH_CLIENT_ID,
+      }),
+    });
+
+    if (response.status !== 200) {
+      throw new Error('Device code not yet verified');
+    }
+
+    const DeviceCodeSuccessSchema = z.object({
+      access_token: z.string(),
+      store_hash: z.string(),
+      context: z.string(),
+      api_uri: z.string().url(),
+    });
+
+    return parse(await response.json(), DeviceCodeSuccessSchema);
+  }
+} 

--- a/packages/create-catalyst/src/utils/cli-api.ts
+++ b/packages/create-catalyst/src/utils/cli-api.ts
@@ -1,0 +1,43 @@
+import { Https } from './https';
+
+interface CliApiConfig {
+  origin: string;
+  storeHash: string;
+  accessToken: string;
+}
+
+export class CliApi {
+  private client: Https;
+
+  constructor({ origin, storeHash, accessToken }: CliApiConfig) {
+    this.client = new Https({
+      baseUrl: `${origin}/stores/${storeHash}/cli-api/v3`,
+      accessToken,
+    });
+  }
+
+  async getChannelInit(channelId: number | string) {
+    return this.client.fetch(`/channels/${channelId}/init`, {
+      method: 'GET',
+    });
+  }
+
+  async checkEligibility() {
+    return this.client.fetch('/channels/catalyst/eligibility', {
+      method: 'GET',
+    });
+  }
+
+  async createChannel(name: string) {
+    return this.client.fetch('/channels/catalyst', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name,
+        initialData: { type: 'none' },
+        deployStorefront: false,
+        devOrigin: 'http://localhost:3000',
+      }),
+    });
+  }
+} 

--- a/packages/create-catalyst/src/utils/cli-api.ts
+++ b/packages/create-catalyst/src/utils/cli-api.ts
@@ -28,13 +28,15 @@ export class CliApi {
     });
   }
 
-  async createChannel(name: string) {
+  async createChannel(name: string, installSampleData: boolean = false) {
     return this.client.fetch('/channels/catalyst', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         name,
-        initialData: { type: 'none' },
+        initialData: { 
+          type: installSampleData ? 'sample' : 'none'
+        },
         deployStorefront: false,
         devOrigin: 'http://localhost:3000',
       }),

--- a/packages/create-catalyst/src/utils/cli-api.ts
+++ b/packages/create-catalyst/src/utils/cli-api.ts
@@ -28,18 +28,18 @@ export class CliApi {
     });
   }
 
-  async createChannel(name: string, installSampleData: boolean = false) {
+  async createChannel(name: string, installSampleData = false) {
     return this.client.fetch('/channels/catalyst', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         name,
-        initialData: { 
-          type: installSampleData ? 'sample' : 'none'
+        initialData: {
+          type: installSampleData ? 'sample' : 'none',
         },
         deployStorefront: false,
         devOrigin: 'http://localhost:3000',
       }),
     });
   }
-} 
+}

--- a/packages/create-catalyst/src/utils/cli-api.ts
+++ b/packages/create-catalyst/src/utils/cli-api.ts
@@ -37,7 +37,7 @@ export class CliApi {
         initialData: {
           type: installSampleData ? 'sample' : 'none',
         },
-        deployStorefront: false,
+        deployStorefront: true,
         devOrigin: 'http://localhost:3000',
       }),
     });

--- a/packages/create-catalyst/src/utils/config.ts
+++ b/packages/create-catalyst/src/utils/config.ts
@@ -1,0 +1,100 @@
+import { parse as parseTOML, stringify as stringifyTOML } from '@iarna/toml';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+
+interface CatalystConfig {
+  auth?: {
+    storeHash?: string;
+    accessToken?: string;
+  };
+}
+
+interface TomlRecord {
+  [key: string]: string | number | boolean | TomlRecord | TomlRecord[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isCatalystConfig(obj: unknown): obj is CatalystConfig {
+  if (!isRecord(obj)) {
+    return false;
+  }
+
+  if ('auth' in obj) {
+    if (!isRecord(obj.auth)) {
+      return false;
+    }
+
+    const { storeHash, accessToken } = obj.auth;
+
+    return (
+      (storeHash === undefined || typeof storeHash === 'string') &&
+      (accessToken === undefined || typeof accessToken === 'string')
+    );
+  }
+
+  return true;
+}
+
+export class Config {
+  private configPath: string;
+  private config: CatalystConfig;
+
+  constructor(projectDir: string) {
+    this.configPath = join(projectDir, '.catalyst');
+    this.config = this.read();
+  }
+
+  getAuth(): { storeHash?: string; accessToken?: string } {
+    return this.config.auth ?? {};
+  }
+
+  setAuth(storeHash: string, accessToken: string): void {
+    this.config.auth = { storeHash, accessToken };
+    this.save();
+  }
+
+  save(): void {
+    const configObj: TomlRecord = {};
+
+    if (this.config.auth?.storeHash && this.config.auth.accessToken) {
+      configObj.auth = {
+        storeHash: this.config.auth.storeHash,
+        accessToken: this.config.auth.accessToken,
+      };
+    }
+
+    const dir = dirname(this.configPath);
+
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+
+    writeFileSync(this.configPath, stringifyTOML(configObj));
+  }
+
+  private read(): CatalystConfig {
+    if (!existsSync(this.configPath)) {
+      return {};
+    }
+
+    try {
+      const contents = readFileSync(this.configPath, 'utf-8');
+      const parsed = parseTOML(contents);
+
+      if (isCatalystConfig(parsed)) {
+        return parsed;
+      }
+
+      console.warn('Invalid config format in .catalyst file, using defaults');
+
+      return {};
+    } catch {
+      console.warn('Failed to parse .catalyst config file, using defaults');
+
+      return {};
+    }
+  }
+}

--- a/packages/create-catalyst/src/utils/config.ts
+++ b/packages/create-catalyst/src/utils/config.ts
@@ -72,7 +72,14 @@ export class Config {
       mkdirSync(dir, { recursive: true });
     }
 
-    writeFileSync(this.configPath, stringifyTOML(configObj));
+    const preamble = `# DO NOT commit this file to your repository!
+# This file contains sensitive configuration specific to your local CLI setup.
+# It includes authentication tokens and store-specific information.
+# If using version control, make sure to add .catalyst to your .gitignore file.
+
+`;
+
+    writeFileSync(this.configPath, preamble + stringifyTOML(configObj));
   }
 
   private read(): CatalystConfig {

--- a/packages/create-catalyst/src/utils/https.ts
+++ b/packages/create-catalyst/src/utils/https.ts
@@ -1,330 +1,34 @@
-/* eslint-disable @typescript-eslint/unified-signatures */
-
-import chalk from 'chalk';
-import { z } from 'zod';
-
-import { parse } from './parse';
 import { getCLIUserAgent } from './user-agent';
 
-interface BigCommerceRestApiConfig {
-  bigCommerceApiUrl: string;
-  storeHash: string;
-  accessToken: string;
-}
-
-interface SampleDataApiConfig {
-  sampleDataApiUrl: string;
-  storeHash: string;
-  accessToken: string;
-}
-
-interface DeviceOAuthConfig {
-  bigCommerceAuthUrl: string;
-}
-
 interface HttpsConfig {
-  bigCommerceApiUrl?: string;
-  bigCommerceAuthUrl?: string;
-  sampleDataApiUrl?: string;
-  storeHash?: string;
+  baseUrl: string;
   accessToken?: string;
 }
 
-const BigCommerceStoreInfo = z.object({
-  features: z.object({
-    storefront_limits: z.object({
-      active: z.number(),
-      total_including_inactive: z.number(),
-    }),
-  }),
-});
-
-export type BigCommerceStoreInfo = z.infer<typeof BigCommerceStoreInfo>;
-
-const BigCommerceV3ApiResponseSchema = <T>(schema: z.ZodType<T>) =>
-  z.object({
-    data: schema,
-    meta: z.object({}),
-  });
-
-const BigCommerceChannelsV3ResponseSchema = BigCommerceV3ApiResponseSchema(
-  z.array(
-    z.object({
-      id: z.number(),
-      name: z.string(),
-      status: z.string(),
-      platform: z.string(),
-    }),
-  ),
-);
-
-export type BigCommerceChannelsV3Response = z.infer<typeof BigCommerceChannelsV3ResponseSchema>;
-
 export class Https {
-  bigCommerceApiUrl: string;
-  bigCommerceAuthUrl: string;
-  sampleDataApiUrl: string;
-  storeHash: string;
-  accessToken: string;
-  userAgent: string;
+  private baseUrl: string;
+  private accessToken?: string;
+  private userAgent: string;
 
-  private DEVICE_OAUTH_CLIENT_ID = 'acse0vvawm9r1n0evag4b8e1ea1fo90';
-  private MAX_EPOC_EXPIRES_AT = 2147483647;
-
-  constructor({ bigCommerceApiUrl, storeHash, accessToken }: BigCommerceRestApiConfig);
-  constructor({ sampleDataApiUrl, storeHash, accessToken }: SampleDataApiConfig);
-  constructor({ bigCommerceAuthUrl }: DeviceOAuthConfig);
-  constructor({
-    bigCommerceApiUrl,
-    bigCommerceAuthUrl,
-    sampleDataApiUrl,
-    storeHash,
-    accessToken,
-  }: HttpsConfig) {
-    this.bigCommerceApiUrl = bigCommerceApiUrl ?? '';
-    this.bigCommerceAuthUrl = bigCommerceAuthUrl ?? '';
-    this.sampleDataApiUrl = sampleDataApiUrl ?? '';
-    this.storeHash = storeHash ?? '';
-    this.accessToken = accessToken ?? '';
+  constructor({ baseUrl, accessToken }: HttpsConfig) {
+    this.baseUrl = baseUrl;
+    this.accessToken = accessToken;
     this.userAgent = getCLIUserAgent();
   }
 
-  auth(path: string, opts: RequestInit = {}) {
-    if (!this.bigCommerceAuthUrl) {
-      throw new Error('bigCommerceAuthUrl is required to make API requests');
-    }
-
-    const { headers = {}, ...rest } = opts;
-
-    const options = {
-      method: 'POST',
-      headers: {
-        ...headers,
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-        'User-Agent': this.userAgent,
-      },
-      ...rest,
-    };
-
-    return fetch(`${this.bigCommerceAuthUrl}${path}`, options);
-  }
-
-  async getDeviceCode() {
-    const response = await this.auth('/device/token', {
-      body: JSON.stringify({
-        scopes: [
-          'store_channel_settings',
-          'store_sites',
-          'store_storefront_api',
-          'store_v2_content',
-          'store_v2_information',
-          'store_v2_products',
-          'store_cart',
-        ].join(' '),
-        client_id: this.DEVICE_OAUTH_CLIENT_ID,
-      }),
-    });
-
-    if (!response.ok) {
-      console.error(
-        chalk.red(`\nPOST /device/token failed: ${response.status} ${response.statusText}\n`),
-      );
-      process.exit(1);
-    }
-
-    const DeviceCodeSchema = z.object({
-      device_code: z.string(),
-      user_code: z.string(),
-      verification_uri: z.string(),
-      expires_in: z.number(),
-      interval: z.number(),
-    });
-
-    return parse(await response.json(), DeviceCodeSchema);
-  }
-
-  async checkDeviceCode(deviceCode: string) {
-    const response = await this.auth('/device/token', {
-      body: JSON.stringify({
-        device_code: deviceCode,
-        client_id: this.DEVICE_OAUTH_CLIENT_ID,
-      }),
-    });
-
-    if (response.status !== 200) {
-      throw new Error('Device code not yet verified');
-    }
-
-    const DeviceCodeSuccessSchema = z.object({
-      access_token: z.string(),
-      store_hash: z.string(),
-      context: z.string(),
-      api_uri: z.string().url(),
-    });
-
-    return parse(await response.json(), DeviceCodeSuccessSchema);
-  }
-
-  api(path: string, opts: RequestInit = {}) {
-    if (!this.bigCommerceApiUrl || !this.storeHash || !this.accessToken) {
-      throw new Error(
-        'bigCommerceApiUrl, storeHash, and accessToken are required to make API requests',
-      );
-    }
-
+  async fetch(path: string, opts: RequestInit = {}) {
     const { headers = {}, ...rest } = opts;
 
     const options = {
       headers: {
         ...headers,
         Accept: 'application/json',
-        'X-Auth-Token': this.accessToken,
         'User-Agent': this.userAgent,
+        ...(this.accessToken && { 'X-Auth-Token': this.accessToken }),
       },
       ...rest,
     };
 
-    return fetch(`${this.bigCommerceApiUrl}/stores/${this.storeHash}${path}`, options);
-  }
-
-  async storeInformation() {
-    const res = await this.api('/v2/store');
-
-    if (!res.ok) {
-      console.error(chalk.red(`\nGET /v2/store failed: ${res.status} ${res.statusText}\n`));
-      process.exit(1);
-    }
-
-    return parse(await res.json(), BigCommerceStoreInfo);
-  }
-
-  async channels(query = '') {
-    const res = await this.api(`/v3/channels${query}`);
-
-    if (!res.ok) {
-      console.error(chalk.red(`\nGET /v3/channels failed: ${res.status} ${res.statusText}\n`));
-      process.exit(1);
-    }
-
-    return parse(await res.json(), BigCommerceChannelsV3ResponseSchema);
-  }
-
-  async createChannelMenus(channelId: number) {
-    const res = await this.api(`/v3/channels/${channelId}/channel-menus`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        bigcommerce_protected_app_sections: [
-          'storefront_settings',
-          'currencies',
-          'domains',
-          'notifications',
-          'social',
-        ],
-      }),
-    });
-
-    if (!res.ok) {
-      console.warn(
-        chalk.yellow(
-          `\nFailed to create channel menus: ${res.status} ${res.statusText}. You may want to create these later: https://developer.bigcommerce.com/docs/rest-management/channels/menus#create-channel-menus\n`,
-        ),
-      );
-    }
-  }
-
-  async storefrontToken() {
-    const res = await this.api('/v3/storefront/api-token', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ expires_at: this.MAX_EPOC_EXPIRES_AT, channel_ids: [] }),
-    });
-
-    if (!res.ok) {
-      console.error(
-        chalk.red(`\nPOST /v3/storefront/api-token failed: ${res.status} ${res.statusText}\n`),
-      );
-      process.exit(1);
-    }
-
-    const BigCommerceStorefrontTokenSchema = z.object({
-      data: z.object({
-        token: z.string(),
-      }),
-    });
-
-    return parse(await res.json(), BigCommerceStorefrontTokenSchema);
-  }
-
-  sampleDataApi(path: string, opts: RequestInit = {}) {
-    if (!this.sampleDataApiUrl || !this.storeHash || !this.accessToken) {
-      throw new Error(
-        'sampleDataApiUrl, storeHash, and accessToken are required to make API requests',
-      );
-    }
-
-    const { headers = {}, ...rest } = opts;
-
-    const options = {
-      method: 'POST',
-      headers: {
-        ...headers,
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-        'X-Auth-Token': this.accessToken,
-        'User-Agent': this.userAgent,
-      },
-      ...rest,
-    };
-
-    return fetch(`${this.sampleDataApiUrl}/stores/${this.storeHash}${path}`, options);
-  }
-
-  async checkEligibility() {
-    const res = await this.sampleDataApi('/v3/channels/catalyst/eligibility', {
-      method: 'GET',
-    });
-
-    if (!res.ok) {
-      console.error(
-        chalk.red(
-          `\nGET /v3/channels/catalyst/eligibility failed: ${res.status} ${res.statusText}\n`,
-        ),
-      );
-      process.exit(1);
-    }
-
-    const CheckEligibilitySchema = z.object({
-      data: z.object({
-        eligible: z.boolean(),
-        message: z.string(),
-      }),
-    });
-
-    return parse(await res.json(), CheckEligibilitySchema);
-  }
-
-  async createChannel(channelName: string) {
-    const res = await this.sampleDataApi('/v3/channels/catalyst', {
-      body: JSON.stringify({ name: channelName, tokenType: 'normal' }),
-    });
-
-    if (!res.ok) {
-      console.error(
-        chalk.red(`\nPOST /v3/channels/catalyst failed: ${res.status} ${res.statusText}\n`),
-      );
-      process.exit(1);
-    }
-
-    const SampleDataChannelCreateSchema = z.object({
-      data: z.object({
-        id: z.number(),
-        name: z.string().min(1),
-        storefront_api_token: z.string(),
-      }),
-    });
-
-    return parse(await res.json(), SampleDataChannelCreateSchema);
+    return fetch(`${this.baseUrl}${path}`, options);
   }
 }

--- a/packages/create-catalyst/src/utils/login.ts
+++ b/packages/create-catalyst/src/utils/login.ts
@@ -1,75 +1,72 @@
-/* eslint-disable no-await-in-loop */
-
-import { select } from '@inquirer/prompts';
 import chalk from 'chalk';
+import open from 'open';
 
 import { Auth } from './auth';
-import { spinner } from './spinner';
+import { Config } from './config';
 
-const poll = async (auth: Auth, deviceCode: string, interval: number, expiresIn: number) => {
-  const intervalMs = interval * 1000;
-  const expiresAtMs = expiresIn * 1000;
-  const retries = expiresAtMs / intervalMs;
+interface LoginResult {
+  storeHash: string;
+  accessToken: string;
+}
 
-  for (let i = 0; i < retries; i += 1) {
-    try {
-      return await auth.checkDeviceCode(deviceCode);
-    } catch {
-      // noop
-    }
+interface DeviceCodeCredentials {
+  store_hash: string;
+  access_token: string;
+}
 
-    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+async function pollDeviceCode(
+  auth: Auth,
+  deviceCode: string,
+  interval: number,
+): Promise<DeviceCodeCredentials | null> {
+  try {
+    const credentials = await auth.checkDeviceCode(deviceCode);
+
+    return credentials;
+  } catch {
+    await new Promise((resolve) => setTimeout(resolve, interval * 1000));
+
+    return null;
+  }
+}
+
+async function waitForCredentials(
+  auth: Auth,
+  deviceCode: string,
+  interval: number,
+): Promise<DeviceCodeCredentials> {
+  const credentials = await pollDeviceCode(auth, deviceCode, interval);
+
+  if (credentials) {
+    return credentials;
   }
 
-  console.error(chalk.red('\nDevice code expired. Please try again.\n'));
-  process.exit(1);
-};
+  return waitForCredentials(auth, deviceCode, interval);
+}
 
-export const login = async (
-  bigCommerceAuthUrl: string,
-  storeHash?: string,
-  accessToken?: string,
-) => {
-  if (storeHash && accessToken) {
-    return { storeHash, accessToken };
-  }
-
-  const shouldLogin = await select({
-    message: 'Would you like to connect to a BigCommerce store?',
-    choices: [
-      { name: 'Yes', value: true },
-      { name: 'No', value: false },
-    ],
-  });
-
-  if (!shouldLogin) {
-    return { storeHash, accessToken };
-  }
-
-  const auth = new Auth({ baseUrl: bigCommerceAuthUrl });
+export async function login(baseUrl: string): Promise<LoginResult> {
+  const auth = new Auth({ baseUrl });
 
   const deviceCode = await auth.getDeviceCode();
 
   console.log(
-    [
-      `\nPlease visit ${chalk.cyan(deviceCode.verification_uri)} and enter the code: ${chalk.yellow(
-        deviceCode.user_code,
-      )}\n`,
-      `The code will expire in ${chalk.yellow(`${deviceCode.expires_in / 60} minutes`)}\n`,
-    ].join('\n'),
+    chalk.cyan('\nPlease visit the following URL to authenticate with your BigCommerce store:'),
   );
+  console.log(chalk.yellow(`\n${deviceCode.verification_uri}\n`));
+  console.log(chalk.cyan(`Enter code: `) + chalk.yellow(`${deviceCode.user_code}\n`));
 
-  const { store_hash, access_token } = await spinner(
-    poll(auth, deviceCode.device_code, deviceCode.interval, deviceCode.expires_in),
-    {
-      text: 'Waiting for device code to be authorized',
-      successText: 'Device code authorized\n',
-      failText: 'Device code expired\n',
-    },
-  );
+  await open(deviceCode.verification_uri);
+
+  const credentials = await waitForCredentials(auth, deviceCode.device_code, deviceCode.interval);
 
   return {
-    storeHash: store_hash,
-    accessToken: access_token,
+    storeHash: credentials.store_hash,
+    accessToken: credentials.access_token,
   };
-};
+}
+
+export function storeCredentials(projectDir: string, credentials: LoginResult): void {
+  const config = new Config(projectDir);
+
+  config.setAuth(credentials.storeHash, credentials.accessToken);
+}

--- a/packages/create-catalyst/src/utils/login.ts
+++ b/packages/create-catalyst/src/utils/login.ts
@@ -3,10 +3,10 @@
 import { select } from '@inquirer/prompts';
 import chalk from 'chalk';
 
-import { Https } from './https';
+import { Auth } from './auth';
 import { spinner } from './spinner';
 
-const poll = async (auth: Https, deviceCode: string, interval: number, expiresIn: number) => {
+const poll = async (auth: Auth, deviceCode: string, interval: number, expiresIn: number) => {
   const intervalMs = interval * 1000;
   const expiresAtMs = expiresIn * 1000;
   const retries = expiresAtMs / intervalMs;
@@ -46,7 +46,7 @@ export const login = async (
     return { storeHash, accessToken };
   }
 
-  const auth = new Https({ bigCommerceAuthUrl });
+  const auth = new Auth({ baseUrl: bigCommerceAuthUrl });
 
   const deviceCode = await auth.getDeviceCode();
 

--- a/packages/create-catalyst/src/utils/write-env.ts
+++ b/packages/create-catalyst/src/utils/write-env.ts
@@ -1,33 +1,11 @@
-import { randomBytes } from 'crypto';
 import { outputFileSync } from 'fs-extra/esm';
 import { join } from 'path';
 
-export const writeEnv = (
-  projectDir: string,
-  {
-    channelId,
-    storeHash,
-    storefrontToken,
-    arbitraryEnv,
-  }: {
-    channelId: string;
-    storeHash: string;
-    storefrontToken?: string;
-    arbitraryEnv?: string[];
-  },
-) => {
+export const writeEnv = (projectDir: string, envVars: Record<string, string>) => {
   outputFileSync(
     join(projectDir, '.env.local'),
-    [
-      `BIGCOMMERCE_STORE_HASH=${storeHash}`,
-      `BIGCOMMERCE_CHANNEL_ID=${channelId}`,
-      `BIGCOMMERCE_STOREFRONT_TOKEN=${storefrontToken}`,
-      '',
-      `AUTH_SECRET=${randomBytes(32).toString('hex')}`,
-      `CLIENT_LOGGER=false`,
-      `ENABLE_ADMIN_ROUTE=true`,
-      `DEFAULT_REVALIDATE_TARGET=3600`,
-      arbitraryEnv?.map((env) => env).join('\n'),
-    ].join('\n'),
+    `${Object.entries(envVars)
+      .map(([key, value]) => `${key}=${value}`)
+      .join('\n')}\n`,
   );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,6 +280,9 @@ importers:
       '@commander-js/extra-typings':
         specifier: ^12.1.0
         version: 12.1.0(commander@12.1.0)
+      '@iarna/toml':
+        specifier: ^2.2.5
+        version: 2.2.5
       '@inquirer/prompts':
         specifier: ^7.2.0
         version: 7.2.0(@types/node@20.17.10)
@@ -310,6 +313,9 @@ importers:
       nypm:
         specifier: ^0.4.1
         version: 0.4.1
+      open:
+        specifier: ^10.1.0
+        version: 10.1.0
       ora:
         specifier: ^8.1.1
         version: 8.1.1
@@ -957,6 +963,9 @@ packages:
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
+
+  '@iarna/toml@2.2.5':
+    resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
 
   '@icons-pack/react-simple-icons@10.2.0':
     resolution: {integrity: sha512-QDUxup8D3GdIIzwGpxQs6bjeFV5mJes25qqf4aqP/PaBYQNCar7AiyD8C14636TosCG0A/QqAUwm/Hviep4d4g==}
@@ -2490,6 +2499,10 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
+
   bundle-require@5.0.0:
     resolution: {integrity: sha512-GuziW3fSSmopcx4KRymQEJVbZUfqlCqcq7dvs6TYwKRZiegK/2buMxQTPs6MGlNv50wms1699qYO54R8XfRX4w==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -2769,9 +2782,21 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
+  default-browser-id@5.0.0:
+    resolution: {integrity: sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==}
+    engines: {node: '>=18'}
+
+  default-browser@5.2.1:
+    resolution: {integrity: sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==}
+    engines: {node: '>=18'}
+
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
 
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
@@ -3542,6 +3567,11 @@ packages:
     resolution: {integrity: sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==}
     engines: {node: '>= 0.4'}
 
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -3564,6 +3594,11 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
 
   is-interactive@2.0.0:
     resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
@@ -3657,6 +3692,10 @@ packages:
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
+
+  is-wsl@3.1.0:
+    resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
+    engines: {node: '>=16'}
 
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
@@ -4254,6 +4293,10 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
+  open@10.1.0:
+    resolution: {integrity: sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==}
+    engines: {node: '>=18'}
+
   opener@1.5.2:
     resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
     hasBin: true
@@ -4742,6 +4785,10 @@ packages:
     resolution: {integrity: sha512-uVbClXmR6wvx5R1M3Od4utyLUxrmOcEm3pAtMphn73Apq19PDtHpgZoEvqH2YnnaNUuvKmg2DgRd2Sqv+odyqg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  run-applescript@7.0.0:
+    resolution: {integrity: sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==}
+    engines: {node: '>=18'}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -6081,6 +6128,8 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/object-schema@2.0.3': {}
+
+  '@iarna/toml@2.2.5': {}
 
   '@icons-pack/react-simple-icons@10.2.0(react@19.0.0)':
     dependencies:
@@ -7741,6 +7790,10 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.0.0
+
   bundle-require@5.0.0(esbuild@0.24.0):
     dependencies:
       esbuild: 0.24.0
@@ -7982,11 +8035,20 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
+  default-browser-id@5.0.0: {}
+
+  default-browser@5.2.1:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.0
+
   define-data-property@1.1.4:
     dependencies:
       es-define-property: 1.0.0
       es-errors: 1.3.0
       gopd: 1.0.1
+
+  define-lazy-prop@3.0.0: {}
 
   define-properties@1.2.1:
     dependencies:
@@ -8228,7 +8290,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.14.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.14.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.14.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.14.0(eslint@8.57.1)(typescript@5.7.2))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.14.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.2(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0(eslint@8.57.1)
@@ -8263,7 +8325,7 @@ snapshots:
       is-bun-module: 1.2.1
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.14.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.14.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.14.0(eslint@8.57.1)(typescript@5.7.2))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.14.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
@@ -8295,7 +8357,7 @@ snapshots:
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 8.57.1
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.14.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.14.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
@@ -8326,16 +8388,6 @@ snapshots:
       '@typescript-eslint/parser': 8.14.0(eslint@8.57.1)(typescript@5.7.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.14.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.14.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.14.0(eslint@8.57.1)(typescript@5.7.2)
-      eslint: 8.57.1
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.14.0(eslint@8.57.1)(typescript@5.7.2))(eslint-plugin-import@2.31.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
@@ -9027,6 +9079,8 @@ snapshots:
     dependencies:
       has-tostringtag: 1.0.2
 
+  is-docker@3.0.0: {}
+
   is-extglob@2.1.1: {}
 
   is-finalizationregistry@1.0.2:
@@ -9044,6 +9098,10 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
 
   is-interactive@2.0.0: {}
 
@@ -9115,6 +9173,10 @@ snapshots:
       get-intrinsic: 1.2.4
 
   is-windows@1.0.2: {}
+
+  is-wsl@3.1.0:
+    dependencies:
+      is-inside-container: 1.0.0
 
   isarray@2.0.5: {}
 
@@ -9883,6 +9945,13 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
+  open@10.1.0:
+    dependencies:
+      default-browser: 5.2.1
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      is-wsl: 3.1.0
+
   opener@1.5.2: {}
 
   optionator@0.9.4:
@@ -10296,6 +10365,8 @@ snapshots:
       '@rollup/rollup-win32-ia32-msvc': 4.25.0
       '@rollup/rollup-win32-x64-msvc': 4.25.0
       fsevents: 2.3.3
+
+  run-applescript@7.0.0: {}
 
   run-parallel@1.2.0:
     dependencies:


### PR DESCRIPTION
## What/Why?
- Update CLI to use OCC APIs
- Restructuring & simplifying code
- Use new OCC client ID
- Add sample data prompt
- Create `.catalyst` file with store hash/access token after login action to be used for other CLI commands without re-prompting for login
- Ensure CLI-created storefronts have the same end state in the control panel as storefronts created in the control panel
- Various UX improvements like automatically opening the device auth URL

## Testing
Create wizard (the extraneous log statement is not there in this actual PR)

https://github.com/user-attachments/assets/4b173c35-000f-4724-8c86-92f4f685b091

Starting from app (I invalidated these credentials before posting this)


https://github.com/user-attachments/assets/368e8a4d-e578-4f25-b92d-2a6df7c38a63



Init command


https://github.com/user-attachments/assets/b1f67f0c-a0dd-42a7-92c2-e5f772d811b7

