### PR TITLE
Set currency on cart at creation time

### DIFF
--- a/.changeset/silver-numbers-divide.md
+++ b/.changeset/silver-numbers-divide.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Set currency on cart at creation time

--- a/core/client/mutations/create-cart.ts
+++ b/core/client/mutations/create-cart.ts
@@ -1,4 +1,5 @@
 import { getSessionCustomerAccessToken } from '~/auth';
+import { getPreferredCurrencyCode } from '~/lib/currency';
 
 import { client } from '..';
 import { graphql, VariablesOf } from '../graphql';
@@ -21,12 +22,14 @@ type LineItems = CreateCartInput['lineItems'];
 
 export const createCart = async (cartItems: LineItems) => {
   const customerAccessToken = await getSessionCustomerAccessToken();
+  const currencyCode = await getPreferredCurrencyCode();
 
   return await client.fetch({
     document: CreateCartMutation,
     variables: {
       createCartInput: {
         lineItems: cartItems,
+        currencyCode,
       },
     },
     customerAccessToken,


### PR DESCRIPTION
## What/Why?
Set the currency from the preferred currency cookie as part of the cart creation call.

## Testing

https://github.com/user-attachments/assets/fea8f89f-2abd-441f-b2ef-ce66590746e7

