### PR TITLE
fix: add `Streamable.from` to avoid eager promises

### DIFF
--- a/.changeset/witty-suns-explode.md
+++ b/.changeset/witty-suns-explode.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Adds `Streamable.from` and uses it wherever we were unintentionally executing an async function in a React Server Component.

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
@@ -4,10 +4,10 @@ import { getFormatter, getTranslations, setRequestLocale } from 'next-intl/serve
 import { createSearchParamsCache } from 'nuqs/server';
 import { cache } from 'react';
 
+import { Streamable } from '@/vibes/soul/lib/streamable';
 import { createCompareLoader } from '@/vibes/soul/primitives/compare-drawer/loader';
 import { CursorPaginationInfo } from '@/vibes/soul/primitives/cursor-pagination';
 import { Product } from '@/vibes/soul/primitives/product-card';
-import { Breadcrumb } from '@/vibes/soul/sections/breadcrumbs';
 import { ProductsListSection } from '@/vibes/soul/sections/products-list-section';
 import { getFilterParsers } from '@/vibes/soul/sections/products-list-section/filter-parsers';
 import { Filter } from '@/vibes/soul/sections/products-list-section/filters-panel';
@@ -31,10 +31,6 @@ const cachedBrandDataVariables = cache((brandId: string) => {
 const cacheBrandFacetedSearch = cache((brandId: string) => {
   return { brand: [brandId] };
 });
-
-function getBreadcrumbs(): Breadcrumb[] {
-  return [];
-}
 
 async function getBrand(props: Props) {
   const { slug } = await props.params;
@@ -286,28 +282,27 @@ export default async function Brand(props: Props) {
 
   return (
     <ProductsListSection
-      breadcrumbs={getBreadcrumbs()}
-      compareLabel={getCompareLabel()}
-      compareProducts={getCompareProducts(props)}
-      emptyStateSubtitle={getEmptyStateSubtitle()}
-      emptyStateTitle={getEmptyStateTitle()}
+      compareLabel={Streamable.from(getCompareLabel)}
+      compareProducts={Streamable.from(() => getCompareProducts(props))}
+      emptyStateSubtitle={Streamable.from(getEmptyStateSubtitle)}
+      emptyStateTitle={Streamable.from(getEmptyStateTitle)}
       filterLabel={await getFilterLabel()}
-      filters={getFilters(props)}
-      filtersPanelTitle={getFiltersPanelTitle()}
-      maxCompareLimitMessage={getMaxCompareLimitMessage()}
+      filters={Streamable.from(() => getFilters(props))}
+      filtersPanelTitle={Streamable.from(getFiltersPanelTitle)}
+      maxCompareLimitMessage={Streamable.from(getMaxCompareLimitMessage)}
       maxItems={MAX_COMPARE_LIMIT}
-      paginationInfo={getPaginationInfo(props)}
-      products={getListProducts(props)}
-      rangeFilterApplyLabel={getRangeFilterApplyLabel()}
-      removeLabel={getRemoveLabel()}
-      resetFiltersLabel={getResetFiltersLabel()}
-      showCompare={getShowCompare(props)}
+      paginationInfo={Streamable.from(() => getPaginationInfo(props))}
+      products={Streamable.from(() => getListProducts(props))}
+      rangeFilterApplyLabel={Streamable.from(getRangeFilterApplyLabel)}
+      removeLabel={Streamable.from(getRemoveLabel)}
+      resetFiltersLabel={Streamable.from(getResetFiltersLabel)}
+      showCompare={Streamable.from(() => getShowCompare(props))}
       sortDefaultValue="featured"
-      sortLabel={getSortLabel()}
-      sortOptions={getSortOptions()}
+      sortLabel={Streamable.from(getSortLabel)}
+      sortOptions={Streamable.from(getSortOptions)}
       sortParamName="sort"
-      title={getTitle(props)}
-      totalCount={getTotalCount(props)}
+      title={Streamable.from(() => getTitle(props))}
+      totalCount={Streamable.from(() => getTotalCount(props))}
     />
   );
 }

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -5,7 +5,7 @@ import { getFormatter, getTranslations, setRequestLocale } from 'next-intl/serve
 import { createSearchParamsCache } from 'nuqs/server';
 import { cache } from 'react';
 
-import { Stream } from '@/vibes/soul/lib/streamable';
+import { Stream, Streamable } from '@/vibes/soul/lib/streamable';
 import { createCompareLoader } from '@/vibes/soul/primitives/compare-drawer/loader';
 import { CursorPaginationInfo } from '@/vibes/soul/primitives/cursor-pagination';
 import { Product } from '@/vibes/soul/primitives/product-card';
@@ -337,30 +337,35 @@ export default async function Category(props: Props) {
   return (
     <>
       <ProductsListSection
-        breadcrumbs={getBreadcrumbs(props)}
-        compareLabel={getCompareLabel()}
-        compareProducts={getCompareProducts(props)}
-        emptyStateSubtitle={getEmptyStateSubtitle()}
-        emptyStateTitle={getEmptyStateTitle()}
+        breadcrumbs={Streamable.from(() => getBreadcrumbs(props))}
+        compareLabel={Streamable.from(getCompareLabel)}
+        compareProducts={Streamable.from(() => getCompareProducts(props))}
+        emptyStateSubtitle={Streamable.from(getEmptyStateSubtitle)}
+        emptyStateTitle={Streamable.from(getEmptyStateTitle)}
         filterLabel={await getFilterLabel()}
-        filters={getFilters(props)}
-        filtersPanelTitle={getFiltersPanelTitle()}
-        maxCompareLimitMessage={getMaxCompareLimitMessage()}
+        filters={Streamable.from(() => getFilters(props))}
+        filtersPanelTitle={Streamable.from(getFiltersPanelTitle)}
+        maxCompareLimitMessage={Streamable.from(getMaxCompareLimitMessage)}
         maxItems={MAX_COMPARE_LIMIT}
-        paginationInfo={getPaginationInfo(props)}
-        products={getListProducts(props)}
-        rangeFilterApplyLabel={getRangeFilterApplyLabel()}
-        removeLabel={getRemoveLabel()}
-        resetFiltersLabel={getResetFiltersLabel()}
-        showCompare={getShowCompare(props)}
+        paginationInfo={Streamable.from(() => getPaginationInfo(props))}
+        products={Streamable.from(() => getListProducts(props))}
+        rangeFilterApplyLabel={Streamable.from(getRangeFilterApplyLabel)}
+        removeLabel={Streamable.from(getRemoveLabel)}
+        resetFiltersLabel={Streamable.from(getResetFiltersLabel)}
+        showCompare={Streamable.from(() => getShowCompare(props))}
         sortDefaultValue="featured"
-        sortLabel={getSortLabel()}
-        sortOptions={getSortOptions()}
+        sortLabel={Streamable.from(getSortLabel)}
+        sortOptions={Streamable.from(getSortOptions)}
         sortParamName="sort"
-        title={getTitle(props)}
-        totalCount={getTotalCount(props)}
+        title={Streamable.from(() => getTitle(props))}
+        totalCount={Streamable.from(() => getTotalCount(props))}
       />
-      <Stream value={Promise.all([getCategory(props), getProducts(props)])}>
+      <Stream
+        value={Streamable.all([
+          Streamable.from(() => getCategory(props)),
+          Streamable.from(() => getProducts(props)),
+        ])}
+      >
         {([category, products]) => (
           <CategoryViewed category={category} categoryId={category.entityId} products={products} />
         )}

--- a/core/app/[locale]/(default)/(faceted)/search/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/search/page.tsx
@@ -3,6 +3,7 @@ import { getFormatter, getTranslations } from 'next-intl/server';
 import { createSearchParamsCache } from 'nuqs/server';
 import { cache } from 'react';
 
+import { Streamable } from '@/vibes/soul/lib/streamable';
 import { createCompareLoader } from '@/vibes/soul/primitives/compare-drawer/loader';
 import { CursorPaginationInfo } from '@/vibes/soul/primitives/cursor-pagination';
 import { Product } from '@/vibes/soul/primitives/product-card';
@@ -301,28 +302,28 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function Search(props: Props) {
   return (
     <ProductsListSection
-      breadcrumbs={getBreadcrumbs()}
-      compareLabel={getCompareLabel()}
-      compareProducts={getCompareProducts(props)}
-      emptyStateSubtitle={getEmptyStateSubtitle()}
-      emptyStateTitle={getEmptyStateTitle(props)}
+      breadcrumbs={Streamable.from(getBreadcrumbs)}
+      compareLabel={Streamable.from(getCompareLabel)}
+      compareProducts={Streamable.from(() => getCompareProducts(props))}
+      emptyStateSubtitle={Streamable.from(getEmptyStateSubtitle)}
+      emptyStateTitle={Streamable.from(() => getEmptyStateTitle(props))}
       filterLabel={await getFilterLabel()}
-      filters={getFilters(props)}
-      filtersPanelTitle={getFiltersPanelTitle()}
-      maxCompareLimitMessage={getMaxCompareLimitMessage()}
+      filters={Streamable.from(() => getFilters(props))}
+      filtersPanelTitle={Streamable.from(getFiltersPanelTitle)}
+      maxCompareLimitMessage={Streamable.from(getMaxCompareLimitMessage)}
       maxItems={MAX_COMPARE_LIMIT}
-      paginationInfo={getPaginationInfo(props)}
-      products={getListProducts(props)}
-      rangeFilterApplyLabel={getRangeFilterApplyLabel()}
-      removeLabel={getRemoveLabel()}
-      resetFiltersLabel={getResetFiltersLabel()}
-      showCompare={getShowCompare()}
+      paginationInfo={Streamable.from(() => getPaginationInfo(props))}
+      products={Streamable.from(() => getListProducts(props))}
+      rangeFilterApplyLabel={Streamable.from(getRangeFilterApplyLabel)}
+      removeLabel={Streamable.from(getRemoveLabel)}
+      resetFiltersLabel={Streamable.from(getResetFiltersLabel)}
+      showCompare={Streamable.from(getShowCompare)}
       sortDefaultValue="featured"
-      sortLabel={getSortLabel()}
-      sortOptions={getSortOptions()}
+      sortLabel={Streamable.from(getSortLabel)}
+      sortOptions={Streamable.from(getSortOptions)}
       sortParamName="sort"
-      title={getTitle(props)}
-      totalCount={getTotalCount(props)}
+      title={Streamable.from(() => getTitle(props))}
+      totalCount={Streamable.from(() => getTotalCount(props))}
     />
   );
 }

--- a/core/app/[locale]/(default)/account/wishlists/[id]/page.tsx
+++ b/core/app/[locale]/(default)/account/wishlists/[id]/page.tsx
@@ -3,6 +3,7 @@ import { getFormatter, getTranslations } from 'next-intl/server';
 import { SearchParams } from 'nuqs';
 import { createSearchParamsCache, parseAsInteger, parseAsString } from 'nuqs/server';
 
+import { Streamable } from '@/vibes/soul/lib/streamable';
 import { CursorPaginationInfo } from '@/vibes/soul/primitives/cursor-pagination';
 import { Wishlist, WishlistDetails } from '@/vibes/soul/sections/wishlist-details';
 import { ExistingResultType } from '~/client/util';
@@ -98,10 +99,10 @@ export default async function WishlistPage({ params, searchParams }: Props) {
       action={addWishlistItemToCart}
       emptyStateText={t('emptyWishlist')}
       headerActions={wishlistActions}
-      paginationInfo={getPaginationInfo(id, searchParams)}
+      paginationInfo={Streamable.from(() => getPaginationInfo(id, searchParams))}
       prevHref="/account/wishlists"
       removeAction={removeWishlistItem}
-      wishlist={getWishlist(id, t, pt, searchParams)}
+      wishlist={Streamable.from(() => getWishlist(id, t, pt, searchParams))}
     />
   );
 }

--- a/core/app/[locale]/(default)/account/wishlists/page.tsx
+++ b/core/app/[locale]/(default)/account/wishlists/page.tsx
@@ -2,6 +2,7 @@ import { getFormatter, getTranslations } from 'next-intl/server';
 import { SearchParams } from 'nuqs';
 import { createSearchParamsCache, parseAsInteger, parseAsString } from 'nuqs/server';
 
+import { Streamable } from '@/vibes/soul/lib/streamable';
 import { CursorPaginationInfo } from '@/vibes/soul/primitives/cursor-pagination';
 import * as Skeleton from '@/vibes/soul/primitives/skeleton';
 import { Wishlist } from '@/vibes/soul/sections/wishlist-details';
@@ -115,11 +116,11 @@ export default async function Wishlists({ searchParams }: Props) {
           );
         },
       }}
-      paginationInfo={getPaginationInfo(searchParams)}
+      paginationInfo={Streamable.from(() => getPaginationInfo(searchParams))}
       placeholderCount={1}
       title={t('title')}
       viewWishlistLabel={t('viewWishlist')}
-      wishlists={listWishlists(searchParams, t)}
+      wishlists={Streamable.from(() => listWishlists(searchParams, t))}
     />
   );
 }

--- a/core/app/[locale]/(default)/blog/page.tsx
+++ b/core/app/[locale]/(default)/blog/page.tsx
@@ -4,6 +4,7 @@ import { getTranslations } from 'next-intl/server';
 import { SearchParams } from 'nuqs';
 import { createSearchParamsCache, parseAsInteger, parseAsString } from 'nuqs/server';
 
+import { Streamable } from '@/vibes/soul/lib/streamable';
 import { FeaturedBlogPostList } from '@/vibes/soul/sections/featured-blog-post-list';
 import { defaultPageInfo, pageInfoTransformer } from '~/data-transformers/page-info-transformer';
 
@@ -88,11 +89,11 @@ export default async function Blog(props: Props) {
         ...tagCrumb,
       ]}
       description={blog.description}
-      emptyStateSubtitle={getEmptyStateSubtitle()}
-      emptyStateTitle={getEmptyStateTitle()}
-      paginationInfo={getPaginationInfo(props.searchParams)}
+      emptyStateSubtitle={Streamable.from(getEmptyStateSubtitle)}
+      emptyStateTitle={Streamable.from(getEmptyStateTitle)}
+      paginationInfo={Streamable.from(() => getPaginationInfo(props.searchParams))}
       placeholderCount={6}
-      posts={listBlogPosts(props.searchParams)}
+      posts={Streamable.from(() => listBlogPosts(props.searchParams))}
       title={blog.name}
     />
   );

--- a/core/app/[locale]/(default)/compare/page.tsx
+++ b/core/app/[locale]/(default)/compare/page.tsx
@@ -4,6 +4,7 @@ import { getFormatter, getTranslations } from 'next-intl/server';
 import { cache } from 'react';
 import * as z from 'zod';
 
+import { Streamable } from '@/vibes/soul/lib/streamable';
 import { CompareCardWithId } from '@/vibes/soul/primitives/compare-card';
 import { CompareSection } from '@/vibes/soul/sections/compare-section';
 import { pricesTransformer } from '~/data-transformers/prices-transformer';
@@ -89,7 +90,7 @@ export default async function Compare(props: Props) {
       noRatingsLabel={t('noRatings')}
       otherDetailsLabel={t('otherDetails')}
       previousLabel={t('previous')}
-      products={getProducts(productIds)}
+      products={Streamable.from(() => getProducts(productIds))}
       ratingLabel={t('rating')}
       title={t('title')}
       viewOptionsLabel={t('viewOptions')}

--- a/core/app/[locale]/(default)/page.tsx
+++ b/core/app/[locale]/(default)/page.tsx
@@ -2,6 +2,7 @@ import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
 import { getFormatter, getTranslations, setRequestLocale } from 'next-intl/server';
 import { cache } from 'react';
 
+import { Streamable } from '@/vibes/soul/lib/streamable';
 import { FeaturedProductCarousel } from '@/vibes/soul/sections/featured-product-carousel';
 import { FeaturedProductList } from '@/vibes/soul/sections/featured-product-list';
 import { getSessionCustomerAccessToken } from '~/auth';
@@ -91,7 +92,7 @@ export default async function Home({ params }: Props) {
         description={t('FeaturedProducts.description')}
         emptyStateSubtitle={t('FeaturedProducts.emptyStateSubtitle')}
         emptyStateTitle={t('FeaturedProducts.emptyStateTitle')}
-        products={getFeaturedProducts()}
+        products={Streamable.from(getFeaturedProducts)}
         title={t('FeaturedProducts.title')}
       />
 
@@ -102,7 +103,7 @@ export default async function Home({ params }: Props) {
         emptyStateTitle={t('NewestProducts.emptyStateTitle')}
         nextLabel={t('NewestProducts.nextProducts')}
         previousLabel={t('NewestProducts.previousProducts')}
-        products={getNewestProducts()}
+        products={Streamable.from(getNewestProducts)}
         title={t('NewestProducts.title')}
       />
 

--- a/core/app/[locale]/(default)/product/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/page.tsx
@@ -4,7 +4,7 @@ import { getFormatter, getTranslations, setRequestLocale } from 'next-intl/serve
 import { createSearchParamsCache, parseAsString } from 'nuqs/server';
 import { cache } from 'react';
 
-import { Stream } from '@/vibes/soul/lib/streamable';
+import { Stream, Streamable } from '@/vibes/soul/lib/streamable';
 import { FeaturedProductCarousel } from '@/vibes/soul/sections/featured-product-carousel';
 import { ProductDetail } from '@/vibes/soul/sections/product-detail';
 import { pricesTransformer } from '~/data-transformers/prices-transformer';
@@ -240,13 +240,13 @@ export default async function Product(props: Props) {
       <ProductDetail
         action={addToCart}
         additionaInformationTitle={t('ProductDetails.additionalInformation')}
-        ctaDisabled={getCtaDisabled(props)}
-        ctaLabel={getCtaLabel(props)}
+        ctaDisabled={Streamable.from(() => getCtaDisabled(props))}
+        ctaLabel={Streamable.from(() => getCtaLabel(props))}
         decrementLabel={t('ProductDetails.decreaseQuantity')}
-        fields={getFields(props)}
+        fields={Streamable.from(() => getFields(props))}
         incrementLabel={t('ProductDetails.increaseQuantity')}
         prefetch={true}
-        product={getProduct(props)}
+        product={Streamable.from(() => getProduct(props))}
         quantityLabel={t('ProductDetails.quantity')}
         thumbnailLabel={t('ProductDetails.thumbnail')}
       />
@@ -257,14 +257,14 @@ export default async function Product(props: Props) {
         emptyStateTitle={t('RelatedProducts.noRelatedProducts')}
         nextLabel={t('RelatedProducts.nextProducts')}
         previousLabel={t('RelatedProducts.previousProducts')}
-        products={getRelatedProducts(props)}
+        products={Streamable.from(() => getRelatedProducts(props))}
         scrollbarLabel={t('RelatedProducts.scrollbar')}
         title={t('RelatedProducts.title')}
       />
 
       <Reviews productId={productId} searchParams={parsedSearchParams} />
 
-      <Stream fallback={null} value={getProductData(variables)}>
+      <Stream fallback={null} value={Streamable.from(() => getProductData(variables))}>
         {(product) => (
           <>
             <ProductSchema product={product} />

--- a/core/app/[locale]/(default)/webpages/[id]/contact/page.tsx
+++ b/core/app/[locale]/(default)/webpages/[id]/contact/page.tsx
@@ -5,6 +5,7 @@ import { cache } from 'react';
 
 import { DynamicForm } from '@/vibes/soul/form/dynamic-form';
 import type { Field, FieldGroup } from '@/vibes/soul/form/dynamic-form/schema';
+import { Streamable } from '@/vibes/soul/lib/streamable';
 import { ButtonLink } from '@/vibes/soul/primitives/button-link';
 import { Breadcrumb } from '@/vibes/soul/sections/breadcrumbs';
 import {
@@ -179,8 +180,8 @@ export default async function ContactPage({ params, searchParams }: Props) {
   if (success === 'true') {
     return (
       <WebPageContent
-        breadcrumbs={getWebPageBreadcrumbs(id)}
-        webPage={getWebPageWithSuccessContent(id, t('success'))}
+        breadcrumbs={Streamable.from(() => getWebPageBreadcrumbs(id))}
+        webPage={Streamable.from(() => getWebPageWithSuccessContent(id, t('success')))}
       >
         <ButtonLink
           className="mt-8 @2xl:mt-12 @4xl:mt-16"
@@ -196,7 +197,10 @@ export default async function ContactPage({ params, searchParams }: Props) {
   }
 
   return (
-    <WebPageContent breadcrumbs={getWebPageBreadcrumbs(id)} webPage={getWebPage(id)}>
+    <WebPageContent
+      breadcrumbs={Streamable.from(() => getWebPageBreadcrumbs(id))}
+      webPage={Streamable.from(() => getWebPage(id))}
+    >
       <div className="mt-8 @2xl:mt-12 @4xl:mt-16">
         <DynamicForm
           action={submitContactForm}

--- a/core/app/[locale]/(default)/webpages/[id]/normal/page.tsx
+++ b/core/app/[locale]/(default)/webpages/[id]/normal/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { cache } from 'react';
 
+import { Streamable } from '@/vibes/soul/lib/streamable';
 import { Breadcrumb } from '@/vibes/soul/sections/breadcrumbs';
 import {
   breadcrumbsTransformer,
@@ -67,5 +68,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function WebPage({ params }: Props) {
   const { id } = await params;
 
-  return <WebPageContent breadcrumbs={getWebPageBreadcrumbs(id)} webPage={getWebPage(id)} />;
+  return (
+    <WebPageContent
+      breadcrumbs={Streamable.from(() => getWebPageBreadcrumbs(id))}
+      webPage={Streamable.from(() => getWebPage(id))}
+    />
+  );
 }

--- a/core/app/[locale]/(default)/wishlist/[token]/page.tsx
+++ b/core/app/[locale]/(default)/wishlist/[token]/page.tsx
@@ -4,6 +4,7 @@ import { getFormatter, getTranslations } from 'next-intl/server';
 import { SearchParams } from 'nuqs';
 import { createSearchParamsCache, parseAsInteger, parseAsString } from 'nuqs/server';
 
+import { Streamable } from '@/vibes/soul/lib/streamable';
 import { CursorPaginationInfo } from '@/vibes/soul/primitives/cursor-pagination';
 import { Breadcrumb, Breadcrumbs } from '@/vibes/soul/sections/breadcrumbs';
 import { SectionLayout } from '@/vibes/soul/sections/section-layout';
@@ -112,7 +113,7 @@ export default async function PublicWishlist({ params, searchParams }: Props) {
           closeLabel={t('Modal.close')}
           copiedMessage={t('shareCopied')}
           disabledTooltip={t('shareDisabled')}
-          isMobileUser={isMobileUser()}
+          isMobileUser={Streamable.from(isMobileUser)}
           isPublic={wishlist.visibility.isPublic}
           label={t('share')}
           modalTitle={t('Modal.shareTitle', { name: wishlist.name })}
@@ -127,15 +128,15 @@ export default async function PublicWishlist({ params, searchParams }: Props) {
 
   return (
     <SectionLayout>
-      <Breadcrumbs breadcrumbs={getBreadcrumbs(token, searchParams)} />
+      <Breadcrumbs breadcrumbs={Streamable.from(() => getBreadcrumbs(token, searchParams))} />
 
       <WishlistDetails
         action={addWishlistItemToCart}
         className="mt-8"
         emptyStateText={t('emptyWishlist')}
         headerActions={wishlistActions}
-        paginationInfo={getPaginationInfo(token, searchParams)}
-        wishlist={getWishlist(token, t, pt, searchParams)}
+        paginationInfo={Streamable.from(() => getPaginationInfo(token, searchParams))}
+        wishlist={Streamable.from(() => getWishlist(token, t, pt, searchParams))}
       />
     </SectionLayout>
   );

--- a/core/components/header/index.tsx
+++ b/core/components/header/index.tsx
@@ -1,7 +1,7 @@
 import { getLocale, getTranslations } from 'next-intl/server';
-import PLazy from 'p-lazy';
 import { cache } from 'react';
 
+import { Streamable } from '@/vibes/soul/lib/streamable';
 import { HeaderSection } from '@/vibes/soul/sections/header-section';
 import { LayoutQuery } from '~/app/[locale]/(default)/query';
 import { getSessionCustomerAccessToken } from '~/auth';
@@ -144,12 +144,12 @@ export const Header = async () => {
         searchLabel: t('Icons.search'),
         searchParamName: 'term',
         searchAction: search,
-        links: getLinks(),
-        logo: getLogo(),
+        links: Streamable.from(getLinks),
+        logo: Streamable.from(getLogo),
         mobileMenuTriggerLabel: t('toggleNavigation'),
         openSearchPopupLabel: t('Search.openSearchPopup'),
         logoLabel: t('home'),
-        cartCount: PLazy.from(getCartCount),
+        cartCount: Streamable.from(getCartCount),
         activeLocaleId: locale,
         locales,
         currencies,

--- a/core/vibes/soul/lib/streamable.tsx
+++ b/core/vibes/soul/lib/streamable.tsx
@@ -1,3 +1,4 @@
+import PLazy from 'p-lazy';
 import { Suspense, use } from 'react';
 import { v4 as uuid } from 'uuid';
 
@@ -75,8 +76,13 @@ function all<T extends readonly unknown[] | []>(
   return result;
 }
 
+function from<T>(thunk: () => Promise<T>): Streamable<T> {
+  return PLazy.from(thunk);
+}
+
 export const Streamable = {
   all,
+  from,
 };
 
 export function useStreamable<T>(streamable: Streamable<T>): T {


### PR DESCRIPTION
## What/Why?
<!--- 
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
--->
Our `Streamable` pattern relies on passing promises as props to RSCs and client components. For RSCs, it "pushes down" data fetching so that Next.js will mark particular components as dynamic when using PPR. For client components, it streams the data to the client while triggering a Suspense boundary.

For the former case, we were getting the following error:
```
Unhandled Rejection: Error: Route /[locale]/category/[slug] needs to bail out of prerendering at this point because it used `await searchParams`, `searchParams.then`, or similar. React throws this special object to indicate where. It should not be caught by your own try/catch. Learn more: https://nextjs.org/docs/messages/ppr-caught-error
    at P (.next/server/chunks/5884.js:1:42808)
    at Object.get (.next/server/chunks/4019.js:4:32956)
    at <unknown> (.next/server/app/[locale]/(default)/(faceted)/category/[slug]/page.js:42:741) {
  ‘$$typeof’: Symbol(react.postpone)
}
Node.js process exited with exit status: 128. The logs above can help with debugging the issue.
```

We believe the reason for this is that promises are _eager_, not lazy. This means that if we call an async function on an RSC, it will start executing even if the RSC that we pass the promise to hasn't rendered yet. In particular, if the execution calls `cookies()`, `await searchParams` or other dynamic APIs which throw, it results in the error above.

This PR introduces `Streamable.from` which abstracts the idea of a "lazy promise", deferring execution until the first `.then` call. It uses `Streamable.from` anywhere we were calling an async function without `await` to avoid the unhandled rejection.

Something particular about `Streamable.from` is that it allows us to refer to values via closure directly in the RSC, removing the need for creating async functions when using the streamable pattern. This PR purposefully keeps this out of scope and I plan to address this in a future PR.

Furthermore, the implementation of `Streamable.from` is a simple wrapper around `p-lazy`. In a future PR, I intend to remove the dependency on `p-lazy` and have a custom implementation for lazy promises.

This PR is pre-work for the move to PPR + `dynamicIO` to better optimize caching and performance of Catalyst.

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->

https://github.com/user-attachments/assets/e2784901-1540-4dad-85eb-ab0e2c422aec

