### PR TITLE
Add Web Pages from vibes

### DIFF
--- a/core/app/[locale]/(default)/webpages/_components/web-page.tsx
+++ b/core/app/[locale]/(default)/webpages/_components/web-page.tsx
@@ -1,0 +1,84 @@
+import { Stream, Streamable } from '@/vibes/soul/lib/streamable';
+import { Breadcrumb, Breadcrumbs, BreadcrumbsSkeleton } from '@/vibes/soul/primitives/breadcrumbs';
+import { SectionLayout } from '@/vibes/soul/sections/section-layout';
+
+export interface WebPage {
+  title: string;
+  content: string;
+  seo: {
+    pageTitle: string;
+    metaDescription: string;
+    metaKeywords: string;
+  };
+}
+
+interface Props {
+  webPage: Streamable<WebPage>;
+  breadcrumbs?: Streamable<Breadcrumb[]>;
+  className?: string;
+}
+
+export function WebPageContent({ webPage: streamableWebPage, className = '', breadcrumbs }: Props) {
+  return (
+    <SectionLayout className={className}>
+      <div className="mx-auto max-w-screen-2xl px-4 py-10 @xl:px-6 @xl:py-14 @4xl:px-8 @4xl:py-20">
+        <Stream fallback={<WebPageContentSkeleton />} value={streamableWebPage}>
+          {(webPage) => {
+            const { title, content } = webPage;
+
+            return (
+              <>
+                <header className="mx-auto w-full max-w-4xl pb-8 @2xl:pb-12 @4xl:pb-16">
+                  {breadcrumbs && <Breadcrumbs breadcrumbs={breadcrumbs} />}
+
+                  <h1 className="mb-4 mt-8 font-heading text-4xl font-medium leading-none @xl:text-5xl @4xl:text-6xl">
+                    {title}
+                  </h1>
+                </header>
+
+                <div
+                  className="prose mx-auto w-full max-w-4xl space-y-4 [&_h2]:font-heading [&_h2]:text-3xl [&_h2]:font-normal [&_h2]:leading-none [&_h2]:@xl:text-4xl [&_img]:mx-auto [&_img]:max-h-[600px] [&_img]:w-fit [&_img]:rounded-2xl [&_img]:object-cover"
+                  dangerouslySetInnerHTML={{ __html: content }}
+                />
+              </>
+            );
+          }}
+        </Stream>
+      </div>
+    </SectionLayout>
+  );
+}
+
+function WebPageTitleSkeleton() {
+  return (
+    <div className="mb-4 mt-8 animate-pulse">
+      <div className="h-9 w-5/6 rounded-lg bg-contrast-100 @xl:h-12 @4xl:h-[3.75rem]" />
+    </div>
+  );
+}
+
+function WebPageBodySkeleton() {
+  return (
+    <div className="mx-auto w-full max-w-4xl animate-pulse pb-8 @2xl:pb-12 @4xl:pb-16">
+      <div className="mb-8 h-[1lh] w-3/5 rounded-lg bg-contrast-100" />
+      <div className="mb-4 h-[0.5lh] w-full rounded-lg bg-contrast-100" />
+      <div className="mb-4 h-[0.5lh] w-full rounded-lg bg-contrast-100" />
+      <div className="mb-4 h-[0.5lh] w-full rounded-lg bg-contrast-100" />
+      <div className="mb-4 h-[0.5lh] w-full rounded-lg bg-contrast-100" />
+      <div className="mb-4 h-[0.5lh] w-full rounded-lg bg-contrast-100" />
+      <div className="mb-4 h-[0.5lh] w-3/4 rounded-lg bg-contrast-100" />
+    </div>
+  );
+}
+
+export function WebPageContentSkeleton() {
+  return (
+    <div>
+      <div className="mx-auto w-full max-w-4xl pb-8 @2xl:pb-12 @4xl:pb-16">
+        <BreadcrumbsSkeleton />
+        <WebPageTitleSkeleton />
+      </div>
+      <WebPageBodySkeleton />
+    </div>
+  );
+}

--- a/core/app/[locale]/(default)/webpages/normal/[id]/page.tsx
+++ b/core/app/[locale]/(default)/webpages/normal/[id]/page.tsx
@@ -1,26 +1,53 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
+import { Breadcrumb } from '@/vibes/soul/primitives/breadcrumbs';
+
+import { WebPageContent, WebPage as WebPageData } from '../../_components/web-page';
+
 import { getWebpageData } from './page-data';
 
 interface Props {
   params: Promise<{ id: string }>;
 }
 
-export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { id } = await params;
-
+async function getWebPage(id: string): Promise<WebPageData> {
   const data = await getWebpageData({ id: decodeURIComponent(id) });
   const webpage = data.node?.__typename === 'NormalPage' ? data.node : null;
 
   if (!webpage) {
-    return {};
+    return notFound();
   }
 
+  return {
+    title: webpage.name,
+    content: webpage.htmlBody,
+    seo: webpage.seo,
+  };
+}
+
+async function getWebPageBreadcrumbs(id: string): Promise<Breadcrumb[]> {
+  const webpage = await getWebPage(id);
+
+  return [
+    {
+      label: 'Home',
+      href: '/',
+    },
+    {
+      label: webpage.title,
+      href: '#',
+    },
+  ];
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params;
+  const webpage = await getWebPage(id);
   const { pageTitle, metaDescription, metaKeywords } = webpage.seo;
 
   return {
-    title: pageTitle || webpage.name,
+    title: pageTitle || webpage.title,
     description: metaDescription,
     keywords: metaKeywords ? metaKeywords.split(',') : null,
   };
@@ -29,19 +56,5 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function WebPage({ params }: Props) {
   const { id } = await params;
 
-  const data = await getWebpageData({ id: decodeURIComponent(id) });
-  const webpage = data.node?.__typename === 'NormalPage' ? data.node : null;
-
-  if (!webpage) {
-    notFound();
-  }
-
-  const { name, htmlBody } = webpage;
-
-  return (
-    <div className="mx-auto mb-10 flex flex-col justify-center gap-8 lg:w-2/3">
-      <h1 className="text-4xl font-black lg:text-5xl">{name}</h1>
-      <div dangerouslySetInnerHTML={{ __html: htmlBody }} />
-    </div>
-  );
+  return <WebPageContent breadcrumbs={getWebPageBreadcrumbs(id)} webPage={getWebPage(id)} />;
 }


### PR DESCRIPTION
## What/Why?
Add Web Page component from vibes. This is only the first iteration.

### Next steps:
- Add support for nested web pages with children, and a way to navigate between them. This will bring full feature parity with BigCommerce.

## Testing

![image](https://github.com/user-attachments/assets/a0750bff-e581-4bbc-8f63-a712f32aff12)