### PR TITLE
fix: configure `NEXT_LOCALE` cookie to work in the builder

### DIFF
--- a/.changeset/spotty-seahorses-type.md
+++ b/.changeset/spotty-seahorses-type.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+fix: configure `NEXT_LOCALE` cookie to work inside of the Makeswift Builder's canvas

--- a/core/i18n/routing.ts
+++ b/core/i18n/routing.ts
@@ -56,6 +56,12 @@ export const routing = defineRouting({
   locales,
   defaultLocale,
   localePrefix,
+  // configure `NEXT_LOCALE` cookie to work inside of the Makeswift Builder's canvas
+  localeCookie: {
+    partitioned: true,
+    secure: true,
+    sameSite: 'none',
+  },
 });
 
 // Lightweight wrappers around Next.js' navigation APIs


### PR DESCRIPTION
## What/Why?

Override `next-intl`'s default cookie options to ensure that the `NEXT_LOCALE` cookie is set when a Catalyst site is loaded in the Makeswift Builder. See [this document](https://www.notion.so/makeswift/iframe-cookies-1886f737ce30809595a8dd7bffbf79a6) for additional context.

## Testing

### Before

<img width="1697" alt="before, network" src="https://github.com/user-attachments/assets/532cae39-c26d-4c13-ba27-141bbe0f4eb7" />

<img width="1675" alt="before, cookies" src="https://github.com/user-attachments/assets/5d475499-fa1a-4d2c-a6ad-9222a7f30a4e" />

### After

<img width="1674" alt="after, network" src="https://github.com/user-attachments/assets/5f102aae-000f-44f8-b2f8-4429cca8ee68" />

<img width="1671" alt="after, cookies" src="https://github.com/user-attachments/assets/21799b20-1550-4906-82d0-d9a95171fe38" />

