### PR TITLE
feat: add anonymous session with cart tracking

### DIFF
--- a/.changeset/ten-pots-vanish.md
+++ b/.changeset/ten-pots-vanish.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Sets a default session when any user first visits the page.

--- a/core/app/[locale]/(default)/(auth)/layout.tsx
+++ b/core/app/[locale]/(default)/(auth)/layout.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren } from 'react';
 
-import { auth } from '~/auth';
+import { isLoggedIn } from '~/auth';
 import { redirect } from '~/i18n/routing';
 
 interface Props extends PropsWithChildren {
@@ -8,10 +8,10 @@ interface Props extends PropsWithChildren {
 }
 
 export default async function Layout({ children, params }: Props) {
-  const session = await auth();
+  const loggedIn = await isLoggedIn();
   const { locale } = await params;
 
-  if (session) {
+  if (loggedIn) {
     redirect({ href: '/account/orders', locale });
   }
 

--- a/core/app/[locale]/(default)/(auth)/login/_actions/login.ts
+++ b/core/app/[locale]/(default)/(auth)/login/_actions/login.ts
@@ -9,10 +9,12 @@ import { getLocale, getTranslations } from 'next-intl/server';
 import { schema } from '@/vibes/soul/sections/sign-in-section/schema';
 import { signIn } from '~/auth';
 import { redirect } from '~/i18n/routing';
+import { getCartId } from '~/lib/cart';
 
 export const login = async (_lastResult: SubmissionResult | null, formData: FormData) => {
   const locale = await getLocale();
   const t = await getTranslations('Login');
+  const cartId = await getCartId();
 
   const submission = parseWithZod(formData, { schema });
 
@@ -24,7 +26,7 @@ export const login = async (_lastResult: SubmissionResult | null, formData: Form
     await signIn('password', {
       email: submission.value.email,
       password: submission.value.password,
-
+      cartId,
       // We want to use next/navigation for the redirect as it
       // follows basePath and trailing slash configurations.
       redirect: false,

--- a/core/app/[locale]/(default)/(auth)/register/_actions/register-customer.ts
+++ b/core/app/[locale]/(default)/(auth)/register/_actions/register-customer.ts
@@ -12,6 +12,7 @@ import { client } from '~/client';
 import { graphql, VariablesOf } from '~/client/graphql';
 import { FieldNameToFieldId } from '~/data-transformers/form-field-transformer/utils';
 import { redirect } from '~/i18n/routing';
+import { getCartId } from '~/lib/cart';
 
 const RegisterCustomerMutation = graphql(`
   mutation RegisterCustomerMutation(
@@ -187,6 +188,7 @@ export async function registerCustomer<F extends Field>(
 ) {
   const t = await getTranslations('Register');
   const locale = await getLocale();
+  const cartId = await getCartId();
 
   const submission = parseWithZod(formData, { schema: schema(prevState.fields) });
 
@@ -222,7 +224,7 @@ export async function registerCustomer<F extends Field>(
     await signIn('password', {
       email: input.email,
       password: input.password,
-
+      cartId,
       // We want to use next/navigation for the redirect as it
       // follows basePath and trailing slash configurations.
       redirect: false,

--- a/core/app/[locale]/(default)/account/layout.tsx
+++ b/core/app/[locale]/(default)/account/layout.tsx
@@ -3,7 +3,7 @@ import { PropsWithChildren } from 'react';
 
 import { SidebarMenu } from '@/vibes/soul/sections/sidebar-menu';
 import { StickySidebarLayout } from '@/vibes/soul/sections/sticky-sidebar-layout';
-import { auth } from '~/auth';
+import { isLoggedIn } from '~/auth';
 import { redirect } from '~/i18n/routing';
 
 interface Props extends PropsWithChildren {
@@ -12,13 +12,13 @@ interface Props extends PropsWithChildren {
 
 export default async function Layout({ children, params }: Props) {
   const { locale } = await params;
-  const session = await auth();
+  const loggedIn = await isLoggedIn();
 
   setRequestLocale(locale);
 
   const t = await getTranslations('Account.Layout');
 
-  if (!session) {
+  if (!loggedIn) {
     redirect({ href: '/login', locale });
   }
 

--- a/core/app/login/token/[token]/route.ts
+++ b/core/app/login/token/[token]/route.ts
@@ -9,6 +9,7 @@ import { decodeJwt } from 'jose';
 import { redirect, unstable_rethrow as rethrow } from 'next/navigation';
 
 import { signIn } from '~/auth';
+import { getCartId } from '~/lib/cart';
 
 interface TokenParams {
   params: Promise<{ token: string }>;
@@ -16,6 +17,7 @@ interface TokenParams {
 
 export async function GET(request: Request, { params }: TokenParams) {
   const token = (await params).token;
+  const cartId = await getCartId();
 
   try {
     // decode token without checking signature to get redirect path
@@ -27,7 +29,7 @@ export async function GET(request: Request, { params }: TokenParams) {
 
     // sign in with token which will check validity against BigCommerce API
     // and redirect to redirectTo
-    await signIn('jwt', { jwt: token, redirectTo });
+    await signIn('jwt', { jwt: token, cartId, redirectTo });
   } catch (error) {
     rethrow(error);
 

--- a/core/lib/cart.ts
+++ b/core/lib/cart.ts
@@ -1,27 +1,17 @@
 'use server';
 
-import { cookies } from 'next/headers';
+import { auth, updateSession } from '~/auth';
 
 export async function getCartId(): Promise<string | undefined> {
-  const cookieStore = await cookies();
-  const cartId = cookieStore.get('cartId')?.value;
+  const session = await auth();
 
-  return cartId;
+  return session?.user?.cartId ?? undefined;
 }
 
 export async function setCartId(cartId: string): Promise<void> {
-  const cookieStore = await cookies();
-
-  cookieStore.set('cartId', cartId, {
-    httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
-    sameSite: 'lax',
-    path: '/',
-  });
+  await updateSession({ user: { cartId } });
 }
 
 export async function clearCartId(): Promise<void> {
-  const cookieStore = await cookies();
-
-  cookieStore.delete('cartId');
+  await updateSession({ user: { cartId: null } });
 }

--- a/core/middlewares/with-auth.ts
+++ b/core/middlewares/with-auth.ts
@@ -1,7 +1,22 @@
-import { auth } from '~/auth';
+import { auth, signIn } from '~/auth';
 
 import { type MiddlewareFactory } from './compose-middlewares';
 
-// The `auth` function doesn't have the correct type to support it as a MiddlewareFactory.
-// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-export const withAuth: MiddlewareFactory = auth as unknown as MiddlewareFactory;
+export const withAuth: MiddlewareFactory = (next) => {
+  return async (request, event) => {
+    // @ts-expect-error: The `auth` function doesn't have the correct type to support it as a MiddlewareFactory.
+    const authWithCallback = auth(async (req) => {
+      if (!req.auth) {
+        await signIn('anonymous', { redirect: false });
+
+        return next(req, event);
+      }
+
+      // Continue the middleware chain
+      return next(req, event);
+    });
+
+    // @ts-expect-error: The `auth` function doesn't have the correct type to support it as a MiddlewareFactory.
+    return authWithCallback(request, event);
+  };
+};

--- a/core/vibes/soul/primitives/compare-card/add-to-cart-form.tsx
+++ b/core/vibes/soul/primitives/compare-card/add-to-cart-form.tsx
@@ -5,6 +5,7 @@ import { ReactNode, useActionState, useEffect } from 'react';
 
 import { Button } from '@/vibes/soul/primitives/button';
 import { toast } from '@/vibes/soul/primitives/toaster';
+import { useRouter } from '~/i18n/routing';
 
 type Action<S, P> = (state: Awaited<S>, payload: P) => S | Promise<S>;
 
@@ -32,6 +33,7 @@ export function AddToCartForm({
   preorderLabel,
   disabled = false,
 }: Props) {
+  const router = useRouter();
   const [{ lastResult, successMessage }, formAction, pending] = useActionState(addToCartAction, {
     lastResult: null,
     successMessage: undefined,
@@ -42,8 +44,12 @@ export function AddToCartForm({
   useEffect(() => {
     if (lastResult?.status === 'success') {
       toast.success(successMessage);
+
+      // This is needed to refresh the Data Cache after the product has been added to the cart.
+      // The cart id is not picked up after the first time the cart is created/updated.
+      router.refresh();
     }
-  }, [lastResult, successMessage]);
+  }, [lastResult, successMessage, router]);
 
   useEffect(() => {
     if (form.errors) {

--- a/core/vibes/soul/primitives/navigation/index.tsx
+++ b/core/vibes/soul/primitives/navigation/index.tsx
@@ -898,6 +898,7 @@ function CurrencyForm({
   action: CurrencyAction;
   currencies: [Currency, ...Currency[]];
 }) {
+  const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [lastResult, formAction] = useActionState(action, null);
   const activeCurrency = currencies.find((currency) => currency.id === activeCurrencyId);
@@ -942,6 +943,10 @@ function CurrencyForm({
 
                   formData.append('id', currency.id);
                   formAction(formData);
+
+                  // This is needed to refresh the Data Cache after the product has been added to the cart.
+                  // The cart id is not picked up after the first time the cart is created/updated.
+                  router.refresh();
                 });
               }}
             >

--- a/core/vibes/soul/sections/product-detail/product-detail-form.tsx
+++ b/core/vibes/soul/sections/product-detail/product-detail-form.tsx
@@ -100,8 +100,12 @@ export function ProductDetailForm<F extends Field>({
   useEffect(() => {
     if (lastResult?.status === 'success') {
       toast.success(successMessage);
+
+      // This is needed to refresh the Data Cache after the product has been added to the cart.
+      // The cart id is not picked up after the first time the cart is created/updated.
+      router.refresh();
     }
-  }, [lastResult, successMessage]);
+  }, [lastResult, successMessage, router]);
 
   const [form, formFields] = useForm({
     lastResult,


### PR DESCRIPTION
## What/Why?
This PR solves a two-fold:
1. Creates an anonymous session whenever a user navigates to a Catalyst page. This will allow us to store a bunch of information we need for shoppers and creates a consistent place to read customer-specific data from.
2. Moves reading/writing the cart id into the session. Regardless of if the session is an anonymous session or a logged-in shopper, the cart id will be tied to the session and can move freely between the two.

This is a better pattern to practice for security reasons. It makes it so attackers can't access the shoppers cart id without being validated by the Catalyst server.

## Testing

### Anonymous session is created:
![Screenshot 2025-03-19 at 16 50 20](https://github.com/user-attachments/assets/9d9a203a-392b-420f-8a9a-dc0b1a25dcfc)

### Cart is created and added onto the session:
https://github.com/user-attachments/assets/0e53a570-6d6f-4449-be0b-c1b153219d8a

### Cart is transferred over to logged-in session:
https://github.com/user-attachments/assets/f6e94ed4-51df-4fdf-a6b4-98600975362d

### Cart is cleared on session when logging out:
https://github.com/user-attachments/assets/71ab0f12-24e2-4d02-a903-6c10341a86c2


