### PR TITLE
fix(core): handle registration errors in form

### DIFF
--- a/core/app/[locale]/(default)/(auth)/login/forgot-password/_actions/reset-password.ts
+++ b/core/app/[locale]/(default)/(auth)/login/forgot-password/_actions/reset-password.ts
@@ -56,15 +56,15 @@ export const resetPassword = async (
 
     const result = response.data.customer.requestResetPassword;
 
-    if (result.errors.length === 0) {
+    if (result.errors.length > 0) {
       return {
-        lastResult: submission.reply(),
-        successMessage: t('Form.confirmResetPassword', { email: submission.value.email }),
+        lastResult: submission.reply({ formErrors: result.errors.map((error) => error.message) }),
       };
     }
 
     return {
-      lastResult: submission.reply({ formErrors: result.errors.map((error) => error.message) }),
+      lastResult: submission.reply(),
+      successMessage: t('Form.confirmResetPassword', { email: submission.value.email }),
     };
   } catch (error) {
     // eslint-disable-next-line no-console

--- a/core/app/[locale]/(default)/(auth)/register/_actions/register-customer.ts
+++ b/core/app/[locale]/(default)/(auth)/register/_actions/register-customer.ts
@@ -208,9 +208,13 @@ export async function registerCustomer<F extends Field>(
       fetchOptions: { cache: 'no-store' },
     });
 
-    if (response.errors != null && response.errors.length > 0) {
+    const result = response.data.customer.registerCustomer;
+
+    if (result.errors.length > 0) {
       return {
-        lastResult: submission.reply({ formErrors: response.errors.map((error) => error.message) }),
+        lastResult: submission.reply({
+          formErrors: response.data.customer.registerCustomer.errors.map((error) => error.message),
+        }),
         fields: prevState.fields,
       };
     }


### PR DESCRIPTION
## What/Why?
We were incorrectly looking for registration errors in the wrong object of the response. With this change, we actually show a correct error response and short-circuit the login flow.

## Testing
Error messages display from response correctly.