### PR TITLE
fix: element tree introspection on Makeswift API routes

### DIFF
--- a/core/app/api/makeswift/[...makeswift]/route.ts
+++ b/core/app/api/makeswift/[...makeswift]/route.ts
@@ -3,6 +3,8 @@ import { strict } from 'assert';
 
 import { runtime } from '~/lib/makeswift/runtime';
 
+import '~/lib/makeswift/components';
+
 strict(process.env.MAKESWIFT_SITE_API_KEY, 'MAKESWIFT_SITE_API_KEY is required');
 
 const defaultVariants: Font['variants'] = [


### PR DESCRIPTION
## What/Why?

Makeswift API route needs a components import, otherwise it won't know about any of the custom components and won't be able to introspect them/replace the resources. See [this thread](https://makeswifthq.slack.com/archives/C014SCS4G75/p1736555455966869) for more context.

## Testing

### Before

The typography resource inside of a `section-layout` component is not replaced:
<img width="1646" alt="before" src="https://github.com/user-attachments/assets/7bb6c150-0ce3-4e20-9614-2495adb269c2" />

### After

The typography resource is correctly replaced:
<img width="1649" alt="after" src="https://github.com/user-attachments/assets/6448c72a-6ee5-40a5-8e2f-3f780c44ada1" />

