### PR TITLE
fix: add hideOverflow to sections and carousels

### DIFF
--- a/core/vibes/soul/primitives/carousel/index.tsx
+++ b/core/vibes/soul/primitives/carousel/index.tsx
@@ -17,6 +17,7 @@ interface CarouselProps extends React.ComponentPropsWithoutRef<'div'> {
   plugins?: CarouselPlugin;
   setApi?: (api: CarouselApi) => void;
   carouselScrollbarLabel?: string;
+  hideOverflow?: boolean;
 }
 
 type CarouselContextProps = {
@@ -40,7 +41,15 @@ function useCarousel() {
   return context;
 }
 
-function Carousel({ opts, setApi, plugins, className, children, ...rest }: CarouselProps) {
+function Carousel({
+  opts,
+  setApi,
+  plugins,
+  className,
+  children,
+  hideOverflow = true,
+  ...rest
+}: CarouselProps) {
   const [carouselRef, api] = useEmblaCarousel(opts, plugins);
   const [canScrollPrev, setCanScrollPrev] = useState(false);
   const [canScrollNext, setCanScrollNext] = useState(false);
@@ -103,7 +112,7 @@ function Carousel({ opts, setApi, plugins, className, children, ...rest }: Carou
       <div
         {...rest}
         aria-roledescription="carousel"
-        className={clsx('relative @container', className)}
+        className={clsx('relative @container', hideOverflow && 'overflow-hidden', className)}
         onKeyDownCapture={handleKeyDown}
         role="region"
       >

--- a/core/vibes/soul/primitives/products-carousel/index.tsx
+++ b/core/vibes/soul/primitives/products-carousel/index.tsx
@@ -29,6 +29,7 @@ interface Props {
   placeholderCount?: number;
   showButtons?: boolean;
   showScrollbar?: boolean;
+  hideOverflow?: boolean;
 }
 
 export function ProductsCarousel({
@@ -44,10 +45,17 @@ export function ProductsCarousel({
   placeholderCount = 8,
   showButtons = true,
   showScrollbar = true,
+  hideOverflow,
 }: Props) {
   return (
     <Stream
-      fallback={<ProductsCarouselSkeleton pending placeholderCount={placeholderCount} />}
+      fallback={
+        <ProductsCarouselSkeleton
+          hideOverflow={hideOverflow}
+          pending
+          placeholderCount={placeholderCount}
+        />
+      }
       value={streamableProducts}
     >
       {(products) => {
@@ -56,13 +64,14 @@ export function ProductsCarousel({
             <ProductsCarouselEmptyState
               emptyStateSubtitle={emptyStateSubtitle}
               emptyStateTitle={emptyStateTitle}
+              hideOverflow={hideOverflow}
               placeholderCount={placeholderCount}
             />
           );
         }
 
         return (
-          <Carousel className={className}>
+          <Carousel className={className} hideOverflow={hideOverflow}>
             <CarouselContent className="mb-10">
               {products.map((product) => (
                 <CarouselItem
@@ -103,13 +112,19 @@ export function ProductsCarouselSkeleton({
   className,
   placeholderCount = 8,
   pending = false,
+  hideOverflow,
 }: {
   className?: string;
   placeholderCount?: number;
   pending?: boolean;
+  hideOverflow?: boolean;
 }) {
   return (
-    <Carousel className={className} data-pending={pending ? '' : undefined}>
+    <Carousel
+      className={className}
+      data-pending={pending ? '' : undefined}
+      hideOverflow={hideOverflow}
+    >
       <CarouselContent className="mb-10">
         {Array.from({ length: placeholderCount }).map((_, index) => (
           <CarouselItem
@@ -130,14 +145,16 @@ export function ProductsCarouselEmptyState({
   placeholderCount = 8,
   emptyStateTitle,
   emptyStateSubtitle,
+  hideOverflow,
 }: {
   className?: string;
   placeholderCount?: number;
   emptyStateTitle?: Streamable<string | null>;
   emptyStateSubtitle?: Streamable<string | null>;
+  hideOverflow?: boolean;
 }) {
   return (
-    <Carousel className={clsx('relative', className)}>
+    <Carousel className={clsx('relative', className)} hideOverflow={hideOverflow}>
       <CarouselContent
         className={clsx('mb-10 [mask-image:linear-gradient(to_bottom,_black_0%,_transparent_90%)]')}
       >

--- a/core/vibes/soul/sections/featured-blog-post-list/index.tsx
+++ b/core/vibes/soul/sections/featured-blog-post-list/index.tsx
@@ -3,6 +3,7 @@ import { BlogPostCardBlogPost } from '@/vibes/soul/primitives/blog-post-card';
 import { Breadcrumb, Breadcrumbs } from '@/vibes/soul/primitives/breadcrumbs';
 import { CursorPagination, CursorPaginationInfo } from '@/vibes/soul/primitives/cursor-pagination';
 import { BlogPostList } from '@/vibes/soul/sections/blog-post-list';
+import { SectionLayout } from '@/vibes/soul/sections/section-layout';
 
 interface Props {
   title: string;
@@ -26,30 +27,28 @@ export function FeaturedBlogPostList({
   placeholderCount,
 }: Props) {
   return (
-    <section className="@container">
-      <div className="mx-auto max-w-screen-2xl px-4 py-10 @xl:px-6 @xl:py-14 @4xl:px-8 @4xl:py-20">
-        {breadcrumbs && <Breadcrumbs breadcrumbs={breadcrumbs} />}
+    <SectionLayout>
+      {breadcrumbs && <Breadcrumbs breadcrumbs={breadcrumbs} />}
 
-        <div className="pt-6">
-          <h1 className="mb-3 font-heading text-4xl font-medium leading-none text-foreground @xl:text-5xl @4xl:text-6xl">
-            {title}
-          </h1>
+      <div className="pt-6">
+        <h1 className="mb-3 font-heading text-4xl font-medium leading-none text-foreground @xl:text-5xl @4xl:text-6xl">
+          {title}
+        </h1>
 
-          {description != null && description !== '' && (
-            <p className="max-w-lg text-lg text-contrast-500">{description}</p>
-          )}
+        {description != null && description !== '' && (
+          <p className="max-w-lg text-lg text-contrast-500">{description}</p>
+        )}
 
-          <BlogPostList
-            className="mb-8 mt-8 @4xl:mb-10 @4xl:mt-10"
-            emptyStateSubtitle={emptyStateSubtitle}
-            emptyStateTitle={emptyStateTitle}
-            placeholderCount={placeholderCount}
-            posts={posts}
-          />
+        <BlogPostList
+          className="mb-8 mt-8 @4xl:mb-10 @4xl:mt-10"
+          emptyStateSubtitle={emptyStateSubtitle}
+          emptyStateTitle={emptyStateTitle}
+          placeholderCount={placeholderCount}
+          posts={posts}
+        />
 
-          {paginationInfo && <CursorPagination info={paginationInfo} />}
-        </div>
+        {paginationInfo && <CursorPagination info={paginationInfo} />}
       </div>
-    </section>
+    </SectionLayout>
   );
 }

--- a/core/vibes/soul/sections/featured-products-carousel/index.tsx
+++ b/core/vibes/soul/sections/featured-products-carousel/index.tsx
@@ -1,6 +1,7 @@
 import { Streamable } from '@/vibes/soul/lib/streamable';
 import { AnimatedLink } from '@/vibes/soul/primitives/animated-link';
 import { CarouselProduct, ProductsCarousel } from '@/vibes/soul/primitives/products-carousel';
+import { SectionLayout } from '@/vibes/soul/sections/section-layout';
 
 interface Link {
   label: string;
@@ -33,34 +34,31 @@ export function FeaturedProductsCarousel({
   nextLabel,
 }: Props) {
   return (
-    <section className="group/pending overflow-hidden @container">
-      <div className="mx-auto w-full max-w-screen-2xl px-4 py-10 @xl:px-6 @xl:py-14 @4xl:px-8 @4xl:py-20">
-        <div className="mb-6 flex w-full flex-row flex-wrap items-end justify-between gap-x-8 gap-y-6 text-foreground @4xl:mb-8">
-          <div>
-            <h2 className="font-heading text-2xl leading-none @xl:text-3xl @4xl:text-4xl">
-              {title}
-            </h2>
-            {description != null && description !== '' && (
-              <p className="mt-3 max-w-xl leading-relaxed text-contrast-500">{description}</p>
-            )}
-          </div>
-
-          {cta != null && cta.href !== '' && cta.label !== '' && (
-            <AnimatedLink className="mr-3" label={cta.label} link={{ href: cta.href }} />
+    <SectionLayout className="group/pending" hideOverflow>
+      <div className="mb-6 flex w-full flex-row flex-wrap items-end justify-between gap-x-8 gap-y-6 text-foreground @4xl:mb-8">
+        <div>
+          <h2 className="font-heading text-2xl leading-none @xl:text-3xl @4xl:text-4xl">{title}</h2>
+          {description != null && description !== '' && (
+            <p className="mt-3 max-w-xl leading-relaxed text-contrast-500">{description}</p>
           )}
         </div>
-        <div className="group-has-[[data-pending]]/pending:animate-pulse">
-          <ProductsCarousel
-            emptyStateSubtitle={emptyStateSubtitle}
-            emptyStateTitle={emptyStateTitle}
-            nextLabel={nextLabel}
-            placeholderCount={placeholderCount}
-            previousLabel={previousLabel}
-            products={products}
-            scrollbarLabel={scrollbarLabel}
-          />
-        </div>
+
+        {cta != null && cta.href !== '' && cta.label !== '' && (
+          <AnimatedLink className="mr-3" label={cta.label} link={{ href: cta.href }} />
+        )}
       </div>
-    </section>
+      <div className="group-has-[[data-pending]]/pending:animate-pulse">
+        <ProductsCarousel
+          emptyStateSubtitle={emptyStateSubtitle}
+          emptyStateTitle={emptyStateTitle}
+          hideOverflow={false}
+          nextLabel={nextLabel}
+          placeholderCount={placeholderCount}
+          previousLabel={previousLabel}
+          products={products}
+          scrollbarLabel={scrollbarLabel}
+        />
+      </div>
+    </SectionLayout>
   );
 }

--- a/core/vibes/soul/sections/section-layout/index.tsx
+++ b/core/vibes/soul/sections/section-layout/index.tsx
@@ -1,5 +1,6 @@
 import { clsx } from 'clsx';
 
+// eslint-disable-next-line valid-jsdoc
 /**
  * This component supports various CSS variables for theming. Here's a comprehensive list, along
  * with their default values:
@@ -17,13 +18,15 @@ export function SectionLayout({
   className,
   children,
   containerSize = '2xl',
+  hideOverflow = false,
 }: {
   className?: string;
   children: React.ReactNode;
   containerSize?: 'md' | 'lg' | 'xl' | '2xl';
+  hideOverflow?: boolean;
 }) {
   return (
-    <section className={clsx('@container', className)}>
+    <section className={clsx('@container', hideOverflow && 'overflow-hidden', className)}>
       <div
         className={clsx(
           'mx-auto px-4 py-10 @xl:px-6 @xl:py-14 @4xl:px-8 @4xl:py-20',

--- a/core/vibes/soul/sections/sticky-sidebar-layout/index.tsx
+++ b/core/vibes/soul/sections/sticky-sidebar-layout/index.tsx
@@ -21,6 +21,7 @@ export function StickySidebarLayout({
   sidebarSize = '1/3',
   sidebarPosition = 'before',
   containerSize = '2xl',
+  hideOverflow = false,
 }: {
   className?: string;
   sidebar: React.ReactNode;
@@ -28,9 +29,12 @@ export function StickySidebarLayout({
   containerSize?: 'md' | 'lg' | 'xl' | '2xl';
   sidebarSize?: '1/4' | '1/3' | '1/2' | 'small' | 'medium' | 'large';
   sidebarPosition?: 'before' | 'after';
+  hideOverflow?: boolean;
 }) {
   return (
-    <section className={clsx('group/pending @container', className)}>
+    <section
+      className={clsx('group/pending @container', hideOverflow && 'overflow-hidden', className)}
+    >
       <div
         className={clsx(
           'mx-auto flex flex-col items-stretch gap-x-16 gap-y-10 px-4 py-10 @xl:px-6 @xl:py-14 @4xl:flex-row @4xl:px-8 @4xl:py-20',


### PR DESCRIPTION
## What/Why?
Added a `hideOverflow` prop to the carousel and section components.

By default, the `Carousel` will hide it's own overflow. In order to create the effect that is present in the designs for Soul, where the carousels appear to "overflow" off the screen, we need to move the overflow clipping up to the section so we can retain the left padding. To do this, we've added a way to toggle overflow visibility on sections independently from the `Carousel`. The sections will default to overflow visible.

I've decided to make this a boolean prop called `hideOverflow` instead of `overflow: 'visible' | 'hidden'` due to the semantic intent of the prop. Given there are many options for the CSS `overflow` property I don't want to confuse users with additional values that don't have an intended use case.

In addition I went ahead and refactored `FeaturedProductCarousel` and `FeaturedBlogPostList` components to use the `SectionLayout` primitive for consistency.

## Testing

https://github.com/user-attachments/assets/9301fbf0-9315-4a99-9b9e-6ebc1fa909e5

