### PR TITLE
fix(core): add missing .pathname to only use relative paths

### DIFF
--- a/core/app/[locale]/(default)/(auth)/logout/route.ts
+++ b/core/app/[locale]/(default)/(auth)/logout/route.ts
@@ -10,7 +10,7 @@ export const GET = async (
 ) => {
   const { locale } = await params;
   const redirectTo = request.nextUrl.searchParams.get('redirectTo') ?? '/login';
-  const redirectToPathname = new URL(redirectTo, request.nextUrl.origin);
+  const redirectToPathname = new URL(redirectTo, request.nextUrl.origin).pathname;
 
   await signOut({ redirect: false });
   await setForceRefreshCookie();


### PR DESCRIPTION
## What/Why?
A miss from https://github.com/bigcommerce/catalyst/pull/2186/files#r2031310242 – adds the `.pathname` to only accept relative paths as the `redirectTo` value.
