### PR TITLE
refactor(core): move checkout redirect as a route

### DIFF
--- a/.changeset/bumpy-waves-behave.md
+++ b/.changeset/bumpy-waves-behave.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Refactors redirecting to checkout as a route. This will enable session syncing to happen through a redirect using the sites and routes API.

--- a/core/app/[locale]/(default)/checkout/route.ts
+++ b/core/app/[locale]/(default)/checkout/route.ts
@@ -1,0 +1,75 @@
+import { unstable_rethrow as rethrow } from 'next/navigation';
+import { NextRequest, NextResponse } from 'next/server';
+
+import { getSessionCustomerAccessToken } from '~/auth';
+import { getChannelIdFromLocale } from '~/channels.config';
+import { client } from '~/client';
+import { graphql } from '~/client/graphql';
+import { redirect } from '~/i18n/routing';
+import { getCartId } from '~/lib/cart';
+
+const CheckoutRedirectMutation = graphql(`
+  mutation CheckoutRedirectMutation($cartId: String!) {
+    cart {
+      createCartRedirectUrls(input: { cartEntityId: $cartId }) {
+        errors {
+          ... on NotFoundError {
+            __typename
+          }
+        }
+        redirectUrls {
+          redirectedCheckoutUrl
+        }
+      }
+    }
+  }
+`);
+
+export async function GET(_: NextRequest, { params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const cartId = await getCartId();
+  const customerAccessToken = await getSessionCustomerAccessToken();
+  const channelId = getChannelIdFromLocale(locale);
+
+  if (!cartId) {
+    return NextResponse.json(
+      { message: 'Cart not found' },
+      { status: 404, statusText: 'Not Found' },
+    );
+  }
+
+  try {
+    const { data } = await client.fetch({
+      document: CheckoutRedirectMutation,
+      variables: { cartId },
+      fetchOptions: { cache: 'no-store' },
+      customerAccessToken,
+      channelId,
+    });
+
+    if (
+      data.cart.createCartRedirectUrls.errors.length > 0 ||
+      !data.cart.createCartRedirectUrls.redirectUrls
+    ) {
+      return NextResponse.json(
+        { message: 'Cart not found' },
+        { status: 404, statusText: 'Not Found' },
+      );
+    }
+
+    return redirect({
+      href: data.cart.createCartRedirectUrls.redirectUrls.redirectedCheckoutUrl,
+      locale,
+    });
+  } catch (error) {
+    rethrow(error);
+
+    // eslint-disable-next-line no-console
+    console.error(error);
+
+    return NextResponse.json(
+      { message: 'Server error' },
+      { status: 500, statusText: 'Server error' },
+    );
+  }
+}

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -443,7 +443,6 @@
     "Errors": {
       "cartNotFound": "No cartId cookie found.",
       "lineItemNotFound": "Line item not found.",
-      "failedToRedirectToCheckout": "Failed to redirect to checkout.",
       "failedToUpdateQuantity": "Failed to update quantity.",
       "somethingWentWrong": "Something went wrong. Please try again later."
     }


### PR DESCRIPTION
## What/Why?
Moves triggering the redirect to checkout as a separate route handler. This will enable us to use the Sites/Routes API to set a checkout route to redirect to. This will be useful when we need to trigger session syncing by redirecting to the login page with a `/checkout` `redirectTo` query param.

## Testing

### Successful login redirect

![Screenshot 2025-04-01 at 11 45 28](https://github.com/user-attachments/assets/f8e636cd-6a6a-4e7f-8476-b095e988c740)
