### PR TITLE
fix: `NEXT_LOCALE` cookie interferes with the builder's locale switcher

### DIFF
--- a/.changeset/wet-rings-unite.md
+++ b/.changeset/wet-rings-unite.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+fix: support switching of the page's locale in the Makeswift Builder


### PR DESCRIPTION
## What/Why?

Support switching of the page's locale through the Makeswift Builder.

## Testing

### Before

https://github.com/user-attachments/assets/0d03eedb-387a-4e4d-a847-74eeea9b5e7c

### After

https://github.com/user-attachments/assets/8350e8d1-c445-4882-86ce-299318d47ff6



