### PR TITLE
refactor(core): brand for dynamicIO

### DIFF
--- a/.changeset/whole-signs-shine.md
+++ b/.changeset/whole-signs-shine.md
@@ -2,4 +2,20 @@
 "@bigcommerce/catalyst-core": minor
 ---
 
-Refactor Brand PLP in preparation for dynamic IO, by making sure there are no blocking calls other than static requests.
+## New
+
+This refactor optimizes brand PLP for caching and the eventual use of dynamicIO. With these changes we leverage data caching to hit mostly cache data for guest shoppers in different locales and with different currencies.
+
+## Key modifications include:
+
+- We don't stream in Brand page data, instead it's a blocking call that will redirect to `notFound` when brand is not found. Same for metadata.
+- Our query functions now take in all params required for fetching, instead of accessing dynamic variables internally. This is important to serialize arguments if we want to eventually `use cache`.
+- Use `Streamable.from` to generate our streaming props that are passed to our UI components.
+- Remove use of nuqs' `createSearchParamsCache` in favor of nuqs' `createLoader`.
+
+## Migration instructions:
+
+- Update `/(facted)/brand/[slug]/page.tsx`
+  - For this page we are now doing a blocking request for brand page data. Instead of having functions that each would read from props, we share streamable functions that can be passed to our UI components. We still stream in filter and product data.
+- Update `/(facted)/brand/[slug]/page-data.tsx`
+  - Request now accept `customerAccessToken` as a prop instead of calling internally.

--- a/.changeset/whole-signs-shine.md
+++ b/.changeset/whole-signs-shine.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Refactor Brand PLP in preparation for dynamic IO, by making sure there are no blocking calls other than static requests.

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page-data.ts
@@ -26,11 +26,12 @@ const BrandPageQuery = graphql(`
   }
 `);
 
-export const getBrandPageData = cache(async (entityId: number) => {
+export const getBrandPageData = cache(async (entityId: number, customerAccessToken?: string) => {
   const response = await client.fetch({
     document: BrandPageQuery,
     variables: { entityId },
-    fetchOptions: { next: { revalidate } },
+    customerAccessToken,
+    fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
   });
 
   return response.data.site;

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page-data.ts
@@ -1,7 +1,7 @@
 import { cache } from 'react';
 
 import { client } from '~/client';
-import { graphql, VariablesOf } from '~/client/graphql';
+import { graphql } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
 
 const BrandPageQuery = graphql(`
@@ -26,12 +26,10 @@ const BrandPageQuery = graphql(`
   }
 `);
 
-type Variables = VariablesOf<typeof BrandPageQuery>;
-
-export const getBrandPageData = cache(async (variables: Variables) => {
+export const getBrandPageData = cache(async (entityId: number) => {
   const response = await client.fetch({
     document: BrandPageQuery,
-    variables,
+    variables: { entityId },
     fetchOptions: { next: { revalidate } },
   });
 

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
@@ -6,15 +6,13 @@ import { cache } from 'react';
 
 import { Streamable } from '@/vibes/soul/lib/streamable';
 import { createCompareLoader } from '@/vibes/soul/primitives/compare-drawer/loader';
-import { CursorPaginationInfo } from '@/vibes/soul/primitives/cursor-pagination';
-import { Product } from '@/vibes/soul/primitives/product-card';
 import { ProductsListSection } from '@/vibes/soul/sections/products-list-section';
 import { getFilterParsers } from '@/vibes/soul/sections/products-list-section/filter-parsers';
-import { Filter } from '@/vibes/soul/sections/products-list-section/filters-panel';
-import { Option as SortOption } from '@/vibes/soul/sections/products-list-section/sorting';
+import { getSessionCustomerAccessToken } from '~/auth';
 import { facetsTransformer } from '~/data-transformers/facets-transformer';
 import { pageInfoTransformer } from '~/data-transformers/page-info-transformer';
 import { pricesTransformer } from '~/data-transformers/prices-transformer';
+import { getPreferredCurrencyCode } from '~/lib/currency';
 
 import { MAX_COMPARE_LIMIT } from '../../../compare/page-data';
 import { getCompareProducts as getCompareProductsData } from '../../fetch-compare-products';
@@ -22,39 +20,8 @@ import { fetchFacetedSearch } from '../../fetch-faceted-search';
 
 import { getBrandPageData } from './page-data';
 
-const cachedBrandDataVariables = cache((brandId: string) => {
-  return {
-    entityId: Number(brandId),
-  };
-});
-
-const cacheBrandFacetedSearch = cache((brandId: string) => {
-  return { brand: [brandId] };
-});
-
-async function getBrand(props: Props) {
-  const { slug } = await props.params;
-
-  const variables = cachedBrandDataVariables(slug);
-  const data = await getBrandPageData(variables);
-
-  const brand = data.brand;
-
-  if (brand == null) notFound();
-
-  return brand;
-}
-
-async function getTitle(props: Props): Promise<string> {
-  const brand = await getBrand(props);
-
-  return brand.name;
-}
-
-const createBrandSearchParamsCache = cache(async (props: Props) => {
-  const { slug } = await props.params;
-  const brand = cacheBrandFacetedSearch(slug);
-  const brandSearch = await fetchFacetedSearch(brand);
+const createBrandSearchParamsCache = cache(async (brandId: string) => {
+  const brandSearch = await fetchFacetedSearch({ brand: [brandId] });
   const brandFacets = brandSearch.facets.items.filter(
     (facet) => facet.__typename !== 'BrandSearchFilter',
   );
@@ -80,181 +47,6 @@ const createBrandSearchParamsCache = cache(async (props: Props) => {
   return createSearchParamsCache(filterParsers);
 });
 
-const getRefinedSearch = cache(async (props: Props) => {
-  const { slug } = await props.params;
-  const searchParams = await props.searchParams;
-  const searchParamsCache = await createBrandSearchParamsCache(props);
-  const parsedSearchParams = searchParamsCache?.parse(searchParams) ?? {};
-
-  return await fetchFacetedSearch({
-    ...searchParams,
-    ...parsedSearchParams,
-    brand: [slug],
-  });
-});
-
-async function getTotalCount(props: Props): Promise<number> {
-  const search = await getRefinedSearch(props);
-
-  return search.products.collectionInfo?.totalItems ?? 0;
-}
-
-async function getFilters(props: Props): Promise<Filter[]> {
-  const { slug } = await props.params;
-  const searchParams = await props.searchParams;
-  const searchParamsCache = await createBrandSearchParamsCache(props);
-  const parsedSearchParams = searchParamsCache?.parse(searchParams) ?? {};
-  const brand = cacheBrandFacetedSearch(slug);
-  const brandSearch = await fetchFacetedSearch(brand);
-  const brandFacets = brandSearch.facets.items.filter(
-    (facet) => facet.__typename !== 'BrandSearchFilter',
-  );
-  const refinedSearch = await getRefinedSearch(props);
-  const refinedFacets = refinedSearch.facets.items.filter(
-    (facet) => facet.__typename !== 'BrandSearchFilter',
-  );
-
-  const transformedFacets = await facetsTransformer({
-    refinedFacets,
-    allFacets: brandFacets,
-    searchParams: { ...searchParams, ...parsedSearchParams },
-  });
-
-  return transformedFacets.filter((facet) => facet != null);
-}
-
-async function getSortOptions(): Promise<SortOption[]> {
-  const t = await getTranslations('Faceted.SortBy');
-
-  return [
-    { value: 'featured', label: t('featuredItems') },
-    { value: 'newest', label: t('newestItems') },
-    { value: 'best_selling', label: t('bestSellingItems') },
-    { value: 'a_to_z', label: t('aToZ') },
-    { value: 'z_to_a', label: t('zToA') },
-    { value: 'best_reviewed', label: t('byReview') },
-    { value: 'lowest_price', label: t('priceAscending') },
-    { value: 'highest_price', label: t('priceDescending') },
-    { value: 'relevance', label: t('relevance') },
-  ];
-}
-
-async function getListProducts(props: Props): Promise<Product[]> {
-  const refinedSearch = await getRefinedSearch(props);
-  const format = await getFormatter();
-
-  return refinedSearch.products.items.map((product) => ({
-    id: product.entityId.toString(),
-    title: product.name,
-    href: product.path,
-    image: product.defaultImage
-      ? { src: product.defaultImage.url, alt: product.defaultImage.altText }
-      : undefined,
-    price: pricesTransformer(product.prices, format),
-    subtitle: product.brand?.name ?? undefined,
-  }));
-}
-
-async function getPaginationInfo(props: Props): Promise<CursorPaginationInfo> {
-  const brandSearch = await getRefinedSearch(props);
-
-  return pageInfoTransformer(brandSearch.products.pageInfo);
-}
-
-async function getShowCompare(props: Props) {
-  const { slug } = await props.params;
-
-  const variables = cachedBrandDataVariables(slug);
-  const data = await getBrandPageData(variables);
-
-  return data.settings?.storefront.catalog?.productComparisonsEnabled ?? false;
-}
-
-const cachedCompareProductIds = cache(async (props: Props) => {
-  const searchParams = await props.searchParams;
-
-  const compareLoader = createCompareLoader();
-
-  const { compare } = compareLoader(searchParams);
-
-  return { entityIds: compare ? compare.map((id: string) => Number(id)) : [] };
-});
-
-async function getCompareProducts(props: Props) {
-  const compareIds = await cachedCompareProductIds(props);
-
-  const products = await getCompareProductsData(compareIds);
-
-  return products.map((product) => ({
-    id: product.entityId.toString(),
-    title: product.name,
-    image: product.defaultImage
-      ? { src: product.defaultImage.url, alt: product.defaultImage.altText }
-      : undefined,
-    href: product.path,
-  }));
-}
-
-async function getFilterLabel(): Promise<string> {
-  const t = await getTranslations('Faceted.FacetedSearch');
-
-  return t('filters');
-}
-
-async function getSortLabel(): Promise<string> {
-  const t = await getTranslations('Faceted.SortBy');
-
-  return t('sortBy');
-}
-
-async function getCompareLabel(): Promise<string> {
-  const t = await getTranslations('Components.ProductCard.Compare');
-
-  return t('compare');
-}
-
-async function getRemoveLabel(): Promise<string> {
-  const t = await getTranslations('Components.ProductCard.Compare');
-
-  return t('remove');
-}
-
-async function getMaxCompareLimitMessage(): Promise<string> {
-  const t = await getTranslations('Components.ProductCard.Compare');
-
-  return t('maxCompareLimit');
-}
-
-async function getEmptyStateTitle(): Promise<string> {
-  const t = await getTranslations('Faceted.Brand.Empty');
-
-  return t('title');
-}
-
-async function getEmptyStateSubtitle(): Promise<string> {
-  const t = await getTranslations('Faceted.Brand.Empty');
-
-  return t('subtitle');
-}
-
-async function getFiltersPanelTitle(): Promise<string> {
-  const t = await getTranslations('Faceted.FacetedSearch');
-
-  return t('filters');
-}
-
-async function getRangeFilterApplyLabel(): Promise<string> {
-  const t = await getTranslations('Faceted.FacetedSearch.Range');
-
-  return t('apply');
-}
-
-async function getResetFiltersLabel(): Promise<string> {
-  const t = await getTranslations('Faceted.FacetedSearch');
-
-  return t('resetFilters');
-}
-
 interface Props {
   params: Promise<{
     slug: string;
@@ -264,7 +56,15 @@ interface Props {
 }
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
-  const brand = await getBrand(props);
+  const { slug } = await props.params;
+
+  const brandId = Number(slug);
+
+  const { brand } = await getBrandPageData(brandId);
+
+  if (!brand) {
+    return notFound();
+  }
 
   const { pageTitle, metaDescription, metaKeywords } = brand.seo;
 
@@ -276,33 +76,156 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 }
 
 export default async function Brand(props: Props) {
-  const { locale } = await props.params;
+  const { locale, slug } = await props.params;
 
   setRequestLocale(locale);
 
+  const t = await getTranslations('Faceted');
+
+  const brandId = Number(slug);
+
+  const { brand, settings } = await getBrandPageData(brandId);
+
+  if (!brand) {
+    return notFound();
+  }
+
+  const productComparisonsEnabled =
+    settings?.storefront.catalog?.productComparisonsEnabled ?? false;
+
+  const streamableFacetedSearch = Streamable.from(async () => {
+    const searchParams = await props.searchParams;
+    const customerAccessToken = await getSessionCustomerAccessToken();
+    const currencyCode = await getPreferredCurrencyCode();
+
+    const searchParamsCache = await createBrandSearchParamsCache(slug);
+    const parsedSearchParams = searchParamsCache?.parse(searchParams) ?? {};
+
+    const search = await fetchFacetedSearch(
+      {
+        ...searchParams,
+        ...parsedSearchParams,
+        brand: [slug],
+      },
+      currencyCode,
+      customerAccessToken,
+    );
+
+    return search;
+  });
+
+  const streamableProducts = Streamable.from(async () => {
+    const format = await getFormatter();
+
+    const search = await streamableFacetedSearch;
+    const products = search.products.items;
+
+    return products.map((product) => ({
+      id: product.entityId.toString(),
+      title: product.name,
+      href: product.path,
+      image: product.defaultImage
+        ? { src: product.defaultImage.url, alt: product.defaultImage.altText }
+        : undefined,
+      price: pricesTransformer(product.prices, format),
+      subtitle: product.brand?.name ?? undefined,
+    }));
+  });
+
+  const streamableTotalCount = Streamable.from(async () => {
+    const search = await streamableFacetedSearch;
+
+    return search.products.collectionInfo?.totalItems ?? 0;
+  });
+
+  const streamablePagination = Streamable.from(async () => {
+    const search = await streamableFacetedSearch;
+
+    return pageInfoTransformer(search.products.pageInfo);
+  });
+
+  const streamableFilters = Streamable.from(async () => {
+    const searchParams = await props.searchParams;
+    const searchParamsCache = await createBrandSearchParamsCache(slug);
+    const parsedSearchParams = searchParamsCache?.parse(searchParams) ?? {};
+    const search = await streamableFacetedSearch;
+
+    const allFacets = search.facets.items.filter(
+      (facet) => facet.__typename !== 'BrandSearchFilter',
+    );
+    const refinedFacets = search.facets.items.filter(
+      (facet) => facet.__typename !== 'BrandSearchFilter',
+    );
+
+    const transformedFacets = await facetsTransformer({
+      refinedFacets,
+      allFacets,
+      searchParams: { ...searchParams, ...parsedSearchParams },
+    });
+
+    return transformedFacets.filter((facet) => facet != null);
+  });
+
+  const streamableCompareProducts = Streamable.from(async () => {
+    const searchParams = await props.searchParams;
+    const customerAccessToken = await getSessionCustomerAccessToken();
+    const currencyCode = await getPreferredCurrencyCode();
+
+    if (!productComparisonsEnabled) {
+      return [];
+    }
+
+    const compareLoader = createCompareLoader();
+
+    const { compare } = compareLoader(searchParams);
+
+    const compareIds = { entityIds: compare ? compare.map((id: string) => Number(id)) : [] };
+
+    const products = await getCompareProductsData(compareIds, currencyCode, customerAccessToken);
+
+    return products.map((product) => ({
+      id: product.entityId.toString(),
+      title: product.name,
+      image: product.defaultImage
+        ? { src: product.defaultImage.url, alt: product.defaultImage.altText }
+        : undefined,
+      href: product.path,
+    }));
+  });
+
   return (
     <ProductsListSection
-      compareLabel={Streamable.from(getCompareLabel)}
-      compareProducts={Streamable.from(() => getCompareProducts(props))}
-      emptyStateSubtitle={Streamable.from(getEmptyStateSubtitle)}
-      emptyStateTitle={Streamable.from(getEmptyStateTitle)}
-      filterLabel={await getFilterLabel()}
-      filters={Streamable.from(() => getFilters(props))}
-      filtersPanelTitle={Streamable.from(getFiltersPanelTitle)}
-      maxCompareLimitMessage={Streamable.from(getMaxCompareLimitMessage)}
+      compareLabel={t('Compare.compare')}
+      compareProducts={streamableCompareProducts}
+      emptyStateSubtitle={t('Brand.Empty.subtitle')}
+      emptyStateTitle={t('Brand.Empty.title')}
+      filterLabel={t('FacetedSearch.filters')}
+      filters={streamableFilters}
+      filtersPanelTitle={t('FacetedSearch.filters')}
+      maxCompareLimitMessage={t('Compare.maxCompareLimit')}
       maxItems={MAX_COMPARE_LIMIT}
-      paginationInfo={Streamable.from(() => getPaginationInfo(props))}
-      products={Streamable.from(() => getListProducts(props))}
-      rangeFilterApplyLabel={Streamable.from(getRangeFilterApplyLabel)}
-      removeLabel={Streamable.from(getRemoveLabel)}
-      resetFiltersLabel={Streamable.from(getResetFiltersLabel)}
-      showCompare={Streamable.from(() => getShowCompare(props))}
+      paginationInfo={streamablePagination}
+      products={streamableProducts}
+      rangeFilterApplyLabel={t('FacetedSearch.Range.apply')}
+      removeLabel={t('Compare.remove')}
+      resetFiltersLabel={t('FacetedSearch.resetFilters')}
+      showCompare={productComparisonsEnabled}
       sortDefaultValue="featured"
-      sortLabel={Streamable.from(getSortLabel)}
-      sortOptions={Streamable.from(getSortOptions)}
+      sortLabel={t('Search.title')}
+      sortOptions={[
+        { value: 'featured', label: t('SortBy.featuredItems') },
+        { value: 'newest', label: t('SortBy.newestItems') },
+        { value: 'best_selling', label: t('SortBy.bestSellingItems') },
+        { value: 'a_to_z', label: t('SortBy.aToZ') },
+        { value: 'z_to_a', label: t('SortBy.zToA') },
+        { value: 'best_reviewed', label: t('SortBy.byReview') },
+        { value: 'lowest_price', label: t('SortBy.priceAscending') },
+        { value: 'highest_price', label: t('SortBy.priceDescending') },
+        { value: 'relevance', label: t('SortBy.relevance') },
+      ]}
       sortParamName="sort"
-      title={Streamable.from(() => getTitle(props))}
-      totalCount={Streamable.from(() => getTotalCount(props))}
+      title={brand.name}
+      totalCount={streamableTotalCount}
     />
   );
 }

--- a/core/app/[locale]/(default)/(faceted)/fetch-compare-products.ts
+++ b/core/app/[locale]/(default)/(faceted)/fetch-compare-products.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
+import { CurrencyCode } from '~/components/header/fragment';
 
 import { MAX_COMPARE_LIMIT } from '../compare/page-data';
 

--- a/core/app/[locale]/(default)/(faceted)/fetch-compare-products.ts
+++ b/core/app/[locale]/(default)/(faceted)/fetch-compare-products.ts
@@ -6,7 +6,6 @@ import { z } from 'zod';
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
-import { CurrencyCode } from '~/components/header/fragment';
 
 import { MAX_COMPARE_LIMIT } from '../compare/page-data';
 

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -439,13 +439,6 @@
       "placeholder": "Enter your email",
       "description": "Stay up to date with the latest news and offers from our store.",
       "success": "Thank you for your interest! Newsletter feature is coming soon!"
-    },
-    "ProductCard": {
-      "Compare": {
-        "compare": "Compare",
-        "remove": "Remove",
-        "maxCompareLimit": "You've reached the maximum number of products for comparison. Remove a product to add a new one."
-      }
     }
   }
 }


### PR DESCRIPTION
## New

This refactor optimizes brand PLP for caching and the eventual use of dynamicIO. With these changes we leverage data caching to hit mostly cache data for guest shoppers in different locales and with different currencies.

## Key modifications include:

- We don't stream in Brand page data, instead it's a blocking call that will redirect to `notFound` when brand is not found. Same for metadata.
- Our query functions now take in all params required for fetching, instead of accessing dynamic variables internally. This is important to serialize arguments if we want to eventually `use cache`.
- Use `Streamable.from` to generate our streaming props that are passed to our UI components.
- Remove use of nuqs' `createSearchParamsCache` in favor of nuqs' `createLoader`.

## Migration instructions:

- Update `/(facted)/brand/[slug]/page.tsx`
  - For this page we are now doing a blocking request for brand page data. Instead of having functions that each would read from props, we share streamable functions that can be passed to our UI components. We still stream in filter and product data.
- Update `/(facted)/brand/[slug]/page-data.tsx`
  - Request now accept `customerAccessToken` as a prop instead of calling internally.

## Testing
Locally, page is faster, and requests are non blocking.