### PR TITLE
 fix(core): disable ppr for compare page

### DIFF
--- a/.changeset/fine-files-enjoy.md
+++ b/.changeset/fine-files-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Disable PPR in Compare page due to an issue of Next.js and PPR, which causes the products to be removed once one is added to cart. More info: https://github.com/vercel/next.js/issues/59407.

--- a/core/app/[locale]/(default)/compare/page.tsx
+++ b/core/app/[locale]/(default)/compare/page.tsx
@@ -105,4 +105,6 @@ export default async function Compare(props: Props) {
   );
 }
 
+// Disabled to circumvent a bug in Next.js and PPR
+// More info: https://github.com/vercel/next.js/issues/59407
 export const experimental_ppr = false;

--- a/core/app/[locale]/(default)/compare/page.tsx
+++ b/core/app/[locale]/(default)/compare/page.tsx
@@ -104,3 +104,5 @@ export default async function Compare(props: Props) {
     />
   );
 }
+
+export const experimental_ppr = false;


### PR DESCRIPTION
## What/Why?
Disables PPR in the Compare page to fix an issue of products disappearing when a product is added to cart. This happens due to a bug in Next.js when PPR is enabled that removes search params when a page is revalidated. More info: https://github.com/vercel/next.js/issues/59407

## Testing
In production, products no longer disappear when added to cart.

## Migration
Add `export const experimental_ppr = false;` to compare page.