### PR TITLE
chore(core): rename query/mutations to standard names

### DIFF
--- a/.changeset/fuzzy-beds-lick.md
+++ b/.changeset/fuzzy-beds-lick.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Rename some GQL query/mutations/fragments to standardized naming.

--- a/core/app/[locale]/(default)/(auth)/change-password/_actions/change-password.ts
+++ b/core/app/[locale]/(default)/(auth)/change-password/_actions/change-password.ts
@@ -10,7 +10,7 @@ import { client } from '~/client';
 import { graphql } from '~/client/graphql';
 
 const ChangePasswordMutation = graphql(`
-  mutation ChangePassword($input: ResetPasswordInput!) {
+  mutation ChangePasswordMutation($input: ResetPasswordInput!) {
     customer {
       resetPassword(input: $input) {
         __typename

--- a/core/app/[locale]/(default)/(auth)/login/forgot-password/_actions/reset-password.ts
+++ b/core/app/[locale]/(default)/(auth)/login/forgot-password/_actions/reset-password.ts
@@ -10,7 +10,7 @@ import { client } from '~/client';
 import { graphql } from '~/client/graphql';
 
 const ResetPasswordMutation = graphql(`
-  mutation ResetPassword($input: RequestResetPasswordInput!, $reCaptcha: ReCaptchaV2Input) {
+  mutation ResetPasswordMutation($input: RequestResetPasswordInput!, $reCaptcha: ReCaptchaV2Input) {
     customer {
       requestResetPassword(input: $input, reCaptchaV2: $reCaptcha) {
         __typename

--- a/core/app/[locale]/(default)/(auth)/register/_actions/register-customer.ts
+++ b/core/app/[locale]/(default)/(auth)/register/_actions/register-customer.ts
@@ -14,7 +14,10 @@ import { FieldNameToFieldId } from '~/data-transformers/form-field-transformer/u
 import { redirect } from '~/i18n/routing';
 
 const RegisterCustomerMutation = graphql(`
-  mutation RegisterCustomer($input: RegisterCustomerInput!, $reCaptchaV2: ReCaptchaV2Input) {
+  mutation RegisterCustomerMutation(
+    $input: RegisterCustomerInput!
+    $reCaptchaV2: ReCaptchaV2Input
+  ) {
     customer {
       registerCustomer(input: $input, reCaptchaV2: $reCaptchaV2) {
         customer {

--- a/core/app/[locale]/(default)/account/settings/_actions/update-customer.ts
+++ b/core/app/[locale]/(default)/account/settings/_actions/update-customer.ts
@@ -6,12 +6,11 @@ import { unstable_expireTag } from 'next/cache';
 import { getTranslations } from 'next-intl/server';
 
 import { updateAccountSchema } from '@/vibes/soul/sections/account-settings-section/schema';
+import { UpdateAccountAction } from '@/vibes/soul/sections/account-settings-section/update-account-form';
 import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
 import { TAGS } from '~/client/tags';
-
-import { UpdateAccountAction } from '../../../../../../vibes/soul/sections/account-settings-section/update-account-form';
 
 const UpdateCustomerMutation = graphql(`
   mutation UpdateCustomerMutation($input: UpdateCustomerInput!) {

--- a/core/app/[locale]/(default)/cart/page-data.ts
+++ b/core/app/[locale]/(default)/cart/page-data.ts
@@ -122,7 +122,7 @@ export const DigitalItemFragment = graphql(`
 `);
 
 const MoneyFieldsFragment = graphql(`
-  fragment MoneyFields on Money {
+  fragment MoneyFieldsFragment on Money {
     currencyCode
     value
   }
@@ -148,18 +148,18 @@ const CartPageQuery = graphql(
         }
         checkout(entityId: $cartId) {
           subtotal {
-            ...MoneyFields
+            ...MoneyFieldsFragment
           }
           grandTotal {
-            ...MoneyFields
+            ...MoneyFieldsFragment
           }
           taxTotal {
-            ...MoneyFields
+            ...MoneyFieldsFragment
           }
           cart {
             currencyCode
             discountedAmount {
-              ...MoneyFields
+              ...MoneyFieldsFragment
             }
           }
         }

--- a/core/app/[locale]/(default)/webpages/[id]/layout.tsx
+++ b/core/app/[locale]/(default)/webpages/[id]/layout.tsx
@@ -12,7 +12,7 @@ interface Props extends React.PropsWithChildren {
 }
 
 const WebPageChildrenQuery = graphql(`
-  query WebPageChildren($id: ID!) {
+  query WebPageChildrenQuery($id: ID!) {
     node(id: $id) {
       ... on WebPage {
         children(first: 20) {

--- a/core/app/favicon.ico/route.ts
+++ b/core/app/favicon.ico/route.ts
@@ -15,7 +15,7 @@ import { graphql } from '~/client/graphql';
 import { defaultLocale } from '~/i18n/routing';
 
 const GetFaviconQuery = graphql(`
-  query GetFavicon {
+  query GetFaviconQuery {
     site {
       settings {
         faviconUrl

--- a/core/app/robots.txt/route.ts
+++ b/core/app/robots.txt/route.ts
@@ -16,7 +16,7 @@ import { graphql } from '~/client/graphql';
 import { defaultLocale } from '~/i18n/routing';
 
 const RobotsTxtQuery = graphql(`
-  query RobotsTxt {
+  query RobotsTxtQuery {
     site {
       settings {
         robotsTxt

--- a/core/auth/index.ts
+++ b/core/auth/index.ts
@@ -9,7 +9,7 @@ import { graphql } from '~/client/graphql';
 import { getCartId } from '~/lib/cart';
 
 const LoginMutation = graphql(`
-  mutation Login($email: String!, $password: String!, $cartEntityId: String) {
+  mutation LoginMutation($email: String!, $password: String!, $cartEntityId: String) {
     login(email: $email, password: $password, guestCartEntityId: $cartEntityId) {
       customerAccessToken {
         value
@@ -25,7 +25,7 @@ const LoginMutation = graphql(`
 `);
 
 const LoginWithTokenMutation = graphql(`
-  mutation LoginWithCustomerLoginJwt($jwt: String!, $cartEntityId: String) {
+  mutation LoginWithCustomerLoginJwtMutation($jwt: String!, $cartEntityId: String) {
     loginWithCustomerLoginJwt(jwt: $jwt, guestCartEntityId: $cartEntityId) {
       customerAccessToken {
         value

--- a/core/components/header/_actions/switch-currency.ts
+++ b/core/components/header/_actions/switch-currency.ts
@@ -22,7 +22,7 @@ const currencySwitchSchema = z.object({
 
 // Note: this results in a new cart being created in the new currency, so the cart ID will change
 const UpdateCartCurrencyMutation = graphql(`
-  mutation UpdateCartCurrency($input: UpdateCartCurrencyInput!) {
+  mutation UpdateCartCurrencyMutation($input: UpdateCartCurrencyInput!) {
     cart {
       updateCartCurrency(input: $input) {
         cart {

--- a/core/middlewares/with-routes.ts
+++ b/core/middlewares/with-routes.ts
@@ -11,7 +11,7 @@ import { kv } from '../lib/kv';
 import { type MiddlewareFactory } from './compose-middlewares';
 
 const GetRouteQuery = graphql(`
-  query getRoute($path: String!) {
+  query GetRouteQuery($path: String!) {
     site {
       route(path: $path, redirectBehavior: FOLLOW) {
         redirect {


### PR DESCRIPTION
## What/Why?
Noticed some queries/mutations were not using the standardized naming. I feel it may seem redundant in many cases, but we either we have all named the same or we remove the trailing `Query`/`Mutation`.

## Testing
Nothing changes.