### PR TITLE
fix(core): ignore errors in orders and render products without links

### DIFF
--- a/.changeset/rotten-pans-sneeze.md
+++ b/.changeset/rotten-pans-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Fix an issue with orders with deleted products throwing an error and stopping page render by settings the errorPolicy for requests to ignore errors and update Soul components to render the products without using links for these cases.

--- a/core/app/[locale]/(default)/account/orders/[id]/page-data.tsx
+++ b/core/app/[locale]/(default)/account/orders/[id]/page-data.tsx
@@ -133,6 +133,7 @@ export const getCustomerOrderDetails = cache(async ({ id }: CustomerOrderDetails
     },
     fetchOptions: { cache: 'no-store', next: { tags: [TAGS.customer] } },
     customerAccessToken,
+    errorPolicy: 'ignore',
   });
 
   const order = response.data.site.order;

--- a/core/app/[locale]/(default)/account/orders/page-data.ts
+++ b/core/app/[locale]/(default)/account/orders/page-data.ts
@@ -94,6 +94,7 @@ export const getCustomerOrders = cache(
       variables: { ...paginationArgs, ...filtersArgs },
       customerAccessToken,
       fetchOptions: { cache: 'no-store', next: { tags: [TAGS.customer] } },
+      errorPolicy: 'ignore',
     });
 
     const orders = response.data.customer?.orders;

--- a/core/data-transformers/order-details-transformer.ts
+++ b/core/data-transformers/order-details-transformer.ts
@@ -57,7 +57,7 @@ export const orderDetailsTransformer = (
                 style: 'currency',
                 currency: lineItem.subTotalListPrice.currencyCode,
               }),
-              href: lineItem.baseCatalogProduct?.path ?? `/product/${lineItem.productEntityId}`,
+              href: lineItem.baseCatalogProduct?.path ?? undefined,
               image: lineItem.image
                 ? {
                     src: lineItem.image.url,

--- a/core/data-transformers/orders-transformer.ts
+++ b/core/data-transformers/orders-transformer.ts
@@ -22,8 +22,7 @@ export const ordersTransformer = (
           return consignment.lineItems.map((lineItem) => {
             return {
               id: lineItem.entityId.toString(),
-              href:
-                lineItem.baseCatalogProduct?.path ?? `/product/${String(lineItem.productEntityId)}`,
+              href: lineItem.baseCatalogProduct?.path ?? undefined,
               title: lineItem.name,
               subtitle: lineItem.brand ?? undefined,
               price: format.number(lineItem.subTotalListPrice.value, {

--- a/core/vibes/soul/sections/order-details-section/index.tsx
+++ b/core/vibes/soul/sections/order-details-section/index.tsx
@@ -47,7 +47,7 @@ interface ShipmentLineItem {
   title: string;
   subtitle?: string;
   price: string;
-  href: string;
+  href?: string;
   image?: { src: string; alt: string };
   quantity: number;
   metadata?: Array<{ label: string; value: string }>;
@@ -197,7 +197,7 @@ function ShipmentTracking({
 }
 
 function ShipmentLineItem({ lineItem }: { lineItem: ShipmentLineItem }) {
-  return (
+  return lineItem.href ? (
     <Link
       className="group grid shrink-0 cursor-pointer gap-8 rounded-xl ring-primary ring-offset-4 focus-visible:outline-0 focus-visible:ring-2 @sm:flex @sm:rounded-2xl"
       href={lineItem.href}
@@ -241,6 +241,46 @@ function ShipmentLineItem({ lineItem }: { lineItem: ShipmentLineItem }) {
         </div>
       </div>
     </Link>
+  ) : (
+    <div className="group grid shrink-0 gap-8 rounded-xl @sm:flex @sm:rounded-2xl" id={lineItem.id}>
+      <div className="relative aspect-square basis-40 overflow-hidden rounded-[inherit] border border-contrast-100 bg-contrast-100">
+        {lineItem.image?.src != null ? (
+          <Image
+            alt={lineItem.image.alt}
+            className="w-full scale-100 select-none bg-contrast-100 object-cover transition-transform duration-500 ease-out group-hover:scale-110"
+            fill
+            sizes="10rem"
+            src={lineItem.image.src}
+          />
+        ) : (
+          <div className="pl-2 pt-3 text-4xl font-bold leading-[0.8] tracking-tighter text-contrast-300 transition-transform duration-500 ease-out group-hover:scale-105">
+            {lineItem.title}
+          </div>
+        )}
+      </div>
+
+      <div className="space-y-3 text-sm leading-snug">
+        <div>
+          <div className="font-semibold">{lineItem.title}</div>
+          {lineItem.subtitle != null && lineItem.subtitle !== '' && (
+            <div className="font-normal text-contrast-500">{lineItem.subtitle}</div>
+          )}
+        </div>
+        <div className="flex gap-1 text-sm">
+          <span className="font-semibold">{lineItem.price}</span>
+          <span>×</span>
+          <span className="font-semibold">{lineItem.quantity}</span>
+        </div>
+        <div>
+          {lineItem.metadata?.map((metadata, index) => (
+            <div className="flex gap-1 text-sm" key={index}>
+              <span className="font-semibold">{metadata.label}:</span>
+              <span>{metadata.value}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/core/vibes/soul/sections/order-list-section/order-list-line-item.tsx
+++ b/core/vibes/soul/sections/order-list-section/order-list-line-item.tsx
@@ -9,7 +9,7 @@ export interface OrderListLineItem {
   title: string;
   subtitle?: string;
   price: string;
-  href: string;
+  href?: string;
   image?: { src: string; alt: string };
 }
 
@@ -19,7 +19,7 @@ interface Props {
 }
 
 export function OrderListLineItem({ className, lineItem }: Props) {
-  return (
+  return lineItem.href ? (
     <Link
       className={clsx(
         'group shrink-0 basis-32 cursor-pointer rounded-xl ring-primary ring-offset-4 focus-visible:outline-0 focus-visible:ring-2 @md:rounded-2xl @lg:basis-40',
@@ -53,5 +53,35 @@ export function OrderListLineItem({ className, lineItem }: Props) {
         <PriceLabel className="mt-1.5" price={lineItem.price} />
       </div>
     </Link>
+  ) : (
+    <div
+      className={clsx('group shrink-0 basis-32 rounded-xl @md:rounded-2xl @lg:basis-40', className)}
+      id={lineItem.id}
+    >
+      <div className="relative aspect-square overflow-hidden rounded-[inherit] bg-contrast-100">
+        {lineItem.image?.src != null ? (
+          <Image
+            alt={lineItem.image.alt}
+            className="w-full scale-100 select-none bg-contrast-100 object-cover transition-transform duration-500 ease-out group-hover:scale-110"
+            fill
+            sizes="(min-width: 32rem) 10rem, 8rem"
+            src={lineItem.image.src}
+          />
+        ) : (
+          <div className="pl-2 pt-3 text-4xl font-bold leading-[0.8] tracking-tighter text-contrast-300 transition-transform duration-500 ease-out group-hover:scale-105">
+            {lineItem.title}
+          </div>
+        )}
+      </div>
+
+      <div className="mt-2 px-1 text-sm leading-snug @xs:mt-3">
+        <span className="block font-semibold">{lineItem.title}</span>
+
+        {lineItem.subtitle != null && lineItem.subtitle !== '' && (
+          <span className="block font-normal text-contrast-400">{lineItem.subtitle}</span>
+        )}
+        <PriceLabel className="mt-1.5" price={lineItem.price} />
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## What/Why?

- Set `errorPolicy` to ignore errors for order queries to fix thrown error when an order has deleted products with no valid paths and an error is returned.
- Make `href` optional for order products.
- If no `href` is passed, render a product without using a Link.

## Testing
Locally, my product with no path renders without being a link and no error is thrown.

![Screenshot 2025-03-24 at 2 56 00 PM](https://github.com/user-attachments/assets/b4237c78-4b0b-49db-a31a-663dc5050f23)

