### PR TITLE
feat(core): add locale switcher to Header

### DIFF
--- a/core/components/header/_actions/switch-locale.ts
+++ b/core/components/header/_actions/switch-locale.ts
@@ -1,0 +1,34 @@
+'use server';
+
+import { SubmissionResult } from '@conform-to/react';
+import { parseWithZod } from '@conform-to/zod';
+import { revalidatePath } from 'next/cache';
+
+import { localeSchema } from '@/vibes/soul/primitives/navigation/schema';
+import { defaultLocale, redirect } from '~/i18n/routing';
+
+export const switchLocale = async (_prevState: SubmissionResult | null, payload: FormData) => {
+  const submission = parseWithZod(payload, { schema: localeSchema });
+
+  if (submission.status !== 'success') {
+    return submission.reply({ formErrors: ['Invalid locale'] });
+  }
+
+  await Promise.resolve();
+
+  revalidatePath('/');
+
+  if (submission.value.id === defaultLocale) {
+    redirect({
+      href: `/${submission.value.id}`,
+      locale: submission.value.id,
+    });
+  } else {
+    redirect({
+      href: `/`,
+      locale: submission.value.id,
+    });
+  }
+
+  return submission.reply({ resetForm: true });
+};

--- a/core/components/header/_actions/switch-locale.ts
+++ b/core/components/header/_actions/switch-locale.ts
@@ -3,15 +3,18 @@
 import { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
 import { revalidatePath } from 'next/cache';
+import { getTranslations } from 'next-intl/server';
 
 import { localeSchema } from '@/vibes/soul/primitives/navigation/schema';
 import { defaultLocale, redirect } from '~/i18n/routing';
 
 export const switchLocale = async (_prevState: SubmissionResult | null, payload: FormData) => {
+  const t = await getTranslations('Components.Header.Locale');
+
   const submission = parseWithZod(payload, { schema: localeSchema });
 
   if (submission.status !== 'success') {
-    return submission.reply({ formErrors: ['Invalid locale'] });
+    return submission.reply({ formErrors: [t('invalidLocale')] });
   }
 
   await Promise.resolve();

--- a/core/components/header/_actions/switch-locale.ts
+++ b/core/components/header/_actions/switch-locale.ts
@@ -21,6 +21,9 @@ export const switchLocale = async (_prevState: SubmissionResult | null, payload:
 
   revalidatePath('/');
 
+  // Since `redirect` doesn't prepend the local to the redirect url
+  // when navigating the a default locale link, we need to prepend
+  // it ourselves to ensure the redirect happens.
   if (submission.value.id === defaultLocale) {
     redirect({
       href: `/${submission.value.id}`,

--- a/core/components/header/index.tsx
+++ b/core/components/header/index.tsx
@@ -1,5 +1,5 @@
 import { cookies } from 'next/headers';
-import { getTranslations } from 'next-intl/server';
+import { getLocale, getTranslations } from 'next-intl/server';
 import PLazy from 'p-lazy';
 import { cache } from 'react';
 
@@ -11,8 +11,10 @@ import { graphql, readFragment } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
 import { TAGS } from '~/client/tags';
 import { logoTransformer } from '~/data-transformers/logo-transformer';
+import { routing } from '~/i18n/routing';
 
 import { search } from './_actions/search';
+import { switchLocale } from './_actions/switch-locale';
 import { HeaderFragment } from './fragment';
 
 const GetCartCountQuery = graphql(`
@@ -95,6 +97,12 @@ const getCartCount = async () => {
 
 export const Header = async () => {
   const t = await getTranslations('Components.Header');
+  const locale = await getLocale();
+
+  const locales = routing.locales.map((enabledLocales) => ({
+    id: enabledLocales,
+    label: enabledLocales.toLocaleUpperCase(),
+  }));
 
   return (
     <HeaderSection
@@ -113,6 +121,9 @@ export const Header = async () => {
         openSearchPopupLabel: t('Search.openSearchPopup'),
         logoLabel: t('home'),
         cartCount: PLazy.from(getCartCount),
+        activeLocaleId: locale,
+        locales,
+        localeAction: switchLocale,
       }}
     />
   );

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -507,9 +507,8 @@
         "login": "Login",
         "logout": "Log out"
       },
-      "LocaleSwitcher": {
-        "chooseCountryAndLanguage": "Choose your country and language",
-        "goToSite": "Go to site"
+      "Locale": {
+        "invalidLocale": "Invalid locale"
       },
       "MiniCart": {
         "cart": "Cart",


### PR DESCRIPTION
## What/Why?
Add locale switcher to the Header, using server action and `redirect`. In this use case we need to revalidate the `/` to make sure the cookies get updated with the new locale. We also had to workaround an issue by redirecting to the `/en` when the default locale is used.

## Testing
Locale switcher works as expected.

https://github.com/user-attachments/assets/b78fcca2-1fc5-4608-b2e9-517797fcafab

