### PR TITLE
chore: add migration section to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,3 +10,9 @@
   Provide as much information as you can about how you tested and
   how another developer can test.
 --->
+
+## Migration
+<!---
+  If you have moved any files around, or made any breaking changes,
+  please provide a migration guide for the developers to make rebases easier.
+--->


### PR DESCRIPTION
## What/Why?
Adds a migration section to the PR template. This should help us think about migration paths for other developers pulling in changes of Catalyst and how we can make that transition easier.

Potential items that might need migrations:
- `git mv`'ing files around – to make this easier on developers, provide the command to move the file(s) around to make rebasing easier.
- Changes in VIBES components – demonstrate how to update VIBES components if we need to add one-off bits of functionality.
- Breaking changes.

## Testing
See this PR description :) 

## Migration
N/A as this is just adding to the PR template.