### PR TITLE
feat(core): Wrap MakeswiftApiHandler so env variables are initialized

### DIFF
--- a/core/app/api/makeswift/[...makeswift]/route.ts
+++ b/core/app/api/makeswift/[...makeswift]/route.ts
@@ -19,7 +19,7 @@ const defaultVariants: Font['variants'] = [
   },
 ];
 
-const getHandler = (apiKey: string, apiOrigin: string, appOrigin: string) => {
+const getHandler = (apiKey: string, apiOrigin: string | undefined, appOrigin: string | undefined) => {
   return MakeswiftApiHandler(apiKey, {
     apiOrigin,
     appOrigin,

--- a/core/app/api/makeswift/[...makeswift]/route.ts
+++ b/core/app/api/makeswift/[...makeswift]/route.ts
@@ -1,11 +1,8 @@
-import { type Font, MakeswiftApiHandler } from '@makeswift/runtime/next/server';
-import { strict } from 'assert';
+import { Font, MakeswiftApiHandler } from '@makeswift/runtime/next/server';
+import { NextRequest } from 'next/server';
 
 import { runtime } from '~/lib/makeswift/runtime';
-
 import '~/lib/makeswift/components';
-
-strict(process.env.MAKESWIFT_SITE_API_KEY, 'MAKESWIFT_SITE_API_KEY is required');
 
 const defaultVariants: Font['variants'] = [
   {
@@ -22,29 +19,67 @@ const defaultVariants: Font['variants'] = [
   },
 ];
 
-const handler = MakeswiftApiHandler(process.env.MAKESWIFT_SITE_API_KEY, {
-  runtime,
-  apiOrigin: process.env.MAKESWIFT_API_ORIGIN,
-  appOrigin: process.env.MAKESWIFT_APP_ORIGIN,
-  getFonts() {
-    return [
-      {
-        family: 'var(--font-family-inter)',
-        label: 'Inter',
-        variants: defaultVariants,
-      },
-      {
-        family: 'var(--font-family-dm-serif-text)',
-        label: 'DM Serif Text',
-        variants: [{ weight: '400', style: 'normal' }],
-      },
-      {
-        family: 'var(--font-family-roboto-mono)',
-        label: 'Roboto Mono',
-        variants: defaultVariants,
-      },
-    ];
-  },
-});
+const getHandler = (apiKey: string, apiOrigin: string, appOrigin: string) => {
+  return MakeswiftApiHandler(apiKey, {
+    apiOrigin,
+    appOrigin,
+    runtime,
+    getFonts() {
+      return [
+        {
+          family: 'var(--font-family-inter)',
+          label: 'Inter',
+          variants: defaultVariants,
+        },
+        {
+          family: 'var(--font-family-dm-serif-text)',
+          label: 'DM Serif Text',
+          variants: [{ weight: '400', style: 'normal' }],
+        },
+        {
+          family: 'var(--font-family-roboto-mono)',
+          label: 'Roboto Mono',
+          variants: defaultVariants,
+        },
+      ];
+    },
+  });
+};
 
-export { handler as GET, handler as POST };
+export async function GET(
+  request: NextRequest,
+  {
+    params,
+  }: {
+    params: { makeswift: string };
+  },
+) {
+  const apiKey = process.env.MAKESWIFT_SITE_API_KEY;
+  const apiOrigin = process.env.MAKESWIFT_API_ORIGIN;
+  const appOrigin = process.env.MAKESWIFT_APP_ORIGIN;
+
+  if (!apiKey) {
+    throw new Error('MAKESWIFT_SITE_API_KEY is required');
+  }
+
+  return getHandler(apiKey, apiOrigin, appOrigin)(request, { params });
+}
+
+export async function POST(
+  request: NextRequest,
+  {
+    params,
+  }: {
+    params: { makeswift: string };
+  },
+) {
+  const apiKey = process.env.MAKESWIFT_SITE_API_KEY;
+  const apiOrigin = process.env.MAKESWIFT_API_ORIGIN;
+  const appOrigin = process.env.MAKESWIFT_APP_ORIGIN;
+
+  if (!apiKey) {
+    throw new Error('MAKESWIFT_SITE_API_KEY is required');
+  }
+
+  return getHandler(apiKey, apiOrigin, appOrigin)(request, { params });
+}


### PR DESCRIPTION
## What/Why?
We are seeing the following error in Cloudflare worker with Catalyst deploy with Makeswift.

```
[wrangler:inf] OPTIONS /api/makeswift/manifest/ 400 Bad Request (40ms)
✘ [ERROR] ⨯ TypeError: Cannot read properties of undefined (reading 'definition')

      at r1 (Users/naqi.syed/catalyst-cf/core/.wrangler/tmp/dev-gV2YQC/worker.js:336810:28)
      at lazyRenderAppPage
  (Users/naqi.syed/catalyst-cf/core/.wrangler/tmp/dev-gV2YQC/worker.js:368362:16)
      at Object.renderHTMLImpl
  (Users/naqi.syed/catalyst-cf/core/.wrangler/tmp/dev-gV2YQC/worker.js:371888:56)
      at <unknown> (Users/naqi.syed/catalyst-cf/core/.wrangler/tmp/dev-gV2YQC/worker.js:371876:107)
      at Object.trace
  (Users/naqi.syed/catalyst-cf/core/.wrangler/tmp/dev-gV2YQC/worker.js:129914:18)
      at Object.renderHTML
  (Users/naqi.syed/catalyst-cf/core/.wrangler/tmp/dev-gV2YQC/worker.js:371876:41)
      at doRender (Users/naqi.syed/catalyst-cf/core/.wrangler/tmp/dev-gV2YQC/worker.js:149744:33)
      at responseGenerator
  (Users/naqi.syed/catalyst-cf/core/.wrangler/tmp/dev-gV2YQC/worker.js:149944:18)
      at Object.get (Users/naqi.syed/catalyst-cf/core/.wrangler/tmp/dev-gV2YQC/worker.js:134502:18)
      at Object.renderToResponseWithComponentsImpl
  (Users/naqi.syed/catalyst-cf/core/.wrangler/tmp/dev-gV2YQC/worker.js:149950:53)
  ```
After debugging, one of the cause of this turned out to be how we are accessing environment variables. Environment variables do not initialize in Cloudflare workers until the handler is triggered. 

The fix is to get env variables before calling `MakeswiftApiHandler`. I am offering a simple solution to it.

