### PR TITLE
feat(core): add store urls to build-config.json

### DIFF
--- a/.changeset/loud-breads-jog.md
+++ b/.changeset/loud-breads-jog.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Fetches the stores URLs on build which can remove the need of setting NEXT_PUBLIC_BIGCOMMERCE_CDN_HOSTNAME. The environment variable is still provided in case customization is needed.

--- a/core/.eslintrc.cjs
+++ b/core/.eslintrc.cjs
@@ -1,6 +1,5 @@
 // @ts-check
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 require('@bigcommerce/eslint-config/patch');
 
 /** @type {import('eslint').Linter.Config} */

--- a/core/build-config/schema.ts
+++ b/core/build-config/schema.ts
@@ -7,6 +7,11 @@ export const buildConfigSchema = z.object({
       isDefault: z.boolean(),
     }),
   ),
+  urls: z.object({
+    vanityUrl: z.string(),
+    cdnUrl: z.string().default('cdn11.bigcommerce.com'),
+    checkoutUrl: z.string(),
+  }),
 });
 
 export type BuildConfigSchema = z.infer<typeof buildConfigSchema>;

--- a/core/build-config/writer.ts
+++ b/core/build-config/writer.ts
@@ -12,9 +12,11 @@ const CONFIG_FILE = join(destinationPath, 'build-config.json');
 // This fn is only intended to be used in the build process (next.config.ts)
 export async function writeBuildConfig(data: unknown) {
   try {
-    buildConfigSchema.parse(data);
+    const parsedData = buildConfigSchema.parse(data);
 
     await writeFile(CONFIG_FILE, JSON.stringify(data), 'utf8');
+
+    return parsedData;
   } catch (error) {
     if (error instanceof z.ZodError) {
       console.error('Data validation failed:', error.errors);

--- a/core/components/image/index.tsx
+++ b/core/components/image/index.tsx
@@ -3,12 +3,14 @@
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import NextImage, { ImageProps } from 'next/image';
 
+import { buildConfig } from '~/build-config/reader';
 import bcCdnImageLoader from '~/lib/cdn-image-loader';
 
-const cdnHostname = process.env.NEXT_PUBLIC_BIGCOMMERCE_CDN_HOSTNAME ?? 'cdn11.bigcommerce.com';
-
 function shouldUseLoaderProp(props: ImageProps): boolean {
-  return typeof props.src === 'string' && props.src.startsWith(`https://${cdnHostname}`);
+  return (
+    typeof props.src === 'string' &&
+    props.src.startsWith(`https://${buildConfig.get('urls').cdnUrl}`)
+  );
 }
 
 /**

--- a/core/lib/store-assets.ts
+++ b/core/lib/store-assets.ts
@@ -1,4 +1,5 @@
-const cdnHostname = process.env.NEXT_PUBLIC_BIGCOMMERCE_CDN_HOSTNAME ?? 'cdn11.bigcommerce.com';
+import { buildConfig } from '~/build-config/reader';
+
 const storeHash = process.env.BIGCOMMERCE_STORE_HASH ?? '';
 
 /**
@@ -12,7 +13,7 @@ const storeHash = process.env.BIGCOMMERCE_STORE_HASH ?? '';
  * @returns {string} The CDN image URL.
  */
 const cdnImageUrlBuilder = (sizeSegment: string, source: string, path: string): string => {
-  return `https://${cdnHostname}/s-${storeHash}/images/stencil/${sizeSegment}/${source}/${path}`;
+  return `https://${buildConfig.get('urls').cdnUrl}/s-${storeHash}/images/stencil/${sizeSegment}/${source}/${path}`;
 };
 
 /**
@@ -25,7 +26,7 @@ const cdnImageUrlBuilder = (sizeSegment: string, source: string, path: string): 
  * @returns {string} The full URL to the content asset.
  */
 export const contentAssetUrl = (path: string): string => {
-  return `https://${cdnHostname}/s-${storeHash}/content/${path}`;
+  return `https://${buildConfig.get('urls').cdnUrl}/s-${storeHash}/content/${path}`;
 };
 
 /**

--- a/core/next.config.ts
+++ b/core/next.config.ts
@@ -9,10 +9,15 @@ import { cspHeader } from './lib/content-security-policy';
 
 const withNextIntl = createNextIntlPlugin();
 
-const LocaleQuery = graphql(`
-  query LocaleQuery {
+const SettingsQuery = graphql(`
+  query SettingsQuery {
     site {
       settings {
+        url {
+          vanityUrl
+          cdnUrl
+          checkoutUrl
+        }
         locales {
           code
           isDefault
@@ -22,7 +27,21 @@ const LocaleQuery = graphql(`
   }
 `);
 
+async function writeSettingsToBuildConfig() {
+  const { data } = await client.fetch({ document: SettingsQuery });
+
+  return await writeBuildConfig({
+    locales: data.site.settings?.locales,
+    urls: {
+      ...data.site.settings?.url,
+      cdnUrl: process.env.NEXT_PUBLIC_BIGCOMMERCE_CDN_HOSTNAME ?? data.site.settings?.url.cdnUrl,
+    },
+  });
+}
+
 export default async (): Promise<NextConfig> => {
+  const settings = await writeSettingsToBuildConfig();
+
   let nextConfig: NextConfig = {
     reactStrictMode: true,
     experimental: {
@@ -63,7 +82,7 @@ export default async (): Promise<NextConfig> => {
             },
             {
               key: 'Link',
-              value: `<https://${process.env.NEXT_PUBLIC_BIGCOMMERCE_CDN_HOSTNAME ?? 'cdn11.bigcommerce.com'}>; rel=preconnect`,
+              value: `<https://${settings.urls.cdnUrl}>; rel=preconnect`,
             },
           ],
         },
@@ -80,13 +99,5 @@ export default async (): Promise<NextConfig> => {
     nextConfig = withBundleAnalyzer(nextConfig);
   }
 
-  await writeLocaleToBuildConfig();
-
   return nextConfig;
 };
-
-async function writeLocaleToBuildConfig() {
-  const { data } = await client.fetch({ document: LocaleQuery });
-
-  await writeBuildConfig({ locales: data.site.settings?.locales });
-}

--- a/core/package.json
+++ b/core/package.json
@@ -75,6 +75,7 @@
   },
   "devDependencies": {
     "@0no-co/graphqlsp": "^1.12.16",
+    "@bigcommerce/eslint-config": "^2.11.0",
     "@bigcommerce/eslint-config-catalyst": "workspace:^",
     "@faker-js/faker": "^9.6.0",
     "@gql.tada/cli-utils": "^1.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,13 +94,13 @@ importers:
         version: 1.34.6
       '@vercel/analytics':
         specifier: ^1.5.0
-        version: 1.5.0(next@15.3.0-canary.20(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(svelte@5.1.15)
+        version: 1.5.0(next@15.3.0-canary.20(@babel/core@7.24.7)(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(svelte@5.1.15)
       '@vercel/kv':
         specifier: ^3.0.0
         version: 3.0.0
       '@vercel/speed-insights':
         specifier: ^1.2.0
-        version: 1.2.0(next@15.3.0-canary.20(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(svelte@5.1.15)
+        version: 1.2.0(next@15.3.0-canary.20(@babel/core@7.24.7)(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(svelte@5.1.15)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -148,16 +148,16 @@ importers:
         version: 0.474.0(react@19.0.0)
       next:
         specifier: 15.3.0-canary.20
-        version: 15.3.0-canary.20(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 15.3.0-canary.20(@babel/core@7.24.7)(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       next-auth:
         specifier: 5.0.0-beta.25
-        version: 5.0.0-beta.25(next@15.3.0-canary.20(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(nodemailer@6.9.16)(react@19.0.0)
+        version: 5.0.0-beta.25(next@15.3.0-canary.20(@babel/core@7.24.7)(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(nodemailer@6.9.16)(react@19.0.0)
       next-intl:
         specifier: ^3.26.5
-        version: 3.26.5(next@15.3.0-canary.20(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
+        version: 3.26.5(next@15.3.0-canary.20(@babel/core@7.24.7)(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
       nuqs:
         specifier: ^2.4.1
-        version: 2.4.1(next@15.3.0-canary.20(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
+        version: 2.4.1(next@15.3.0-canary.20(@babel/core@7.24.7)(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
       p-lazy:
         specifier: ^5.0.0
         version: 5.0.0
@@ -207,6 +207,9 @@ importers:
       '@0no-co/graphqlsp':
         specifier: ^1.12.16
         version: 1.12.16(graphql@16.10.0)(typescript@5.8.2)
+      '@bigcommerce/eslint-config':
+        specifier: ^2.11.0
+        version: 2.11.0(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0)(typescript@5.8.2)
       '@bigcommerce/eslint-config-catalyst':
         specifier: workspace:^
         version: link:../packages/eslint-config-catalyst
@@ -8263,9 +8266,9 @@ snapshots:
     dependencies:
       crypto-js: 4.2.0
 
-  '@vercel/analytics@1.5.0(next@15.3.0-canary.20(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(svelte@5.1.15)':
+  '@vercel/analytics@1.5.0(next@15.3.0-canary.20(@babel/core@7.24.7)(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(svelte@5.1.15)':
     optionalDependencies:
-      next: 15.3.0-canary.20(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next: 15.3.0-canary.20(@babel/core@7.24.7)(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       svelte: 5.1.15
 
@@ -8273,9 +8276,9 @@ snapshots:
     dependencies:
       '@upstash/redis': 1.34.6
 
-  '@vercel/speed-insights@1.2.0(next@15.3.0-canary.20(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(svelte@5.1.15)':
+  '@vercel/speed-insights@1.2.0(next@15.3.0-canary.20(@babel/core@7.24.7)(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(svelte@5.1.15)':
     optionalDependencies:
-      next: 15.3.0-canary.20(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next: 15.3.0-canary.20(@babel/core@7.24.7)(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       svelte: 5.1.15
 
@@ -9212,7 +9215,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -9244,7 +9247,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -10646,23 +10649,23 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  next-auth@5.0.0-beta.25(next@15.3.0-canary.20(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(nodemailer@6.9.16)(react@19.0.0):
+  next-auth@5.0.0-beta.25(next@15.3.0-canary.20(@babel/core@7.24.7)(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(nodemailer@6.9.16)(react@19.0.0):
     dependencies:
       '@auth/core': 0.37.2(nodemailer@6.9.16)
-      next: 15.3.0-canary.20(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next: 15.3.0-canary.20(@babel/core@7.24.7)(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
     optionalDependencies:
       nodemailer: 6.9.16
 
-  next-intl@3.26.5(next@15.3.0-canary.20(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0):
+  next-intl@3.26.5(next@15.3.0-canary.20(@babel/core@7.24.7)(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0):
     dependencies:
       '@formatjs/intl-localematcher': 0.5.7
       negotiator: 1.0.0
-      next: 15.3.0-canary.20(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next: 15.3.0-canary.20(@babel/core@7.24.7)(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       use-intl: 3.26.5(react@19.0.0)
 
-  next@15.3.0-canary.20(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  next@15.3.0-canary.20(@babel/core@7.24.7)(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       '@next/env': 15.3.0-canary.20
       '@swc/counter': 0.1.3
@@ -10672,7 +10675,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      styled-jsx: 5.1.6(react@19.0.0)
+      styled-jsx: 5.1.6(@babel/core@7.24.7)(react@19.0.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.3.0-canary.20
       '@next/swc-darwin-x64': 15.3.0-canary.20
@@ -10711,12 +10714,12 @@ snapshots:
     dependencies:
       path-key: 3.1.1
 
-  nuqs@2.4.1(next@15.3.0-canary.20(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0):
+  nuqs@2.4.1(next@15.3.0-canary.20(@babel/core@7.24.7)(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0):
     dependencies:
       mitt: 3.0.1
       react: 19.0.0
     optionalDependencies:
-      next: 15.3.0-canary.20(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next: 15.3.0-canary.20(@babel/core@7.24.7)(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
 
   nypm@0.5.4:
     dependencies:
@@ -11536,10 +11539,12 @@ snapshots:
 
   stubborn-fs@1.2.5: {}
 
-  styled-jsx@5.1.6(react@19.0.0):
+  styled-jsx@5.1.6(@babel/core@7.24.7)(react@19.0.0):
     dependencies:
       client-only: 0.0.1
       react: 19.0.0
+    optionalDependencies:
+      '@babel/core': 7.24.7
 
   sucrase@3.35.0:
     dependencies:


### PR DESCRIPTION
## What/Why?
Fetches the store urls on build and consumes it for CDN urls. This is some pre-work to validate urls coming from session-sync endpoints.

Also, fixes some eslint issues since `pnpm@10` resolved dependencies a little differently.

## Testing
![Screenshot 2025-03-31 at 11 45 01](https://github.com/user-attachments/assets/62ebf658-fe1a-4ece-aab0-5579c2ca68d8)