### PR TITLE
Bump options and option values to 50/50

### DIFF
--- a/core/app/[locale]/(default)/product/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/product/[slug]/page-data.ts
@@ -18,7 +18,7 @@ const MultipleChoiceFieldFragment = graphql(`
     displayName
     displayStyle
     isRequired
-    values(first: 10) {
+    values(first: 50) {
       edges {
         node {
           entityId
@@ -125,7 +125,7 @@ export const ProductFormFragment = graphql(
           }
         }
       }
-      productOptions(first: 10) {
+      productOptions(first: 50) {
         edges {
           node {
             __typename


### PR DESCRIPTION
## What/Why?
Bump the number of product options and product option values loaded on the PDP to the largest number the API supports without pagination; this ensures product pages will load completely without missing options (up to these new limits).

Above these, pagination will be required, or changes to the API to increase limits further.

## Testing
Before:
<img width="791" alt="image" src="https://github.com/user-attachments/assets/4ca51d4e-2668-46e5-95ed-1df59ccc9040" />
After:
<img width="864" alt="image" src="https://github.com/user-attachments/assets/912ca0aa-682a-431e-b1ca-4668dd8d92b6" />
