### PR TITLE
fix: correct spelling of 'additionalInformationTitle' in ProductDetail component

### DIFF
--- a/core/app/[locale]/(default)/product/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/page.tsx
@@ -239,7 +239,7 @@ export default async function Product(props: Props) {
     <>
       <ProductDetail
         action={addToCart}
-        additionaInformationTitle={t('ProductDetails.additionalInformation')}
+        additionalInformationTitle={t('ProductDetails.additionalInformation')}
         ctaDisabled={Streamable.from(() => getCtaDisabled(props))}
         ctaLabel={Streamable.from(() => getCtaLabel(props))}
         decrementLabel={t('ProductDetails.decreaseQuantity')}

--- a/core/vibes/soul/sections/product-detail/index.tsx
+++ b/core/vibes/soul/sections/product-detail/index.tsx
@@ -39,7 +39,7 @@ interface Props<F extends Field> {
   ctaDisabled?: Streamable<boolean | null>;
   prefetch?: boolean;
   thumbnailLabel?: string;
-  additionaInformationTitle?: string;
+  additionalInformationTitle?: string;
 }
 
 export function ProductDetail<F extends Field>({
@@ -54,7 +54,7 @@ export function ProductDetail<F extends Field>({
   ctaDisabled: streamableCtaDisabled,
   prefetch,
   thumbnailLabel,
-  additionaInformationTitle = 'Additional information',
+  additionalInformationTitle = 'Additional information',
 }: Props<F>) {
   return (
     <section className="@container">
@@ -139,7 +139,7 @@ export function ProductDetail<F extends Field>({
                     }
                   </Stream>
 
-                  <h2 className="sr-only">{additionaInformationTitle}</h2>
+                  <h2 className="sr-only">{additionalInformationTitle}</h2>
                   <Stream fallback={<ProductAccordionsSkeleton />} value={product.accordions}>
                     {(accordions) =>
                       accordions && (


### PR DESCRIPTION
## What/Why?

Typo found in ProductDetail param.

Updates `additionaInformationTitle` to `additionalInformationTitle`

## Testing

Ensure ProductDetail component is still rendering the additional information title as expected.