### PR TITLE
refactor: update signin behavior to use different providers

### DIFF
--- a/.changeset/cold-poets-refuse.md
+++ b/.changeset/cold-poets-refuse.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Refactors the sign in functionality to use two separate providers instead of one. This is some work needed to be done in order to provide a better API for session syncing so it shouldn't effect any existing functionality.

--- a/core/app/[locale]/(default)/(auth)/login/_actions/login.ts
+++ b/core/app/[locale]/(default)/(auth)/login/_actions/login.ts
@@ -21,18 +21,14 @@ export const login = async (_lastResult: SubmissionResult | null, formData: Form
   }
 
   try {
-    await signIn(
-      {
-        type: 'password',
-        email: submission.value.email,
-        password: submission.value.password,
-      },
-      {
-        // We want to use next/navigation for the redirect as it
-        // follows basePath and trailing slash configurations.
-        redirect: false,
-      },
-    );
+    await signIn('password', {
+      email: submission.value.email,
+      password: submission.value.password,
+
+      // We want to use next/navigation for the redirect as it
+      // follows basePath and trailing slash configurations.
+      redirect: false,
+    });
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error(error);

--- a/core/app/[locale]/(default)/(auth)/register/_actions/register-customer.ts
+++ b/core/app/[locale]/(default)/(auth)/register/_actions/register-customer.ts
@@ -219,18 +219,14 @@ export async function registerCustomer<F extends Field>(
       };
     }
 
-    await signIn(
-      {
-        type: 'password',
-        email: input.email,
-        password: input.password,
-      },
-      {
-        // We want to use next/navigation for the redirect as it
-        // follows basePath and trailing slash configurations.
-        redirect: false,
-      },
-    );
+    await signIn('password', {
+      email: input.email,
+      password: input.password,
+
+      // We want to use next/navigation for the redirect as it
+      // follows basePath and trailing slash configurations.
+      redirect: false,
+    });
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error(error);

--- a/core/app/login/token/[token]/route.ts
+++ b/core/app/login/token/[token]/route.ts
@@ -27,7 +27,7 @@ export async function GET(request: Request, { params }: TokenParams) {
 
     // sign in with token which will check validity against BigCommerce API
     // and redirect to redirectTo
-    await signIn({ type: 'jwt', jwt: token }, { redirectTo });
+    await signIn('jwt', { jwt: token, redirectTo });
   } catch (error) {
     rethrow(error);
 

--- a/core/auth/customer-login-api.ts
+++ b/core/auth/customer-login-api.ts
@@ -21,8 +21,8 @@ import { SignJWT } from 'jose';
 export const generateCustomerLoginApiJwt = async (
   customerId: number,
   channelId: number,
-  redirectTo: string = '/account/orders',
-  additionalClaims?: Record<string, any>,
+  redirectTo = '/account/orders',
+  additionalClaims?: Record<string, unknown>,
 ): Promise<string> => {
   const clientId = process.env.BIGCOMMERCE_CLIENT_ID;
   const clientSecret = process.env.BIGCOMMERCE_CLIENT_SECRET;
@@ -56,5 +56,7 @@ export const generateCustomerLoginApiJwt = async (
   const secretKey = new TextEncoder().encode(clientSecret);
 
   // Create and sign the JWT
-  return await new SignJWT(payload).setProtectedHeader({ alg: 'HS256', typ: 'JWT' }).sign(secretKey);
+  return await new SignJWT(payload)
+    .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
+    .sign(secretKey);
 };

--- a/core/next.config.ts
+++ b/core/next.config.ts
@@ -34,7 +34,20 @@ export default async (): Promise<NextConfig> => {
     },
     eslint: {
       ignoreDuringBuilds: !!process.env.CI,
-      dirs: ['app', 'client', 'components', 'lib', 'middlewares'],
+      dirs: [
+        'app',
+        'auth',
+        'build-config',
+        'client',
+        'components',
+        'data-transformers',
+        'i18n',
+        'lib',
+        'middlewares',
+        'scripts',
+        'tests',
+        'vibes',
+      ],
     },
     // default URL generation in BigCommerce uses trailing slash
     trailingSlash: process.env.TRAILING_SLASH !== 'false',

--- a/core/tests/fixtures/utils/account/delete.ts
+++ b/core/tests/fixtures/utils/account/delete.ts
@@ -19,6 +19,7 @@ export async function deleteAccount(customerId: number) {
       },
     );
   } catch (error) {
+    // eslint-disable-next-line no-console
     console.error(error);
   }
 }

--- a/core/tests/fixtures/utils/order/delete.ts
+++ b/core/tests/fixtures/utils/order/delete.ts
@@ -21,6 +21,7 @@ export async function deleteOrder(orderId: number) {
 
   if (!response.ok) {
     const errorText = await response.text();
+
     throw new Error(`Failed to delete order with id ${orderId}: ${errorText}`);
   }
 }

--- a/core/tests/ui/components/radio-group.spec.ts
+++ b/core/tests/ui/components/radio-group.spec.ts
@@ -1,5 +1,4 @@
 import { expect, test } from '~/tests/fixtures';
-
 import routes from '~/tests/routes';
 
 test('Changing selection on radio button options should update query parameters', async ({

--- a/core/tests/ui/components/swatch.spec.ts
+++ b/core/tests/ui/components/swatch.spec.ts
@@ -1,5 +1,4 @@
 import { expect, test } from '~/tests/fixtures';
-
 import routes from '~/tests/routes';
 
 test('Selecting various options on color panel should update query parameters', async ({

--- a/core/tests/ui/e2e/order-details.spec.ts
+++ b/core/tests/ui/e2e/order-details.spec.ts
@@ -1,6 +1,10 @@
 import { expect, test } from '~/tests/fixtures';
 
-test('Order contains all necessary info and sections on Order Details page', async ({ page, account, order }) => {
+test('Order contains all necessary info and sections on Order Details page', async ({
+  page,
+  account,
+  order,
+}) => {
   const customer = await account.create();
 
   await customer.login();

--- a/core/vibes/soul/primitives/navigation/index.tsx
+++ b/core/vibes/soul/primitives/navigation/index.tsx
@@ -574,6 +574,7 @@ export const Navigation = forwardRef(function Navigation<S extends SearchResult>
             <CurrencyForm
               action={currencyAction}
               activeCurrencyId={activeCurrencyId}
+              // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
               currencies={currencies as [Currency, ...Currency[]]}
             />
           ) : null}
@@ -902,6 +903,7 @@ function CurrencyForm({
   const activeCurrency = currencies.find((currency) => currency.id === activeCurrencyId);
 
   useEffect(() => {
+    // eslint-disable-next-line no-console
     if (lastResult?.error) console.log(lastResult.error);
   }, [lastResult?.error]);
 

--- a/core/vibes/soul/sections/account-settings-section/change-password-form.tsx
+++ b/core/vibes/soul/sections/account-settings-section/change-password-form.tsx
@@ -41,6 +41,7 @@ export function ChangePasswordForm({
 
   useEffect(() => {
     if (lastResult?.error) {
+      // eslint-disable-next-line no-console
       console.log(lastResult.error);
     }
   }, [lastResult]);

--- a/core/vibes/soul/sections/header-section/index.tsx
+++ b/core/vibes/soul/sections/header-section/index.tsx
@@ -21,6 +21,7 @@ export const HeaderSection = forwardRef<React.ComponentRef<'div'>, Props>(
       if (!bannerElement) return;
 
       const resizeObserver = new ResizeObserver((entries: ResizeObserverEntry[]) => {
+        // eslint-disable-next-line no-restricted-syntax
         for (const entry of entries) {
           setBannerHeight(entry.contentRect.height);
         }

--- a/core/vibes/soul/sections/product-detail/schema.ts
+++ b/core/vibes/soul/sections/product-detail/schema.ts
@@ -126,6 +126,7 @@ export function schema(fields: Field[]): z.ZodObject<SchemaRawShape> {
 
   fields.forEach((field) => {
     let fieldSchema: z.ZodString | z.ZodNumber;
+
     switch (field.type) {
       case 'number':
         fieldSchema = z.number();
@@ -135,6 +136,7 @@ export function schema(fields: Field[]): z.ZodObject<SchemaRawShape> {
 
         shape[field.name] = fieldSchema;
         break;
+
       default:
         fieldSchema = z.string();
 


### PR DESCRIPTION
## What/Why?
Updates the sign in behavior to use different providers instead of relying on a single provider. This is prework to in order to properly handle session syncing.

### Additional changes
Also added some folders to be linted by `next lint` and fixed them: https://github.com/bigcommerce/catalyst/pull/2103/commits/77634f9c8c734337ff731417a839cbc8c83a4c2a

## Testing
![Screenshot 2025-03-14 at 17 04 15](https://github.com/user-attachments/assets/8dbb3658-16d7-44cb-babd-0665aaa340f0)
