### PR TITLE
fix: revert expireTag to revalidateTag

### DIFF
--- a/core/app/[locale]/(default)/account/addresses/_actions/delete-address.ts
+++ b/core/app/[locale]/(default)/account/addresses/_actions/delete-address.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { expireTag } from 'next/cache';
+import { revalidateTag } from 'next/cache';
 import { getTranslations } from 'next-intl/server';
 
 import { getSessionCustomerAccessToken } from '~/auth';
@@ -56,7 +56,7 @@ export const deleteAddress = async (addressId: number): Promise<DeleteAddressRes
       });
     }
 
-    expireTag(TAGS.customer);
+    revalidateTag(TAGS.customer);
 
     return { status: 'success', message: t('success') };
   } catch (error: unknown) {

--- a/core/app/[locale]/(default)/account/addresses/add/_actions/add-address.ts
+++ b/core/app/[locale]/(default)/account/addresses/add/_actions/add-address.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { expireTag } from 'next/cache';
+import { revalidateTag } from 'next/cache';
 import { getTranslations } from 'next-intl/server';
 
 import { getSessionCustomerAccessToken } from '~/auth';
@@ -83,7 +83,7 @@ export const addAddress = async (formData: FormData): Promise<AddAddressResponse
       });
     }
 
-    expireTag(TAGS.customer);
+    revalidateTag(TAGS.customer);
 
     return { status: 'success', message: t('success') };
   } catch (error: unknown) {

--- a/core/app/[locale]/(default)/account/addresses/edit/[slug]/_actions/update-address.ts
+++ b/core/app/[locale]/(default)/account/addresses/edit/[slug]/_actions/update-address.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { expireTag } from 'next/cache';
+import { revalidateTag } from 'next/cache';
 import { getTranslations } from 'next-intl/server';
 
 import { getSessionCustomerAccessToken } from '~/auth';
@@ -95,7 +95,7 @@ export const updateAddress = async (
       });
     }
 
-    expireTag(TAGS.customer);
+    revalidateTag(TAGS.customer);
 
     return { status: 'success', message: t('success') };
   } catch (error: unknown) {

--- a/core/app/[locale]/(default)/account/settings/_actions/update-customer.ts
+++ b/core/app/[locale]/(default)/account/settings/_actions/update-customer.ts
@@ -2,7 +2,7 @@
 
 import { BigCommerceAPIError } from '@bigcommerce/catalyst-client';
 import { parseWithZod } from '@conform-to/zod';
-import { expireTag } from 'next/cache';
+import { revalidateTag } from 'next/cache';
 import { getTranslations } from 'next-intl/server';
 
 import { updateAccountSchema } from '@/vibes/soul/sections/account-settings-section/schema';
@@ -76,7 +76,7 @@ export const updateCustomer: UpdateAccountAction = async (prevState, formData) =
       };
     }
 
-    expireTag(TAGS.customer);
+    revalidateTag(TAGS.customer);
 
     return {
       account: submission.value,

--- a/core/app/[locale]/(default)/cart/_actions/remove-item.ts
+++ b/core/app/[locale]/(default)/cart/_actions/remove-item.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { expireTag } from 'next/cache';
+import { revalidateTag } from 'next/cache';
 import { cookies } from 'next/headers';
 import { getTranslations } from 'next-intl/server';
 
@@ -64,7 +64,7 @@ export async function removeItem({
       cookieStore.delete('cartId');
     }
 
-    expireTag(TAGS.cart);
+    revalidateTag(TAGS.cart);
 
     return cart;
   } catch (error: unknown) {

--- a/core/app/[locale]/(default)/cart/_actions/update-quantity.ts
+++ b/core/app/[locale]/(default)/cart/_actions/update-quantity.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { expirePath } from 'next/cache';
+import { revalidatePath } from 'next/cache';
 import { cookies } from 'next/headers';
 import { getTranslations } from 'next-intl/server';
 
@@ -89,7 +89,7 @@ export const updateQuantity = async ({
       throw new Error(t('failedToUpdateQuantity'));
     }
 
-    expirePath('/cart');
+    revalidatePath('/cart');
 
     return cart;
   } catch (error: unknown) {

--- a/core/app/[locale]/(default)/compare/_actions/add-to-cart.ts
+++ b/core/app/[locale]/(default)/compare/_actions/add-to-cart.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { expireTag } from 'next/cache';
+import { revalidateTag } from 'next/cache';
 import { cookies } from 'next/headers';
 
 import {
@@ -40,7 +40,7 @@ export const addToCart = async (data: FormData) => {
         return { status: 'error', error: 'Failed to add product to cart.' };
       }
 
-      expireTag(TAGS.cart);
+      revalidateTag(TAGS.cart);
 
       return { status: 'success', data: cart };
     }
@@ -64,7 +64,7 @@ export const addToCart = async (data: FormData) => {
       path: '/',
     });
 
-    expireTag(TAGS.cart);
+    revalidateTag(TAGS.cart);
 
     return { status: 'success', data: cart };
   } catch (error: unknown) {

--- a/core/app/[locale]/(default)/product/[slug]/_actions/add-to-cart.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/_actions/add-to-cart.tsx
@@ -2,7 +2,7 @@
 
 import { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
-import { expireTag } from 'next/cache';
+import { revalidateTag } from 'next/cache';
 import { cookies } from 'next/headers';
 import { getTranslations } from 'next-intl/server';
 import { ReactNode } from 'react';
@@ -187,7 +187,7 @@ export const addToCart = async (
         };
       }
 
-      expireTag(TAGS.cart);
+      revalidateTag(TAGS.cart);
 
       return {
         lastResult: submission.reply(),
@@ -232,7 +232,7 @@ export const addToCart = async (
       path: '/',
     });
 
-    expireTag(TAGS.cart);
+    revalidateTag(TAGS.cart);
 
     return {
       lastResult: submission.reply(),

--- a/core/components/product-card/add-to-cart/form/_actions/add-to-cart.ts
+++ b/core/components/product-card/add-to-cart/form/_actions/add-to-cart.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { expireTag } from 'next/cache';
+import { revalidateTag } from 'next/cache';
 import { cookies } from 'next/headers';
 
 import {
@@ -39,7 +39,7 @@ export const addToCart = async (data: FormData) => {
         return { status: 'error', error: 'Failed to add product to cart.' };
       }
 
-      expireTag(TAGS.cart);
+      revalidateTag(TAGS.cart);
 
       return { status: 'success', data: cart };
     }
@@ -63,7 +63,7 @@ export const addToCart = async (data: FormData) => {
       path: '/',
     });
 
-    expireTag(TAGS.cart);
+    revalidateTag(TAGS.cart);
 
     return { status: 'success', data: cart };
   } catch (error: unknown) {


### PR DESCRIPTION
## What/Why?
Next has tagged `expireTag/expireTag` as `unstable_`. This PR reverts to use `revalidateTag/revalidatePath`.

## Testing
Locally no issues.