### PR TITLE
fix: dedupe default image in PDP

### DIFF
--- a/.changeset/khaki-rice-design.md
+++ b/.changeset/khaki-rice-design.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Deduplicate default image in the image gallery in PDP.

--- a/core/app/[locale]/(default)/product/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/page.tsx
@@ -116,7 +116,10 @@ const getProduct = async (props: Props) => {
     description: <div dangerouslySetInnerHTML={{ __html: product.description }} />,
     href: product.path,
     images: product.defaultImage
-      ? [{ src: product.defaultImage.url, alt: product.defaultImage.altText }, ...images]
+      ? [
+          { src: product.defaultImage.url, alt: product.defaultImage.altText },
+          ...images.filter((image) => image.src !== product.defaultImage?.url),
+        ]
       : images,
     price: pricesTransformer(product.prices, format),
     subtitle: product.brand?.name,


### PR DESCRIPTION
## What/Why?
Since we render the default image first, and append all of the images, this causes duplicate images in product. This fix dedupes the default image from the product gallery. 

## Testing
Duplicate image is no longer present.

| Before | After |
| ------ | ------ |
| ![Screenshot 2025-03-27 at 2 37 19 PM](https://github.com/user-attachments/assets/861cb0f5-3e8c-4acc-9441-3a4ce4893110) | ![Screenshot 2025-03-27 at 2 40 10 PM](https://github.com/user-attachments/assets/d2bfaac7-325b-4869-aa97-740a26fc3b05) |
