### PR TITLE
Manually update version number in package.json to indicate 1.0.0-rc

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigcommerce/catalyst-core",
   "description": "BigCommerce Catalyst is a Next.js starter kit for building headless BigCommerce storefronts.",
-  "version": "0.24.1",
+  "version": "1.0.0-rc",
   "private": true,
   "scripts": {
     "dev": "npm run generate && next dev",


### PR DESCRIPTION
## What/Why?
It's confusing to customers (and our telemetry) that the version number in package.json is still <1.0.

Manually updating it for now; once we are out of RC this will be set automatically by changesets or CI/CD.

## Testing
N/A