### PR TITLE
fix: sticky sidebar layout overflow

### DIFF
--- a/core/vibes/soul/sections/sticky-sidebar-layout/index.tsx
+++ b/core/vibes/soul/sections/sticky-sidebar-layout/index.tsx
@@ -48,7 +48,7 @@ export function StickySidebarLayout({
       >
         <div
           className={clsx(
-            'shrink-0',
+            'min-w-0',
             sidebarPosition === 'after' ? 'order-2' : 'order-1',
             {
               '1/3': '@4xl:w-1/3',
@@ -64,6 +64,7 @@ export function StickySidebarLayout({
         </div>
         <div
           className={clsx(
+            'min-w-0',
             sidebarPosition === 'after' ? 'order-1' : 'order-2',
             {
               '1/3': '@4xl:w-2/3',


### PR DESCRIPTION
## What/Why?
When using an Image inside of a `StickySidebarLayout` a min width was being set preventing it from shrinking in a flex layout. This PR fixes this by setting a min width of 0 on the columns in the `StickySidebarLayout` component.

## Testing
![CleanShot 2025-01-10 at 16 33 39](https://github.com/user-attachments/assets/5e14db58-cc88-4156-932d-e5636ca492c7)
