### PR TITLE
feat(client): add errorPolicy option to GQL requests

### DIFF
--- a/.changeset/itchy-ways-do.md
+++ b/.changeset/itchy-ways-do.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-client": minor
+---
+
+Add an `errorPolicy` option for GQL requests. Accepts `none`, `ignore`, `all`. Defaults to `none` which throws an error if there are GQL errors, `ignore` returns the data without error object, and `all` returns both data and errors.

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -69,6 +69,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     customerAccessToken?: string;
     fetchOptions?: FetcherRequestInit;
     channelId?: string;
+    errorPolicy?: 'none' | 'all' | 'ignore';
   }): Promise<BigCommerceResponse<TResult>>;
 
   // Overload for documents that do not require variables
@@ -78,6 +79,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     customerAccessToken?: string;
     fetchOptions?: FetcherRequestInit;
     channelId?: string;
+    errorPolicy?: 'none' | 'all' | 'ignore';
   }): Promise<BigCommerceResponse<TResult>>;
 
   async fetch<TResult, TVariables>({
@@ -86,12 +88,14 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     customerAccessToken,
     fetchOptions = {} as FetcherRequestInit,
     channelId,
+    errorPolicy = 'none',
   }: {
     document: DocumentDecoration<TResult, TVariables>;
     variables?: TVariables;
     customerAccessToken?: string;
     fetchOptions?: FetcherRequestInit;
     channelId?: string;
+    errorPolicy?: 'none' | 'all' | 'ignore';
   }): Promise<BigCommerceResponse<TResult>> {
     const { headers = {}, ...rest } = fetchOptions;
     const query = normalizeQuery(document);
@@ -130,11 +134,18 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
 
     const { errors, ...data } = result;
 
-    if (errors) {
+    // If errorPolicy is 'none', we throw an error if there are any errors
+    if (errorPolicy === 'none' && errors) {
       throw BigCommerceGQLError.createFromResult(errors);
     }
 
-    return data;
+    // If errorPolicy is 'ignore', we return the data and ignore the errors
+    if (errorPolicy === 'ignore') {
+      return data;
+    }
+
+    // If errorPolicy is 'all', we return the errors with the data
+    return result;
   }
 
   async fetchShippingZones() {


### PR DESCRIPTION
## What/Why?
Add an `errorPolicy` option for GQL requests. Accepts `none`, `ignore`, `all`. Defaults to `none` which throws an error if there are GQL errors, `ignore` returns the data without error object, and `all` returns both data and errors.