### PR TITLE
fix(core): disable prefetch for the /logout link

### DIFF
--- a/.changeset/weak-nails-rule.md
+++ b/.changeset/weak-nails-rule.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Disable prefetch for the `/logout` link.

--- a/core/app/[locale]/(default)/account/layout.tsx
+++ b/core/app/[locale]/(default)/account/layout.tsx
@@ -30,7 +30,7 @@ export default async function Layout({ children, params }: Props) {
             { href: '/account/orders', label: t('orders') },
             { href: '/account/addresses', label: t('addresses') },
             { href: '/account/settings', label: t('settings') },
-            { href: '/logout', label: t('logout') },
+            { href: '/logout', label: t('logout'), prefetch: 'none' },
           ]}
         />
       }

--- a/core/vibes/soul/sections/sidebar-menu/index.tsx
+++ b/core/vibes/soul/sections/sidebar-menu/index.tsx
@@ -1,3 +1,5 @@
+import { ComponentPropsWithoutRef } from 'react';
+
 import { Stream, Streamable } from '@/vibes/soul/lib/streamable';
 
 import { SidebarMenuLink } from './sidebar-menu-link';
@@ -6,6 +8,7 @@ import { SidebarMenuSelect } from './sidebar-menu-select';
 interface MenuLink {
   href: string;
   label: string;
+  prefetch?: ComponentPropsWithoutRef<typeof SidebarMenuLink>['prefetch'];
 }
 
 interface Props {
@@ -29,7 +32,9 @@ export function SidebarMenu({ links: streamableLinks, placeholderCount = 5 }: Pr
             <ul className="hidden @2xl:block">
               {links.map((link, index) => (
                 <li key={index}>
-                  <SidebarMenuLink href={link.href}>{link.label}</SidebarMenuLink>
+                  <SidebarMenuLink href={link.href} prefetch={link.prefetch}>
+                    {link.label}
+                  </SidebarMenuLink>
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
## What/Why?
Since `prefetch: hover` is enabled by default on all links, even the `/logout` button is prefetched when you hover over it—causing users to be logged out inadvertently.

## Testing
Make sure you run `next build` to test prefetching.

Before:

https://github.com/user-attachments/assets/b397ec12-d093-43f0-9c94-dbb20f24cae4


After:


https://github.com/user-attachments/assets/47e73adf-a38b-4296-84a7-94e2657a8f79


