### PR TITLE
feat(core): add discounts summary item to Cart

### DIFF
--- a/.changeset/hip-countries-tap.md
+++ b/.changeset/hip-countries-tap.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Add discounts summary item to Cart.

--- a/core/app/[locale]/(default)/cart/page.tsx
+++ b/core/app/[locale]/(default)/cart/page.tsx
@@ -105,8 +105,15 @@ export default async function Cart() {
                 currency: cart.currencyCode,
               }),
             },
+            {
+              label: t('CheckoutSummary.discounts'),
+              value: `-${format.number(checkout?.cart?.discountedAmount.value ?? 0, {
+                style: 'currency',
+                currency: cart.currencyCode,
+              })}`,
+            },
             checkout?.taxTotal && {
-              label: 'Tax',
+              label: t('CheckoutSummary.tax'),
               value: format.number(checkout.taxTotal.value, {
                 style: 'currency',
                 currency: cart.currencyCode,


### PR DESCRIPTION
## What/Why?
Add cart discounts to summary in Cart.

<img width="408" alt="Screenshot 2025-02-05 at 10 26 04 AM" src="https://github.com/user-attachments/assets/5357848c-4c43-4802-a500-102d074a280b" />

## Testing
I don't have discounts set up but this follows the previous pattern in prelude.