### PR TITLE
Bring in latest PLP changes from Soul VIBE

### DIFF
--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
@@ -162,6 +162,12 @@ async function getSortLabel(): Promise<string> {
   return t('ariaLabel');
 }
 
+async function getCompareLabel(): Promise<string> {
+  const t = await getTranslations('Components.ProductCard.Compare');
+
+  return t('compare');
+}
+
 async function getEmptyStateTitle(): Promise<string> {
   const t = await getTranslations('Brand');
 
@@ -172,6 +178,24 @@ async function getEmptyStateSubtitle(): Promise<string> {
   const t = await getTranslations('Brand');
 
   return t('emptyStateSubtitle');
+}
+
+async function getFiltersPanelTitle(): Promise<string> {
+  const t = await getTranslations('FacetedGroup.FacetedSearch');
+
+  return t('filters');
+}
+
+async function getRangeFilterApplyLabel(): Promise<string> {
+  const t = await getTranslations('FacetedGroup.FacetedSearch.Range');
+
+  return t('apply');
+}
+
+async function getResetFiltersLabel(): Promise<string> {
+  const t = await getTranslations('FacetedGroup.FacetedSearch');
+
+  return t('resetFilters');
 }
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
@@ -194,12 +218,16 @@ export default async function Brand(props: Props) {
   return (
     <ProductsListSection
       breadcrumbs={getBreadcrumbs()}
+      compareLabel={getCompareLabel()}
       emptyStateSubtitle={getEmptyStateSubtitle()}
       emptyStateTitle={getEmptyStateTitle()}
       filterLabel={await getFilterLabel()}
       filters={getFilters(props)}
+      filtersPanelTitle={getFiltersPanelTitle()}
       paginationInfo={getPaginationInfo(props)}
       products={getListProducts(props)}
+      rangeFilterApplyLabel={getRangeFilterApplyLabel()}
+      resetFiltersLabel={getResetFiltersLabel()}
       sortDefaultValue="featured"
       sortLabel={getSortLabel()}
       sortOptions={getSortOptions()}

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -189,6 +189,30 @@ async function getFilterLabel(): Promise<string> {
   return t('filters');
 }
 
+async function getCompareLabel(): Promise<string> {
+  const t = await getTranslations('Components.ProductCard.Compare');
+
+  return t('compare');
+}
+
+async function getFiltersPanelTitle(): Promise<string> {
+  const t = await getTranslations('FacetedGroup.FacetedSearch');
+
+  return t('filters');
+}
+
+async function getRangeFilterApplyLabel(): Promise<string> {
+  const t = await getTranslations('FacetedGroup.FacetedSearch.Range');
+
+  return t('apply');
+}
+
+async function getResetFiltersLabel(): Promise<string> {
+  const t = await getTranslations('FacetedGroup.FacetedSearch');
+
+  return t('resetFilters');
+}
+
 async function getEmptyStateTitle(): Promise<string | null> {
   const t = await getTranslations('Category.Empty');
 
@@ -222,12 +246,16 @@ export default async function Category(props: Props) {
     <>
       <ProductsListSection
         breadcrumbs={getBreadcrumbs(props)}
+        compareLabel={getCompareLabel()}
         emptyStateSubtitle={getEmptyStateSubtitle()}
         emptyStateTitle={getEmptyStateTitle()}
         filterLabel={await getFilterLabel()}
         filters={getFilters(props)}
+        filtersPanelTitle={getFiltersPanelTitle()}
         paginationInfo={getPaginationInfo(props)}
         products={getListProducts(props)}
+        rangeFilterApplyLabel={getRangeFilterApplyLabel()}
+        resetFiltersLabel={getResetFiltersLabel()}
         sortDefaultValue="featured"
         sortLabel={getSortLabel()}
         sortOptions={getSortOptions()}

--- a/core/app/[locale]/(default)/(faceted)/search/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/search/page.tsx
@@ -178,6 +178,30 @@ async function getFilterLabel(): Promise<string> {
   return t('filters');
 }
 
+async function getCompareLabel(): Promise<string> {
+  const t = await getTranslations('Components.ProductCard.Compare');
+
+  return t('compare');
+}
+
+async function getFiltersPanelTitle(): Promise<string> {
+  const t = await getTranslations('FacetedGroup.FacetedSearch');
+
+  return t('filters');
+}
+
+async function getResetFiltersLabel(): Promise<string> {
+  const t = await getTranslations('FacetedGroup.FacetedSearch');
+
+  return t('resetFilters');
+}
+
+async function getRangeFilterApplyLabel(): Promise<string> {
+  const t = await getTranslations('FacetedGroup.FacetedSearch.Range');
+
+  return t('apply');
+}
+
 async function getEmptyStateTitle(props: Props): Promise<string> {
   const searchTerm = await getSearchTerm(props);
   const t = await getTranslations('Search');
@@ -212,12 +236,16 @@ export default async function Search(props: Props) {
   return (
     <ProductsListSection
       breadcrumbs={getBreadcrumbs()}
+      compareLabel={getCompareLabel()}
       emptyStateSubtitle={getEmptyStateSubtitle()}
       emptyStateTitle={getEmptyStateTitle(props)}
       filterLabel={await getFilterLabel()}
       filters={getFilters(props)}
+      filtersPanelTitle={getFiltersPanelTitle()}
       paginationInfo={getPaginationInfo(props)}
       products={getListProducts(props)}
+      rangeFilterApplyLabel={getRangeFilterApplyLabel()}
+      resetFiltersLabel={getResetFiltersLabel()}
       sortDefaultValue="featured"
       sortLabel={getSortLabel()}
       sortOptions={getSortOptions()}

--- a/core/data-transformers/facets-transformer.ts
+++ b/core/data-transformers/facets-transformer.ts
@@ -121,7 +121,7 @@ export const facetsTransformer = async ({
         minParamName: 'minPrice',
         maxParamName: 'maxPrice',
         label: facet.name,
-        min: refinedPriceSearchFilter?.selected?.minPrice ?? undefined,
+        min: facet.selected?.minPrice ?? undefined,
         max: facet.selected?.maxPrice ?? undefined,
         disabled: refinedPriceSearchFilter == null && !isSelected,
       };

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -128,6 +128,10 @@
     },
     "FacetedSearch": {
       "filters": "Filters",
+      "resetFilters": "Reset filters",
+      "Range": {
+        "apply": "Apply"
+      },
       "RefineBy": {
         "refineBy": "Refine by",
         "clearAllRefinements": "Clear all"

--- a/core/vibes/soul/form/checkbox/index.tsx
+++ b/core/vibes/soul/form/checkbox/index.tsx
@@ -47,12 +47,14 @@ type Props = Omit<React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>,
  */
 export function Checkbox({ label, errors, className, colorScheme = 'light', ...rest }: Props) {
   const id = React.useId();
+  const labelId = `${id}-label`;
 
   return (
     <div className="space-y-2">
       <div className={clsx('flex items-center gap-3', className)}>
         <CheckboxPrimitive.Root
           {...rest}
+          aria-labelledby={labelId}
           className={clsx(
             'flex h-5 w-5 items-center justify-center rounded-md border transition-colors duration-150 focus-visible:outline-0 focus-visible:ring-2 focus-visible:ring-[var(--checkbox-focus,hsl(var(--primary)))]',
             {
@@ -66,7 +68,6 @@ export function Checkbox({ label, errors, className, colorScheme = 'light', ...r
                   : 'data-[state=checked]:border-[var(--checkbox-dark-checked-border,hsl(var(--background)))] data-[state=unchecked]:border-[var(--checkbox-dark-unchecked-border,hsl(var(--contrast-400)))] data-[state=checked]:bg-[var(--checkbox-dark-checked-background,hsl(var(--foreground)))] data-[state=unchecked]:bg-[var(--checkbox-dark-unchecked-background,hsl(var(--foreground)))] data-[state=checked]:text-[var(--checkbox-dark-checked-text,hsl(var(--background)))] data-[state=unchecked]:text-[var(--checkbox-dark-unchecked-text,hsl(var(--background)))] data-[state=checked]:hover:border-[var(--checkbox-dark-checked-border-hover,hsl(var(--background)))] data-[state=unchecked]:hover:border-[var(--checkbox-dark-unchecked-border-hover,hsl(var(--contrast-300)))]',
             }[colorScheme],
           )}
-          id={id}
         >
           <CheckboxPrimitive.Indicator>
             <Check className="h-4 w-4" color="currentColor" />
@@ -82,7 +83,7 @@ export function Checkbox({ label, errors, className, colorScheme = 'light', ...r
                 dark: 'text-[var(--checkbox-dark-label,hsl(var(--background)))]',
               }[colorScheme],
             )}
-            htmlFor={id}
+            id={labelId}
           >
             {label}
           </LabelPrimitive.Root>

--- a/core/vibes/soul/form/range-input/index.tsx
+++ b/core/vibes/soul/form/range-input/index.tsx
@@ -1,93 +1,139 @@
 'use client';
 
+import { ArrowRight } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
 import { Input } from '@/vibes/soul/form/input';
+import { Button } from '@/vibes/soul/primitives/button';
 
 interface Props {
-  minName?: string;
-  maxName?: string;
-  min?: number;
-  max?: number;
-  minLabel?: string;
-  maxLabel?: string;
-  minPlaceholder?: string;
-  maxPlaceholder?: string;
-  minPrepend?: React.ReactNode;
-  maxPrepend?: React.ReactNode;
-  minValue?: number | null;
-  maxValue?: number | null;
-  onMinValueChange?: (value: number) => void;
-  onMaxValueChange?: (value: number) => void;
-  minStep?: number;
-  maxStep?: number;
+  applyLabel?: string;
   disabled?: boolean;
+  max?: number;
+  maxLabel?: string;
+  maxName?: string;
+  maxPlaceholder?: string;
+  maxPrepend?: React.ReactNode;
+  maxStep?: number;
+  min?: number;
+  minLabel?: string;
+  minName?: string;
+  minPlaceholder?: string;
+  minPrepend?: React.ReactNode;
+  minStep?: number;
+  onChange?: (value: { min: number | null; max: number | null }) => void;
+  value?: { min: number | null; max: number | null };
 }
 
-const clamp = (value: number, min = -Infinity, max = Infinity) =>
-  Math.min(Math.max(value, min), max);
+const clamp = (value: number, min: number | null, max?: number | null) =>
+  Math.min(Math.max(value, min ?? -Infinity), max ?? Infinity);
 
 export function RangeInput({
-  minName = 'min',
-  maxName = 'max',
-  min,
+  applyLabel = 'Apply',
+  disabled = false,
   max,
-  minLabel,
   maxLabel,
-  minPrepend,
-  maxPrepend,
-  minPlaceholder = 'Min',
+  maxName = 'max',
   maxPlaceholder = 'Max',
-  minValue,
-  maxValue,
-  onMinValueChange,
-  onMaxValueChange,
-  minStep,
+  maxPrepend,
   maxStep,
-  disabled,
+  min,
+  minLabel,
+  minName = 'min',
+  minPlaceholder = 'Min',
+  minPrepend,
+  minStep,
+  onChange,
+  value,
 }: Props) {
+  const [state, setState] = useState({
+    min: value?.min?.toString() ?? '',
+    max: value?.max?.toString() ?? '',
+  });
+
+  useEffect(() => {
+    setState({ min: value?.min?.toString() ?? '', max: value?.max?.toString() ?? '' });
+  }, [value]);
+
+  const parsedMinState = parseInt(state.min, 10);
+  const parsedMaxState = parseInt(state.max, 10);
+  const minStateAsNumber = Number.isNaN(parsedMinState) ? null : parsedMinState;
+  const maxStateAsNumber = Number.isNaN(parsedMaxState) ? null : parsedMaxState;
+
   return (
     <div className="flex w-full items-center gap-2">
       <Input
         className="flex-1"
         disabled={disabled}
         label={minLabel}
-        max={maxValue ?? max}
+        max={maxStateAsNumber ?? max}
         min={min}
         name={minName}
         onBlur={(e) => {
-          const clamped = clamp(e.currentTarget.valueAsNumber, min, maxValue ?? max);
+          const clamped = clamp(
+            e.currentTarget.valueAsNumber,
+            min ?? null,
+            e.currentTarget.max === '' ? null : parseInt(e.currentTarget.max, 10),
+          );
+          const nextValue = Number.isNaN(clamped) ? null : clamped;
 
-          if (Number.isNaN(clamped)) e.currentTarget.value = clamped.toString();
-
-          onMinValueChange?.(clamped);
+          setState((prev) => ({ ...prev, min: nextValue?.toString() ?? '' }));
         }}
-        onChange={(e) => onMinValueChange?.(e.currentTarget.valueAsNumber)}
+        onChange={(e) => {
+          const nextValue = e.currentTarget.value;
+
+          setState((prev) => ({ ...prev, min: nextValue }));
+        }}
         placeholder={minPlaceholder}
         prepend={minPrepend}
         step={minStep}
         type="number"
-        value={minValue ?? ''}
+        value={state.min}
       />
       <Input
         className="flex-1"
         disabled={disabled}
         label={maxLabel}
         max={max}
-        min={minValue ?? min}
+        min={minStateAsNumber ?? min}
         name={maxName}
         onBlur={(e) => {
-          const clamped = clamp(e.currentTarget.valueAsNumber, minValue ?? min, max);
+          const clamped = clamp(
+            e.currentTarget.valueAsNumber,
+            e.currentTarget.min === '' ? null : parseInt(e.currentTarget.min, 10),
+            max,
+          );
+          const nextValue = Number.isNaN(clamped) ? null : clamped;
 
-          if (!Number.isNaN(clamped)) e.currentTarget.value = clamped.toString();
-
-          onMaxValueChange?.(clamped);
+          setState((prev) => ({ ...prev, max: nextValue?.toString() ?? '' }));
         }}
-        onChange={(e) => onMaxValueChange?.(e.currentTarget.valueAsNumber)}
+        onChange={(e) => {
+          const nextValue = e.currentTarget.value;
+
+          setState((prev) => ({ ...prev, max: nextValue }));
+        }}
         placeholder={maxPlaceholder}
         prepend={maxPrepend}
         step={maxStep}
         type="number"
-        value={maxValue ?? ''}
+        value={state.max}
       />
+      <Button
+        className="shrink-0"
+        disabled={disabled || (state.min === state.max && state.min !== '' && state.max !== '')}
+        onClick={() =>
+          onChange?.({
+            min: state.min === '' ? null : Number(state.min),
+            max: state.max === '' ? null : Number(state.max),
+          })
+        }
+        shape="circle"
+        size="small"
+        variant="secondary"
+      >
+        <span className="sr-only">{applyLabel}</span>
+        <ArrowRight size={20} strokeWidth={1} />
+      </Button>
     </div>
   );
 }

--- a/core/vibes/soul/primitives/accordions/index.tsx
+++ b/core/vibes/soul/primitives/accordions/index.tsx
@@ -2,7 +2,7 @@
 
 import * as AccordionsPrimitive from '@radix-ui/react-accordion';
 import { clsx } from 'clsx';
-import React from 'react';
+import { useEffect, useState } from 'react';
 
 // eslint-disable-next-line valid-jsdoc
 /**
@@ -34,36 +34,47 @@ function Accordion({
 }: React.ComponentPropsWithoutRef<typeof AccordionsPrimitive.Item> & {
   colorScheme?: 'light' | 'dark';
 }) {
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
   return (
     <AccordionsPrimitive.Item {...rest}>
       <AccordionsPrimitive.Header>
-        <AccordionsPrimitive.Trigger asChild>
-          <div className="group cursor-pointer items-start gap-8 py-3 last:flex @md:py-4">
-            <div
-              className={clsx(
-                'flex-1 select-none font-[family-name:var(--accordion-title-font-family,var(--font-family-mono))] text-sm uppercase transition-colors duration-300 ease-out',
-                {
-                  light:
-                    'text-[var(--accordion-light-title-text,hsl(var(--contrast-400)))] group-hover:text-[var(--accordion-light-title-text-hover,hsl(var(--foreground)))]',
-                  dark: 'text-[var(--accordion-dark-title-text,hsl(var(--contrast-200)))] group-hover:text-[var(--accordion-dark-title-text-hover,hsl(var(--background)))]',
-                }[colorScheme],
-              )}
-            >
-              {title}
-            </div>
-            <AnimatedChevron
-              className={clsx(
-                {
-                  light:
-                    'stroke-[var(--accordion-light-title-icon,hsl(var(--contrast-500)))] group-hover:stroke-[var(--accordion-light-title-icon-hover,hsl(var(--foreground)))]',
-                  dark: 'stroke-[var(--accordion-dark-title-icon,hsl(var(--contrast-200)))] group-hover:stroke-[var(--accordion-dark-title-icon-hover,hsl(var(--background)))]',
-                }[colorScheme],
-              )}
-            />
+        <AccordionsPrimitive.Trigger className="group flex w-full cursor-pointer items-start gap-8 py-3 text-start @md:py-4">
+          <div
+            className={clsx(
+              'flex-1 select-none font-[family-name:var(--accordion-title-font-family,var(--font-family-mono))] text-sm uppercase transition-colors duration-300 ease-out',
+              {
+                light:
+                  'text-[var(--accordion-light-title-text,hsl(var(--contrast-400)))] group-hover:text-[var(--accordion-light-title-text-hover,hsl(var(--foreground)))]',
+                dark: 'text-[var(--accordion-dark-title-text,hsl(var(--contrast-200)))] group-hover:text-[var(--accordion-dark-title-text-hover,hsl(var(--background)))]',
+              }[colorScheme],
+            )}
+          >
+            {title}
           </div>
+          <AnimatedChevron
+            className={clsx(
+              {
+                light:
+                  'stroke-[var(--accordion-light-title-icon,hsl(var(--contrast-500)))] group-hover:stroke-[var(--accordion-light-title-icon-hover,hsl(var(--foreground)))]',
+                dark: 'stroke-[var(--accordion-dark-title-icon,hsl(var(--contrast-200)))] group-hover:stroke-[var(--accordion-dark-title-icon-hover,hsl(var(--background)))]',
+              }[colorScheme],
+            )}
+          />
         </AccordionsPrimitive.Trigger>
       </AccordionsPrimitive.Header>
-      <AccordionsPrimitive.Content className="overflow-hidden data-[state=closed]:animate-collapse data-[state=open]:animate-expand">
+      <AccordionsPrimitive.Content
+        className={clsx(
+          'overflow-hidden',
+          // We need to delay the animation until the component is mounted to avoid the animation
+          // from being triggered when the component is first rendered.
+          isMounted && 'data-[state=closed]:animate-collapse data-[state=open]:animate-expand',
+        )}
+      >
         <div
           className={clsx(
             'pb-5 font-[family-name:var(--accordion-content-font-family)] font-medium leading-normal',

--- a/core/vibes/soul/primitives/products-list/index.tsx
+++ b/core/vibes/soul/primitives/products-list/index.tsx
@@ -19,7 +19,7 @@ interface Props {
   aspectRatio?: '5:6' | '3:4' | '1:1';
   showCompare?: boolean;
   compareAction?: React.ComponentProps<'form'>['action'];
-  compareLabel?: string;
+  compareLabel?: Streamable<string>;
   compareParamName?: string;
   emptyStateTitle?: Streamable<string | null>;
   emptyStateSubtitle?: Streamable<string | null>;
@@ -34,7 +34,7 @@ export function ProductsList({
   showCompare,
   compareAction,
   compareProducts: streamableCompareProducts,
-  compareLabel,
+  compareLabel: streamableCompareLabel,
   compareParamName,
   emptyStateTitle,
   emptyStateSubtitle,
@@ -44,9 +44,9 @@ export function ProductsList({
     <>
       <Stream
         fallback={<ProductsListSkeleton pending placeholderCount={placeholderCount} />}
-        value={streamableProducts}
+        value={Promise.all([streamableProducts, streamableCompareLabel])}
       >
-        {(products) => {
+        {([products, compareLabel]) => {
           if (products.length === 0) {
             return (
               <ProductsListEmptyState
@@ -76,8 +76,8 @@ export function ProductsList({
           );
         }}
       </Stream>
-      <Stream value={streamableCompareProducts}>
-        {(compareProducts) =>
+      <Stream value={Promise.all([streamableCompareProducts, streamableCompareLabel])}>
+        {([compareProducts, compareLabel]) =>
           compareProducts && (
             <CompareDrawer
               action={compareAction}

--- a/core/vibes/soul/sections/products-list-section/index.tsx
+++ b/core/vibes/soul/sections/products-list-section/index.tsx
@@ -24,9 +24,11 @@ interface Props {
   compareProducts?: Streamable<ListProduct[] | null>;
   paginationInfo?: Streamable<CursorPaginationInfo>;
   compareAction?: React.ComponentProps<'form'>['action'];
-  compareLabel?: string;
+  compareLabel?: Streamable<string>;
   filterLabel?: string;
-  resetFiltersLabel?: string;
+  filtersPanelTitle?: Streamable<string>;
+  resetFiltersLabel?: Streamable<string>;
+  rangeFilterApplyLabel?: Streamable<string>;
   sortLabel?: Streamable<string | null>;
   sortPlaceholder?: Streamable<string | null>;
   sortParamName?: string;
@@ -50,7 +52,9 @@ export function ProductsListSection({
   compareLabel,
   paginationInfo,
   filterLabel = 'Filters',
+  filtersPanelTitle: streamableFiltersPanelTitle,
   resetFiltersLabel,
+  rangeFilterApplyLabel,
   sortLabel: streamableSortLabel,
   sortPlaceholder: streamableSortPlaceholder,
   sortParamName,
@@ -104,7 +108,7 @@ export function ProductsListSection({
                   />
                 )}
               </Stream>
-              <div className="block @3xl:hidden">
+              <aside className="block @3xl:hidden">
                 <SidePanel.Root>
                   <SidePanel.Trigger asChild>
                     <Button size="medium" variant="secondary">
@@ -114,29 +118,36 @@ export function ProductsListSection({
                       </span>
                     </Button>
                   </SidePanel.Trigger>
-                  <SidePanel.Content title={filterLabel}>
-                    <Suspense>
-                      <FiltersPanel
-                        filters={filters}
-                        paginationInfo={paginationInfo}
-                        resetFiltersLabel={resetFiltersLabel}
-                      />
-                    </Suspense>
-                  </SidePanel.Content>
+                  <Stream value={streamableFiltersPanelTitle}>
+                    {(filtersPanelTitle) => (
+                      <SidePanel.Content title={<h2>{filtersPanelTitle}</h2>}>
+                        <FiltersPanel
+                          filters={filters}
+                          paginationInfo={paginationInfo}
+                          rangeFilterApplyLabel={rangeFilterApplyLabel}
+                          resetFiltersLabel={resetFiltersLabel}
+                        />
+                      </SidePanel.Content>
+                    )}
+                  </Stream>
                 </SidePanel.Root>
-              </div>
+              </aside>
             </div>
           </div>
         </div>
         <div className="flex items-stretch gap-8 @4xl:gap-10">
-          <div className="hidden w-52 @3xl:block @4xl:w-60">
+          <aside className="hidden w-52 @3xl:block @4xl:w-60">
+            <Stream value={streamableFiltersPanelTitle}>
+              {(filtersPanelTitle) => <h2 className="sr-only">{filtersPanelTitle}</h2>}
+            </Stream>
             <FiltersPanel
               className="sticky top-4"
               filters={filters}
               paginationInfo={paginationInfo}
+              rangeFilterApplyLabel={rangeFilterApplyLabel}
               resetFiltersLabel={resetFiltersLabel}
             />
-          </div>
+          </aside>
 
           <div className="flex-1 group-has-[[data-pending]]/products-list-section:animate-pulse">
             <ProductsList


### PR DESCRIPTION
## What/Why?
<!--- 
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
--->
This PR brings in the latest changes for PLPs from the Soul VIBE:
- Adds new translated labels for product card compare, filters panel title, range filter apply button, and reset filters button
- Fixes min value for price filter
- Refactors range input to fix interaction edge cases that would result in a crash due to NaN values as well as the apply button not being disabled when it had to be and values not being clamped correctly
- a11y improvements to compare checkbox, range input, accordion, and product list section filters
- Fix accordion default open state

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->
### Translated Labels
![CleanShot 2024-12-31 at 16 57 02@2x](https://github.com/user-attachments/assets/8cc3e2cf-d8df-40ab-a922-9d66ee063ac0)
![CleanShot 2024-12-31 at 16 57 25@2x](https://github.com/user-attachments/assets/a2f79834-cab2-4e6f-bf33-6a955a3f22a7)
![CleanShot 2024-12-31 at 16 57 45@2x](https://github.com/user-attachments/assets/2048d953-8294-4da3-a172-40198562c97a)
![CleanShot 2024-12-31 at 16 58 08@2x](https://github.com/user-attachments/assets/bfad8ed5-ac63-4895-a4f6-7e9ade8a41f5)
![CleanShot 2024-12-31 at 16 58 20@2x](https://github.com/user-attachments/assets/2252db22-de77-4d28-9b41-d126262fadda)

### Price Filter Interactions & Accordion Open States

https://github.com/user-attachments/assets/d77e0e92-808f-4566-a0e9-474ab652b95e

### Accessibility
![CleanShot 2024-12-31 at 17 05 44@2x](https://github.com/user-attachments/assets/ae702bef-8ae4-40bc-a229-4826f957717d)
