### PR TITLE
fix: rename price label's prop to match its CSS variables' prefix

### DIFF
--- a/.changeset/tame-trains-dance.md
+++ b/.changeset/tame-trains-dance.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+fix(theming): changing price label colors has no effect

--- a/core/lib/makeswift/components/site-theme/components/index.ts
+++ b/core/lib/makeswift/components/site-theme/components/index.ts
@@ -5,7 +5,7 @@ import { carousel } from './carousel';
 import { footer } from './footer';
 import { header } from './header';
 import { logo } from './logo';
-import { priceLabel } from './price-label';
+import { price } from './price-label';
 import { productCard } from './product-card';
 import { section } from './section';
 import { slideshow } from './slide-show';
@@ -18,7 +18,7 @@ export default {
   footer,
   header,
   logo,
-  priceLabel,
+  price,
   productCard,
   section,
   slideshow,

--- a/core/lib/makeswift/components/site-theme/components/price-label.ts
+++ b/core/lib/makeswift/components/site-theme/components/price-label.ts
@@ -20,7 +20,7 @@ const colorGroup = (
     },
   });
 
-export const priceLabel = Group({
+export const price = Group({
   label: 'Price label',
   preferredLayout: Group.Layout.Popover,
   props: {

--- a/core/lib/makeswift/components/site-theme/to-css.ts
+++ b/core/lib/makeswift/components/site-theme/to-css.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
 
-// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
 export type ThemeProps = {
   [key in string]?: string | number | ThemeProps;
 };


### PR DESCRIPTION
## What/Why?

Price label color changes had no effect because of the CSS variables mismatch.

## Testing

### Before

<img width="1093" alt="before, shop all" src="https://github.com/user-attachments/assets/c6e79e9d-15bb-4224-bcc4-a0cb64ef2e35" />

<img width="1113" alt="before, PDP" src="https://github.com/user-attachments/assets/cad2a75f-715a-4243-b7a8-0e2cf466f0fd" />


### After

<img width="1087" alt="after" src="https://github.com/user-attachments/assets/6e3ebdd1-977d-4d21-8f1c-1ae3b8cd34e7" />

<img width="1109" alt="after" src="https://github.com/user-attachments/assets/8e2aa181-5e17-4fe0-aa33-1b02d4592435" />

