### PR TITLE
feat(core): add store hash meta tag

### DIFF
--- a/.changeset/slow-dodos-ring.md
+++ b/.changeset/slow-dodos-ring.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Add the `store_hash` `<meta />` element to better support merchants. This enabled BigCommerce to identify the store more easily.

--- a/core/app/[locale]/layout.tsx
+++ b/core/app/[locale]/layout.tsx
@@ -58,6 +58,7 @@ export async function generateMetadata(): Promise<Metadata> {
     other: {
       platform: 'bigcommerce.catalyst',
       build_sha: process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA ?? '',
+      store_hash: process.env.BIGCOMMERCE_STORE_HASH ?? '',
     },
   };
 }


### PR DESCRIPTION
## What/Why?
Adds the store hash to a meta tag for easily debugging merchants sites.

## Testing
![Screenshot 2025-03-25 at 16 34 37](https://github.com/user-attachments/assets/dda1aa76-54c7-47b8-be91-e44eaed7a05f)
