### PR TITLE
chore: upgrade next to 15.1.1-canary.26

### DIFF
--- a/core/app/[locale]/(default)/account/addresses/_actions/delete-address.ts
+++ b/core/app/[locale]/(default)/account/addresses/_actions/delete-address.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { expireTag } from 'next/cache';
+import { unstable_expireTag } from 'next/cache';
 import { getTranslations } from 'next-intl/server';
 
 import { getSessionCustomerAccessToken } from '~/auth';
@@ -56,7 +56,7 @@ export const deleteAddress = async (addressId: number): Promise<DeleteAddressRes
       });
     }
 
-    expireTag(TAGS.customer);
+    unstable_expireTag(TAGS.customer);
 
     return { status: 'success', message: t('success') };
   } catch (error: unknown) {

--- a/core/app/[locale]/(default)/account/addresses/add/_actions/add-address.ts
+++ b/core/app/[locale]/(default)/account/addresses/add/_actions/add-address.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { expireTag } from 'next/cache';
+import { unstable_expireTag } from 'next/cache';
 import { getTranslations } from 'next-intl/server';
 
 import { getSessionCustomerAccessToken } from '~/auth';
@@ -83,7 +83,7 @@ export const addAddress = async (formData: FormData): Promise<AddAddressResponse
       });
     }
 
-    expireTag(TAGS.customer);
+    unstable_expireTag(TAGS.customer);
 
     return { status: 'success', message: t('success') };
   } catch (error: unknown) {

--- a/core/app/[locale]/(default)/account/addresses/edit/[slug]/_actions/update-address.ts
+++ b/core/app/[locale]/(default)/account/addresses/edit/[slug]/_actions/update-address.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { expireTag } from 'next/cache';
+import { unstable_expireTag } from 'next/cache';
 import { getTranslations } from 'next-intl/server';
 
 import { getSessionCustomerAccessToken } from '~/auth';
@@ -95,7 +95,7 @@ export const updateAddress = async (
       });
     }
 
-    expireTag(TAGS.customer);
+    unstable_expireTag(TAGS.customer);
 
     return { status: 'success', message: t('success') };
   } catch (error: unknown) {

--- a/core/app/[locale]/(default)/account/settings/_actions/update-customer.ts
+++ b/core/app/[locale]/(default)/account/settings/_actions/update-customer.ts
@@ -2,7 +2,7 @@
 
 import { BigCommerceAPIError } from '@bigcommerce/catalyst-client';
 import { parseWithZod } from '@conform-to/zod';
-import { expireTag } from 'next/cache';
+import { unstable_expireTag } from 'next/cache';
 import { getTranslations } from 'next-intl/server';
 
 import { updateAccountSchema } from '@/vibes/soul/sections/account-settings-section/schema';
@@ -76,7 +76,7 @@ export const updateCustomer: UpdateAccountAction = async (prevState, formData) =
       };
     }
 
-    expireTag(TAGS.customer);
+    unstable_expireTag(TAGS.customer);
 
     return {
       account: submission.value,

--- a/core/app/[locale]/(default)/cart/_actions/remove-item.ts
+++ b/core/app/[locale]/(default)/cart/_actions/remove-item.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { expireTag } from 'next/cache';
+import { unstable_expireTag } from 'next/cache';
 import { cookies } from 'next/headers';
 import { getTranslations } from 'next-intl/server';
 
@@ -64,7 +64,7 @@ export async function removeItem({
       cookieStore.delete('cartId');
     }
 
-    expireTag(TAGS.cart);
+    unstable_expireTag(TAGS.cart);
 
     return cart;
   } catch (error: unknown) {

--- a/core/app/[locale]/(default)/cart/_actions/update-quantity.ts
+++ b/core/app/[locale]/(default)/cart/_actions/update-quantity.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { expirePath } from 'next/cache';
+import { unstable_expirePath } from 'next/cache';
 import { cookies } from 'next/headers';
 import { getTranslations } from 'next-intl/server';
 
@@ -89,7 +89,7 @@ export const updateQuantity = async ({
       throw new Error(t('failedToUpdateQuantity'));
     }
 
-    expirePath('/cart');
+    unstable_expirePath('/cart');
 
     return cart;
   } catch (error: unknown) {

--- a/core/app/[locale]/(default)/compare/_actions/add-to-cart.ts
+++ b/core/app/[locale]/(default)/compare/_actions/add-to-cart.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { expireTag } from 'next/cache';
+import { unstable_expireTag } from 'next/cache';
 import { cookies } from 'next/headers';
 
 import {
@@ -40,7 +40,7 @@ export const addToCart = async (data: FormData) => {
         return { status: 'error', error: 'Failed to add product to cart.' };
       }
 
-      expireTag(TAGS.cart);
+      unstable_expireTag(TAGS.cart);
 
       return { status: 'success', data: cart };
     }
@@ -64,7 +64,7 @@ export const addToCart = async (data: FormData) => {
       path: '/',
     });
 
-    expireTag(TAGS.cart);
+    unstable_expireTag(TAGS.cart);
 
     return { status: 'success', data: cart };
   } catch (error: unknown) {

--- a/core/app/[locale]/(default)/product/[slug]/_actions/add-to-cart.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/_actions/add-to-cart.tsx
@@ -2,7 +2,7 @@
 
 import { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
-import { expireTag } from 'next/cache';
+import { unstable_expireTag } from 'next/cache';
 import { cookies } from 'next/headers';
 import { getTranslations } from 'next-intl/server';
 import { ReactNode } from 'react';
@@ -187,7 +187,7 @@ export const addToCart = async (
         };
       }
 
-      expireTag(TAGS.cart);
+      unstable_expireTag(TAGS.cart);
 
       return {
         lastResult: submission.reply(),
@@ -232,7 +232,7 @@ export const addToCart = async (
       path: '/',
     });
 
-    expireTag(TAGS.cart);
+    unstable_expireTag(TAGS.cart);
 
     return {
       lastResult: submission.reply(),

--- a/core/components/product-card/add-to-cart/form/_actions/add-to-cart.ts
+++ b/core/components/product-card/add-to-cart/form/_actions/add-to-cart.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { expireTag } from 'next/cache';
+import { unstable_expireTag } from 'next/cache';
 import { cookies } from 'next/headers';
 
 import {
@@ -39,7 +39,7 @@ export const addToCart = async (data: FormData) => {
         return { status: 'error', error: 'Failed to add product to cart.' };
       }
 
-      expireTag(TAGS.cart);
+      unstable_expireTag(TAGS.cart);
 
       return { status: 'success', data: cart };
     }
@@ -63,7 +63,7 @@ export const addToCart = async (data: FormData) => {
       path: '/',
     });
 
-    expireTag(TAGS.cart);
+    unstable_expireTag(TAGS.cart);
 
     return { status: 'success', data: cart };
   } catch (error: unknown) {

--- a/core/package.json
+++ b/core/package.json
@@ -51,7 +51,7 @@
     "lodash.debounce": "^4.0.8",
     "lru-cache": "^11.0.2",
     "lucide-react": "^0.468.0",
-    "next": "15.0.4-canary.18",
+    "next": "15.1.1-canary.26",
     "next-auth": "5.0.0-beta.25",
     "next-intl": "^3.26.1",
     "nuqs": "^2.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,13 +88,13 @@ importers:
         version: 1.34.3
       '@vercel/analytics':
         specifier: ^1.4.1
-        version: 1.4.1(next@15.0.4-canary.18(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(svelte@5.1.15)
+        version: 1.4.1(next@15.1.1-canary.26(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(svelte@5.1.15)
       '@vercel/kv':
         specifier: ^3.0.0
         version: 3.0.0
       '@vercel/speed-insights':
         specifier: ^1.1.0
-        version: 1.1.0(next@15.0.4-canary.18(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(svelte@5.1.15)
+        version: 1.1.0(next@15.1.1-canary.26(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(svelte@5.1.15)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -141,17 +141,17 @@ importers:
         specifier: ^0.468.0
         version: 0.468.0(react@19.0.0)
       next:
-        specifier: 15.0.4-canary.18
-        version: 15.0.4-canary.18(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: 15.1.1-canary.26
+        version: 15.1.1-canary.26(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       next-auth:
         specifier: 5.0.0-beta.25
-        version: 5.0.0-beta.25(next@15.0.4-canary.18(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(nodemailer@6.9.16)(react@19.0.0)
+        version: 5.0.0-beta.25(next@15.1.1-canary.26(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(nodemailer@6.9.16)(react@19.0.0)
       next-intl:
         specifier: ^3.26.1
-        version: 3.26.1(next@15.0.4-canary.18(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
+        version: 3.26.1(next@15.1.1-canary.26(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
       nuqs:
         specifier: ^2.2.2
-        version: 2.3.0(next@15.0.4-canary.18(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
+        version: 2.3.0(next@15.1.1-canary.26(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -1330,56 +1330,56 @@ packages:
   '@next/bundle-analyzer@15.1.0':
     resolution: {integrity: sha512-uEyuNZZgAbSWgiUbtihTA8y6QgEzc4b8Fpslmc4SXAjj67Ax5mlcv1HLlez+5dIGwO+vJ9PgCoI8ngWtBh/g1Q==}
 
-  '@next/env@15.0.4-canary.18':
-    resolution: {integrity: sha512-iMvlOu17qnXruB7jBg9L7PD1ohRcsDtfOQu1cOV6I9+fkerAzQOSRz4otKB9z+M1C4JROKw8YQXxd10sfORvQQ==}
+  '@next/env@15.1.1-canary.26':
+    resolution: {integrity: sha512-VVIqHRX5XRvtiUBM+HLfeQ692KsfMDbJEVxVDcyeozwciNeC4tc6RkRoHyj+lH+RmYvc1OBNYHGjmnDVmm4aAQ==}
 
   '@next/eslint-plugin-next@15.1.0':
     resolution: {integrity: sha512-+jPT0h+nelBT6HC9ZCHGc7DgGVy04cv4shYdAe6tKlEbjQUtwU3LzQhzbDHQyY2m6g39m6B0kOFVuLGBrxxbGg==}
 
-  '@next/swc-darwin-arm64@15.0.4-canary.18':
-    resolution: {integrity: sha512-UkVlc57+Avzln6a/JHvpDaHUd67xrZyH+FtoJpRTtAhfnsAiqXEKvklMarfRhI3H/3ZzVWS/kvHmMRNEmREC0w==}
+  '@next/swc-darwin-arm64@15.1.1-canary.26':
+    resolution: {integrity: sha512-T9vPhmBYYB4Alfty2BgaiXhWKTBvn2zWmlRY1hbV1gY6TQj9w2jF36JtSrBdbczzv9PpHohT+Qbtaf750PTZkw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.0.4-canary.18':
-    resolution: {integrity: sha512-gFtNOZyBJ+VJzH99o1X5iySBp5OBhBvn7hmwm3glpexI+WdHjsu3gqeX0W01EFAJHfkZryF3eLQ9WzDykafNZg==}
+  '@next/swc-darwin-x64@15.1.1-canary.26':
+    resolution: {integrity: sha512-5DzRrPIAw6zd5Zj4FJRBHmpgM9Xfsu6aUGVuyFgywfE0KGrn4Kn81s+uAIKgN7xk9oQAhiemmWmeacv3c5J3jg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@15.0.4-canary.18':
-    resolution: {integrity: sha512-eD0z3mEqQcgb3swew+DaH1qTRALApwI7JShXRbs4pQoIw5NC3iFCqat/EnNdnuGnHz6m/B+pMOGlGzJDAKF+yw==}
+  '@next/swc-linux-arm64-gnu@15.1.1-canary.26':
+    resolution: {integrity: sha512-oH0QiYKVtATR38URXREKxa7BIP+CsZczHvQc+Vm+nGj39pLSDhH0YMkhN42QxpAIJEuhlOg1YzuRAwGDilQBPA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@15.0.4-canary.18':
-    resolution: {integrity: sha512-/Monhk57eg4pwUGjhVdzaWBjn98xgLZ2UzbCJgz+/V1bEbQ2cdsiAY2396vDJN6xL6QC1T44jQWnnRmxDoIwCg==}
+  '@next/swc-linux-arm64-musl@15.1.1-canary.26':
+    resolution: {integrity: sha512-6IR3Yhc9UEXfJONJHo37sBuRnENln6Ijivv+185ieLzX2xnO3Mq9+ik5vk/cJ0cWz89w/G6sg/yzkL0iRegvFA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@15.0.4-canary.18':
-    resolution: {integrity: sha512-C2MeKImORC9hta3Mu3EN/BoCP5b8LhqlqibH0d7/fIGl0kwGEWFtY6GNkLfkjheznbyi+IrTC0whw0IuP1zq2w==}
+  '@next/swc-linux-x64-gnu@15.1.1-canary.26':
+    resolution: {integrity: sha512-7txlyyVNxQwvEF+Oz5dLCyIbt9Qq8mJvfq/2oM7mCW1XcDAnXAgp2x8CUudJys76cABc01SJAQete2GTlAwF+Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@15.0.4-canary.18':
-    resolution: {integrity: sha512-u8aVGeYbVqAXiW5HhFnoxjTA4hBedId8ySxiMuPZkwLZSunKN4k7UVL1CuU6WLhw4pKN4A5awtVO2polQJBkhQ==}
+  '@next/swc-linux-x64-musl@15.1.1-canary.26':
+    resolution: {integrity: sha512-+sCnNtaKje6Tw8pp/oF/ETSfcq/2exn5I1e9Ke9Zgwb7ZKMc6FDGU796zkNLvrlwxmq1ZZ/nyeSmi7AvjT5D6g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@15.0.4-canary.18':
-    resolution: {integrity: sha512-rdwne0Bmw/6Lxug6XlsyMCeM+rF2aN5SM1mcanQAjCFL/UWCOtzf4aXt6DDu5cKKNik6jtWJ/9KzcvM3aYytDQ==}
+  '@next/swc-win32-arm64-msvc@15.1.1-canary.26':
+    resolution: {integrity: sha512-2lExwwGMfzvptYOS6Bwq2Or5UYyIJo0xbBMcFaZLj20NcuWSMAmYIRfnCCPF4PMAvcPXe1U6R3vlsjSGGgnVMg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.0.4-canary.18':
-    resolution: {integrity: sha512-8bvtOx955ulXPtYJ55rsyLdaDJUQdRwTOU+vnbbixRe/ski2vxM2j9Qbv9aVSBaxUCSBSbIxH2I7s+JmBRyhHA==}
+  '@next/swc-win32-x64-msvc@15.1.1-canary.26':
+    resolution: {integrity: sha512-TcroRkM1ybB4CA2TWZPFYBP6UGnheAD89+1zSgX1qEF3M2OWpI0mzjrbbrDpiG0GZoBfTPYpQx/JyrWqVS3Jyw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2153,9 +2153,6 @@ packages:
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
-
-  '@swc/helpers@0.5.13':
-    resolution: {integrity: sha512-UoKGxQ3r5kYI9dALKJapMmuK+1zWM/H17Z1+iwnNmzcJRnfFuevZs375TA5rW31pu4BS4NoSy1fRsexDXfWn5w==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -4331,16 +4328,16 @@ packages:
       next: ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
 
-  next@15.0.4-canary.18:
-    resolution: {integrity: sha512-nsEmZn47CSIRPMzZxwT4U8oDZppSgxnW2vfLRnZC1F1ZyLOxiBdmqA/25w5aQ5nkBLpjAbOLMpPOq9TKgQpjyA==}
+  next@15.1.1-canary.26:
+    resolution: {integrity: sha512-59jMEcnqJymBn9fCOzvPdasmpmgwet2LeYNtjm1T7KdV7F5ZSo5l9Lgne2F+LoHh2zEQGHvn0qfOB+3Rqz/8Zw==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
       '@playwright/test': ^1.41.2
       babel-plugin-react-compiler: '*'
-      react: ^18.2.0 || 19.0.0-rc-380f5d67-20241113
-      react-dom: ^18.2.0 || 19.0.0-rc-380f5d67-20241113
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
       sass: ^1.3.0
     peerDependenciesMeta:
       '@opentelemetry/api':
@@ -6737,34 +6734,34 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@next/env@15.0.4-canary.18': {}
+  '@next/env@15.1.1-canary.26': {}
 
   '@next/eslint-plugin-next@15.1.0':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@15.0.4-canary.18':
+  '@next/swc-darwin-arm64@15.1.1-canary.26':
     optional: true
 
-  '@next/swc-darwin-x64@15.0.4-canary.18':
+  '@next/swc-darwin-x64@15.1.1-canary.26':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.0.4-canary.18':
+  '@next/swc-linux-arm64-gnu@15.1.1-canary.26':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.0.4-canary.18':
+  '@next/swc-linux-arm64-musl@15.1.1-canary.26':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.0.4-canary.18':
+  '@next/swc-linux-x64-gnu@15.1.1-canary.26':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.0.4-canary.18':
+  '@next/swc-linux-x64-musl@15.1.1-canary.26':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.0.4-canary.18':
+  '@next/swc-win32-arm64-msvc@15.1.1-canary.26':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.0.4-canary.18':
+  '@next/swc-win32-x64-msvc@15.1.1-canary.26':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -7506,14 +7503,9 @@ snapshots:
 
   '@swc/counter@0.1.3': {}
 
-  '@swc/helpers@0.5.13':
-    dependencies:
-      tslib: 2.8.1
-
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
-    optional: true
 
   '@swc/jest@0.2.37(@swc/core@1.10.1(@swc/helpers@0.5.15))':
     dependencies:
@@ -7773,9 +7765,9 @@ snapshots:
     dependencies:
       crypto-js: 4.2.0
 
-  '@vercel/analytics@1.4.1(next@15.0.4-canary.18(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(svelte@5.1.15)':
+  '@vercel/analytics@1.4.1(next@15.1.1-canary.26(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(svelte@5.1.15)':
     optionalDependencies:
-      next: 15.0.4-canary.18(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next: 15.1.1-canary.26(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       svelte: 5.1.15
 
@@ -7783,9 +7775,9 @@ snapshots:
     dependencies:
       '@upstash/redis': 1.34.3
 
-  '@vercel/speed-insights@1.1.0(next@15.0.4-canary.18(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(svelte@5.1.15)':
+  '@vercel/speed-insights@1.1.0(next@15.1.1-canary.26(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(svelte@5.1.15)':
     optionalDependencies:
-      next: 15.0.4-canary.18(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next: 15.1.1-canary.26(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       svelte: 5.1.15
 
@@ -10032,27 +10024,27 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  next-auth@5.0.0-beta.25(next@15.0.4-canary.18(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(nodemailer@6.9.16)(react@19.0.0):
+  next-auth@5.0.0-beta.25(next@15.1.1-canary.26(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(nodemailer@6.9.16)(react@19.0.0):
     dependencies:
       '@auth/core': 0.37.2(nodemailer@6.9.16)
-      next: 15.0.4-canary.18(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next: 15.1.1-canary.26(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
     optionalDependencies:
       nodemailer: 6.9.16
 
-  next-intl@3.26.1(next@15.0.4-canary.18(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0):
+  next-intl@3.26.1(next@15.1.1-canary.26(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0):
     dependencies:
       '@formatjs/intl-localematcher': 0.5.7
       negotiator: 1.0.0
-      next: 15.0.4-canary.18(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next: 15.1.1-canary.26(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       use-intl: 3.26.1(react@19.0.0)
 
-  next@15.0.4-canary.18(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  next@15.1.1-canary.26(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
-      '@next/env': 15.0.4-canary.18
+      '@next/env': 15.1.1-canary.26
       '@swc/counter': 0.1.3
-      '@swc/helpers': 0.5.13
+      '@swc/helpers': 0.5.15
       busboy: 1.6.0
       caniuse-lite: 1.0.30001680
       postcss: 8.4.31
@@ -10060,14 +10052,14 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
       styled-jsx: 5.1.6(react@19.0.0)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.0.4-canary.18
-      '@next/swc-darwin-x64': 15.0.4-canary.18
-      '@next/swc-linux-arm64-gnu': 15.0.4-canary.18
-      '@next/swc-linux-arm64-musl': 15.0.4-canary.18
-      '@next/swc-linux-x64-gnu': 15.0.4-canary.18
-      '@next/swc-linux-x64-musl': 15.0.4-canary.18
-      '@next/swc-win32-arm64-msvc': 15.0.4-canary.18
-      '@next/swc-win32-x64-msvc': 15.0.4-canary.18
+      '@next/swc-darwin-arm64': 15.1.1-canary.26
+      '@next/swc-darwin-x64': 15.1.1-canary.26
+      '@next/swc-linux-arm64-gnu': 15.1.1-canary.26
+      '@next/swc-linux-arm64-musl': 15.1.1-canary.26
+      '@next/swc-linux-x64-gnu': 15.1.1-canary.26
+      '@next/swc-linux-x64-musl': 15.1.1-canary.26
+      '@next/swc-win32-arm64-msvc': 15.1.1-canary.26
+      '@next/swc-win32-x64-msvc': 15.1.1-canary.26
       '@playwright/test': 1.49.1
       sharp: 0.33.5
     transitivePeerDependencies:
@@ -10101,12 +10093,12 @@ snapshots:
     dependencies:
       path-key: 4.0.0
 
-  nuqs@2.3.0(next@15.0.4-canary.18(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0):
+  nuqs@2.3.0(next@15.1.1-canary.26(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0):
     dependencies:
       mitt: 3.0.1
       react: 19.0.0
     optionalDependencies:
-      next: 15.0.4-canary.18(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next: 15.1.1-canary.26(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
 
   nypm@0.3.12:
     dependencies:


### PR DESCRIPTION
## What/Why?
Upgrade `next` to the latest canary.

Notes:
- They renamed `expireTag` and `expirePath` to `unstable_expireTag` and `unstable_expirePath`. They also removed the docs because they "We are not recommending people use it yet." https://github.com/vercel/next.js/pull/73856

## Testing
https://catalyst-soul-git-fikri-next-bigcommerce-platform.vercel.app/

https://github.com/user-attachments/assets/43363c60-a759-4ab2-be4b-1fb0311d5118


