### PR TITLE
Temporary fix on Page to allow editing of non-published pages

### DIFF
--- a/core/lib/makeswift/page.tsx
+++ b/core/lib/makeswift/page.tsx
@@ -1,12 +1,18 @@
 import { Page as MakeswiftPage } from '@makeswift/runtime/next';
 import { notFound } from 'next/navigation';
+import { connection } from 'next/server';
 
 import { getPageSnapshot } from './client';
 
 export async function Page({ path, locale }: { path: string; locale: string }) {
   const snapshot = await getPageSnapshot({ path, locale });
 
-  if (snapshot == null) return notFound();
+  if (snapshot == null) {
+    // This is a temporary solution to fix the issue where non-published pages are not editable in the builder.
+    await connection();
+
+    return notFound();
+  }
 
   return <MakeswiftPage snapshot={snapshot} />;
 }


### PR DESCRIPTION
## What/Why?
- After we correctly use PPR, the non-published pages are not editable in the builder.
- We're still investigating the root cause of the issue. [Discussion link](https://makeswifthq.slack.com/archives/C07DAL1D8JK/p1736505188282539).
- We have this temporary solution so we can cut a stable release for the `integrations/makeswift` branch.


## Testing

https://github.com/user-attachments/assets/611c3ece-c1a3-4e84-8a6c-c0b5bd60a8fa

