### PR TITLE
feat: add es-419 to list of allowed locale for selecting in CLI

### DIFF
--- a/.changeset/gentle-seals-sing.md
+++ b/.changeset/gentle-seals-sing.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": patch
+---
+
+Add es-419 to list of allowed locale for selecting in CLI

--- a/packages/create-catalyst/src/utils/localization.ts
+++ b/packages/create-catalyst/src/utils/localization.ts
@@ -10,6 +10,7 @@ const allowedLocales = [
   'es-CO',
   'es-MX',
   'es-PE',
+  'es-419',
   'es',
   'it',
   'nl',


### PR DESCRIPTION
## What/Why?
Add es-419 to list of allowed locale for selecting in CLI

## Testing
<img width="515" alt="Screenshot 2025-03-07 at 18 53 53" src="https://github.com/user-attachments/assets/ed1db210-e911-4119-b550-7b00c8650ae9" />
<img width="896" alt="Screenshot 2025-03-07 at 18 54 08" src="https://github.com/user-attachments/assets/6567b60d-8be9-4ee7-916c-f0a819d3615e" />
