### PR TITLE
fix: configure NextAuth cookies to work inside the builder

### DIFF
--- a/.changeset/dry-dragons-burn.md
+++ b/.changeset/dry-dragons-burn.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+fix: configure NextAuth cookies to work inside of the Makeswift Builder's canvas

--- a/core/auth/index.ts
+++ b/core/auth/index.ts
@@ -144,6 +144,16 @@ async function authorize(credentials: unknown): Promise<User | null> {
   }
 }
 
+const partitionedCookie = (name?: string) =>
+  ({
+    ...(name !== undefined ? { name } : {}),
+    options: {
+      partitioned: true,
+      secure: true,
+      sameSite: 'none',
+    },
+  }) as const;
+
 const config = {
   session: {
     strategy: 'jwt',
@@ -201,6 +211,16 @@ const config = {
       authorize,
     }),
   ],
+  // configure NextAuth cookies to work inside of the Makeswift Builder's canvas
+  cookies: {
+    sessionToken: partitionedCookie(),
+    callbackUrl: partitionedCookie(),
+    csrfToken: partitionedCookie(),
+    pkceCodeVerifier: partitionedCookie(),
+    state: partitionedCookie(),
+    nonce: partitionedCookie(),
+    webauthnChallenge: partitionedCookie(),
+  },
 } satisfies NextAuthConfig;
 
 const { handlers, auth, signIn: nextAuthSignIn, signOut } = NextAuth(config);


### PR DESCRIPTION
## What/Why?

Configure NextAuth cookies to ensure they are set when a Catalyst site is loaded in the Makeswift Builder. See [this document](https://www.notion.so/makeswift/iframe-cookies-1886f737ce30809595a8dd7bffbf79a6) for additional context.

Related: https://github.com/bigcommerce/catalyst/pull/1959

## Testing

### Before

<img width="1700" alt="before, network" src="https://github.com/user-attachments/assets/b2f9b400-9eba-42fa-a284-e07a005eb70e" />

<img width="1674" alt="before, orders" src="https://github.com/user-attachments/assets/926b0ca7-3760-4e0a-8760-acd43a966713" />


### After

<img width="1669" alt="after" src="https://github.com/user-attachments/assets/07b2272a-8c49-45e8-b09e-1647a12cf185" />

