### PR TITLE
feat: improve styling of html product descriptions

### DIFF
--- a/core/app/[locale]/(default)/product/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/page.tsx
@@ -113,7 +113,10 @@ const getProduct = async (props: Props) => {
     id: product.entityId.toString(),
     title: product.name,
     description: (
-      <div className="prose" dangerouslySetInnerHTML={{ __html: product.description }} />
+      <div
+        className="prose space-y-4 [&_h2]:font-heading [&_h2]:text-3xl [&_h2]:font-normal [&_h2]:leading-none [&_h2]:@xl:text-4xl [&_h3]:font-heading [&_h3]:text-2xl [&_h3]:font-normal [&_h3]:leading-none [&_h3]:@xl:text-3xl [&_h4]:font-heading [&_h4]:text-xl [&_h4]:font-normal [&_h4]:leading-none [&_h4]:@xl:text-2xl"
+        dangerouslySetInnerHTML={{ __html: product.description }}
+      />
     ),
     href: product.path,
     images: product.defaultImage


### PR DESCRIPTION
## What/Why?

Updates the product description styles to space out elements and support the same header styling as the web page route.

This helps the content blend into the aesthetic better. The content is smashed together now, which is strange to have as a default!

Note: I could totally see this being inside `vibe` components themselves. If that makes more sense, I'll close this PR and make the changes there.

## Testing

Before:
<img width="1437" alt="Screenshot 2025-02-11 at 11 03 04 AM" src="https://github.com/user-attachments/assets/a48b053c-667d-41bf-acab-28dda2ef6841" />

After:
<img width="1438" alt="Screenshot 2025-02-11 at 11 03 34 AM" src="https://github.com/user-attachments/assets/7ba86375-717a-4a95-a1a4-6010cab85f9e" />
