### PR TITLE
fix: flicker on rerendering `<ProductList />`

### DIFF
--- a/.changeset/weak-candles-buy.md
+++ b/.changeset/weak-candles-buy.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+fix: flicker on rerendering `<ProductList />`

--- a/core/lib/makeswift/utils/use-bc-product-to-vibes-product/use-bc-product-to-vibes-product.ts
+++ b/core/lib/makeswift/utils/use-bc-product-to-vibes-product/use-bc-product-to-vibes-product.ts
@@ -1,4 +1,5 @@
 import { useFormatter } from 'next-intl';
+import { useCallback } from 'react';
 import { string, z } from 'zod';
 
 import { CardProduct } from '@/vibes/soul/primitives/product-card';
@@ -34,17 +35,20 @@ export type BcProductSchema = z.infer<typeof BcProductSchema>;
 export function useBcProductToVibesProduct(): (product: BcProductSchema) => CardProduct {
   const format = useFormatter();
 
-  return (product) => {
-    const { entityId, name, defaultImage, brand, path, prices } = product;
-    const price = pricesTransformer(prices, format);
+  return useCallback(
+    (product) => {
+      const { entityId, name, defaultImage, brand, path, prices } = product;
+      const price = pricesTransformer(prices, format);
 
-    return {
-      id: entityId.toString(),
-      title: name,
-      href: path,
-      image: defaultImage ? { src: defaultImage.url, alt: defaultImage.altText } : undefined,
-      price,
-      subtitle: brand?.name,
-    };
-  };
+      return {
+        id: entityId.toString(),
+        title: name,
+        href: path,
+        image: defaultImage ? { src: defaultImage.url, alt: defaultImage.altText } : undefined,
+        price,
+        subtitle: brand?.name,
+      };
+    },
+    [format],
+  );
 }

--- a/core/lib/makeswift/utils/use-products.ts
+++ b/core/lib/makeswift/utils/use-products.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import useSWR from 'swr';
 import { z } from 'zod';
 
@@ -40,14 +41,20 @@ export function useProducts({ collection, collectionLimit = 20, additionalProduc
     fetcher,
   );
 
-  const combinedProducts = [
-    ...(collectionData?.products.slice(0, collectionLimit) ?? []),
-    ...(additionalData?.products ?? []),
-  ];
+  const combinedProducts = useMemo(
+    () => [
+      ...(collectionData?.products.slice(0, collectionLimit) ?? []),
+      ...(additionalData?.products ?? []),
+    ],
+    [collectionData, additionalData, collectionLimit],
+  );
 
   const isLoading = isCollectionLoading || isAdditionalLoading;
 
-  const products = isLoading ? null : combinedProducts.map(bcProductToVibesProduct);
+  const products = useMemo(
+    () => (isLoading ? null : combinedProducts.map(bcProductToVibesProduct)),
+    [isLoading, combinedProducts, bcProductToVibesProduct],
+  );
 
   return { products, isLoading };
 }

--- a/core/vibes/soul/lib/streamable.tsx
+++ b/core/vibes/soul/lib/streamable.tsx
@@ -53,6 +53,10 @@ function weakRefCache<K, T extends object>() {
 
 const promiseCache = weakRefCache<string, Promise<unknown>>();
 
+function isPromise<T>(value: Streamable<T>): value is Promise<T> {
+  return value instanceof Promise;
+}
+
 // eslint-disable-next-line valid-jsdoc
 /**
  * A suspense-friendly upgrade to `Promise.all`, guarantees stability of
@@ -61,6 +65,13 @@ const promiseCache = weakRefCache<string, Promise<unknown>>();
 function all<T extends readonly unknown[] | []>(
   streamables: T,
 ): Streamable<{ -readonly [P in keyof T]: Awaited<T[P]> }> {
+  // Avoid creating an unnecessary promise with the `Promise.all` call below
+  // if none of the streamables is a promise
+  if (!streamables.some(isPromise)) {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    return streamables as { -readonly [P in keyof T]: Awaited<T[P]> };
+  }
+
   const cacheKey = getCompositeKey(streamables);
 
   const cached = promiseCache.get(cacheKey);
@@ -80,7 +91,7 @@ export const Streamable = {
 };
 
 export function useStreamable<T>(streamable: Streamable<T>): T {
-  return streamable instanceof Promise ? use(streamable) : streamable;
+  return isPromise(streamable) ? use(streamable) : streamable;
 }
 
 function UseStreamable<T>({


### PR DESCRIPTION
## What/Why?

Fix incidental rendering of `<ProductList />` elements, most visible when the page is edited in the builder.

## Testing

### Before

https://github.com/user-attachments/assets/d4087405-12c9-4c37-9bd1-fefb807df35c


### After

https://github.com/user-attachments/assets/dc687f9b-0b94-4de0-81d4-e748928f9098


