### PR TITLE
chore(security): add documentation around CSRF checks

### DIFF
--- a/core/auth/index.ts
+++ b/core/auth/index.ts
@@ -149,13 +149,15 @@ async function loginWithJwt(credentials: unknown): Promise<User | null> {
 }
 
 const config = {
+  // Set this environment variable if you want to trust the host when using `next build` & `next start`.
+  // Otherwise, this will be controlled by process.env.NODE_ENV within the library.
+  trustHost: process.env.AUTH_TRUST_HOST === 'true' ? true : undefined,
   session: {
     strategy: 'jwt',
   },
   pages: {
     signIn: '/login',
   },
-  trustHost: true,
   callbacks: {
     jwt: ({ token, user }) => {
       // user can actually be undefined

--- a/core/auth/index.ts
+++ b/core/auth/index.ts
@@ -149,6 +149,10 @@ async function loginWithJwt(credentials: unknown): Promise<User | null> {
 }
 
 const config = {
+  // Explicitly setting this value to be undefined. We want the library to handle CSRF checks when taking sensitive actions.
+  // When handling sensitive actions like sign in, sign out, etc., the library will automatically check for CSRF tokens.
+  // If you need to implement your own sensitive actions, you will need to implement CSRF checks yourself.
+  skipCSRFCheck: undefined,
   // Set this environment variable if you want to trust the host when using `next build` & `next start`.
   // Otherwise, this will be controlled by process.env.NODE_ENV within the library.
   trustHost: process.env.AUTH_TRUST_HOST === 'true' ? true : undefined,


### PR DESCRIPTION
## What/Why?
- Adds some documation around CSRF checks and explicitly sets it to undefined. We want to ensure users handle CSRF checks if they need to roll their own sensitive actions as the next-auth/auth.js lib won't handle it for them if doing something custom.
- `trustHost` value is determined by an env var to ensure we can set it up when running `next build` & `next start` locally. Setting it to always be true is detrimental to cookie security when deploying the application to production, but is needed to be set to true when running on `localhost`.

## Testing
N/A