### PR TITLE
fix: use x-makeswift-draft-mode header for proxy

### DIFF
--- a/core/middlewares/with-makeswift.ts
+++ b/core/middlewares/with-makeswift.ts
@@ -5,7 +5,9 @@ import { MiddlewareFactory } from './compose-middlewares';
 
 export const withMakeswift: MiddlewareFactory = (middleware) => {
   return async (request, event) => {
-    const apiKey = request.nextUrl.searchParams.get('x-makeswift-draft-mode');
+    const apiKey =
+      request.nextUrl.searchParams.get('x-makeswift-draft-mode') ??
+      request.headers.get('x-makeswift-draft-mode');
 
     if (apiKey === process.env.MAKESWIFT_SITE_API_KEY) {
       const response = await fetch(new URL('/api/makeswift/draft-mode', request.nextUrl.origin), {


### PR DESCRIPTION
## What/Why?
<!--- 
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
--->
The URL search param is only set on the very first request. For the proxy to work as intended, the `x-makeswift-draft-mode` header must be used to determine whether to proxy Draft Mode or not.

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->

https://github.com/user-attachments/assets/475ac733-4d7c-47d9-8e84-6db712d1ed58

