### PR TITLE
fix(core): dedupe requests in various pages

### DIFF
--- a/.changeset/ninety-files-begin.md
+++ b/.changeset/ninety-files-begin.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Pass in currency code to quick search results.

--- a/.changeset/warm-drinks-think.md
+++ b/.changeset/warm-drinks-think.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Dedupe requests in various pages by properly caching/memoizing the function per page render.

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
@@ -19,13 +19,15 @@ import { fetchFacetedSearch } from '../../fetch-faceted-search';
 
 import { getBrand as getBrandData } from './page-data';
 
-interface Props {
-  params: Promise<{
-    slug: string;
-    locale: string;
-  }>;
-  searchParams: Promise<Record<string, string | string[] | undefined>>;
-}
+const cachedBrandDataVariables = cache((brandId: string) => {
+  return {
+    entityId: Number(brandId),
+  };
+});
+
+const cacheBrandFacetedSearch = cache((brandId: string) => {
+  return { brand: [brandId] };
+});
 
 function getBreadcrumbs(): Breadcrumb[] {
   return [];
@@ -33,7 +35,9 @@ function getBreadcrumbs(): Breadcrumb[] {
 
 async function getBrand(props: Props) {
   const { slug } = await props.params;
-  const brand = await getBrandData({ entityId: Number(slug) });
+
+  const variables = cachedBrandDataVariables(slug);
+  const brand = await getBrandData(variables);
 
   if (brand == null) notFound();
 
@@ -46,15 +50,10 @@ async function getTitle(props: Props): Promise<string> {
   return brand.name;
 }
 
-async function getTotalCount(props: Props): Promise<number> {
-  const search = await getRefinedSearch(props);
-
-  return search.products.collectionInfo?.totalItems ?? 0;
-}
-
 const createBrandSearchParamsCache = cache(async (props: Props) => {
   const { slug } = await props.params;
-  const brandSearch = await fetchFacetedSearch({ brand: [slug] });
+  const brand = cacheBrandFacetedSearch(slug);
+  const brandSearch = await fetchFacetedSearch(brand);
   const brandFacets = brandSearch.facets.items.filter(
     (facet) => facet.__typename !== 'BrandSearchFilter',
   );
@@ -80,7 +79,7 @@ const createBrandSearchParamsCache = cache(async (props: Props) => {
   return createSearchParamsCache(filterParsers);
 });
 
-async function getRefinedSearch(props: Props) {
+const getRefinedSearch = cache(async (props: Props) => {
   const { slug } = await props.params;
   const searchParams = await props.searchParams;
   const searchParamsCache = await createBrandSearchParamsCache(props);
@@ -91,6 +90,12 @@ async function getRefinedSearch(props: Props) {
     ...parsedSearchParams,
     brand: [slug],
   });
+});
+
+async function getTotalCount(props: Props): Promise<number> {
+  const search = await getRefinedSearch(props);
+
+  return search.products.collectionInfo?.totalItems ?? 0;
 }
 
 async function getFilters(props: Props): Promise<Filter[]> {
@@ -98,7 +103,9 @@ async function getFilters(props: Props): Promise<Filter[]> {
   const searchParams = await props.searchParams;
   const searchParamsCache = await createBrandSearchParamsCache(props);
   const parsedSearchParams = searchParamsCache?.parse(searchParams) ?? {};
-  const brandSearch = await fetchFacetedSearch({ brand: [slug] });
+  const brand = cacheBrandFacetedSearch(slug);
+  const brandSearch = await fetchFacetedSearch(brand);
+  // const brandSearch = await fetchFacetedSearch({ brand: [slug] });
   const brandFacets = brandSearch.facets.items.filter(
     (facet) => facet.__typename !== 'BrandSearchFilter',
   );
@@ -149,15 +156,7 @@ async function getListProducts(props: Props): Promise<ListProduct[]> {
 }
 
 async function getPaginationInfo(props: Props): Promise<CursorPaginationInfo> {
-  const { slug } = await props.params;
-  const searchParams = await props.searchParams;
-  const searchParamsCache = await createBrandSearchParamsCache(props);
-  const parsedSearchParams = searchParamsCache?.parse(searchParams) ?? {};
-  const brandSearch = await fetchFacetedSearch({
-    ...searchParams,
-    ...parsedSearchParams,
-    brand: [slug],
-  });
+  const brandSearch = await getRefinedSearch(props);
 
   return pageInfoTransformer(brandSearch.products.pageInfo);
 }
@@ -208,6 +207,14 @@ async function getResetFiltersLabel(): Promise<string> {
   const t = await getTranslations('FacetedGroup.FacetedSearch');
 
   return t('resetFilters');
+}
+
+interface Props {
+  params: Promise<{
+    slug: string;
+    locale: string;
+  }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }
 
 export async function generateMetadata(props: Props): Promise<Metadata> {

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
@@ -105,7 +105,6 @@ async function getFilters(props: Props): Promise<Filter[]> {
   const parsedSearchParams = searchParamsCache?.parse(searchParams) ?? {};
   const brand = cacheBrandFacetedSearch(slug);
   const brandSearch = await fetchFacetedSearch(brand);
-  // const brandSearch = await fetchFacetedSearch({ brand: [slug] });
   const brandFacets = brandSearch.facets.items.filter(
     (facet) => facet.__typename !== 'BrandSearchFilter',
   );

--- a/core/app/[locale]/(default)/blog/[blogId]/page-data.ts
+++ b/core/app/[locale]/(default)/blog/[blogId]/page-data.ts
@@ -1,7 +1,7 @@
 import { cache } from 'react';
 
 import { client } from '~/client';
-import { graphql } from '~/client/graphql';
+import { graphql, VariablesOf } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
 
 const BlogPageQuery = graphql(`
@@ -35,10 +35,12 @@ const BlogPageQuery = graphql(`
   }
 `);
 
-export const getBlogPageData = cache(async ({ entityId }: { entityId: number }) => {
+type Variables = VariablesOf<typeof BlogPageQuery>;
+
+export const getBlogPageData = cache(async (variables: Variables) => {
   const response = await client.fetch({
     document: BlogPageQuery,
-    variables: { entityId },
+    variables,
     fetchOptions: { next: { revalidate } },
   });
 

--- a/core/app/[locale]/(default)/blog/page-data.ts
+++ b/core/app/[locale]/(default)/blog/page-data.ts
@@ -1,5 +1,5 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
-import { getFormatter, getTranslations } from 'next-intl/server';
+import { getFormatter } from 'next-intl/server';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -110,16 +110,3 @@ export const getBlogPosts = cache(
     };
   },
 );
-
-export async function getBlogMetaData() {
-  const t = await getTranslations('Blog');
-  const blog = await getBlog();
-
-  return {
-    title: blog?.name ?? t('title'),
-    description:
-      blog?.description && blog.description.length > 150
-        ? `${blog.description.substring(0, 150)}...`
-        : blog?.description,
-  };
-}

--- a/core/app/[locale]/(default)/blog/page.tsx
+++ b/core/app/[locale]/(default)/blog/page.tsx
@@ -7,7 +7,7 @@ import { createSearchParamsCache, parseAsInteger, parseAsString } from 'nuqs/ser
 import { FeaturedBlogPostList } from '@/vibes/soul/sections/featured-blog-post-list';
 import { defaultPageInfo, pageInfoTransformer } from '~/data-transformers/page-info-transformer';
 
-import { getBlog, getBlogMetaData, getBlogPosts } from './page-data';
+import { getBlog, getBlogPosts } from './page-data';
 
 interface Props {
   params: Promise<{ locale: string }>;
@@ -24,7 +24,16 @@ const searchParamsCache = createSearchParamsCache({
 });
 
 export async function generateMetadata(): Promise<Metadata> {
-  return await getBlogMetaData();
+  const t = await getTranslations('Blog');
+  const blog = await getBlog();
+
+  return {
+    title: blog?.name ?? t('title'),
+    description:
+      blog?.description && blog.description.length > 150
+        ? `${blog.description.substring(0, 150)}...`
+        : blog?.description,
+  };
 }
 
 async function listBlogPosts(searchParamsPromise: Promise<SearchParams>) {

--- a/core/app/[locale]/(default)/cart/page-data.ts
+++ b/core/app/[locale]/(default)/cart/page-data.ts
@@ -1,6 +1,6 @@
 import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
-import { graphql } from '~/client/graphql';
+import { graphql, VariablesOf } from '~/client/graphql';
 import { TAGS } from '~/client/tags';
 
 export const PhysicalItemFragment = graphql(`
@@ -169,12 +169,14 @@ const CartPageQuery = graphql(
   [PhysicalItemFragment, DigitalItemFragment, MoneyFieldsFragment],
 );
 
-export const getCart = async (cartId: string) => {
+type Variables = VariablesOf<typeof CartPageQuery>;
+
+export const getCart = async (variables: Variables) => {
   const customerAccessToken = await getSessionCustomerAccessToken();
 
   const { data } = await client.fetch({
     document: CartPageQuery,
-    variables: { cartId },
+    variables,
     customerAccessToken,
     fetchOptions: {
       cache: 'no-store',

--- a/core/app/[locale]/(default)/cart/page.tsx
+++ b/core/app/[locale]/(default)/cart/page.tsx
@@ -32,7 +32,7 @@ export default async function Cart() {
     );
   }
 
-  const data = await getCart(cartId);
+  const data = await getCart({ cartId });
 
   const cart = data.site.cart;
   const checkout = data.site.checkout;

--- a/core/app/[locale]/(default)/webpages/[id]/contact/page-data.ts
+++ b/core/app/[locale]/(default)/webpages/[id]/contact/page-data.ts
@@ -1,7 +1,7 @@
 import { cache } from 'react';
 
 import { client } from '~/client';
-import { graphql } from '~/client/graphql';
+import { graphql, VariablesOf } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
 import { BreadcrumbsWebPageFragment } from '~/components/breadcrumbs/fragment';
 
@@ -37,7 +37,9 @@ const ContactPageQuery = graphql(
   [BreadcrumbsWebPageFragment],
 );
 
-export const getWebpageData = cache(async (variables: { id: string }) => {
+type Variables = VariablesOf<typeof ContactPageQuery>;
+
+export const getWebpageData = cache(async (variables: Variables) => {
   const { data } = await client.fetch({
     document: ContactPageQuery,
     variables,

--- a/core/app/[locale]/(default)/webpages/[id]/normal/page-data.ts
+++ b/core/app/[locale]/(default)/webpages/[id]/normal/page-data.ts
@@ -1,7 +1,7 @@
 import { cache } from 'react';
 
 import { client } from '~/client';
-import { graphql } from '~/client/graphql';
+import { graphql, VariablesOf } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
 import { BreadcrumbsWebPageFragment } from '~/components/breadcrumbs/fragment';
 
@@ -27,7 +27,9 @@ const NormalPageQuery = graphql(
   [BreadcrumbsWebPageFragment],
 );
 
-export const getWebpageData = cache(async (variables: { id: string }) => {
+type Variables = VariablesOf<typeof NormalPageQuery>;
+
+export const getWebpageData = cache(async (variables: Variables) => {
   const { data } = await client.fetch({
     document: NormalPageQuery,
     variables,

--- a/core/components/header/_actions/search.ts
+++ b/core/components/header/_actions/search.ts
@@ -12,6 +12,7 @@ import { client } from '~/client';
 import { graphql } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
 import { searchResultsTransformer } from '~/data-transformers/search-results-transformer';
+import { getPreferredCurrencyCode } from '~/lib/currency';
 
 import { SearchProductFragment } from './fragment';
 
@@ -80,10 +81,12 @@ export async function search(
 
   const customerAccessToken = await getSessionCustomerAccessToken();
 
+  const currencyCode = await getPreferredCurrencyCode();
+
   try {
     const response = await client.fetch({
       document: GetQuickSearchResultsQuery,
-      variables: { filters: { searchTerm: submission.value.term } },
+      variables: { filters: { searchTerm: submission.value.term }, currencyCode },
       customerAccessToken,
       fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
     });

--- a/core/components/header/_actions/search.ts
+++ b/core/components/header/_actions/search.ts
@@ -17,7 +17,10 @@ import { SearchProductFragment } from './fragment';
 
 const GetQuickSearchResultsQuery = graphql(
   `
-    query getQuickSearchResults($filters: SearchProductsFiltersInput!) {
+    query getQuickSearchResults(
+      $filters: SearchProductsFiltersInput!
+      $currencyCode: currencyCode
+    ) {
       site {
         search {
           searchProducts(filters: $filters) {


### PR DESCRIPTION
## What/Why?

- Dedupe requests in various pages by properly caching/memoizing the function per page render.
- Fix an issue with quick search result.

## Testing
Tested and see less function calls that call `fetch`.