### PR TITLE
fix: do not crash on attempt to search while in the builder

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -17,7 +17,7 @@
     "@conform-to/react": "^1.2.2",
     "@conform-to/zod": "^1.2.2",
     "@icons-pack/react-simple-icons": "^10.2.0",
-    "@makeswift/runtime": "0.0.0-snapshot-20241227210524",
+    "@makeswift/runtime": "0.0.0-snapshot-20250108161914",
     "@radix-ui/react-accordion": "^1.2.2",
     "@radix-ui/react-alert-dialog": "^1.1.3",
     "@radix-ui/react-checkbox": "^1.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^10.2.0
         version: 10.2.0(react@19.0.0)
       '@makeswift/runtime':
-        specifier: 0.0.0-snapshot-20241227210524
-        version: 0.0.0-snapshot-20241227210524(@types/react-dom@19.0.2(@types/react@19.0.1))(@types/react@19.0.1)(next@15.2.0-canary.1(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: 0.0.0-snapshot-20250108161914
+        version: 0.0.0-snapshot-20250108161914(@types/react-dom@19.0.2(@types/react@19.0.1))(@types/react@19.0.1)(next@15.2.0-canary.1(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-accordion':
         specifier: ^1.2.2
         version: 1.2.2(@types/react-dom@19.0.2(@types/react@19.0.1))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -1376,19 +1376,19 @@ packages:
     resolution: {integrity: sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==}
     engines: {node: '>=8'}
 
-  '@makeswift/controls@0.0.0-snapshot-20241227210524':
-    resolution: {integrity: sha512-NmICV2WjlAf46T3xpSk0O1o21Fhsynx+GctuxjSyDsbfl33RrorCLSXMyxReswbWbiqY5iVxGkTd4W7BJ/yMzQ==}
+  '@makeswift/controls@0.0.0-snapshot-20250108161914':
+    resolution: {integrity: sha512-bYcV60IenaNLiFbHC9j75y7VVqXx/SM/iUvMggTatK4G7dHI72w0h+mOfbeztZXZYGRFYn4+adSc950QpThL0A==}
 
   '@makeswift/next-plugin@0.3.0':
     resolution: {integrity: sha512-pGe0D6KrVxZcyaM8hFCIK806yNV6YJtRcjjD+2Wpn5qkFStIMTlACkGRVHVLftFyfi8/E3lGkbR05Jo3aTecwQ==}
     peerDependencies:
       next: ^13.4.0 || ^14.0.0
 
-  '@makeswift/prop-controllers@0.0.0-snapshot-20241227210524':
-    resolution: {integrity: sha512-O4+rcvGNoxT+FLEm4zUUUfVtI/6//9W+qfQatM+eK0TDZWwg3GV8HNq7cZ3z0rbfTBtnauCH0ik1qeVZJvxmRA==}
+  '@makeswift/prop-controllers@0.0.0-snapshot-20250108161914':
+    resolution: {integrity: sha512-OpjPnDOgdjGpZrSSGhupBFrwsDjEilIet/Ew6PONXkznXIzBvG3N+lLVEcMv31yHcrwawxuDtFIGTcjtuX0UtQ==}
 
-  '@makeswift/runtime@0.0.0-snapshot-20241227210524':
-    resolution: {integrity: sha512-PJT7V9saNNj0WGXfklTeY/lXZwtPbIHj9q1vQ1DF0E7I7QnbbbGxNP5Nqq+FTzanIrj7DTLOJC243Un52Ur7Ow==}
+  '@makeswift/runtime@0.0.0-snapshot-20250108161914':
+    resolution: {integrity: sha512-ZYhXYeIQCz+qo9JnTnbpfv/Ffh00HapWXt/u2hfHOzdW7MWKtIS66lizsGJt00sYC+h1mkXEAwjQD2o1w0ypSA==}
     peerDependencies:
       '@types/react': ^18.0.0
       '@types/react-dom': ^18.0.0
@@ -7179,7 +7179,7 @@ snapshots:
     dependencies:
       '@lukeed/csprng': 1.1.0
 
-  '@makeswift/controls@0.0.0-snapshot-20241227210524':
+  '@makeswift/controls@0.0.0-snapshot-20250108161914':
     dependencies:
       color: 3.2.1
       css-box-model: 1.2.1
@@ -7195,13 +7195,13 @@ snapshots:
       next: 15.2.0-canary.1(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       semver: 7.6.3
 
-  '@makeswift/prop-controllers@0.0.0-snapshot-20241227210524':
+  '@makeswift/prop-controllers@0.0.0-snapshot-20250108161914':
     dependencies:
-      '@makeswift/controls': 0.0.0-snapshot-20241227210524
+      '@makeswift/controls': 0.0.0-snapshot-20250108161914
       ts-pattern: 5.5.0
       zod: 3.24.1
 
-  '@makeswift/runtime@0.0.0-snapshot-20241227210524(@types/react-dom@19.0.2(@types/react@19.0.1))(@types/react@19.0.1)(next@15.2.0-canary.1(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@makeswift/runtime@0.0.0-snapshot-20250108161914(@types/react-dom@19.0.2(@types/react@19.0.1))(@types/react@19.0.1)(next@15.2.0-canary.1(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@emotion/cache': 11.14.0
       '@emotion/css': 11.13.5
@@ -7209,9 +7209,9 @@ snapshots:
       '@emotion/server': 11.11.0(@emotion/css@11.13.5)
       '@emotion/sheet': 1.4.0
       '@emotion/utils': 1.4.2
-      '@makeswift/controls': 0.0.0-snapshot-20241227210524
+      '@makeswift/controls': 0.0.0-snapshot-20250108161914
       '@makeswift/next-plugin': 0.3.0(next@15.2.0-canary.1(@playwright/test@1.49.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
-      '@makeswift/prop-controllers': 0.0.0-snapshot-20241227210524
+      '@makeswift/prop-controllers': 0.0.0-snapshot-20250108161914
       '@popmotion/popcorn': 0.4.4
       '@redux-devtools/extension': 3.3.0(redux@4.2.1)
       '@types/is-hotkey': 0.1.10


### PR DESCRIPTION
## What/Why?

Upgrade to the latest Makeswift runtime with [this fix](https://github.com/makeswift/makeswift/pull/905). Note that this doesn't make the site search functional (the search dropdown disappears before user can see any search results/take an action), but it does resolve the 500 error.

## Testing

https://github.com/user-attachments/assets/1d7f3967-538e-49b8-97ee-9a104f859524


