### PR TITLE
fix: textPosition defualt value set to outside

### DIFF
--- a/core/lib/makeswift/components/card/card.makeswift.tsx
+++ b/core/lib/makeswift/components/card/card.makeswift.tsx
@@ -60,7 +60,7 @@ runtime.registerComponent(
           { value: 'inside', label: 'Inside' },
           { value: 'outside', label: 'Outside' },
         ],
-        defaultValue: 'inside',
+        defaultValue: 'outside',
       }),
       textSize: Select({
         label: 'Text size',


### PR DESCRIPTION
## What/Why?
- changes the default value for `textPostion` to `outside` for the `Card` component to avoid breaking changes for users that might have already created `Card` components

## Testing
https://github.com/user-attachments/assets/2d4a35ae-7515-4c40-833f-596b6a5ba6b6

