### PR TITLE
feat: localize empty select placeholders on the PDP page

### DIFF
--- a/core/app/[locale]/(default)/product/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/page.tsx
@@ -246,6 +246,7 @@ export default async function Product(props: Props) {
         ctaDisabled={Streamable.from(() => getCtaDisabled(props))}
         ctaLabel={Streamable.from(() => getCtaLabel(props))}
         decrementLabel={t('ProductDetails.decreaseQuantity')}
+        emptySelectPlaceholder={t('ProductDetails.emptySelectPlaceholder')}
         fields={Streamable.from(() => getFields(props))}
         incrementLabel={t('ProductDetails.increaseQuantity')}
         prefetch={true}

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -471,6 +471,7 @@
       "quantity": "Quantity",
       "increaseQuantity": "Increase quantity",
       "decreaseQuantity": "Decrease quantity",
+      "emptySelectPlaceholder": "Select an option",
       "successMessage": "{cartItems, plural, =1 {1 item} other {# items}} added to <cartLink> your cart</cartLink>",
       "missingCart": "Cart not found. Please try again later!",
       "unknownError": "Unknown error. Please try again later.",

--- a/core/messages/fr.json
+++ b/core/messages/fr.json
@@ -470,6 +470,7 @@
             "quantity": "Quantité",
             "increaseQuantity": "Augmenter la quantité :",
             "decreaseQuantity": "Réduire la quantité",
+            "emptySelectPlaceholder": "Sélectionner une option",
             "successMessage": "<cartLink>{CartItems, plural, =1 {1 article} other {# articles}} ajouté(s) à votre panier</cartLink>",
             "missingCart": "Panier introuvable. Veuillez réessayer plus tard !",
             "unknownError": "Erreur inconnue. Veuillez réessayer plus tard.",

--- a/core/vibes/soul/sections/product-detail/index.tsx
+++ b/core/vibes/soul/sections/product-detail/index.tsx
@@ -38,6 +38,7 @@ export interface ProductDetailProps<F extends Field> {
   quantityLabel?: string;
   incrementLabel?: string;
   decrementLabel?: string;
+  emptySelectPlaceholder?: string;
   ctaLabel?: Streamable<string | null>;
   ctaDisabled?: Streamable<boolean | null>;
   prefetch?: boolean;
@@ -68,6 +69,7 @@ export function ProductDetail<F extends Field>({
   quantityLabel,
   incrementLabel,
   decrementLabel,
+  emptySelectPlaceholder,
   ctaLabel: streamableCtaLabel,
   ctaDisabled: streamableCtaDisabled,
   prefetch,
@@ -146,6 +148,7 @@ export function ProductDetail<F extends Field>({
                           ctaDisabled={ctaDisabled ?? undefined}
                           ctaLabel={ctaLabel ?? undefined}
                           decrementLabel={decrementLabel}
+                          emptySelectPlaceholder={emptySelectPlaceholder}
                           fields={fields}
                           incrementLabel={incrementLabel}
                           prefetch={prefetch}

--- a/core/vibes/soul/sections/product-detail/product-detail-form.tsx
+++ b/core/vibes/soul/sections/product-detail/product-detail-form.tsx
@@ -48,6 +48,7 @@ export interface ProductDetailFormProps<F extends Field> {
   quantityLabel?: string;
   incrementLabel?: string;
   decrementLabel?: string;
+  emptySelectPlaceholder?: string;
   ctaDisabled?: boolean;
   prefetch?: boolean;
 }
@@ -60,6 +61,7 @@ export function ProductDetailForm<F extends Field>({
   quantityLabel = 'Quantity',
   incrementLabel = 'Increase quantity',
   decrementLabel = 'Decrease quantity',
+  emptySelectPlaceholder = 'Select an option',
   ctaDisabled = false,
   prefetch = false,
 }: ProductDetailFormProps<F>) {
@@ -130,6 +132,7 @@ export function ProductDetailForm<F extends Field>({
           {fields.map((field) => {
             return (
               <FormField
+                emptySelectPlaceholder={emptySelectPlaceholder}
                 field={field}
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 formField={formFields[field.name]!}
@@ -185,10 +188,12 @@ function FormField({
   field,
   formField,
   onPrefetch,
+  emptySelectPlaceholder,
 }: {
   field: Field;
   formField: FieldMetadata<string | number | boolean | Date | undefined>;
   onPrefetch: (fieldName: string, value: string) => void;
+  emptySelectPlaceholder?: string;
 }) {
   const controls = useInputControl(formField);
 
@@ -270,6 +275,7 @@ function FormField({
           onOptionMouseEnter={handleOnOptionMouseEnter}
           onValueChange={handleChange}
           options={field.options}
+          placeholder={emptySelectPlaceholder}
           required={formField.required}
           value={controls.value ?? ''}
         />


### PR DESCRIPTION
## What/Why?

Add ability to localize default `Select` placeholder labels on the PDP page.

## Testing

https://github.com/user-attachments/assets/c6c33493-8ae7-4096-801b-dcd675b52778


