### PR TITLE
Add turbo start

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "dev": "dotenv -e .env.local -- turbo run dev",
     "build": "dotenv -e .env.local -- turbo run build",
+    "start": "dotenv -e .env.local -- turbo run start",
     "lint": "dotenv -e .env.local -- turbo lint",
     "typecheck": "turbo typecheck"
   },

--- a/turbo.json
+++ b/turbo.json
@@ -23,6 +23,17 @@
         "!.next/cache/**"
       ]
     },
+    "start": {
+      "env": ["*"],
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [
+        "dist/**",
+        ".next/**",
+        "!.next/cache/**"
+      ]
+    },
     "lint": {
       "env": ["*"],
       "dependsOn": [


### PR DESCRIPTION
## What/Why?
Add `start` command to turbo. This will allow testing production builds locally.

## Testing
Ran locally, confirmed NextJS runs in production mode