### PR TITLE
fix(core): show coupon discounts as a separate summary item

### DIFF
--- a/.changeset/shiny-insects-swim.md
+++ b/.changeset/shiny-insects-swim.md
@@ -2,4 +2,4 @@
 "@bigcommerce/catalyst-core": patch
 ---
 
-Split coupon discounts and regular discounts from summary items, use totla `cart.discountedAmount` for discounts.
+Split coupon discounts and regular discounts from summary items, use total `cart.discountedAmount` for discounts.

--- a/.changeset/shiny-insects-swim.md
+++ b/.changeset/shiny-insects-swim.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Split coupon discounts and regular discounts from summary items, use totla `cart.discountedAmount` for discounts.

--- a/core/app/[locale]/(default)/cart/page-data.ts
+++ b/core/app/[locale]/(default)/cart/page-data.ts
@@ -136,10 +136,8 @@ const CartPageQuery = graphql(
           entityId
           version
           currencyCode
-          discounts {
-            discountedAmount {
-              ...MoneyFieldsFragment
-            }
+          discountedAmount {
+            ...MoneyFieldsFragment
           }
           lineItems {
             physicalItems {
@@ -167,6 +165,9 @@ const CartPageQuery = graphql(
           }
           coupons {
             code
+            discountedAmount {
+              ...MoneyFieldsFragment
+            }
           }
         }
       }

--- a/core/app/[locale]/(default)/cart/page.tsx
+++ b/core/app/[locale]/(default)/cart/page.tsx
@@ -88,13 +88,8 @@ export default async function Cart() {
     variantEntityId: item.variantEntityId,
   }));
 
-  const discounts = cart.discounts.map((discount) => ({
-    value: `-${format.number(discount.discountedAmount.value, {
-      style: 'currency',
-      currency: cart.currencyCode,
-    })}`,
-    label: t('CheckoutSummary.discounts'),
-  }));
+  const totalCouponDiscount =
+    checkout?.coupons.reduce((sum, coupon) => sum + coupon.discountedAmount.value, 0) ?? 0;
 
   return (
     <>
@@ -114,7 +109,24 @@ export default async function Cart() {
                 currency: cart.currencyCode,
               }),
             },
-            ...discounts,
+            cart.discountedAmount.value > 0
+              ? {
+                  label: t('CheckoutSummary.discounts'),
+                  value: `-${format.number(cart.discountedAmount.value, {
+                    style: 'currency',
+                    currency: cart.currencyCode,
+                  })}`,
+                }
+              : null,
+            totalCouponDiscount > 0
+              ? {
+                  label: t('CheckoutSummary.coupon'),
+                  value: `-${format.number(totalCouponDiscount, {
+                    style: 'currency',
+                    currency: cart.currencyCode,
+                  })}`,
+                }
+              : null,
             checkout?.taxTotal && {
               label: t('CheckoutSummary.tax'),
               value: format.number(checkout.taxTotal.value, {


### PR DESCRIPTION
## What/Why?
The `cart.discounts` array can return N number of discounts (one for each item, for example). This is not very useful and it is better to show the total sum, however this total sum does not account for coupon discounts. Use `cart.discountedAmount` and sum `checkout.coupons` to show as a separate summary item. Hide these summary items if they are 0.

![Screenshot 2025-03-14 at 9 54 52 AM](https://github.com/user-attachments/assets/ed691cc7-b0c2-496f-b830-8de262ee1b86)

## Testing
Discounts show accordingly on the right summary item.