### PR TITLE
Makeswift bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/🐞📝-bug-report-makeswift.md
+++ b/.github/ISSUE_TEMPLATE/🐞📝-bug-report-makeswift.md
@@ -22,7 +22,7 @@ Steps to reproduce the behavior:
 Please link to a repo that can be used to reproduce this issue, if possible. It'll help fix the bug faster.
 
 **Previously working?**
-Was this fucntionality previously working? If so, please link to a commit or PR that caused it to stop working.
+Was this functionality previously working? If so, please link to a commit or PR that caused it to stop working.
 
 **Any Errors?**
 Were there any errors that surfaced when merging the above PR?

--- a/.github/ISSUE_TEMPLATE/🐞📝-bug-report-makeswift.md
+++ b/.github/ISSUE_TEMPLATE/🐞📝-bug-report-makeswift.md
@@ -1,0 +1,37 @@
+---
+name: "\U0001F41E\U0001F4DD Makeswift Bug report"
+about: You're running into a reproducible error while developing with Catalyst and Makeswift.
+title: '[x] is not working when I [y]'
+labels: ''
+assignees: ''
+---
+
+We really appreciate the help making Catalyst and Makeswift better. Every issue helps!
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+Please link to a repo that can be used to reproduce this issue, if possible. It'll help fix the bug faster.
+
+**Previously working?**
+Was this fucntionality previously working? If so, please link to a commit or PR that caused it to stop working.
+
+**Any Errors?**
+Were there any errors that surfaced when merging the above PR?
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
This adds a bug report template that is more specific to Makeswift. Right now, it is pretty similar to the existing bug report, but this gives us the ability to evolve this one separately as needed and also track issues with Makeswift more easily.