### PR TITLE
fix: handle empty root params Makeswift catch-all

### DIFF
--- a/core/app/[locale]/(default)/[...rest]/page.tsx
+++ b/core/app/[locale]/(default)/[...rest]/page.tsx
@@ -1,4 +1,4 @@
-import { locales } from '~/i18n/routing';
+import { defaultLocale, locales } from '~/i18n/routing';
 import { client, Page } from '~/lib/makeswift';
 
 interface PageParams {
@@ -9,7 +9,18 @@ interface PageParams {
 export async function generateStaticParams(): Promise<PageParams[]> {
   const pages = await client.getPages().toArray();
 
-  return pages.filter((page) => page.path !== '/').flatMap((page) => localesFanOut(page.path));
+  const params = pages
+    .filter((page) => page.path !== '/')
+    .flatMap((page) => localesFanOut(page.path));
+
+  // Next.js requires providing at least one value in `generateStaticParams`.
+  //
+  // See https://github.com/vercel/next.js/pull/73933
+  if (params.length === 0) {
+    return [{ rest: ['dev', 'null'], locale: defaultLocale }];
+  }
+
+  return params;
 }
 
 export default async function CatchAllPage({ params }: { params: Promise<PageParams> }) {


### PR DESCRIPTION
## What/Why?
<!--- 
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
--->
In the current Next.js canary version we're using, when PPR is enabled, returning empty parameters from `generateStaticParams` results in an error:

```
[Error: A required root parameter (locale) was not provided in generateStaticParams for /[locale]/[...rest], please provide at least one value.]
```

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->
Locally ran `next build` while returning `[{ rest: [''], locale: defaultLocale }]` from `generateStaticParams`.

Also tested by deploying OCC with only the Makeswift homepage, which results in the parameters being empty. @bookernath tested this with me.