### PR TITLE
chore: add demo section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ By choosing Catalyst, you'll have a fully-functional storefront within a few sec
 up APIs or building SEO, Accessibility, and Performance-optimized ecommerce components you've probably written many
 times before. You can instead go straight to work building your brand and making this your own.
 
+## Demo
+
+- [Catalyst Demo](https://catalyst-demo.site)
+
 ![-----------------------------------------------------](https://storage.googleapis.com/bigcommerce-developers/images/catalyst_readme_hr.png)
 
 <p align="center">


### PR DESCRIPTION
## What/Why?
Moving the demo links into the README as we changed the entrypoint link in Github.

## Testing
Documentation changes.