### PR TITLE
Makeswift integration QA fixes

### DIFF
--- a/core/lib/makeswift/components/button-link/button-link.makeswift.tsx
+++ b/core/lib/makeswift/components/button-link/button-link.makeswift.tsx
@@ -50,7 +50,7 @@ runtime.registerComponent(
         options: [
           { value: 'pill', label: 'Pill' },
           { value: 'rounded', label: 'Rounded' },
-          { value: 'square', label: 'Square' },
+          { value: 'square', label: 'Rectangle' },
           { value: 'circle', label: 'Circle' },
         ],
         defaultValue: 'pill',

--- a/core/lib/makeswift/components/carousel/carousel.makeswift.tsx
+++ b/core/lib/makeswift/components/carousel/carousel.makeswift.tsx
@@ -46,7 +46,7 @@ runtime.registerComponent(
           <div className="p-4 text-center text-lg text-gray-400">Add items to the carousel</div>
         ) : (
           <Carousel>
-            <CarouselContent className="mb-20">
+            <CarouselContent className="mb-10">
               {slides.map(({ link, children }, index) => (
                 <CarouselItem
                   className="basis-full @md:basis-1/2 @lg:basis-1/3 @2xl:basis-1/4"
@@ -59,7 +59,7 @@ runtime.registerComponent(
               ))}
             </CarouselContent>
             {(showScrollbar || showArrows) && (
-              <div className="flex w-full items-center justify-between">
+              <div className="mt-10 flex w-full items-center justify-between">
                 {showScrollbar && <CarouselScrollbar colorScheme={colorScheme} />}
                 {showArrows && <CarouselButtons colorScheme={colorScheme} />}
               </div>
@@ -76,7 +76,7 @@ runtime.registerComponent(
     props: {
       className: Style(),
       slides: List({
-        label: 'Slides',
+        label: 'Items',
         type: Shape({
           type: {
             name: TextInput({ label: 'Name', defaultValue: '' }),
@@ -85,7 +85,7 @@ runtime.registerComponent(
           },
         }),
         getItemLabel(slide) {
-          return slide?.name || 'Slide';
+          return slide?.name || 'Item';
         },
       }),
       showScrollbar: Checkbox({

--- a/core/lib/makeswift/components/products-carousel/products-carousel.makeswift.tsx
+++ b/core/lib/makeswift/components/products-carousel/products-carousel.makeswift.tsx
@@ -108,7 +108,7 @@ runtime.registerComponent(
         defaultValue: '5:6',
       }),
       colorScheme: Select({
-        label: 'Text Color Scheme',
+        label: 'Text color scheme',
         options: [
           { value: 'light', label: 'Light' },
           { value: 'dark', label: 'Dark' },
@@ -116,11 +116,11 @@ runtime.registerComponent(
         defaultValue: 'light',
       }),
       showScrollbar: Checkbox({
-        label: 'Show Scrollbar',
+        label: 'Show scrollbar',
         defaultValue: true,
       }),
       showButtons: Checkbox({
-        label: 'Show Buttons',
+        label: 'Show buttons',
         defaultValue: true,
       }),
     },

--- a/core/lib/makeswift/components/section/section.makeswift.ts
+++ b/core/lib/makeswift/components/section/section.makeswift.ts
@@ -11,7 +11,7 @@ runtime.registerComponent(SectionLayout, {
     className: Style({ properties: [...Style.Default, Style.Border] }),
     children: Slot(),
     containerSize: Select({
-      label: 'Container Size',
+      label: 'Container size',
       options: [
         { value: 'md', label: 'Medium' },
         { value: 'lg', label: 'Large' },

--- a/core/vibes/soul/sections/slideshow/index.tsx
+++ b/core/vibes/soul/sections/slideshow/index.tsx
@@ -172,7 +172,7 @@ export function Slideshow({ slides, playOnInit = true, interval = 5000, classNam
                         {title}
                       </h1>
                       {showDescription && (
-                        <p className="max-w-x mt-2 font-[family-name:var(--slideshow-description-font-family,var(--font-family-body))] text-base leading-normal text-[var(--slideshow-description,hsl(var(--background)/80%))] @xl:mt-3 @xl:text-lg">
+                        <p className="mt-2 max-w-xl font-[family-name:var(--slideshow-description-font-family,var(--font-family-body))] text-base leading-normal text-[var(--slideshow-description,hsl(var(--background)/80%))] @xl:mt-3 @xl:text-lg">
                           {description}
                         </p>
                       )}


### PR DESCRIPTION
## What/Why?
- [x] Carousel - Change default Name value for each item from "Slide" to "Item"
- [x] Carousel - Rename "Slides" to "Items"
- [x] Carousel - Vertical space missing between carousel items and controls (added `mt-10` to match Products carousel))
- [x] Slideshow - Description text is missing `max-width` so it matches the width of the title text more (typo `max-w-x` -> `max-w-xl`) [Vibes PR](https://github.com/makeswift/vibes/pull/447)
- [x] Button - Button shape option for "Square" should be renamed to "Rectangle"
- [x] Products Carousel - Only capitalize first word for panel labels