### PR TITLE
Set default ghref for CLI to @bigcommerce/catalyst-core@latest

### DIFF
--- a/packages/create-catalyst/src/commands/create.ts
+++ b/packages/create-catalyst/src/commands/create.ts
@@ -244,7 +244,11 @@ export const create = new Command('create')
   .option('--access-token <token>', 'BigCommerce access token')
   .option('--channel-id <id>', 'BigCommerce channel ID')
   .option('--storefront-token <token>', 'BigCommerce storefront token')
-  .option('--gh-ref <ref>', 'Clone a specific ref from the source repository')
+  .option(
+    '--gh-ref <ref>',
+    'Clone a specific ref from the source repository',
+    '@bigcommerce/catalyst-core@latest',
+  )
   .option('--reset-main', 'Reset the main branch to the gh-ref')
   .option('--repository <repository>', 'GitHub repository to clone from', 'bigcommerce/catalyst')
   .option('--env <vars...>', 'Arbitrary environment variables to set in .env.local')


### PR DESCRIPTION
## What/Why?
Set default ghref to use the latest tag, so that CLI users will not be exposed to canary code by default.

## Testing
Ran `create` with no args:
<img width="488" alt="image" src="https://github.com/user-attachments/assets/516212eb-ad2a-46f9-b19a-a395575dff35" />
