### PR TITLE
Set default ghref for CLI to @bigcommerce/catalyst-core@latest

### DIFF
--- a/.changeset/fresh-pens-accept.md
+++ b/.changeset/fresh-pens-accept.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": minor
+---
+
+Set default gh-ref to @bigcommerce/catalyst-core@latest

--- a/.changeset/little-seals-carry.md
+++ b/.changeset/little-seals-carry.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": patch
+---
+
+Add notice that preview storefront has been deployed

--- a/.changeset/wise-hats-drive.md
+++ b/.changeset/wise-hats-drive.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": patch
+---
+
+Fix --reset-main and improve OTP copying experience

--- a/packages/create-catalyst/src/commands/create.ts
+++ b/packages/create-catalyst/src/commands/create.ts
@@ -244,7 +244,11 @@ export const create = new Command('create')
   .option('--access-token <token>', 'BigCommerce access token')
   .option('--channel-id <id>', 'BigCommerce channel ID')
   .option('--storefront-token <token>', 'BigCommerce storefront token')
-  .option('--gh-ref <ref>', 'Clone a specific ref from the source repository')
+  .option(
+    '--gh-ref <ref>',
+    'Clone a specific ref from the source repository',
+    '@bigcommerce/catalyst-core@latest',
+  )
   .option('--reset-main', 'Reset the main branch to the gh-ref')
   .option('--repository <repository>', 'GitHub repository to clone from', 'bigcommerce/catalyst')
   .option('--env <vars...>', 'Arbitrary environment variables to set in .env.local')

--- a/packages/create-catalyst/src/commands/create.ts
+++ b/packages/create-catalyst/src/commands/create.ts
@@ -402,6 +402,11 @@ export const create = new Command('create')
             envVars = { ...channelData.envVars };
 
             console.log(chalk.green(`Channel created successfully`));
+            console.warn(
+              chalk.yellow(
+                '\nNote: A preview storefront has been deployed in your BigCommerce control panel. This preview may look different from your local environment as it may be running different code.',
+              ),
+            );
           }
 
           if (!shouldCreateChannel) {

--- a/packages/create-catalyst/src/utils/clone-catalyst.ts
+++ b/packages/create-catalyst/src/utils/clone-catalyst.ts
@@ -33,8 +33,10 @@ export const cloneCatalyst = ({
 
   if (ghRef) {
     if (resetMain) {
-      checkoutRef(projectDir, 'main');
+      // Create and checkout a new main branch
+      execSync('git checkout -b main', { cwd: projectDir, stdio: 'inherit' });
 
+      // Reset it to the specified ref
       resetBranchToRef(projectDir, ghRef);
 
       console.log(`Reset main to ${ghRef} successfully.`);

--- a/packages/create-catalyst/src/utils/login.ts
+++ b/packages/create-catalyst/src/utils/login.ts
@@ -63,8 +63,8 @@ async function waitForKeyPress(prompt: string): Promise<boolean> {
       process.stdin.pause();
       rl.close();
 
-      // Check if escape key was pressed (27 is the ASCII code for escape)
-      const shouldProceed = data[0] !== 27;
+      // Only proceed if Enter was pressed (13 or 10 are the ASCII codes for CR and LF)
+      const shouldProceed = data[0] === 13 || data[0] === 10;
 
       // Add a newline since we're in raw mode
       process.stdout.write('\n');
@@ -83,14 +83,11 @@ export async function login(baseUrl: string): Promise<LoginResult> {
   const deviceCode = await auth.getDeviceCode();
 
   console.log(
-    chalk.cyan('\nPlease visit the following URL to authenticate with your BigCommerce store:'),
+    chalk.yellow('\n! First copy your one-time code: ') + chalk.bold(deviceCode.user_code),
   );
-  console.log(chalk.yellow(`\n${deviceCode.verification_uri}\n`));
-  console.log(chalk.cyan(`Enter code: `) + chalk.yellow(`${deviceCode.user_code}\n`));
+  console.log(`Press Enter to open ${deviceCode.verification_uri} in your browser...`);
 
-  const shouldOpenUrl = await waitForKeyPress(
-    'Press any key to open the URL in your browser (or ESC to skip)...',
-  );
+  const shouldOpenUrl = await waitForKeyPress('');
 
   if (shouldOpenUrl) {
     await open(deviceCode.verification_uri);
@@ -98,7 +95,7 @@ export async function login(baseUrl: string): Promise<LoginResult> {
 
   const credentials = await spinner(
     () => waitForCredentials(auth, deviceCode.device_code, deviceCode.interval),
-    { text: 'Waiting for authentication...', successText: 'Authentication successful!' },
+    { text: 'Waiting for authentication...', successText: 'Authentication complete' },
   );
 
   return {


### PR DESCRIPTION
## What/Why?
Set default ghref to use the latest tag, so that CLI users will not be exposed to canary code by default.

## Testing
Ran `create` with no args:
<img width="563" alt="image" src="https://github.com/user-attachments/assets/7759ca1c-3d29-4206-b5e3-e0685e6529f8" />
<img width="365" alt="image" src="https://github.com/user-attachments/assets/4e05ccb8-44ce-4d18-b9cb-088f9f1b8ede" />


Ran `create` with `--reset-main`:
<img width="446" alt="image" src="https://github.com/user-attachments/assets/665b6a66-e51c-407a-bf45-81ebb4a692cb" />
<img width="273" alt="image" src="https://github.com/user-attachments/assets/25e77993-6a3b-4674-b3b0-4d14fd140a0d" />


Ran `create` with a `--gh-ref` and `--reset-main`:
<img width="529" alt="image" src="https://github.com/user-attachments/assets/2997f663-3e99-4648-9586-017396158309" />
<img width="273" alt="image" src="https://github.com/user-attachments/assets/926179db-39e8-47d6-bcf0-b4edba3e3993" />


