### PR TITLE
fix: use lazy promise for searchParams to defers execution

### DIFF
--- a/core/app/[locale]/(default)/(faceted)/search/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/search/page.tsx
@@ -1,5 +1,6 @@
 import { getFormatter, getTranslations } from 'next-intl/server';
 import { createSearchParamsCache } from 'nuqs/server';
+import PLazy from 'p-lazy';
 import { cache } from 'react';
 
 import { Breadcrumb } from '@/vibes/soul/primitives/breadcrumbs';
@@ -244,7 +245,10 @@ export async function generateMetadata() {
   };
 }
 
-export default async function Search(props: Props) {
+export default async function Search(pageProps: Props) {
+  const searchParams = PLazy.from(() => pageProps.searchParams);
+  const props = { searchParams };
+
   return (
     <ProductsListSection
       breadcrumbs={getBreadcrumbs()}


### PR DESCRIPTION
## What/Why?
Use lazy promise on `searchParams` to defers execution.

This is needed to fix the 500 error:

```
Route /[locale]/search needs to bail out of prerendering at this point because it used `await searchParams`, `searchParams.then`, or similar.
```

## Testing
We had the same problem with `cookies()` on the `Header`: https://github.com/bigcommerce/catalyst/pull/1880