### PR TITLE
Update BIGCOMMERCE_CDN_HOSTNAME to NEXT_PUBLIC_BIGCOMMERCE_CDN_HOSTNAME

### DIFF
--- a/core/components/image/index.tsx
+++ b/core/components/image/index.tsx
@@ -5,7 +5,7 @@ import NextImage, { ImageProps } from 'next/image';
 
 import bcCdnImageLoader from '~/lib/cdn-image-loader';
 
-const cdnHostname = process.env.BIGCOMMERCE_CDN_HOSTNAME ?? 'cdn11.bigcommerce.com';
+const cdnHostname = process.env.NEXT_PUBLIC_BIGCOMMERCE_CDN_HOSTNAME ?? 'cdn11.bigcommerce.com';
 
 function shouldUseLoaderProp(props: ImageProps): boolean {
   return typeof props.src === 'string' && props.src.startsWith(`https://${cdnHostname}`);

--- a/core/lib/store-assets.ts
+++ b/core/lib/store-assets.ts
@@ -1,4 +1,4 @@
-const cdnHostname = process.env.BIGCOMMERCE_CDN_HOSTNAME ?? 'cdn11.bigcommerce.com';
+const cdnHostname = process.env.NEXT_PUBLIC_BIGCOMMERCE_CDN_HOSTNAME ?? 'cdn11.bigcommerce.com';
 const storeHash = process.env.BIGCOMMERCE_STORE_HASH ?? '';
 
 /**

--- a/core/next.config.ts
+++ b/core/next.config.ts
@@ -50,7 +50,7 @@ export default async (): Promise<NextConfig> => {
             },
             {
               key: 'Link',
-              value: `<https://${process.env.BIGCOMMERCE_CDN_HOSTNAME ?? 'cdn11.bigcommerce.com'}>; rel=preconnect`,
+              value: `<https://${process.env.NEXT_PUBLIC_BIGCOMMERCE_CDN_HOSTNAME ?? 'cdn11.bigcommerce.com'}>; rel=preconnect`,
             },
           ],
         },


### PR DESCRIPTION
## What/Why?
This BIGCOMMERCE_CDN_HOSTNAME variable is supposed to indicate the allowlisted hostname for the bigcommerce CDN, in the case of using Catalyst against a non-production environment. However, it was not exposed to the image client component because it was not prefixed with NEXT_PUBLIC_, so this PR renames the env var in order to allow it to work in a client component.

https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables#bundling-environment-variables-for-the-browser

## Testing
Tested locally against a non-production CDN URL