### PR TITLE
fix(site header): move banner & logo props into popovers, add group titles etc.

### DIFF
--- a/core/lib/makeswift/components/site-header/site-header.client.tsx
+++ b/core/lib/makeswift/components/site-header/site-header.client.tsx
@@ -39,6 +39,13 @@ export const PropsContextProvider = ({
   <PropsContext.Provider value={value}>{children}</PropsContext.Provider>
 );
 
+interface ImageProps {
+  src?: string;
+  alt: string;
+  width: number;
+  height: number;
+}
+
 interface Props {
   banner: {
     id: string;
@@ -59,14 +66,8 @@ interface Props {
     }>;
   }>;
   logo: {
-    desktopSrc?: string;
-    desktopAlt: string;
-    desktopWidth: number;
-    desktopHeight: number;
-    mobileSrc?: string;
-    mobileAlt: string;
-    mobileWidth: number;
-    mobileHeight: number;
+    desktop: ImageProps;
+    mobile: ImageProps;
     link?: { href: string };
   };
   linksPosition: 'center' | 'left' | 'right';
@@ -108,14 +109,16 @@ export const MakeswiftHeader = forwardRef(
         navigation={{
           ...passedProps,
           links: combineLinks(passedProps.links, links),
-          logo: logo.desktopSrc ? { src: logo.desktopSrc, alt: logo.desktopAlt } : passedProps.logo,
-          logoWidth: logo.desktopWidth,
-          logoHeight: logo.desktopHeight,
-          mobileLogo: logo.mobileSrc
-            ? { src: logo.mobileSrc, alt: logo.mobileAlt }
+          logo: logo.desktop.src
+            ? { src: logo.desktop.src, alt: logo.desktop.alt }
+            : passedProps.logo,
+          logoWidth: logo.desktop.width,
+          logoHeight: logo.desktop.height,
+          mobileLogo: logo.mobile.src
+            ? { src: logo.mobile.src, alt: logo.mobile.alt }
             : passedProps.mobileLogo,
-          mobileLogoWidth: logo.mobileWidth,
-          mobileLogoHeight: logo.mobileHeight,
+          mobileLogoWidth: logo.mobile.width,
+          mobileLogoHeight: logo.mobile.height,
           linksPosition,
           logoHref: logo.link?.href ?? passedProps.logoHref,
         }}

--- a/core/lib/makeswift/components/site-header/site-header.makeswift.tsx
+++ b/core/lib/makeswift/components/site-header/site-header.makeswift.tsx
@@ -16,58 +16,84 @@ import { MakeswiftHeader } from './site-header.client';
 
 export const COMPONENT_TYPE = 'catalyst-makeswift-header';
 
+const banner = Shape({
+  label: 'Banner',
+  layout: Shape.Layout.Popover,
+  type: {
+    show: Checkbox({ label: 'Show banner', defaultValue: false }),
+    allowClose: Checkbox({ label: 'Allow banner to close', defaultValue: true }),
+    id: TextInput({ label: 'Banner ID', defaultValue: 'black_friday_2025' }),
+    children: Slot(),
+  },
+});
+
+const logoGroup = (
+  label: string,
+  defaults: {
+    width: number;
+    height: number;
+  },
+) =>
+  Shape({
+    label,
+    type: {
+      src: Image({ label: 'Logo' }),
+      alt: TextInput({ label: 'Alt text', defaultValue: 'Logo alt' }),
+      width: Number({ label: 'Max width', suffix: 'px', defaultValue: defaults.width }),
+      height: Number({ label: 'Max height', suffix: 'px', defaultValue: defaults.height }),
+    },
+  });
+
+const logo = Shape({
+  label: 'Logo',
+  layout: Shape.Layout.Popover,
+  type: {
+    desktop: logoGroup('Desktop', { width: 200, height: 40 }),
+    mobile: logoGroup('Mobile', { width: 100, height: 40 }),
+    link: Link({ label: 'Logo link' }),
+  },
+});
+
+const links = List({
+  label: 'Links',
+  type: Shape({
+    label: 'Link',
+    type: {
+      label: TextInput({ label: 'Text', defaultValue: 'Text' }),
+      link: Link({ label: 'URL' }),
+    },
+  }),
+  getItemLabel: (item) => item?.label ?? 'Text',
+});
+
+const groups = List({
+  label: 'Groups',
+  type: Shape({
+    label: 'Link group',
+    type: {
+      label: TextInput({ label: 'Text', defaultValue: 'Text' }),
+      link: Link({ label: 'URL' }),
+      links,
+    },
+  }),
+  getItemLabel: (item) => item?.label ?? 'Text',
+});
+
 runtime.registerComponent(MakeswiftHeader, {
   type: COMPONENT_TYPE,
   label: 'Site Header',
   hidden: true,
   props: {
-    banner: Shape({
-      type: {
-        show: Checkbox({ label: 'Show banner', defaultValue: false }),
-        allowClose: Checkbox({ label: 'Allow banner to close', defaultValue: true }),
-        id: TextInput({ label: 'Banner ID', defaultValue: 'black_friday_2025' }),
-        children: Slot(),
-      },
-    }),
-    logo: Shape({
-      type: {
-        desktopSrc: Image({ label: 'Desktop logo' }),
-        desktopAlt: TextInput({ label: 'Desktop logo alt', defaultValue: 'Desktop logo alt' }),
-        desktopWidth: Number({ label: 'Desktop logo width', suffix: 'px', defaultValue: 200 }),
-        desktopHeight: Number({ label: 'Desktop logo height', suffix: 'px', defaultValue: 40 }),
-        mobileSrc: Image({ label: 'Mobile logo' }),
-        mobileAlt: TextInput({ label: 'Mobile logo alt', defaultValue: 'Mobile logo alt' }),
-        mobileWidth: Number({ label: 'Mobile logo width', suffix: 'px', defaultValue: 100 }),
-        mobileHeight: Number({ label: 'Mobile logo height', suffix: 'px', defaultValue: 40 }),
-        link: Link({ label: 'Logo link' }),
-      },
-    }),
+    banner,
+    logo,
     links: List({
       label: 'Additional links',
       type: Shape({
+        label: 'Link',
         type: {
           label: TextInput({ label: 'Text', defaultValue: 'Text' }),
           link: Link({ label: 'URL' }),
-          groups: List({
-            label: 'Groups',
-            type: Shape({
-              type: {
-                label: TextInput({ label: 'Text', defaultValue: 'Text' }),
-                link: Link({ label: 'URL' }),
-                links: List({
-                  label: 'Links',
-                  type: Shape({
-                    type: {
-                      label: TextInput({ label: 'Text', defaultValue: 'Text' }),
-                      link: Link({ label: 'URL' }),
-                    },
-                  }),
-                  getItemLabel: (item) => item?.label ?? 'Text',
-                }),
-              },
-            }),
-            getItemLabel: (item) => item?.label ?? 'Text',
-          }),
+          groups,
         },
       }),
       getItemLabel: (item) => item?.label ?? 'Text',


### PR DESCRIPTION
## What/Why?

Making site header props more organized/manageable.

Companion PR for the footer: https://github.com/bigcommerce/catalyst/pull/1834

## Testing

https://github.com/user-attachments/assets/2d233521-562e-4ee6-a118-14a88f7165c9

