### PR TITLE
fix: use lazy promise on getCartCount to defer cookies() execution

### DIFF
--- a/core/components/header/index.tsx
+++ b/core/components/header/index.tsx
@@ -1,5 +1,6 @@
 import { cookies } from 'next/headers';
 import { getTranslations } from 'next-intl/server';
+import PLazy from 'p-lazy';
 import { cache } from 'react';
 
 import { HeaderSection } from '@/vibes/soul/sections/header-section';
@@ -111,7 +112,7 @@ export const Header = async () => {
         mobileMenuTriggerLabel: t('toggleNavigation'),
         openSearchPopupLabel: t('Search.openSearchPopup'),
         logoLabel: t('home'),
-        cartCount: getCartCount(),
+        cartCount: PLazy.from(getCartCount),
       }}
     />
   );

--- a/core/package.json
+++ b/core/package.json
@@ -55,6 +55,7 @@
     "next-auth": "5.0.0-beta.25",
     "next-intl": "^3.26.1",
     "nuqs": "^2.2.2",
+    "p-lazy": "^5.0.0",
     "react": "^19.0.0",
     "react-day-picker": "^9.0.8",
     "react-dom": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       nuqs:
         specifier: ^2.2.2
         version: 2.3.0(next@15.2.0-canary.1(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
+      p-lazy:
+        specifier: ^5.0.0
+        version: 5.0.0
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -4500,6 +4503,10 @@ packages:
   p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
     engines: {node: '>=8'}
+
+  p-lazy@5.0.0:
+    resolution: {integrity: sha512-C4xW5/wLGqswBx1xgu/t7fBaHMDKm7SXycgc0MEQvQ5KwzjT1E4MmE9cg0RXn9d0MTgUGJLUCb2EkLBevXi6eA==}
+    engines: {node: '>=18'}
 
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
@@ -10217,6 +10224,8 @@ snapshots:
   p-filter@2.1.0:
     dependencies:
       p-map: 2.1.0
+
+  p-lazy@5.0.0: {}
 
   p-limit@2.3.0:
     dependencies:


### PR DESCRIPTION
## What/Why?
This fixes 500 error:
```
needs to bail out of prerendering at this point because it used cookies()
```

Without the lazy promise, the `getCartCount()` is immediately executed, and calls `cookies()` on the Header.

With lazy promise, the `getCartCount()` execution is deferred, until `await`/`then` is used.

## Testing
This bug was only reproducible if we reverted the [temporary fix commit](https://github.com/bigcommerce/catalyst/pull/1856) on the `soul/makeswift/integration` branch. See this [deployment](https://vercel.com/bigcommerce-platform/catalyst-soul/BmZk2nfaemBus1EQzeJP5JrCGcH2).

Makeswift pages are PPRed correctly instead of being server-rendered
```
@bigcommerce/catalyst-core:build: ├ ◐ /[locale]                                  1.8 kB          441 kB
@bigcommerce/catalyst-core:build: ├   ├ /[locale]
@bigcommerce/catalyst-core:build: ├   └ /en
@bigcommerce/catalyst-core:build: ├ ◐ /[locale]/[...rest]                        1.8 kB          441 kB
@bigcommerce/catalyst-core:build: ├   ├ /[locale]/[...rest]
@bigcommerce/catalyst-core:build: ├   ├ /en/[...rest]
@bigcommerce/catalyst-core:build: ├   ├ /en/blog
@bigcommerce/catalyst-core:build: ├   └ [+5 more paths]
```

No 500 error [logs](https://vercel.com/bigcommerce-platform/catalyst-soul/BmZk2nfaemBus1EQzeJP5JrCGcH2/logs?page=2&levels=):
<img width="1271" alt="image" src="https://github.com/user-attachments/assets/25dde3c1-3ddd-49ed-804c-90f149860a10" />
