### PR TITLE
fix: store the cart id in a signed JWT

### DIFF
--- a/.changeset/metal-tools-flash.md
+++ b/.changeset/metal-tools-flash.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Cart ID is now written to a signed JWT to improve security around reading cart IDs. Provides backwards compatibility to reading unsigned cart cookie but signs the value for the next read.

--- a/core/lib/cart.ts
+++ b/core/lib/cart.ts
@@ -1,18 +1,52 @@
 'use server';
 
+import { JWTPayload, jwtVerify, SignJWT } from 'jose';
+import { JWEInvalid, JWSInvalid, JWTInvalid } from 'jose/errors';
 import { cookies } from 'next/headers';
+
+interface CartJwt extends JWTPayload {
+  cartId: string;
+}
 
 export async function getCartId(): Promise<string | undefined> {
   const cookieStore = await cookies();
-  const cartId = cookieStore.get('cartId')?.value;
+  const cartIdJwt = cookieStore.get('cartId')?.value;
 
-  return cartId;
+  if (!cartIdJwt) {
+    return;
+  }
+
+  try {
+    const secretKey = new TextEncoder().encode(process.env.AUTH_SECRET);
+    const verifiedJwt = await jwtVerify<CartJwt>(cartIdJwt, secretKey, {
+      algorithms: ['HS256'],
+      typ: 'JWT',
+    });
+
+    return verifiedJwt.payload.cartId;
+  } catch (error) {
+    // Backwards compatibility with the old cartId cookie:
+    // If the JWT is invalid, set the cart cookie to a signed JWT
+    // and use the old unencoded cartId value for just the next read.
+    if (error instanceof JWSInvalid || error instanceof JWTInvalid || error instanceof JWEInvalid) {
+      await setCartId(cartIdJwt);
+
+      return cartIdJwt;
+    }
+
+    throw error;
+  }
 }
 
 export async function setCartId(cartId: string): Promise<void> {
   const cookieStore = await cookies();
+  const secretKey = new TextEncoder().encode(process.env.AUTH_SECRET);
 
-  cookieStore.set('cartId', cartId, {
+  const cartJwt = await new SignJWT({ cartId })
+    .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
+    .sign(secretKey);
+
+  cookieStore.set('cartId', cartJwt, {
     httpOnly: true,
     secure: process.env.NODE_ENV === 'production',
     sameSite: 'lax',


### PR DESCRIPTION
## What/Why?
Stores the cart id in a signed JWT that Catalyst can verify before reading. This improves the security implications around hijacking another customers session. This also provides backwards compatibility to reading the old cart id value on the first read, but resets the cart id value to the new signed JWT value so future consumption is now verified.

## Testing

### Signed JWT value:
![Screenshot 2025-02-21 at 10 18 13](https://github.com/user-attachments/assets/6a2e5d8c-f7ac-4864-8ec7-2199df62f5da)

### Decoded JWT value:
![Screenshot 2025-02-21 at 10 18 28](https://github.com/user-attachments/assets/5f0cbcb4-0324-4dce-a661-c48332cfb6c1)

### Verified JWT is read and cart information populates:
![Screenshot 2025-02-21 at 10 23 03](https://github.com/user-attachments/assets/551a464c-6894-42b7-9732-55b065ff9310)

ping @bigcommerce/security 