### PR TITLE
feat: manage locales when creating storefronts from the CLI

### DIFF
--- a/.changeset/short-lies-draw.md
+++ b/.changeset/short-lies-draw.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": minor
+---
+
+Allow configuration of locales when creating a new channel

--- a/packages/create-catalyst/package.json
+++ b/packages/create-catalyst/package.json
@@ -20,8 +20,12 @@
   "dependencies": {
     "@commander-js/extra-typings": "^13.1.0",
     "@iarna/toml": "^2.2.5",
+    "@inquirer/core": "^10.1.6",
+    "@inquirer/figures": "^1.0.10",
     "@inquirer/prompts": "^7.2.3",
+    "@inquirer/type": "^3.0.4",
     "@segment/analytics-node": "^2.2.1",
+    "ansi-escapes": "^7.0.0",
     "chalk": "^5.4.1",
     "commander": "^13.1.0",
     "conf": "^13.1.0",

--- a/packages/create-catalyst/src/commands/create.ts
+++ b/packages/create-catalyst/src/commands/create.ts
@@ -6,10 +6,12 @@ import { pathExistsSync } from 'fs-extra/esm';
 import kebabCase from 'lodash.kebabcase';
 import { join } from 'path';
 
+import { multiSelect } from '../prompts/multi-select';
 import { CliApi } from '../utils/cli-api';
 import { cloneCatalyst } from '../utils/clone-catalyst';
 import { Https } from '../utils/https';
 import { installDependencies } from '../utils/install-dependencies';
+import { getAvailableLocales } from '../utils/localization';
 import { login, storeCredentials } from '../utils/login';
 import { Telemetry } from '../utils/telemetry/telemetry';
 import { writeEnv } from '../utils/write-env';
@@ -55,10 +57,62 @@ function getPlatformCheckCommand(command: string): string {
 
 const telemetry = new Telemetry();
 
-async function handleChannelCreation(cliApi: CliApi) {
+async function handleChannelCreation(bc: Https, cliApi: CliApi) {
   const newChannelName = await input({
     message: 'What would you like to name your new channel?',
   });
+
+  let availableLocales = [];
+
+  try {
+    availableLocales = await getAvailableLocales(bc);
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(chalk.red(error.message));
+    }
+
+    process.exit(1);
+  }
+
+  const storefrontLocale = await select({
+    message: 'Which default language would you like to set for your channel?',
+    default: 'en',
+    choices: availableLocales,
+    theme: {
+      style: {
+        help: () => chalk.dim('(Select locale from the list or start typing the name)'),
+      },
+    },
+  });
+
+  const shouldAddAdditionalLocales = await select({
+    message: 'Would you like to add additional languages?',
+    choices: [
+      { name: 'Yes', value: true },
+      { name: 'No', value: false },
+    ],
+  });
+
+  let additionalLocales: string[] = [];
+
+  if (shouldAddAdditionalLocales) {
+    additionalLocales = await multiSelect({
+      choices: availableLocales.filter(({ value }) => value !== storefrontLocale),
+      message: 'Which additional languages would you like to add to your channel?',
+      theme: {
+        style: {
+          help: () => chalk.dim('(Select locale from the list or start typing the name)'),
+        },
+      },
+      validate: (selections) => {
+        if (selections.length > 4) {
+          return 'You can only select up to 4 additional languages';
+        }
+
+        return true;
+      },
+    });
+  }
 
   const shouldInstallSampleData = await select({
     message: 'Would you like to install sample data?',
@@ -68,7 +122,12 @@ async function handleChannelCreation(cliApi: CliApi) {
     ],
   });
 
-  const response = await cliApi.createChannel(newChannelName, shouldInstallSampleData);
+  const response = await cliApi.createChannel(
+    newChannelName,
+    storefrontLocale,
+    additionalLocales,
+    shouldInstallSampleData,
+  );
 
   if (!response.ok) {
     console.error(
@@ -395,7 +454,7 @@ export const create = new Command('create')
           }
 
           if (shouldCreateChannel) {
-            const channelData = await handleChannelCreation(cliApi);
+            const channelData = await handleChannelCreation(bc, cliApi);
 
             channelId = channelData.channelId;
             storefrontToken = channelData.storefrontToken;

--- a/packages/create-catalyst/src/prompts/multi-select/helpers.ts
+++ b/packages/create-catalyst/src/prompts/multi-select/helpers.ts
@@ -1,0 +1,60 @@
+import { Separator } from '@inquirer/core';
+import figures from '@inquirer/figures';
+import chalk from 'chalk';
+
+import { Choice, Item, NormalizedChoice, SelectTheme } from './types';
+
+export const selectTheme: SelectTheme = {
+  helpMode: 'auto',
+  icon: {
+    checked: chalk.green(figures.circleFilled),
+    unchecked: figures.circle,
+    cursor: figures.pointer,
+  },
+  style: {
+    description: (text: string) => chalk.cyan(text),
+    disabledChoice: (text: string) => chalk.dim(`- ${text}`),
+    renderSelectedChoices: (selectedChoices) =>
+      selectedChoices.map((choice) => choice.short).join(', '),
+  },
+};
+
+export const isSelectable = <Value>(item: Item<Value>): item is NormalizedChoice<Value> =>
+  !Separator.isSeparator(item) && !item.disabled;
+
+export const isChecked = <Value>(item: Item<Value>): item is NormalizedChoice<Value> =>
+  isSelectable(item) && Boolean(item.checked);
+
+export const toggle = <Value>(item: Item<Value>): Item<Value> =>
+  isSelectable(item) ? { ...item, checked: !item.checked } : item;
+
+export const normalizeChoices = <Value>(
+  choices: ReadonlyArray<string | Choice<Value> | Separator>,
+): Array<Item<Value>> =>
+  choices.map((choice) => {
+    if (Separator.isSeparator(choice)) {
+      return choice;
+    }
+
+    if (typeof choice === 'string') {
+      return {
+        checked: false,
+        disabled: false,
+        name: choice,
+        short: choice,
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        value: choice as Value,
+      };
+    }
+
+    const name = choice.name ?? String(choice.value);
+
+    return {
+      checked: choice.checked ?? false,
+      description: choice.description,
+      disabled: choice.disabled ?? false,
+      name,
+      short: choice.short ?? name,
+      value: choice.value,
+    };
+  });

--- a/packages/create-catalyst/src/prompts/multi-select/index.ts
+++ b/packages/create-catalyst/src/prompts/multi-select/index.ts
@@ -1,0 +1,1 @@
+export * from './multi-select';

--- a/packages/create-catalyst/src/prompts/multi-select/multi-select.ts
+++ b/packages/create-catalyst/src/prompts/multi-select/multi-select.ts
@@ -1,0 +1,218 @@
+import {
+  createPrompt,
+  isBackspaceKey,
+  isDownKey,
+  isEnterKey,
+  isNumberKey,
+  isSpaceKey,
+  isUpKey,
+  makeTheme,
+  Separator,
+  type Status,
+  useEffect,
+  useKeypress,
+  useMemo,
+  usePagination,
+  usePrefix,
+  useRef,
+  useState,
+  ValidationError,
+} from '@inquirer/core';
+import ansiEscapes from 'ansi-escapes';
+
+import { isChecked, isSelectable, normalizeChoices, selectTheme, toggle } from './helpers';
+import { Item, MultiSelectConfig, SelectTheme } from './types';
+
+export const multiSelect = createPrompt(
+  <Value>(config: MultiSelectConfig<Value>, done: (value: Value[]) => void) => {
+    const theme = makeTheme<SelectTheme>(selectTheme, config.theme);
+    const searchTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+    const firstRender = useRef(true);
+    const [items, setItems] = useState<ReadonlyArray<Item<Value>>>(
+      normalizeChoices(config.choices),
+    );
+    const [status, setStatus] = useState<Status>('idle');
+    const [errorMsg, setError] = useState<string>();
+    const prefix = usePrefix({ status, theme });
+    const { instructions, loop = true, pageSize = 7, required, validate = () => true } = config;
+
+    const bounds = useMemo(() => {
+      const first = items.findIndex(isSelectable);
+      const last = items.findLastIndex(isSelectable);
+
+      if (first === -1) {
+        throw new ValidationError(
+          '[multi select prompt] No selectable choices. All choices are disabled.',
+        );
+      }
+
+      return { first, last };
+    }, [items]);
+
+    const [showHelpTip, setShowHelpTip] = useState(true);
+    const [active, setActive] = useState(bounds.first);
+
+    useEffect(
+      () => () => {
+        clearTimeout(searchTimeoutRef.current);
+      },
+      [],
+    );
+
+    // eslint-disable-next-line complexity
+    useKeypress(async (key, rl) => {
+      clearTimeout(searchTimeoutRef.current);
+
+      if (isEnterKey(key)) {
+        const selection = items.filter(isChecked);
+        const isValid = await validate([...selection]);
+
+        if (required && !items.some(isChecked)) {
+          setError('At least one choice must be selected');
+        } else if (isValid === true) {
+          setStatus('done');
+          done(selection.map((choice) => choice.value));
+        } else {
+          setError(isValid || 'You must select a valid value');
+        }
+      } else if (isUpKey(key) || isDownKey(key)) {
+        rl.clearLine(0);
+
+        if (
+          loop ||
+          (isUpKey(key) && active !== bounds.first) ||
+          (isDownKey(key) && active !== bounds.last)
+        ) {
+          const offset = isUpKey(key) ? -1 : 1;
+          let next = active;
+
+          do {
+            next = (next + offset + items.length) % items.length;
+          } while (!isSelectable(items[next]));
+
+          setActive(next);
+        }
+      } else if (isNumberKey(key)) {
+        rl.clearLine(0);
+
+        const position = Number(key.name) - 1;
+
+        if (isSelectable(items[position])) {
+          setActive(position);
+        }
+      } else if (isBackspaceKey(key)) {
+        rl.clearLine(0);
+      } else if (isSpaceKey(key)) {
+        rl.clearLine(0);
+        setShowHelpTip(false);
+
+        const nextItems = items.map((choice, i) => (i === active ? toggle(choice) : choice));
+        const selection = nextItems.filter(isChecked);
+        const isValid = await validate([...selection]);
+
+        if (isValid === true) {
+          setError(undefined);
+          setItems(nextItems);
+        } else {
+          setError(isValid || 'You must select a valid value');
+        }
+      } else {
+        // Default to search
+        const searchTerm = rl.line.toLowerCase();
+        const matchIndex = items.findIndex((item) =>
+          Separator.isSeparator(item) || !isSelectable(item)
+            ? false
+            : item.name.toLowerCase().startsWith(searchTerm),
+        );
+
+        if (matchIndex !== -1) {
+          setActive(matchIndex);
+        }
+
+        searchTimeoutRef.current = setTimeout(() => {
+          rl.clearLine(0);
+        }, 700);
+      }
+    });
+
+    const message = theme.style.message(config.message, status);
+
+    let helpTipTop = '';
+    let helpTipBottom = '';
+    let description: string | undefined;
+
+    if (
+      theme.helpMode === 'always' ||
+      (theme.helpMode === 'auto' && showHelpTip && (instructions === undefined || instructions))
+    ) {
+      if (typeof instructions === 'string') {
+        helpTipTop = instructions;
+      } else {
+        const keys = [
+          `${theme.style.key('space')} to select`,
+          `${theme.style.key('enter')} to proceed`,
+        ];
+
+        helpTipTop = ` (Press ${keys.filter((key) => key !== '').join(', ')})`;
+      }
+
+      if (
+        items.length > pageSize &&
+        (theme.helpMode === 'always' ||
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+          (theme.helpMode === 'auto' && firstRender.current))
+      ) {
+        helpTipBottom = `\n${theme.style.help('(Use arrow keys to reveal more choices)')}`;
+        firstRender.current = false;
+      }
+    }
+
+    const page = usePagination({
+      items,
+      active,
+      renderItem({ item, isActive }) {
+        if (Separator.isSeparator(item)) {
+          return ` ${item.separator}`;
+        }
+
+        if (item.disabled) {
+          return theme.style.disabledChoice(
+            `${item.name} ${typeof item.disabled === 'string' ? item.disabled : '(disabled)'}`,
+          );
+        }
+
+        if (isActive) {
+          description = item.description;
+        }
+
+        const checkbox = item.checked ? theme.icon.checked : theme.icon.unchecked;
+        const color = isActive ? theme.style.highlight : (x: string) => x;
+        const cursor = isActive ? theme.icon.cursor : ` `;
+
+        return color(`${cursor}${checkbox} ${item.name}`);
+      },
+      pageSize,
+      loop,
+    });
+
+    if (status === 'done') {
+      return `${prefix} ${message} ${theme.style.answer(theme.style.renderSelectedChoices(items.filter(isChecked), items))}`;
+    }
+
+    const selectedChoices =
+      items.filter(isChecked).length > 0
+        ? ` (${theme.style.answer(theme.style.renderSelectedChoices(items.filter(isChecked), items))})`
+        : '';
+    const choiceDescription = description ? `\n${theme.style.description(description)}` : ``;
+
+    let error = '';
+
+    if (errorMsg) {
+      error = `\n${theme.style.error(errorMsg)}`;
+    }
+
+    return `${prefix} ${message}${selectedChoices}${helpTipTop}\n${page}${helpTipBottom}${choiceDescription}${error}${ansiEscapes.cursorHide}`;
+  },
+);
+
+export { Separator } from '@inquirer/core';

--- a/packages/create-catalyst/src/prompts/multi-select/types.ts
+++ b/packages/create-catalyst/src/prompts/multi-select/types.ts
@@ -1,0 +1,59 @@
+import { Separator, type Theme } from '@inquirer/core';
+import type { PartialDeep } from '@inquirer/type';
+
+export interface SelectTheme {
+  helpMode: 'always' | 'never' | 'auto';
+  icon: {
+    checked: string;
+    unchecked: string;
+    cursor: string;
+  };
+  style: {
+    description: (text: string) => string;
+    disabledChoice: (text: string) => string;
+    renderSelectedChoices: <T>(
+      selectedChoices: ReadonlyArray<NormalizedChoice<T>>,
+      allChoices: ReadonlyArray<NormalizedChoice<T> | Separator>,
+    ) => string;
+  };
+}
+
+export interface Choice<Value> {
+  checked?: boolean;
+  description?: string;
+  disabled?: boolean | string;
+  name?: string;
+  short?: string;
+  type?: never;
+  value: Value;
+}
+
+export interface NormalizedChoice<Value> {
+  checked: boolean;
+  description?: string;
+  disabled: boolean | string;
+  name: string;
+  short: string;
+  value: Value;
+}
+
+export interface MultiSelectConfig<
+  Value,
+  ChoicesObject = ReadonlyArray<string | Separator> | ReadonlyArray<Choice<Value> | Separator>,
+> {
+  choices: ChoicesObject extends ReadonlyArray<string | Separator>
+    ? ChoicesObject
+    : ReadonlyArray<Choice<Value> | Separator>;
+  default?: unknown;
+  instructions?: string | boolean;
+  loop?: boolean;
+  message: string;
+  pageSize?: number;
+  required?: boolean;
+  theme?: PartialDeep<Theme<SelectTheme>>;
+  validate?: (
+    choices: ReadonlyArray<Choice<Value>>,
+  ) => boolean | string | Promise<string | boolean>;
+}
+
+export type Item<Value> = NormalizedChoice<Value> | Separator;

--- a/packages/create-catalyst/src/utils/cli-api.ts
+++ b/packages/create-catalyst/src/utils/cli-api.ts
@@ -28,7 +28,12 @@ export class CliApi {
     });
   }
 
-  async createChannel(name: string, installSampleData = false) {
+  async createChannel(
+    name: string,
+    storefrontLocale: string,
+    additionalLocales: string[],
+    installSampleData = false,
+  ) {
     return this.client.fetch('/channels/catalyst', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -39,6 +44,8 @@ export class CliApi {
         },
         deployStorefront: true,
         devOrigin: 'http://localhost:3000',
+        storefrontLanguage: storefrontLocale,
+        additionalLocales,
       }),
     });
   }

--- a/packages/create-catalyst/src/utils/localization.ts
+++ b/packages/create-catalyst/src/utils/localization.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+
+import { Https } from './https';
+
+const allowedLocales = [
+  'en',
+  'da',
+  'es-AR',
+  'es-CL',
+  'es-CO',
+  'es-MX',
+  'es-PE',
+  'es',
+  'it',
+  'nl',
+  'pl',
+  'pt',
+  'de',
+  'fr',
+  'ja',
+  'no',
+  'pt-BR',
+  'sv',
+];
+
+const AvailableLocalesSuccessSchema = z.object({
+  data: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+      fallback: z.string().nullable(),
+      is_supported: z.boolean(),
+    }),
+  ),
+});
+
+export const getAvailableLocales = async (bc: Https) => {
+  const response = await bc.fetch('/v3/settings/store/available-locales');
+
+  if (!response.ok) {
+    throw new Error(
+      `GET /v3/settings/store/available-locales failed: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  return AvailableLocalesSuccessSchema.parse(await response.json())
+    .data.filter(({ id }) => allowedLocales.includes(id))
+    .map(({ name, id }) => ({ name: `${name} (${id})`, value: id }));
+};

--- a/packages/create-catalyst/tsconfig.json
+++ b/packages/create-catalyst/tsconfig.json
@@ -3,6 +3,7 @@
   "display": "Node",
   "compilerOptions": {
     "strict": true,
+    "lib": ["esnext"],
     "target": "es6",
     "module": "esnext",
     "moduleResolution": "bundler",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,7 +291,7 @@ importers:
     devDependencies:
       '@bigcommerce/eslint-config':
         specifier: ^2.10.0
-        version: 2.10.0(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0(@types/node@20.17.16))(typescript@5.7.3)
+        version: 2.10.0(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0)(typescript@5.7.3)
       '@bigcommerce/eslint-config-catalyst':
         specifier: workspace:^
         version: link:../eslint-config-catalyst
@@ -322,12 +322,24 @@ importers:
       '@iarna/toml':
         specifier: ^2.2.5
         version: 2.2.5
+      '@inquirer/core':
+        specifier: ^10.1.6
+        version: 10.1.7(@types/node@20.17.16)
+      '@inquirer/figures':
+        specifier: ^1.0.10
+        version: 1.0.10
       '@inquirer/prompts':
         specifier: ^7.2.3
         version: 7.2.3(@types/node@20.17.16)
+      '@inquirer/type':
+        specifier: ^3.0.4
+        version: 3.0.4(@types/node@20.17.16)
       '@segment/analytics-node':
         specifier: ^2.2.1
         version: 2.2.1(encoding@0.1.13)
+      ansi-escapes:
+        specifier: ^7.0.0
+        version: 7.0.0
       chalk:
         specifier: ^5.4.1
         version: 5.4.1
@@ -376,7 +388,7 @@ importers:
     devDependencies:
       '@bigcommerce/eslint-config':
         specifier: ^2.10.0
-        version: 2.10.0(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0(@types/node@20.17.16))(typescript@5.7.3)
+        version: 2.10.0(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0)(typescript@5.7.3)
       '@bigcommerce/eslint-config-catalyst':
         specifier: workspace:^
         version: link:../eslint-config-catalyst
@@ -430,7 +442,7 @@ importers:
     dependencies:
       '@bigcommerce/eslint-config':
         specifier: ^2.10.0
-        version: 2.10.0(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0(@types/node@20.17.16))(typescript@5.7.3)
+        version: 2.10.0(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0)(typescript@5.7.3)
       '@next/eslint-plugin-next':
         specifier: ^15.1.6
         version: 15.1.6
@@ -1138,9 +1150,14 @@ packages:
     peerDependencies:
       '@types/node': '>=18'
 
-  '@inquirer/core@10.1.4':
-    resolution: {integrity: sha512-5y4/PUJVnRb4bwWY67KLdebWOhOc7xj5IP2J80oWXa64mVag24rwQ1VAdnj7/eDY/odhguW0zQ1Mp1pj6fO/2w==}
+  '@inquirer/core@10.1.7':
+    resolution: {integrity: sha512-AA9CQhlrt6ZgiSy6qoAigiA1izOa751ugX6ioSjqgJ+/Gd+tEN/TORk5sUYNjXuHWfW0r1n/a6ak4u/NqHHrtA==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   '@inquirer/editor@4.2.3':
     resolution: {integrity: sha512-S9KnIOJuTZpb9upeRSBBhoDZv7aSV3pG9TECrBj0f+ZsFwccz886hzKBrChGrXMJwd4NKY+pOA9Vy72uqnd6Eg==}
@@ -1154,8 +1171,8 @@ packages:
     peerDependencies:
       '@types/node': '>=18'
 
-  '@inquirer/figures@1.0.9':
-    resolution: {integrity: sha512-BXvGj0ehzrngHTPTDqUoDT3NXL8U0RxUk2zJm2A66RhCEIWdtU1v6GuUqNAgArW4PQ9CinqIWyHdQgdwOj06zQ==}
+  '@inquirer/figures@1.0.10':
+    resolution: {integrity: sha512-Ey6176gZmeqZuY/W/nZiUyvmb1/qInjcpiZjXWi6nON+nxJpD1bxtSoBxNliGISae32n6OwbY+TSXPZ1CfS4bw==}
     engines: {node: '>=18'}
 
   '@inquirer/input@4.1.3':
@@ -1200,11 +1217,14 @@ packages:
     peerDependencies:
       '@types/node': '>=18'
 
-  '@inquirer/type@3.0.2':
-    resolution: {integrity: sha512-ZhQ4TvhwHZF+lGhQ2O/rsjo80XoZR5/5qhOY3t6FJuX5XBg5Be8YzYTvaUGJnc12AUGI2nr4QSUE4PhKSigx7g==}
+  '@inquirer/type@3.0.4':
+    resolution: {integrity: sha512-2MNFrDY8jkFYc9Il9DgLsHhMzuHnOYM1+CUYVWbzu9oT0hC7V7EcYvdCKeoll/Fcci04A+ERZ9wcc7cQ8lTkIA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -2358,6 +2378,10 @@ packages:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
 
+  ansi-escapes@7.0.0:
+    resolution: {integrity: sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==}
+    engines: {node: '>=18'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -2960,6 +2984,10 @@ packages:
   env-paths@3.0.0:
     resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
 
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
@@ -5799,7 +5827,7 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@bigcommerce/eslint-config@2.10.0(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0(@types/node@20.17.16))(typescript@5.7.3)':
+  '@bigcommerce/eslint-config@2.10.0(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0)(typescript@5.7.3)':
     dependencies:
       '@bigcommerce/eslint-plugin': 1.3.1(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)
       '@rushstack/eslint-patch': 1.10.5
@@ -5811,7 +5839,7 @@ snapshots:
       eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1)
       eslint-plugin-gettext: 1.2.0
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
-      eslint-plugin-jest: 28.8.3(@typescript-eslint/eslint-plugin@8.21.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(jest@29.7.0(@types/node@20.17.16))(typescript@5.7.3)
+      eslint-plugin-jest: 28.8.3(@typescript-eslint/eslint-plugin@8.21.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(jest@29.7.0)(typescript@5.7.3)
       eslint-plugin-jest-dom: 5.5.0(eslint@8.57.1)
       eslint-plugin-jest-formatting: 3.1.0(eslint@8.57.1)
       eslint-plugin-jsdoc: 50.2.2(eslint@8.57.1)
@@ -6290,65 +6318,64 @@ snapshots:
 
   '@inquirer/checkbox@4.0.6(@types/node@20.17.16)':
     dependencies:
-      '@inquirer/core': 10.1.4(@types/node@20.17.16)
-      '@inquirer/figures': 1.0.9
-      '@inquirer/type': 3.0.2(@types/node@20.17.16)
+      '@inquirer/core': 10.1.7(@types/node@20.17.16)
+      '@inquirer/figures': 1.0.10
+      '@inquirer/type': 3.0.4(@types/node@20.17.16)
       '@types/node': 20.17.16
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
 
   '@inquirer/confirm@5.1.3(@types/node@20.17.16)':
     dependencies:
-      '@inquirer/core': 10.1.4(@types/node@20.17.16)
-      '@inquirer/type': 3.0.2(@types/node@20.17.16)
+      '@inquirer/core': 10.1.7(@types/node@20.17.16)
+      '@inquirer/type': 3.0.4(@types/node@20.17.16)
       '@types/node': 20.17.16
 
-  '@inquirer/core@10.1.4(@types/node@20.17.16)':
+  '@inquirer/core@10.1.7(@types/node@20.17.16)':
     dependencies:
-      '@inquirer/figures': 1.0.9
-      '@inquirer/type': 3.0.2(@types/node@20.17.16)
+      '@inquirer/figures': 1.0.10
+      '@inquirer/type': 3.0.4(@types/node@20.17.16)
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
-      strip-ansi: 6.0.1
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.2
-    transitivePeerDependencies:
-      - '@types/node'
+    optionalDependencies:
+      '@types/node': 20.17.16
 
   '@inquirer/editor@4.2.3(@types/node@20.17.16)':
     dependencies:
-      '@inquirer/core': 10.1.4(@types/node@20.17.16)
-      '@inquirer/type': 3.0.2(@types/node@20.17.16)
+      '@inquirer/core': 10.1.7(@types/node@20.17.16)
+      '@inquirer/type': 3.0.4(@types/node@20.17.16)
       '@types/node': 20.17.16
       external-editor: 3.1.0
 
   '@inquirer/expand@4.0.6(@types/node@20.17.16)':
     dependencies:
-      '@inquirer/core': 10.1.4(@types/node@20.17.16)
-      '@inquirer/type': 3.0.2(@types/node@20.17.16)
+      '@inquirer/core': 10.1.7(@types/node@20.17.16)
+      '@inquirer/type': 3.0.4(@types/node@20.17.16)
       '@types/node': 20.17.16
       yoctocolors-cjs: 2.1.2
 
-  '@inquirer/figures@1.0.9': {}
+  '@inquirer/figures@1.0.10': {}
 
   '@inquirer/input@4.1.3(@types/node@20.17.16)':
     dependencies:
-      '@inquirer/core': 10.1.4(@types/node@20.17.16)
-      '@inquirer/type': 3.0.2(@types/node@20.17.16)
+      '@inquirer/core': 10.1.7(@types/node@20.17.16)
+      '@inquirer/type': 3.0.4(@types/node@20.17.16)
       '@types/node': 20.17.16
 
   '@inquirer/number@3.0.6(@types/node@20.17.16)':
     dependencies:
-      '@inquirer/core': 10.1.4(@types/node@20.17.16)
-      '@inquirer/type': 3.0.2(@types/node@20.17.16)
+      '@inquirer/core': 10.1.7(@types/node@20.17.16)
+      '@inquirer/type': 3.0.4(@types/node@20.17.16)
       '@types/node': 20.17.16
 
   '@inquirer/password@4.0.6(@types/node@20.17.16)':
     dependencies:
-      '@inquirer/core': 10.1.4(@types/node@20.17.16)
-      '@inquirer/type': 3.0.2(@types/node@20.17.16)
+      '@inquirer/core': 10.1.7(@types/node@20.17.16)
+      '@inquirer/type': 3.0.4(@types/node@20.17.16)
       '@types/node': 20.17.16
       ansi-escapes: 4.3.2
 
@@ -6368,30 +6395,30 @@ snapshots:
 
   '@inquirer/rawlist@4.0.6(@types/node@20.17.16)':
     dependencies:
-      '@inquirer/core': 10.1.4(@types/node@20.17.16)
-      '@inquirer/type': 3.0.2(@types/node@20.17.16)
+      '@inquirer/core': 10.1.7(@types/node@20.17.16)
+      '@inquirer/type': 3.0.4(@types/node@20.17.16)
       '@types/node': 20.17.16
       yoctocolors-cjs: 2.1.2
 
   '@inquirer/search@3.0.6(@types/node@20.17.16)':
     dependencies:
-      '@inquirer/core': 10.1.4(@types/node@20.17.16)
-      '@inquirer/figures': 1.0.9
-      '@inquirer/type': 3.0.2(@types/node@20.17.16)
+      '@inquirer/core': 10.1.7(@types/node@20.17.16)
+      '@inquirer/figures': 1.0.10
+      '@inquirer/type': 3.0.4(@types/node@20.17.16)
       '@types/node': 20.17.16
       yoctocolors-cjs: 2.1.2
 
   '@inquirer/select@4.0.6(@types/node@20.17.16)':
     dependencies:
-      '@inquirer/core': 10.1.4(@types/node@20.17.16)
-      '@inquirer/figures': 1.0.9
-      '@inquirer/type': 3.0.2(@types/node@20.17.16)
+      '@inquirer/core': 10.1.7(@types/node@20.17.16)
+      '@inquirer/figures': 1.0.10
+      '@inquirer/type': 3.0.4(@types/node@20.17.16)
       '@types/node': 20.17.16
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
 
-  '@inquirer/type@3.0.2(@types/node@20.17.16)':
-    dependencies:
+  '@inquirer/type@3.0.4(@types/node@20.17.16)':
+    optionalDependencies:
       '@types/node': 20.17.16
 
   '@isaacs/cliui@8.0.2':
@@ -7625,6 +7652,10 @@ snapshots:
     dependencies:
       type-fest: 0.21.3
 
+  ansi-escapes@7.0.0:
+    dependencies:
+      environment: 1.1.0
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.1.0: {}
@@ -8216,6 +8247,8 @@ snapshots:
 
   env-paths@3.0.0: {}
 
+  environment@1.1.0: {}
+
   error-ex@1.3.2:
     dependencies:
       is-arrayish: 0.2.1
@@ -8468,7 +8501,7 @@ snapshots:
     dependencies:
       eslint: 8.57.1
 
-  eslint-plugin-jest@28.8.3(@typescript-eslint/eslint-plugin@8.21.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(jest@29.7.0(@types/node@20.17.16))(typescript@5.7.3):
+  eslint-plugin-jest@28.8.3(@typescript-eslint/eslint-plugin@8.21.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(jest@29.7.0)(typescript@5.7.3):
     dependencies:
       '@typescript-eslint/utils': 8.21.0(eslint@8.57.1)(typescript@5.7.3)
       eslint: 8.57.1


### PR DESCRIPTION
## What/Why?
Manage locales via CLI when creating a channel.

To rich a goal I created multi-select solution to select additional locales.

### About the Multi-Select Solution.
To enable the selection of multiple locales, a custom multi-select component is required with the following features:

- **Multiple Selection**: Users must be able to select more than one locale.
- **Search Functionality**: Due to the extensive list of available locales, a search feature is essential for efficient navigation and selection.
- **Selection Limit**: A maximum of five locales per channel is permitted. The component should enforce this limit and provide clear feedback to the user when they attempt to exceed it.
- **Informative Tooltips**: Helpful tooltips should be displayed to guide users and provide additional context about each locale.

No one of existing libraries fully met all requirements. While the `@inquirer/prompts` library offers similar `checkbox` functionality, it lacks the necessary search capability. Therefore, I developed a custom solution, combining the `select` and` checkbox` behaviors of `@inquirer/prompts` to meet these specific needs.

## Testing
Run channel creating 