### PR TITLE
chore: remove @bigcommerce/makeswift group from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
 * @bigcommerce/team-catalyst
-* @bigcommerce/makeswift


### PR DESCRIPTION
## What/Why?
Remove group from codeowners for the canary merge.