### PR TITLE
refactor(core): category for dynamicIO 

### DIFF
--- a/.changeset/salty-laws-hunt.md
+++ b/.changeset/salty-laws-hunt.md
@@ -2,4 +2,24 @@
 "@bigcommerce/catalyst-core": minor
 ---
 
-Refactor Category PLP in preparation for dynamic IO, by making sure there are no blocking calls other than static requests.
+## New
+
+This refactor optimizes category PLP for caching and the eventual use of dynamicIO. With these changes we leverage data caching to hit mostly cache data for guest shoppers in different locales and with different currencies.
+
+## Key modifications include:
+
+- We don't stream in Category page data, instead it's a blocking call that will redirect to `notFound` when category is not found. Same for metadata.
+- Our query functions now take in all params required for fetching, instead of accessing dynamic variables internally. This is important to serialize arguments if we want to eventually `use cache`.
+- Use `Streamable.from` to generate our streaming props that are passed to our UI components.
+- Remove use of nuqs' `createSearchParamsCache` in favor of nuqs' `createLoader`.
+
+## Migration instructions:
+
+- Update `/(facted)/category/[slug]/page.tsx`
+  - For this page we are now doing a blocking request for category page data. Instead of having functions that each would read from props, we share streamable functions that can be passed to our UI components. We still stream in filter and product data.
+- Update `/(facted)/category/[slug]/page-data.tsx`
+  - Request now accept `customerAccessToken` as a prop instead of calling internally.
+- Update`/(facted)/category/[slug]/fetch-compare-products.ts`
+  - Request now accept `customerAccessToken` as a prop instead of calling internally.
+- Update `/(faceted)/fetch-faceted-search.ts`
+  - Request now accept `customerAccessToken` and `currencyCode` as a prop instead of calling internally.

--- a/.changeset/salty-laws-hunt.md
+++ b/.changeset/salty-laws-hunt.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Refactor Category PLP in preparation for dynamic IO, by making sure there are no blocking calls other than static requests.

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page-data.ts
@@ -1,16 +1,14 @@
 import { cache } from 'react';
 
-import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
-import { graphql, VariablesOf } from '~/client/graphql';
-import { revalidate } from '~/client/revalidate-target';
+import { graphql } from '~/client/graphql';
 import { BreadcrumbsCategoryFragment } from '~/components/breadcrumbs/fragment';
 
 const CategoryPageQuery = graphql(
   `
-    query CategoryPageQuery($categoryId: Int!) {
+    query CategoryPageQuery($entityId: Int!) {
       site {
-        category(entityId: $categoryId) {
+        category(entityId: $entityId) {
           entityId
           name
           ...BreadcrumbsFragment
@@ -20,21 +18,21 @@ const CategoryPageQuery = graphql(
             metaKeywords
           }
         }
-        categoryTree(rootEntityId: $categoryId) {
-          entityId
-          name
-          path
-          children {
-            entityId
-            name
-            path
-            children {
-              entityId
-              name
-              path
-            }
-          }
-        }
+        # categoryTree(rootEntityId: $entityId) {
+        #   entityId
+        #   name
+        #   path
+        #   children {
+        #     entityId
+        #     name
+        #     path
+        #     children {
+        #       entityId
+        #       name
+        #       path
+        #     }
+        #   }
+        # }
         settings {
           storefront {
             catalog {
@@ -48,16 +46,12 @@ const CategoryPageQuery = graphql(
   [BreadcrumbsCategoryFragment],
 );
 
-type Variables = VariablesOf<typeof CategoryPageQuery>;
-
-export const getCategoryPageData = cache(async (variables: Variables) => {
-  const customerAccessToken = await getSessionCustomerAccessToken();
+export const getCategoryPageData = cache(async (entityId: number) => {
+  console.log('getCategoryPageData');
 
   const response = await client.fetch({
     document: CategoryPageQuery,
-    variables,
-    customerAccessToken,
-    fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
+    variables: { entityId },
   });
 
   return response.data.site;

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page-data.ts
@@ -18,21 +18,21 @@ const CategoryPageQuery = graphql(
             metaKeywords
           }
         }
-        # categoryTree(rootEntityId: $entityId) {
-        #   entityId
-        #   name
-        #   path
-        #   children {
-        #     entityId
-        #     name
-        #     path
-        #     children {
-        #       entityId
-        #       name
-        #       path
-        #     }
-        #   }
-        # }
+        categoryTree(rootEntityId: $entityId) {
+          entityId
+          name
+          path
+          children {
+            entityId
+            name
+            path
+            children {
+              entityId
+              name
+              path
+            }
+          }
+        }
         settings {
           storefront {
             catalog {

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page-data.ts
@@ -2,6 +2,7 @@ import { cache } from 'react';
 
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
+import { revalidate } from '~/client/revalidate-target';
 import { BreadcrumbsCategoryFragment } from '~/components/breadcrumbs/fragment';
 
 const CategoryPageQuery = graphql(
@@ -46,10 +47,12 @@ const CategoryPageQuery = graphql(
   [BreadcrumbsCategoryFragment],
 );
 
-export const getCategoryPageData = cache(async (entityId: number) => {
+export const getCategoryPageData = cache(async (entityId: number, customerAccessToken?: string) => {
   const response = await client.fetch({
     document: CategoryPageQuery,
     variables: { entityId },
+    customerAccessToken,
+    fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
   });
 
   return response.data.site;

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page-data.ts
@@ -47,8 +47,6 @@ const CategoryPageQuery = graphql(
 );
 
 export const getCategoryPageData = cache(async (entityId: number) => {
-  console.log('getCategoryPageData');
-
   const response = await client.fetch({
     document: CategoryPageQuery,
     variables: { entityId },

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -81,6 +81,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 
 export default async function Category(props: Props) {
   const { slug, locale } = await props.params;
+  const customerAccessToken = await getSessionCustomerAccessToken();
 
   setRequestLocale(locale);
 
@@ -88,7 +89,10 @@ export default async function Category(props: Props) {
 
   const categoryId = Number(slug);
 
-  const { category, settings, categoryTree } = await getCategoryPageData(categoryId);
+  const { category, settings, categoryTree } = await getCategoryPageData(
+    categoryId,
+    customerAccessToken,
+  );
 
   if (!category) {
     return notFound();
@@ -104,7 +108,6 @@ export default async function Category(props: Props) {
 
   const streamableFacetedSearch = Streamable.from(async () => {
     const searchParams = await props.searchParams;
-    const customerAccessToken = await getSessionCustomerAccessToken();
     const currencyCode = await getPreferredCurrencyCode();
 
     const searchParamsCache = await createCategorySearchParamsCache(categoryId);
@@ -194,7 +197,6 @@ export default async function Category(props: Props) {
 
   const streamableCompareProducts = Streamable.from(async () => {
     const searchParams = await props.searchParams;
-    const customerAccessToken = await getSessionCustomerAccessToken();
     const currencyCode = await getPreferredCurrencyCode();
 
     if (!productComparisonsEnabled) {

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -197,6 +197,10 @@ export default async function Category(props: Props) {
     const customerAccessToken = await getSessionCustomerAccessToken();
     const currencyCode = await getPreferredCurrencyCode();
 
+    if (!productComparisonsEnabled) {
+      return [];
+    }
+
     const compareLoader = createCompareLoader();
 
     const { compare } = compareLoader(searchParams);

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -5,12 +5,11 @@ import { getFormatter, getTranslations, setRequestLocale } from 'next-intl/serve
 import { createSearchParamsCache } from 'nuqs/server';
 import { cache } from 'react';
 
-import { Streamable } from '@/vibes/soul/lib/streamable';
+import { Stream, Streamable } from '@/vibes/soul/lib/streamable';
 import { createCompareLoader } from '@/vibes/soul/primitives/compare-drawer/loader';
 import { ProductsListSection } from '@/vibes/soul/sections/products-list-section';
 import { getFilterParsers } from '@/vibes/soul/sections/products-list-section/filter-parsers';
 import { getSessionCustomerAccessToken } from '~/auth';
-import { CurrencyCodeSchema } from '~/components/header/schema';
 import { facetsTransformer } from '~/data-transformers/facets-transformer';
 import { pageInfoTransformer } from '~/data-transformers/page-info-transformer';
 import { pricesTransformer } from '~/data-transformers/prices-transformer';
@@ -20,6 +19,7 @@ import { MAX_COMPARE_LIMIT } from '../../../compare/page-data';
 import { getCompareProducts as getCompareProductsData } from '../../fetch-compare-products';
 import { fetchFacetedSearch } from '../../fetch-faceted-search';
 
+import { CategoryViewed } from './_components/category-viewed';
 import { getCategoryPageData } from './page-data';
 
 const createCategorySearchParamsCache = cache(async (categoryId: number) => {
@@ -251,16 +251,15 @@ export default async function Category(props: Props) {
         title={category.name}
         totalCount={streamableTotalCount}
       />
-      {/* <Stream
-        value={Streamable.all([
-          Streamable.from(() => getCategory(props)),
-          Streamable.from(() => getProducts(props)),
-        ])}
-      >
-        {([category, products]) => (
-          <CategoryViewed category={category} categoryId={category.entityId} products={products} />
+      <Stream value={streamableFacetedSearch}>
+        {(search) => (
+          <CategoryViewed
+            category={category}
+            categoryId={category.entityId}
+            products={search.products.items}
+          />
         )}
-      </Stream> */}
+      </Stream>
     </>
   );
 }

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -191,12 +191,6 @@ async function getFilters(props: Props): Promise<Filter[]> {
   return [...subCategoriesFilters, ...filters];
 }
 
-async function getSortLabel(): Promise<string> {
-  const t = await getTranslations('Faceted.SortBy');
-
-  return t('sortBy');
-}
-
 async function getSortOptions(): Promise<SortOption[]> {
   const t = await getTranslations('Faceted.SortBy');
 
@@ -253,60 +247,6 @@ async function getCompareProducts(props: Props) {
   }));
 }
 
-async function getFilterLabel(): Promise<string> {
-  const t = await getTranslations('Faceted.FacetedSearch');
-
-  return t('filters');
-}
-
-async function getCompareLabel(): Promise<string> {
-  const t = await getTranslations('Components.ProductCard.Compare');
-
-  return t('compare');
-}
-
-async function getRemoveLabel(): Promise<string> {
-  const t = await getTranslations('Components.ProductCard.Compare');
-
-  return t('remove');
-}
-
-async function getMaxCompareLimitMessage(): Promise<string> {
-  const t = await getTranslations('Components.ProductCard.Compare');
-
-  return t('maxCompareLimit');
-}
-
-async function getFiltersPanelTitle(): Promise<string> {
-  const t = await getTranslations('Faceted.FacetedSearch');
-
-  return t('filters');
-}
-
-async function getRangeFilterApplyLabel(): Promise<string> {
-  const t = await getTranslations('Faceted.FacetedSearch.Range');
-
-  return t('apply');
-}
-
-async function getResetFiltersLabel(): Promise<string> {
-  const t = await getTranslations('Faceted.FacetedSearch');
-
-  return t('resetFilters');
-}
-
-async function getEmptyStateTitle(): Promise<string> {
-  const t = await getTranslations('Faceted.Category.Empty');
-
-  return t('title');
-}
-
-async function getEmptyStateSubtitle(): Promise<string> {
-  const t = await getTranslations('Faceted.Category.Empty');
-
-  return t('subtitle');
-}
-
 type SearchParams = Record<string, string | string[] | undefined>;
 
 interface Props {
@@ -334,27 +274,29 @@ export default async function Category(props: Props) {
 
   setRequestLocale(locale);
 
+  const t = await getTranslations('Faceted');
+
   return (
     <>
       <ProductsListSection
         breadcrumbs={Streamable.from(() => getBreadcrumbs(props))}
-        compareLabel={Streamable.from(getCompareLabel)}
+        compareLabel={t('Compare.compare')}
         compareProducts={Streamable.from(() => getCompareProducts(props))}
-        emptyStateSubtitle={Streamable.from(getEmptyStateSubtitle)}
-        emptyStateTitle={Streamable.from(getEmptyStateTitle)}
-        filterLabel={await getFilterLabel()}
+        emptyStateSubtitle={t('Category.Empty.subtitle')}
+        emptyStateTitle={t('Category.Empty.title')}
+        filterLabel={t('FacetedSearch.filters')}
         filters={Streamable.from(() => getFilters(props))}
-        filtersPanelTitle={Streamable.from(getFiltersPanelTitle)}
-        maxCompareLimitMessage={Streamable.from(getMaxCompareLimitMessage)}
+        filtersPanelTitle={t('FacetedSearch.filters')}
+        maxCompareLimitMessage={t('Compare.maxCompareLimit')}
         maxItems={MAX_COMPARE_LIMIT}
         paginationInfo={Streamable.from(() => getPaginationInfo(props))}
         products={Streamable.from(() => getListProducts(props))}
-        rangeFilterApplyLabel={Streamable.from(getRangeFilterApplyLabel)}
-        removeLabel={Streamable.from(getRemoveLabel)}
-        resetFiltersLabel={Streamable.from(getResetFiltersLabel)}
+        rangeFilterApplyLabel={t('FacetedSearch.Range.apply')}
+        removeLabel={t('Compare.remove')}
+        resetFiltersLabel={t('FacetedSearch.resetFilters')}
         showCompare={Streamable.from(() => getShowCompare(props))}
         sortDefaultValue="featured"
-        sortLabel={Streamable.from(getSortLabel)}
+        sortLabel={t('SortBy.sortBy')}
         sortOptions={Streamable.from(getSortOptions)}
         sortParamName="sort"
         title={Streamable.from(() => getTitle(props))}

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -61,10 +61,11 @@ interface Props {
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
   const { slug } = await props.params;
+  const customerAccessToken = await getSessionCustomerAccessToken();
 
   const categoryId = Number(slug);
 
-  const { category } = await getCategoryPageData(categoryId);
+  const { category } = await getCategoryPageData(categoryId, customerAccessToken);
 
   if (!category) {
     return notFound();

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -16,7 +16,7 @@ import { pricesTransformer } from '~/data-transformers/prices-transformer';
 import { getPreferredCurrencyCode } from '~/lib/currency';
 
 import { MAX_COMPARE_LIMIT } from '../../../compare/page-data';
-import { getCompareProducts as getCompareProductsData } from '../../fetch-compare-products';
+import { getCompareProducts } from '../../fetch-compare-products';
 import { fetchFacetedSearch } from '../../fetch-faceted-search';
 
 import { CategoryViewed } from './_components/category-viewed';
@@ -199,7 +199,6 @@ export default async function Category(props: Props) {
 
   const streamableCompareProducts = Streamable.from(async () => {
     const searchParams = await props.searchParams;
-    const currencyCode = await getPreferredCurrencyCode();
 
     if (!productComparisonsEnabled) {
       return [];
@@ -209,7 +208,7 @@ export default async function Category(props: Props) {
 
     const compareIds = { entityIds: compare ? compare.map((id: string) => Number(id)) : [] };
 
-    const products = await getCompareProductsData(compareIds, currencyCode, customerAccessToken);
+    const products = await getCompareProducts(compareIds, customerAccessToken);
 
     return products.map((product) => ({
       id: product.entityId.toString(),

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -18,6 +18,7 @@ import { ProductsListSection } from '@/vibes/soul/sections/products-list-section
 // import { pricesTransformer } from '~/data-transformers/prices-transformer';
 
 import { getSessionCustomerAccessToken } from '~/auth';
+import { pageInfoTransformer } from '~/data-transformers/page-info-transformer';
 import { pricesTransformer } from '~/data-transformers/prices-transformer';
 import { getPreferredCurrencyCode } from '~/lib/currency';
 
@@ -311,6 +312,12 @@ export default async function Category(props: Props) {
     return search.products.collectionInfo?.totalItems ?? 0;
   });
 
+  const streamablePagination = Streamable.from(async () => {
+    const search = await streamableFacetedSearch;
+
+    return pageInfoTransformer(search.products.pageInfo);
+  });
+
   return (
     <>
       <ProductsListSection
@@ -325,7 +332,7 @@ export default async function Category(props: Props) {
         filtersPanelTitle={t('FacetedSearch.filters')}
         maxCompareLimitMessage={t('Compare.maxCompareLimit')}
         maxItems={MAX_COMPARE_LIMIT}
-        // paginationInfo={Streamable.from(() => getPaginationInfo(props))}
+        paginationInfo={streamablePagination}
         products={streamableProducts}
         rangeFilterApplyLabel={t('FacetedSearch.Range.apply')}
         removeLabel={t('Compare.remove')}

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -10,7 +10,6 @@ import { createCompareLoader } from '@/vibes/soul/primitives/compare-drawer/load
 import { ProductsListSection } from '@/vibes/soul/sections/products-list-section';
 import { getFilterParsers } from '@/vibes/soul/sections/products-list-section/filter-parsers';
 import { getSessionCustomerAccessToken } from '~/auth';
-import { CurrencyCode } from '~/components/header/fragment';
 import { facetsTransformer } from '~/data-transformers/facets-transformer';
 import { pageInfoTransformer } from '~/data-transformers/page-info-transformer';
 import { pricesTransformer } from '~/data-transformers/prices-transformer';
@@ -32,13 +31,9 @@ const getCachedCategory = cache((categoryId: number) => {
 const compareLoader = createCompareLoader();
 
 const createCategorySearchParamsLoader = cache(
-  async (categoryId: number, currencyCode?: CurrencyCode, customerAccessToken?: string) => {
+  async (categoryId: number, customerAccessToken?: string) => {
     const cachedCategory = getCachedCategory(categoryId);
-    const categorySearch = await fetchFacetedSearch(
-      cachedCategory,
-      currencyCode,
-      customerAccessToken,
-    );
+    const categorySearch = await fetchFacetedSearch(cachedCategory, undefined, customerAccessToken);
     const categoryFacets = categorySearch.facets.items.filter(
       (facet) => facet.__typename !== 'CategorySearchFilter',
     );
@@ -127,7 +122,6 @@ export default async function Category(props: Props) {
 
     const loadSearchParams = await createCategorySearchParamsLoader(
       categoryId,
-      currencyCode,
       customerAccessToken,
     );
     const parsedSearchParams = loadSearchParams?.(searchParams) ?? {};
@@ -177,20 +171,14 @@ export default async function Category(props: Props) {
 
   const streamableFilters = Streamable.from(async () => {
     const searchParams = await props.searchParams;
-    const currencyCode = await getPreferredCurrencyCode();
 
     const loadSearchParams = await createCategorySearchParamsLoader(
       categoryId,
-      currencyCode,
       customerAccessToken,
     );
     const parsedSearchParams = loadSearchParams?.(searchParams) ?? {};
     const cachedCategory = getCachedCategory(categoryId);
-    const categorySearch = await fetchFacetedSearch(
-      cachedCategory,
-      currencyCode,
-      customerAccessToken,
-    );
+    const categorySearch = await fetchFacetedSearch(cachedCategory, undefined, customerAccessToken);
     const refinedSearch = await streamableFacetedSearch;
 
     const allFacets = categorySearch.facets.items.filter(

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -23,7 +23,7 @@ import { fetchFacetedSearch } from '../../fetch-faceted-search';
 import { CategoryViewed } from './_components/category-viewed';
 import { getCategoryPageData } from './page-data';
 
-const cachedCategoryDataVariables = cache((categoryId: number) => {
+const getCachedCategory = cache((categoryId: number) => {
   return {
     category: categoryId,
   };
@@ -33,8 +33,12 @@ const compareLoader = createCompareLoader();
 
 const createCategorySearchParamsLoader = cache(
   async (categoryId: number, currencyCode?: CurrencyCode, customerAccessToken?: string) => {
-    const variables = cachedCategoryDataVariables(categoryId);
-    const categorySearch = await fetchFacetedSearch(variables, currencyCode, customerAccessToken);
+    const cachedCategory = getCachedCategory(categoryId);
+    const categorySearch = await fetchFacetedSearch(
+      cachedCategory,
+      currencyCode,
+      customerAccessToken,
+    );
     const categoryFacets = categorySearch.facets.items.filter(
       (facet) => facet.__typename !== 'CategorySearchFilter',
     );
@@ -181,8 +185,12 @@ export default async function Category(props: Props) {
       customerAccessToken,
     );
     const parsedSearchParams = loadSearchParams?.(searchParams) ?? {};
-    const variables = cachedCategoryDataVariables(categoryId);
-    const categorySearch = await fetchFacetedSearch(variables, currencyCode, customerAccessToken);
+    const cachedCategory = getCachedCategory(categoryId);
+    const categorySearch = await fetchFacetedSearch(
+      cachedCategory,
+      currencyCode,
+      customerAccessToken,
+    );
     const refinedSearch = await streamableFacetedSearch;
 
     const allFacets = categorySearch.facets.items.filter(

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -13,7 +13,6 @@ import { Breadcrumb } from '@/vibes/soul/sections/breadcrumbs';
 import { ProductsListSection } from '@/vibes/soul/sections/products-list-section';
 import { getFilterParsers } from '@/vibes/soul/sections/products-list-section/filter-parsers';
 import { Filter } from '@/vibes/soul/sections/products-list-section/filters-panel';
-import { Option as SortOption } from '@/vibes/soul/sections/products-list-section/sorting';
 import { facetsTransformer } from '~/data-transformers/facets-transformer';
 import { pageInfoTransformer } from '~/data-transformers/page-info-transformer';
 import { pricesTransformer } from '~/data-transformers/prices-transformer';
@@ -191,22 +190,6 @@ async function getFilters(props: Props): Promise<Filter[]> {
   return [...subCategoriesFilters, ...filters];
 }
 
-async function getSortOptions(): Promise<SortOption[]> {
-  const t = await getTranslations('Faceted.SortBy');
-
-  return [
-    { value: 'featured', label: t('featuredItems') },
-    { value: 'newest', label: t('newestItems') },
-    { value: 'best_selling', label: t('bestSellingItems') },
-    { value: 'a_to_z', label: t('aToZ') },
-    { value: 'z_to_a', label: t('zToA') },
-    { value: 'best_reviewed', label: t('byReview') },
-    { value: 'lowest_price', label: t('priceAscending') },
-    { value: 'highest_price', label: t('priceDescending') },
-    { value: 'relevance', label: t('relevance') },
-  ];
-}
-
 async function getPaginationInfo(props: Props): Promise<CursorPaginationInfo> {
   const search = await getRefinedSearch(props);
 
@@ -297,7 +280,17 @@ export default async function Category(props: Props) {
         showCompare={Streamable.from(() => getShowCompare(props))}
         sortDefaultValue="featured"
         sortLabel={t('SortBy.sortBy')}
-        sortOptions={Streamable.from(getSortOptions)}
+        sortOptions={[
+          { value: 'featured', label: t('SortBy.featuredItems') },
+          { value: 'newest', label: t('SortBy.newestItems') },
+          { value: 'best_selling', label: t('SortBy.bestSellingItems') },
+          { value: 'a_to_z', label: t('SortBy.aToZ') },
+          { value: 'z_to_a', label: t('SortBy.zToA') },
+          { value: 'best_reviewed', label: t('SortBy.byReview') },
+          { value: 'lowest_price', label: t('SortBy.priceAscending') },
+          { value: 'highest_price', label: t('SortBy.priceDescending') },
+          { value: 'relevance', label: t('SortBy.relevance') },
+        ]}
         sortParamName="sort"
         title={Streamable.from(() => getTitle(props))}
         totalCount={Streamable.from(() => getTotalCount(props))}

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -1,209 +1,209 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import { getFormatter, getTranslations, setRequestLocale } from 'next-intl/server';
-import { createSearchParamsCache } from 'nuqs/server';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+// import { createSearchParamsCache } from 'nuqs/server';
 import { cache } from 'react';
 
-import { Stream, Streamable } from '@/vibes/soul/lib/streamable';
+import { Streamable } from '@/vibes/soul/lib/streamable';
 import { createCompareLoader } from '@/vibes/soul/primitives/compare-drawer/loader';
-import { CursorPaginationInfo } from '@/vibes/soul/primitives/cursor-pagination';
-import { Product } from '@/vibes/soul/primitives/product-card';
-import { Breadcrumb } from '@/vibes/soul/sections/breadcrumbs';
+// import { CursorPaginationInfo } from '@/vibes/soul/primitives/cursor-pagination';
+// import { Product } from '@/vibes/soul/primitives/product-card';
+// import { Breadcrumb } from '@/vibes/soul/sections/breadcrumbs';
 import { ProductsListSection } from '@/vibes/soul/sections/products-list-section';
-import { getFilterParsers } from '@/vibes/soul/sections/products-list-section/filter-parsers';
-import { Filter } from '@/vibes/soul/sections/products-list-section/filters-panel';
-import { facetsTransformer } from '~/data-transformers/facets-transformer';
-import { pageInfoTransformer } from '~/data-transformers/page-info-transformer';
-import { pricesTransformer } from '~/data-transformers/prices-transformer';
+// import { getFilterParsers } from '@/vibes/soul/sections/products-list-section/filter-parsers';
+// import { Filter } from '@/vibes/soul/sections/products-list-section/filters-panel';
+// import { facetsTransformer } from '~/data-transformers/facets-transformer';
+// import { pageInfoTransformer } from '~/data-transformers/page-info-transformer';
+// import { pricesTransformer } from '~/data-transformers/prices-transformer';
 
 import { MAX_COMPARE_LIMIT } from '../../../compare/page-data';
 import { getCompareProducts as getCompareProductsData } from '../../fetch-compare-products';
-import { fetchFacetedSearch } from '../../fetch-faceted-search';
+// import { fetchFacetedSearch } from '../../fetch-faceted-search';
 
-import { CategoryViewed } from './_components/category-viewed';
+// import { CategoryViewed } from './_components/category-viewed';
 import { getCategoryPageData } from './page-data';
 
-const cachedCategoryDataVariables = cache((categoyId: string) => {
-  return {
-    categoryId: Number(categoyId),
-  };
-});
+// const cachedCategoryDataVariables = cache((categoyId: string) => {
+//   return {
+//     categoryId: Number(categoyId),
+//   };
+// });
 
-const cacheCategoryFacetedSearch = cache((categoryId: string) => {
-  return { category: Number(categoryId) };
-});
+// const cacheCategoryFacetedSearch = cache((categoryId: string) => {
+//   return { category: Number(categoryId) };
+// });
 
-async function getCategory(props: Props) {
-  const { slug } = await props.params;
+// async function getCategory(props: Props) {
+//   const { slug } = await props.params;
 
-  const variables = cachedCategoryDataVariables(slug);
-  const data = await getCategoryPageData(variables);
+//   const variables = cachedCategoryDataVariables(slug);
+//   const data = await getCategoryPageData(variables);
 
-  const category = data.category;
+//   const category = data.category;
 
-  if (category == null) notFound();
+//   if (category == null) notFound();
 
-  return category;
-}
+//   return category;
+// }
 
-const createCategorySearchParamsCache = cache(async (props: Props) => {
-  const { slug } = await props.params;
-  const category = cacheCategoryFacetedSearch(slug);
-  const categorySearch = await fetchFacetedSearch(category);
-  const categoryFacets = categorySearch.facets.items.filter(
-    (facet) => facet.__typename !== 'CategorySearchFilter',
-  );
-  const transformedCategoryFacets = await facetsTransformer({
-    refinedFacets: categoryFacets,
-    allFacets: categoryFacets,
-    searchParams: {},
-  });
-  const categoryFilters = transformedCategoryFacets.filter((facet) => facet != null);
-  const filterParsers = getFilterParsers(categoryFilters);
+// const createCategorySearchParamsCache = cache(async (props: Props) => {
+//   const { slug } = await props.params;
+//   const category = cacheCategoryFacetedSearch(slug);
+//   const categorySearch = await fetchFacetedSearch(category);
+//   const categoryFacets = categorySearch.facets.items.filter(
+//     (facet) => facet.__typename !== 'CategorySearchFilter',
+//   );
+//   const transformedCategoryFacets = await facetsTransformer({
+//     refinedFacets: categoryFacets,
+//     allFacets: categoryFacets,
+//     searchParams: {},
+//   });
+//   const categoryFilters = transformedCategoryFacets.filter((facet) => facet != null);
+//   const filterParsers = getFilterParsers(categoryFilters);
 
-  // If there are no filters, return `null`, since calling `createSearchParamsCache` with an empty
-  // object will throw the following cryptic error:
-  //
-  // ```
-  // Error: [nuqs] Empty search params cache. Search params can't be accessed in Layouts.
-  //   See https://err.47ng.com/NUQS-500
-  // ```
-  if (Object.keys(filterParsers).length === 0) {
-    return null;
-  }
+//   // If there are no filters, return `null`, since calling `createSearchParamsCache` with an empty
+//   // object will throw the following cryptic error:
+//   //
+//   // ```
+//   // Error: [nuqs] Empty search params cache. Search params can't be accessed in Layouts.
+//   //   See https://err.47ng.com/NUQS-500
+//   // ```
+//   if (Object.keys(filterParsers).length === 0) {
+//     return null;
+//   }
 
-  return createSearchParamsCache(filterParsers);
-});
+//   return createSearchParamsCache(filterParsers);
+// });
 
-const getRefinedSearch = cache(async (props: Props) => {
-  const { slug } = await props.params;
-  const categoryId = Number(slug);
-  const searchParams = await props.searchParams;
-  const searchParamsCache = await createCategorySearchParamsCache(props);
-  const parsedSearchParams = searchParamsCache?.parse(searchParams) ?? {};
+// const getRefinedSearch = cache(async (props: Props) => {
+//   const { slug } = await props.params;
+//   const categoryId = Number(slug);
+//   const searchParams = await props.searchParams;
+//   const searchParamsCache = await createCategorySearchParamsCache(props);
+//   const parsedSearchParams = searchParamsCache?.parse(searchParams) ?? {};
 
-  return await fetchFacetedSearch({
-    ...searchParams,
-    ...parsedSearchParams,
-    category: categoryId,
-  });
-});
+//   return await fetchFacetedSearch({
+//     ...searchParams,
+//     ...parsedSearchParams,
+//     category: categoryId,
+//   });
+// });
 
-async function getBreadcrumbs(props: Props): Promise<Breadcrumb[]> {
-  const category = await getCategory(props);
+// async function getBreadcrumbs(props: Props): Promise<Breadcrumb[]> {
+//   const category = await getCategory(props);
 
-  return removeEdgesAndNodes(category.breadcrumbs).map(({ name, path }) => ({
-    label: name,
-    href: path ?? '#',
-  }));
-}
+//   return removeEdgesAndNodes(category.breadcrumbs).map(({ name, path }) => ({
+//     label: name,
+//     href: path ?? '#',
+//   }));
+// }
 
-async function getSubCategoriesFilters(props: Props): Promise<Filter[]> {
-  const { slug } = await props.params;
+// async function getSubCategoriesFilters(props: Props): Promise<Filter[]> {
+//   const { slug } = await props.params;
 
-  const variables = cachedCategoryDataVariables(slug);
-  const data = await getCategoryPageData(variables);
-  const t = await getTranslations('Faceted.Category');
+//   const variables = cachedCategoryDataVariables(slug);
+//   const data = await getCategoryPageData(variables);
+//   const t = await getTranslations('Faceted.Category');
 
-  const categoryTree = data.categoryTree[0];
+//   const categoryTree = data.categoryTree[0];
 
-  if (categoryTree == null || categoryTree.children.length === 0) return [];
+//   if (categoryTree == null || categoryTree.children.length === 0) return [];
 
-  return [
-    {
-      type: 'link-group',
-      label: t('subCategories'),
-      links: categoryTree.children.map((category) => ({
-        label: category.name,
-        href: category.path,
-      })),
-    },
-  ];
-}
+//   return [
+//     {
+//       type: 'link-group',
+//       label: t('subCategories'),
+//       links: categoryTree.children.map((category) => ({
+//         label: category.name,
+//         href: category.path,
+//       })),
+//     },
+//   ];
+// }
 
-async function getTitle(props: Props): Promise<string | null> {
-  const category = await getCategory(props);
+// async function getTitle(props: Props): Promise<string | null> {
+//   const category = await getCategory(props);
 
-  return category.name;
-}
+//   return category.name;
+// }
 
-const getSearch = cache(async (props: Props) => {
-  const search = await getRefinedSearch(props);
+// const getSearch = cache(async (props: Props) => {
+//   const search = await getRefinedSearch(props);
 
-  return search;
-});
+//   return search;
+// });
 
-async function getTotalCount(props: Props): Promise<number> {
-  const search = await getSearch(props);
+// async function getTotalCount(props: Props): Promise<number> {
+//   const search = await getSearch(props);
 
-  return search.products.collectionInfo?.totalItems ?? 0;
-}
+//   return search.products.collectionInfo?.totalItems ?? 0;
+// }
 
-async function getProducts(props: Props) {
-  const search = await getSearch(props);
+// async function getProducts(props: Props) {
+//   const search = await getSearch(props);
 
-  return search.products.items;
-}
+//   return search.products.items;
+// }
 
-async function getListProducts(props: Props): Promise<Product[]> {
-  const products = await getProducts(props);
-  const format = await getFormatter();
+// async function getListProducts(props: Props): Promise<Product[]> {
+//   const products = await getProducts(props);
+//   const format = await getFormatter();
 
-  return products.map((product) => ({
-    id: product.entityId.toString(),
-    title: product.name,
-    href: product.path,
-    image: product.defaultImage
-      ? { src: product.defaultImage.url, alt: product.defaultImage.altText }
-      : undefined,
-    price: pricesTransformer(product.prices, format),
-    subtitle: product.brand?.name ?? undefined,
-  }));
-}
+//   return products.map((product) => ({
+//     id: product.entityId.toString(),
+//     title: product.name,
+//     href: product.path,
+//     image: product.defaultImage
+//       ? { src: product.defaultImage.url, alt: product.defaultImage.altText }
+//       : undefined,
+//     price: pricesTransformer(product.prices, format),
+//     subtitle: product.brand?.name ?? undefined,
+//   }));
+// }
 
-async function getFilters(props: Props): Promise<Filter[]> {
-  const { slug } = await props.params;
-  const searchParams = await props.searchParams;
-  const searchParamsCache = await createCategorySearchParamsCache(props);
-  const parsedSearchParams = searchParamsCache?.parse(searchParams) ?? {};
-  const category = cacheCategoryFacetedSearch(slug);
-  const categorySearch = await fetchFacetedSearch(category);
-  const refinedSearch = await getRefinedSearch(props);
+// async function getFilters(props: Props): Promise<Filter[]> {
+//   const { slug } = await props.params;
+//   const searchParams = await props.searchParams;
+//   const searchParamsCache = await createCategorySearchParamsCache(props);
+//   const parsedSearchParams = searchParamsCache?.parse(searchParams) ?? {};
+//   const category = cacheCategoryFacetedSearch(slug);
+//   const categorySearch = await fetchFacetedSearch(category);
+//   const refinedSearch = await getRefinedSearch(props);
 
-  const allFacets = categorySearch.facets.items.filter(
-    (facet) => facet.__typename !== 'CategorySearchFilter',
-  );
-  const refinedFacets = refinedSearch.facets.items.filter(
-    (facet) => facet.__typename !== 'CategorySearchFilter',
-  );
+//   const allFacets = categorySearch.facets.items.filter(
+//     (facet) => facet.__typename !== 'CategorySearchFilter',
+//   );
+//   const refinedFacets = refinedSearch.facets.items.filter(
+//     (facet) => facet.__typename !== 'CategorySearchFilter',
+//   );
 
-  const transformedFacets = await facetsTransformer({
-    refinedFacets,
-    allFacets,
-    searchParams: { ...searchParams, ...parsedSearchParams },
-  });
+//   const transformedFacets = await facetsTransformer({
+//     refinedFacets,
+//     allFacets,
+//     searchParams: { ...searchParams, ...parsedSearchParams },
+//   });
 
-  const filters = transformedFacets.filter((facet) => facet != null);
-  const subCategoriesFilters = await getSubCategoriesFilters(props);
+//   const filters = transformedFacets.filter((facet) => facet != null);
+//   const subCategoriesFilters = await getSubCategoriesFilters(props);
 
-  return [...subCategoriesFilters, ...filters];
-}
+//   return [...subCategoriesFilters, ...filters];
+// }
 
-async function getPaginationInfo(props: Props): Promise<CursorPaginationInfo> {
-  const search = await getRefinedSearch(props);
+// async function getPaginationInfo(props: Props): Promise<CursorPaginationInfo> {
+//   const search = await getRefinedSearch(props);
 
-  return pageInfoTransformer(search.products.pageInfo);
-}
+//   return pageInfoTransformer(search.products.pageInfo);
+// }
 
-async function getShowCompare(props: Props) {
-  const { slug } = await props.params;
+// async function getShowCompare(props: Props) {
+//   const { slug } = await props.params;
 
-  const variables = cachedCategoryDataVariables(slug);
-  const data = await getCategoryPageData(variables);
+//   const variables = cachedCategoryDataVariables(slug);
+//   const data = await getCategoryPageData(variables);
 
-  return data.settings?.storefront.catalog?.productComparisonsEnabled ?? false;
-}
+//   return data.settings?.storefront.catalog?.productComparisonsEnabled ?? false;
+// }
 
 const cachedCompareProductIds = cache(async (props: Props) => {
   const searchParams = await props.searchParams;
@@ -241,7 +241,15 @@ interface Props {
 }
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
-  const category = await getCategory(props);
+  const { slug } = await props.params;
+
+  const categoryId = Number(slug);
+
+  const { category } = await getCategoryPageData(categoryId);
+
+  if (!category) {
+    return notFound();
+  }
 
   const { pageTitle, metaDescription, metaKeywords } = category.seo;
 
@@ -253,31 +261,49 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 }
 
 export default async function Category(props: Props) {
-  const { locale } = await props.params;
+  const { slug, locale } = await props.params;
 
   setRequestLocale(locale);
 
   const t = await getTranslations('Faceted');
 
+  const categoryId = Number(slug);
+
+  const { category, settings } = await getCategoryPageData(categoryId);
+
+  if (!category) {
+    return notFound();
+  }
+
+  const breadcrumbs = removeEdgesAndNodes(category.breadcrumbs).map(({ name, path }) => ({
+    label: name,
+    href: path ?? '#',
+  }));
+
+  const productComparisonsEnabled =
+    settings?.storefront.catalog?.productComparisonsEnabled ?? false;
+
   return (
     <>
       <ProductsListSection
-        breadcrumbs={Streamable.from(() => getBreadcrumbs(props))}
+        breadcrumbs={breadcrumbs}
         compareLabel={t('Compare.compare')}
         compareProducts={Streamable.from(() => getCompareProducts(props))}
         emptyStateSubtitle={t('Category.Empty.subtitle')}
         emptyStateTitle={t('Category.Empty.title')}
         filterLabel={t('FacetedSearch.filters')}
-        filters={Streamable.from(() => getFilters(props))}
+        // filters={Streamable.from(() => getFilters(props))}
+        filters={[]}
         filtersPanelTitle={t('FacetedSearch.filters')}
         maxCompareLimitMessage={t('Compare.maxCompareLimit')}
         maxItems={MAX_COMPARE_LIMIT}
-        paginationInfo={Streamable.from(() => getPaginationInfo(props))}
-        products={Streamable.from(() => getListProducts(props))}
+        // paginationInfo={Streamable.from(() => getPaginationInfo(props))}
+        // products={Streamable.from(() => getListProducts(props))}
+        products={[]}
         rangeFilterApplyLabel={t('FacetedSearch.Range.apply')}
         removeLabel={t('Compare.remove')}
         resetFiltersLabel={t('FacetedSearch.resetFilters')}
-        showCompare={Streamable.from(() => getShowCompare(props))}
+        showCompare={productComparisonsEnabled}
         sortDefaultValue="featured"
         sortLabel={t('SortBy.sortBy')}
         sortOptions={[
@@ -292,10 +318,11 @@ export default async function Category(props: Props) {
           { value: 'relevance', label: t('SortBy.relevance') },
         ]}
         sortParamName="sort"
-        title={Streamable.from(() => getTitle(props))}
-        totalCount={Streamable.from(() => getTotalCount(props))}
+        title={category.name}
+        // totalCount={Streamable.from(() => getTotalCount(props))}
+        totalCount={0}
       />
-      <Stream
+      {/* <Stream
         value={Streamable.all([
           Streamable.from(() => getCategory(props)),
           Streamable.from(() => getProducts(props)),
@@ -304,7 +331,7 @@ export default async function Category(props: Props) {
         {([category, products]) => (
           <CategoryViewed category={category} categoryId={category.entityId} products={products} />
         )}
-      </Stream>
+      </Stream> */}
     </>
   );
 }

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -2,7 +2,7 @@ import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { getFormatter, getTranslations, setRequestLocale } from 'next-intl/server';
-import { createSearchParamsCache } from 'nuqs/server';
+import { createSearchParamsCache, SearchParams } from 'nuqs/server';
 import { cache } from 'react';
 
 import { Stream, Streamable } from '@/vibes/soul/lib/streamable';
@@ -21,6 +21,8 @@ import { fetchFacetedSearch } from '../../fetch-faceted-search';
 
 import { CategoryViewed } from './_components/category-viewed';
 import { getCategoryPageData } from './page-data';
+
+const compareLoader = createCompareLoader();
 
 const createCategorySearchParamsCache = cache(async (categoryId: number) => {
   const categorySearch = await fetchFacetedSearch({ category: categoryId });
@@ -48,8 +50,6 @@ const createCategorySearchParamsCache = cache(async (categoryId: number) => {
 
   return createSearchParamsCache(filterParsers);
 });
-
-type SearchParams = Record<string, string | string[] | undefined>;
 
 interface Props {
   params: Promise<{
@@ -200,8 +200,6 @@ export default async function Category(props: Props) {
     if (!productComparisonsEnabled) {
       return [];
     }
-
-    const compareLoader = createCompareLoader();
 
     const { compare } = compareLoader(searchParams);
 

--- a/core/app/[locale]/(default)/(faceted)/fetch-compare-products.ts
+++ b/core/app/[locale]/(default)/(faceted)/fetch-compare-products.ts
@@ -6,7 +6,6 @@ import { z } from 'zod';
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
-import { CurrencyCode } from '~/components/header/fragment';
 
 import { MAX_COMPARE_LIMIT } from '../compare/page-data';
 
@@ -44,7 +43,7 @@ const CompareProductsQuery = graphql(`
 type Variables = VariablesOf<typeof CompareProductsQuery>;
 
 export const getCompareProducts = cache(
-  async (variables: Variables, currencyCode?: CurrencyCode, customerAccessToken?: string) => {
+  async (variables: Variables, customerAccessToken?: string) => {
     const parsedVariables = CompareProductsSchema.parse(variables);
 
     if (parsedVariables.entityIds.length === 0) {
@@ -53,7 +52,7 @@ export const getCompareProducts = cache(
 
     const response = await client.fetch({
       document: CompareProductsQuery,
-      variables: { ...parsedVariables, first: MAX_COMPARE_LIMIT, currencyCode },
+      variables: { ...parsedVariables, first: MAX_COMPARE_LIMIT },
       customerAccessToken,
       fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
     });

--- a/core/app/[locale]/(default)/(faceted)/fetch-faceted-search.ts
+++ b/core/app/[locale]/(default)/(faceted)/fetch-faceted-search.ts
@@ -2,12 +2,11 @@ import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
 import { cache } from 'react';
 import { z } from 'zod';
 
-import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
 import { PaginationFragment } from '~/client/fragments/pagination';
 import { graphql, VariablesOf } from '~/client/graphql';
+import { CurrencyCode } from '~/components/header/fragment';
 import { ProductCardFragment } from '~/components/product-card/fragment';
-import { getPreferredCurrencyCode } from '~/lib/currency';
 
 const GetProductSearchResultsQuery = graphql(
   `
@@ -174,9 +173,13 @@ interface ProductSearch {
 }
 
 const getProductSearchResults = cache(
-  async ({ limit = 9, after, before, sort, filters }: ProductSearch) => {
-    const customerAccessToken = await getSessionCustomerAccessToken();
-    const currencyCode = await getPreferredCurrencyCode();
+  async (
+    { limit = 9, after, before, sort, filters }: ProductSearch,
+    currencyCode?: CurrencyCode,
+    customerAccessToken?: string,
+  ) => {
+    // const customerAccessToken = await getSessionCustomerAccessToken();
+    // const currencyCode = await getPreferredCurrencyCode();
     const filterArgs = { filters, sort };
     const paginationArgs = before ? { last: limit, before } : { first: limit, after };
 
@@ -398,15 +401,23 @@ export const PublicToPrivateParams = PublicSearchParamsSchema.catchall(SearchPar
 
 export const fetchFacetedSearch = cache(
   // We need to make sure the reference passed into this function is the same if we want it to be memoized.
-  async (params: z.input<typeof PublicSearchParamsSchema>) => {
+  async (
+    params: z.input<typeof PublicSearchParamsSchema>,
+    currencyCode?: CurrencyCode,
+    customerAccessToken?: string,
+  ) => {
     const { after, before, limit = 9, sort, filters } = PublicToPrivateParams.parse(params);
 
-    return getProductSearchResults({
-      after,
-      before,
-      limit,
-      sort,
-      filters,
-    });
+    return getProductSearchResults(
+      {
+        after,
+        before,
+        limit,
+        sort,
+        filters,
+      },
+      currencyCode,
+      customerAccessToken,
+    );
   },
 );

--- a/core/app/[locale]/(default)/(faceted)/fetch-faceted-search.ts
+++ b/core/app/[locale]/(default)/(faceted)/fetch-faceted-search.ts
@@ -408,6 +408,8 @@ export const fetchFacetedSearch = cache(
   ) => {
     const { after, before, limit = 9, sort, filters } = PublicToPrivateParams.parse(params);
 
+    console.log('fetchFacetedSearch');
+
     return getProductSearchResults(
       {
         after,

--- a/core/app/[locale]/(default)/(faceted)/fetch-faceted-search.ts
+++ b/core/app/[locale]/(default)/(faceted)/fetch-faceted-search.ts
@@ -178,8 +178,6 @@ const getProductSearchResults = cache(
     currencyCode?: CurrencyCode,
     customerAccessToken?: string,
   ) => {
-    // const customerAccessToken = await getSessionCustomerAccessToken();
-    // const currencyCode = await getPreferredCurrencyCode();
     const filterArgs = { filters, sort };
     const paginationArgs = before ? { last: limit, before } : { first: limit, after };
 
@@ -407,8 +405,6 @@ export const fetchFacetedSearch = cache(
     customerAccessToken?: string,
   ) => {
     const { after, before, limit = 9, sort, filters } = PublicToPrivateParams.parse(params);
-
-    console.log('fetchFacetedSearch');
 
     return getProductSearchResults(
       {

--- a/core/app/[locale]/(default)/product/[slug]/loading.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/loading.tsx
@@ -1,3 +1,0 @@
-export default function Loading() {
-  return <div>Loading...</div>;
-}

--- a/core/app/[locale]/(default)/product/[slug]/loading.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div>Loading...</div>;
+}

--- a/core/app/[locale]/(default)/product/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/page.tsx
@@ -31,10 +31,10 @@ interface Props {
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
   const { slug } = await props.params;
+  const customerAccessToken = await getSessionCustomerAccessToken();
 
   const productId = Number(slug);
 
-  const customerAccessToken = await getSessionCustomerAccessToken();
   const product = await getProductPageMetadata(productId, customerAccessToken);
 
   if (!product) {

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -126,6 +126,11 @@
       "priceAscending": "Price: ascending",
       "priceDescending": "Price: descending",
       "relevance": "Relevance"
+    },
+    "Compare": {
+      "compare": "Compare",
+      "remove": "Remove",
+      "maxCompareLimit": "You've reached the maximum number of products for comparison. Remove a product to add a new one."
     }
   },
   "Account": {


### PR DESCRIPTION
## What/Why?
## New

This refactor optimizes category PLP for caching and the eventual use of dynamicIO. With these changes we leverage data caching to hit mostly cache data for guest shoppers in different locales and with different currencies.

## Key modifications include:

- We don't stream in Category page data, instead it's a blocking call that will redirect to `notFound` when category is not found. Same for metadata.
- Our query functions now take in all params required for fetching, instead of accessing dynamic variables internally. This is important to serialize arguments if we want to eventually `use cache`.
- Use `Streamable.from` to generate our streaming props that are passed to our UI components.
- Remove use of nuqs' `createSearchParamsCache` in favor of nuqs' `createLoader`.

## Migration instructions:

- Update `/(facted)/category/[slug]/page.tsx`
  - For this page we are now doing a blocking request for category page data. Instead of having functions that each would read from props, we share streamable functions that can be passed to our UI components. We still stream in filter and product data.
- Update `/(facted)/category/[slug]/page-data.tsx`
  - Request now accept `customerAccessToken` as a prop instead of calling internally.
- Update`/(facted)/category/[slug]/fetch-compare-products.ts`
  - Request now accept `customerAccessToken` as a prop instead of calling internally.
- Update `/(faceted)/fetch-faceted-search.ts`
  - Request now accept `customerAccessToken` and `currencyCode` as a prop instead of calling internally.

## Testing
Locally, page is faster, and requests are non blocking.