### PR TITLE
feat(core): add the ability to redirect from login

### DIFF
--- a/.changeset/late-ends-nail.md
+++ b/.changeset/late-ends-nail.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Add the ability to redirect from the login page. Developers can now append a relative path to the `?redirectTo=` query param on the `/login` page. When a shopper successfully logs in, it'll redirect them to the given relative path. Defaults to `/account/orders` to prevent a breaking change.

--- a/core/app/[locale]/(default)/(auth)/login/_actions/login.ts
+++ b/core/app/[locale]/(default)/(auth)/login/_actions/login.ts
@@ -11,7 +11,11 @@ import { signIn } from '~/auth';
 import { redirect } from '~/i18n/routing';
 import { getCartId } from '~/lib/cart';
 
-export const login = async (_lastResult: SubmissionResult | null, formData: FormData) => {
+export const login = async (
+  { redirectTo }: { redirectTo: string },
+  _lastResult: SubmissionResult | null,
+  formData: FormData,
+) => {
   const locale = await getLocale();
   const t = await getTranslations('Login');
   const cartId = await getCartId();
@@ -27,8 +31,6 @@ export const login = async (_lastResult: SubmissionResult | null, formData: Form
       email: submission.value.email,
       password: submission.value.password,
       cartId,
-      // We want to use next/navigation for the redirect as it
-      // follows basePath and trailing slash configurations.
       redirect: false,
     });
   } catch (error) {
@@ -53,5 +55,5 @@ export const login = async (_lastResult: SubmissionResult | null, formData: Form
     return submission.reply({ formErrors: [t('Form.somethingWentWrong')] });
   }
 
-  return redirect({ href: '/account/orders', locale });
+  return redirect({ href: redirectTo, locale });
 };

--- a/core/app/[locale]/(default)/(auth)/login/page.tsx
+++ b/core/app/[locale]/(default)/(auth)/login/page.tsx
@@ -1,14 +1,19 @@
+/* eslint-disable react/jsx-no-bind */
 import { Metadata } from 'next';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { ButtonLink } from '@/vibes/soul/primitives/button-link';
 import { SignInSection } from '@/vibes/soul/sections/sign-in-section';
+import { buildConfig } from '~/build-config/reader';
 import { ForceRefresh } from '~/components/force-refresh';
 
 import { login } from './_actions/login';
 
 interface Props {
   params: Promise<{ locale: string }>;
+  searchParams: Promise<{
+    redirectTo?: string;
+  }>;
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
@@ -21,18 +26,22 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-export default async function Login({ params }: Props) {
+export default async function Login({ params, searchParams }: Props) {
   const { locale } = await params;
+  const { redirectTo = '/account/orders' } = await searchParams;
 
   setRequestLocale(locale);
 
   const t = await getTranslations('Login');
 
+  const vanityUrl = buildConfig.get('urls').vanityUrl;
+  const redirectToPathname = new URL(redirectTo, vanityUrl).pathname;
+
   return (
     <>
       <ForceRefresh />
       <SignInSection
-        action={login}
+        action={login.bind(null, { redirectTo: redirectToPathname })}
         forgotPasswordHref="/login/forgot-password"
         forgotPasswordLabel={t('Form.forgotPassword')}
         submitLabel={t('Form.logIn')}

--- a/core/app/[locale]/(default)/checkout/route.ts
+++ b/core/app/[locale]/(default)/checkout/route.ts
@@ -32,10 +32,7 @@ export async function GET(_: NextRequest, { params }: { params: Promise<{ locale
   const channelId = getChannelIdFromLocale(locale);
 
   if (!cartId) {
-    return NextResponse.json(
-      { message: 'Cart not found' },
-      { status: 404, statusText: 'Not Found' },
-    );
+    return redirect({ href: '/cart', locale });
   }
 
   try {
@@ -51,10 +48,7 @@ export async function GET(_: NextRequest, { params }: { params: Promise<{ locale
       data.cart.createCartRedirectUrls.errors.length > 0 ||
       !data.cart.createCartRedirectUrls.redirectUrls
     ) {
-      return NextResponse.json(
-        { message: 'Cart not found' },
-        { status: 404, statusText: 'Not Found' },
-      );
+      return redirect({ href: '/cart', locale });
     }
 
     return redirect({


### PR DESCRIPTION
## What/Why?
Add the ability to redirect from the login page. Developers can now append a relative path to the `?redirectTo=` query param on the `/login` page. When a shopper successfully logs in, it'll redirect them to the given relative path. Defaults to `/account/orders` to prevent a breaking change.

This functionality will be critical for redirecting a user back to checkout to ensure the session is synced between headless and checkout (stencil).

## Testing

https://github.com/user-attachments/assets/06586442-0d67-465c-9398-27574546851e

