### PR TITLE
Pass cart locale into redirect mutation

### DIFF
--- a/.changeset/funny-camels-press.md
+++ b/.changeset/funny-camels-press.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Pass cart locale into redirect mutation to ensure correct locale appears in checkout

--- a/core/app/[locale]/(default)/cart/_actions/redirect-to-checkout.ts
+++ b/core/app/[locale]/(default)/cart/_actions/redirect-to-checkout.ts
@@ -13,9 +13,9 @@ import { redirect } from '~/i18n/routing';
 import { getCartId } from '~/lib/cart';
 
 const CheckoutRedirectMutation = graphql(`
-  mutation CheckoutRedirectMutation($cartId: String!) {
+  mutation CheckoutRedirectMutation($cartId: String!, $locale: String!) {
     cart {
-      createCartRedirectUrls(input: { cartEntityId: $cartId }) {
+      createCartRedirectUrls(input: { cartEntityId: $cartId, locale: $locale }) {
         redirectUrls {
           redirectedCheckoutUrl
         }
@@ -46,7 +46,7 @@ export const redirectToCheckout = async (
   try {
     const { data } = await client.fetch({
       document: CheckoutRedirectMutation,
-      variables: { cartId },
+      variables: { cartId, locale },
       fetchOptions: { cache: 'no-store' },
       customerAccessToken,
     });


### PR DESCRIPTION
## What/Why?
Pass cart locale into redirect mutation to ensure locale matches once the customer arrives at checkout.

Adding `do not merge` until the API is fully rolled out.

## Testing

https://github.com/user-attachments/assets/69a7d3da-7e07-49be-ada6-472a061cf23f

