### PR TITLE
fix(core): handle invalid credentials error message in Login

### DIFF
--- a/.changeset/flat-kiwis-design.md
+++ b/.changeset/flat-kiwis-design.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Properly handle the auth error when login is invalid.

--- a/core/app/[locale]/(default)/(auth)/login/_actions/login.ts
+++ b/core/app/[locale]/(default)/(auth)/login/_actions/login.ts
@@ -3,6 +3,7 @@
 import { BigCommerceGQLError } from '@bigcommerce/catalyst-client';
 import { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
+import { AuthError } from 'next-auth';
 import { getLocale, getTranslations } from 'next-intl/server';
 
 import { schema } from '@/vibes/soul/sections/sign-in-section/schema';
@@ -42,11 +43,17 @@ export const login = async (_lastResult: SubmissionResult | null, formData: Form
       });
     }
 
-    if (error instanceof Error) {
-      return submission.reply({ formErrors: [error.message] });
+    if (error instanceof AuthError) {
+      if (error.name === 'CallbackRouteError') {
+        if (error.cause && error.cause.err?.message.includes('Invalid credentials')) {
+          return submission.reply({ formErrors: [t('Form.invalidCredentials')] });
+        }
+      }
+
+      return submission.reply({ formErrors: [error.name] });
     }
 
-    return submission.reply({ formErrors: [t('Form.error')] });
+    return submission.reply({ formErrors: [t('Form.somethingWentWrong')] });
   }
 
   return redirect({ href: '/account/orders', locale });

--- a/core/app/[locale]/(default)/(auth)/login/_actions/login.ts
+++ b/core/app/[locale]/(default)/(auth)/login/_actions/login.ts
@@ -43,14 +43,13 @@ export const login = async (_lastResult: SubmissionResult | null, formData: Form
       });
     }
 
-    if (error instanceof AuthError) {
-      if (error.name === 'CallbackRouteError') {
-        if (error.cause && error.cause.err?.message.includes('Invalid credentials')) {
-          return submission.reply({ formErrors: [t('Form.invalidCredentials')] });
-        }
-      }
-
-      return submission.reply({ formErrors: [error.name] });
+    if (
+      error instanceof AuthError &&
+      error.name === 'CallbackRouteError' &&
+      error.cause &&
+      error.cause.err?.message.includes('Invalid credentials')
+    ) {
+      return submission.reply({ formErrors: [t('Form.invalidCredentials')] });
     }
 
     return submission.reply({ formErrors: [t('Form.somethingWentWrong')] });

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -66,7 +66,7 @@
     "title": "Login",
     "heading": "Log In",
     "Form": {
-      "error": "Your email address or password is incorrect. Try signing in again or reset your password",
+      "invalidCredentials": "Your email address or password is incorrect. Try signing in again or reset your password",
       "successful": "You have successfully logged in.",
       "emailLabel": "Email",
       "enterEmailMessage": "Enter your email",
@@ -74,7 +74,8 @@
       "enterPasswordMessage": "Enter your password",
       "submitting": "Submitting...",
       "logIn": "Log in",
-      "forgotPassword": "Forgot your password?"
+      "forgotPassword": "Forgot your password?",
+      "somethingWentWrong": "Something went wrong. Please try again later."
     },
     "CreateAccount": {
       "heading": "New customer?",


### PR DESCRIPTION
## What/Why?
Properly look for the type of error we get from next-auth and show the correct message when credentials are invalid.

### Before

![Screenshot 2025-01-30 at 2 37 19 PM](https://github.com/user-attachments/assets/ed8bb802-6f96-409f-84c1-3884b5552775)

### After
![Screenshot 2025-01-30 at 3 12 15 PM](https://github.com/user-attachments/assets/8f3e076c-e2e4-4d83-9c13-6e6d36c1b33a)
