### PR TITLE
fix: temp unregister of Customer Group Slot

### DIFF
--- a/core/lib/makeswift/components.ts
+++ b/core/lib/makeswift/components.ts
@@ -3,7 +3,6 @@ import './components/button-link/button-link.makeswift';
 import './components/card-carousel/card-carousel.makeswift';
 import './components/card/card.makeswift';
 import './components/carousel/carousel.makeswift';
-import './components/customer-group-slot/customer-group-slot.makeswift';
 import './components/product-card/product-card.makeswift';
 import './components/products-carousel/products-carousel.makeswift';
 import './components/products-list/products-list.makeswift';


### PR DESCRIPTION
Admin API key was removed from Catalyst for security purposes. A higher level API key is required to query Customer Groups for the Customer Group Slot. We need to unregister this component while we find a solution to this.