### PR TITLE
fix(core): revert to ids search param in compare page

### DIFF
--- a/core/app/[locale]/(default)/compare/page.tsx
+++ b/core/app/[locale]/(default)/compare/page.tsx
@@ -12,7 +12,7 @@ import { addToCart } from './_actions/add-to-cart';
 import { getCompareData } from './page-data';
 
 const CompareParamsSchema = z.object({
-  compare: z
+  ids: z
     .union([z.string(), z.array(z.string()), z.undefined()])
     .transform((value) => {
       if (Array.isArray(value)) {
@@ -75,7 +75,7 @@ export default async function Compare(props: Props) {
 
   const searchParams = await props.searchParams;
   const parsed = CompareParamsSchema.parse(searchParams);
-  const productIds = parsed.compare?.filter((id) => !Number.isNaN(id));
+  const productIds = parsed.ids?.filter((id) => !Number.isNaN(id));
 
   return (
     <CompareSection

--- a/core/vibes/soul/primitives/compare-drawer/index.tsx
+++ b/core/vibes/soul/primitives/compare-drawer/index.tsx
@@ -206,7 +206,7 @@ export function CompareDrawer({
             </div>
             <ButtonLink
               className="hidden @md:block"
-              href={`${href}?${paramName}=${params?.toString()}`}
+              href={`${href}?ids=${params?.toString()}`}
               size="medium"
               variant="primary"
             >


### PR DESCRIPTION
## What/Why?
Reverts to the previous behavior by overriding the link generated in the compare drawer component.

## Testing
Locally, ids use the `ids` search param in compare page.