### PR TITLE
fix: localized home page routes are rewritten to the "catch all" page

### DIFF
--- a/.changeset/new-books-drop.md
+++ b/.changeset/new-books-drop.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+fix: localized home page routes are rewritten to the "catch all" page

--- a/core/middlewares/with-routes.ts
+++ b/core/middlewares/with-routes.ts
@@ -205,6 +205,10 @@ const updateStatusCache = async (
 };
 
 const clearLocaleFromPath = (path: string, locale: string) => {
+  if (path === `/${locale}` || path === `/${locale}/`) {
+    return '/';
+  }
+
   if (path.startsWith(`/${locale}/`)) {
     return path.replace(`/${locale}`, '');
   }


### PR DESCRIPTION
## What/Why?

Fix `withRoutes` middleware to properly rewrite localized home page routes (`/fr`, `/es-MX`, etc.)

## Testing

### Before

https://github.com/user-attachments/assets/e52ab236-5ff1-4ce4-add2-42bc8bc926b0

### After

https://github.com/user-attachments/assets/88b973e1-ec24-41bb-bb19-2e3c6e169936



