### PR TITLE
refactor(core): search for dynamicIO

### DIFF
--- a/.changeset/bitter-comics-cry.md
+++ b/.changeset/bitter-comics-cry.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Refactor Search PLP in preparation for dynamic IO, by making sure there are no blocking calls other than static requests.

--- a/.changeset/bitter-comics-cry.md
+++ b/.changeset/bitter-comics-cry.md
@@ -2,4 +2,18 @@
 "@bigcommerce/catalyst-core": minor
 ---
 
-Refactor Search PLP in preparation for dynamic IO, by making sure there are no blocking calls other than static requests.
+## New
+
+This refactor optimizes search PLP for caching and the eventual use of dynamicIO. With these changes we leverage data caching to hit mostly cache data for guest shoppers in different locales and with different currencies.
+
+## Key modifications include:
+
+- We don't stream in Search page data, instead it's a blocking call to get page data.
+- Our query functions now take in all params required for fetching, instead of accessing dynamic variables internally. This is important to serialize arguments if we want to eventually `use cache`.
+- Use `Streamable.from` to generate our streaming props that are passed to our UI components.
+- Remove use of nuqs' `createSearchParamsCache` in favor of nuqs' `createLoader`.
+
+## Migration instructions:
+
+- Update `/(facted)/search/page.tsx`
+  - For this page we are now doing a blocking request for brand page data. Instead of having functions that each would read from props, we share streamable functions that can be passed to our UI components. We still stream in filter and product data.

--- a/core/app/[locale]/(default)/(faceted)/fetch-compare-products.ts
+++ b/core/app/[locale]/(default)/(faceted)/fetch-compare-products.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
+import { CurrencyCode } from '~/components/header/fragment';
 
 import { MAX_COMPARE_LIMIT } from '../compare/page-data';
 

--- a/core/app/[locale]/(default)/(faceted)/fetch-compare-products.ts
+++ b/core/app/[locale]/(default)/(faceted)/fetch-compare-products.ts
@@ -6,7 +6,6 @@ import { z } from 'zod';
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
-import { CurrencyCode } from '~/components/header/fragment';
 
 import { MAX_COMPARE_LIMIT } from '../compare/page-data';
 

--- a/core/app/[locale]/(default)/(faceted)/search/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/search/page.tsx
@@ -5,287 +5,19 @@ import { cache } from 'react';
 
 import { Streamable } from '@/vibes/soul/lib/streamable';
 import { createCompareLoader } from '@/vibes/soul/primitives/compare-drawer/loader';
-import { CursorPaginationInfo } from '@/vibes/soul/primitives/cursor-pagination';
-import { Product } from '@/vibes/soul/primitives/product-card';
-import { Breadcrumb } from '@/vibes/soul/sections/breadcrumbs';
 import { ProductsListSection } from '@/vibes/soul/sections/products-list-section';
 import { getFilterParsers } from '@/vibes/soul/sections/products-list-section/filter-parsers';
-import { Filter } from '@/vibes/soul/sections/products-list-section/filters-panel';
-import { Option as SortOption } from '@/vibes/soul/sections/products-list-section/sorting';
+import { getSessionCustomerAccessToken } from '~/auth';
 import { facetsTransformer } from '~/data-transformers/facets-transformer';
+import { pageInfoTransformer } from '~/data-transformers/page-info-transformer';
 import { pricesTransformer } from '~/data-transformers/prices-transformer';
+import { getPreferredCurrencyCode } from '~/lib/currency';
 
 import { MAX_COMPARE_LIMIT } from '../../compare/page-data';
 import { getCompareProducts as getCompareProductsData } from '../fetch-compare-products';
 import { fetchFacetedSearch } from '../fetch-faceted-search';
 
 import { getSearchPageData } from './page-data';
-
-const createSearchSearchParamsCache = cache(async (props: Props) => {
-  const searchParams = await props.searchParams;
-  const search = await fetchFacetedSearch(searchParams);
-  const searchFacets = search.facets.items;
-  const transformedSearchFacets = await facetsTransformer({
-    refinedFacets: searchFacets,
-    allFacets: searchFacets,
-    searchParams: {},
-  });
-  const searchFilters = transformedSearchFacets.filter((facet) => facet != null);
-  const filterParsers = getFilterParsers(searchFilters);
-
-  // If there are no filters, return `null`, since calling `createSearchParamsCache` with an empty
-  // object will throw the following cryptic error:
-  //
-  // ```
-  // Error: [nuqs] Empty search params cache. Search params can't be accessed in Layouts.
-  //   See https://err.47ng.com/NUQS-500
-  // ```
-  if (Object.keys(filterParsers).length === 0) {
-    return null;
-  }
-
-  return createSearchParamsCache(filterParsers);
-});
-
-const getRefinedSearch = cache(async (props: Props) => {
-  const searchParams = await props.searchParams;
-  const searchParamsCache = await createSearchSearchParamsCache(props);
-  const parsedSearchParams = searchParamsCache?.parse(searchParams) ?? {};
-
-  return await fetchFacetedSearch({
-    ...searchParams,
-    ...parsedSearchParams,
-  });
-});
-
-async function getSearchTerm(props: Props): Promise<string> {
-  const searchParams = await props.searchParams;
-  const searchTerm = typeof searchParams.term === 'string' ? searchParams.term : '';
-
-  return searchTerm;
-}
-
-const getSearch = cache(async (props: Props) => {
-  const search = await getRefinedSearch(props);
-
-  return search;
-});
-
-async function getProducts(props: Props) {
-  const searchTerm = await getSearchTerm(props);
-
-  if (searchTerm === '') {
-    return [];
-  }
-
-  const search = await getSearch(props);
-
-  return search.products.items;
-}
-
-async function getTitle(props: Props): Promise<string> {
-  const searchTerm = await getSearchTerm(props);
-  const t = await getTranslations('Faceted.Search');
-
-  return `${t('searchResults')} "${searchTerm}"`;
-}
-
-async function getFilters(props: Props): Promise<Filter[]> {
-  const searchParams = await props.searchParams;
-  const searchTerm = await getSearchTerm(props);
-  const searchParamsCache = await createSearchSearchParamsCache(props);
-  const parsedSearchParams = searchParamsCache?.parse(searchParams) ?? {};
-
-  let refinedSearch: Awaited<ReturnType<typeof fetchFacetedSearch>> | null = null;
-
-  if (searchTerm !== '') {
-    refinedSearch = await getRefinedSearch(props);
-  }
-
-  const categorySearch = await fetchFacetedSearch({});
-  const allFacets = categorySearch.facets.items.filter(
-    (facet) => facet.__typename !== 'CategorySearchFilter',
-  );
-
-  const refinedFacets =
-    refinedSearch?.facets.items.filter((facet) => facet.__typename !== 'CategorySearchFilter') ??
-    [];
-  const transformedFacets = await facetsTransformer({
-    refinedFacets,
-    allFacets,
-    searchParams: { ...searchParams, ...parsedSearchParams },
-  });
-
-  return transformedFacets.filter((facet) => facet != null);
-}
-
-async function getListProducts(props: Props): Promise<Product[]> {
-  const products = await getProducts(props);
-  const format = await getFormatter();
-
-  return products.map((product) => ({
-    id: product.entityId.toString(),
-    title: product.name,
-    href: product.path,
-    image: product.defaultImage
-      ? { src: product.defaultImage.url, alt: product.defaultImage.altText }
-      : undefined,
-    price: pricesTransformer(product.prices, format),
-    subtitle: product.brand?.name ?? undefined,
-  }));
-}
-
-async function getTotalCount(props: Props): Promise<number> {
-  const searchTerm = await getSearchTerm(props);
-
-  if (searchTerm === '') {
-    return 0;
-  }
-
-  const search = await getSearch(props);
-
-  return search.products.collectionInfo?.totalItems ?? 0;
-}
-
-async function getSortLabel(): Promise<string> {
-  const t = await getTranslations('Faceted.SortBy');
-
-  return t('sortBy');
-}
-
-async function getSortOptions(): Promise<SortOption[]> {
-  const t = await getTranslations('Faceted.SortBy');
-
-  return [
-    { value: 'featured', label: t('featuredItems') },
-    { value: 'newest', label: t('newestItems') },
-    { value: 'best_selling', label: t('bestSellingItems') },
-    { value: 'a_to_z', label: t('aToZ') },
-    { value: 'z_to_a', label: t('zToA') },
-    { value: 'best_reviewed', label: t('byReview') },
-    { value: 'lowest_price', label: t('priceAscending') },
-    { value: 'highest_price', label: t('priceDescending') },
-    { value: 'relevance', label: t('relevance') },
-  ];
-}
-
-async function getPaginationInfo(props: Props): Promise<CursorPaginationInfo> {
-  const searchTerm = await getSearchTerm(props);
-
-  if (searchTerm === '') {
-    return {
-      startCursorParamName: 'before',
-      endCursorParamName: 'after',
-      endCursor: null,
-      startCursor: null,
-    };
-  }
-
-  const search = await getSearch(props);
-  const { hasNextPage, hasPreviousPage, endCursor, startCursor } = search.products.pageInfo;
-
-  return {
-    startCursorParamName: 'before',
-    endCursorParamName: 'after',
-    endCursor: hasNextPage ? endCursor : null,
-    startCursor: hasPreviousPage ? startCursor : null,
-  };
-}
-
-async function getShowCompare() {
-  const data = await getSearchPageData();
-
-  return data.settings?.storefront.catalog?.productComparisonsEnabled ?? false;
-}
-
-const cachedCompareProductIds = cache(async (props: Props) => {
-  const searchParams = await props.searchParams;
-
-  const compareLoader = createCompareLoader();
-
-  const { compare } = compareLoader(searchParams);
-
-  return { entityIds: compare ? compare.map((id: string) => Number(id)) : [] };
-});
-
-async function getCompareProducts(props: Props) {
-  const compareIds = await cachedCompareProductIds(props);
-
-  const products = await getCompareProductsData(compareIds);
-
-  return products.map((product) => ({
-    id: product.entityId.toString(),
-    title: product.name,
-    image: product.defaultImage
-      ? { src: product.defaultImage.url, alt: product.defaultImage.altText }
-      : undefined,
-    href: product.path,
-  }));
-}
-
-async function getFilterLabel(): Promise<string> {
-  const t = await getTranslations('Faceted.FacetedSearch');
-
-  return t('filters');
-}
-
-async function getCompareLabel(): Promise<string> {
-  const t = await getTranslations('Components.ProductCard.Compare');
-
-  return t('compare');
-}
-
-async function getRemoveLabel(): Promise<string> {
-  const t = await getTranslations('Components.ProductCard.Compare');
-
-  return t('remove');
-}
-
-async function getMaxCompareLimitMessage(): Promise<string> {
-  const t = await getTranslations('Components.ProductCard.Compare');
-
-  return t('maxCompareLimit');
-}
-
-async function getFiltersPanelTitle(): Promise<string> {
-  const t = await getTranslations('Faceted.FacetedSearch');
-
-  return t('filters');
-}
-
-async function getResetFiltersLabel(): Promise<string> {
-  const t = await getTranslations('Faceted.FacetedSearch');
-
-  return t('resetFilters');
-}
-
-async function getRangeFilterApplyLabel(): Promise<string> {
-  const t = await getTranslations('Faceted.FacetedSearch.Range');
-
-  return t('apply');
-}
-
-async function getEmptyStateTitle(props: Props): Promise<string> {
-  const searchTerm = await getSearchTerm(props);
-  const t = await getTranslations('Faceted.Search.Empty');
-
-  return t('title', { term: searchTerm });
-}
-
-async function getEmptyStateSubtitle(): Promise<string> {
-  const t = await getTranslations('Faceted.Search.Empty');
-
-  return t('subtitle');
-}
-
-async function getBreadcrumbs(): Promise<Breadcrumb[]> {
-  const t = await getTranslations('Faceted.Search.Breadcrumbs');
-
-  return [
-    { label: t('home'), href: '/' },
-    { label: t('search'), href: `#` },
-  ];
-}
 
 interface Props {
   params: Promise<{ locale: string }>;
@@ -307,30 +39,227 @@ export default async function Search(props: Props) {
 
   setRequestLocale(locale);
 
+  const t = await getTranslations('Faceted');
+
+  const { settings } = await getSearchPageData();
+
+  const productComparisonsEnabled =
+    settings?.storefront.catalog?.productComparisonsEnabled ?? false;
+
+  const createSearchSearchParamsCache = cache(async () => {
+    const searchParams = await props.searchParams;
+    const searchTerm = typeof searchParams.term === 'string' ? searchParams.term : '';
+
+    if (!searchTerm) {
+      return null;
+    }
+
+    const search = await fetchFacetedSearch(searchParams);
+    const searchFacets = search.facets.items;
+    const transformedSearchFacets = await facetsTransformer({
+      refinedFacets: searchFacets,
+      allFacets: searchFacets,
+      searchParams: {},
+    });
+    const searchFilters = transformedSearchFacets.filter((facet) => facet != null);
+    const filterParsers = getFilterParsers(searchFilters);
+
+    // If there are no filters, return `null`, since calling `createSearchParamsCache` with an empty
+    // object will throw the following cryptic error:
+    //
+    // ```
+    // Error: [nuqs] Empty search params cache. Search params can't be accessed in Layouts.
+    //   See https://err.47ng.com/NUQS-500
+    // ```
+    if (Object.keys(filterParsers).length === 0) {
+      return null;
+    }
+
+    return createSearchParamsCache(filterParsers);
+  });
+
+  const streamableFacetedSearch = Streamable.from(async () => {
+    const searchParams = await props.searchParams;
+    const customerAccessToken = await getSessionCustomerAccessToken();
+    const currencyCode = await getPreferredCurrencyCode();
+
+    const searchParamsCache = await createSearchSearchParamsCache();
+    const parsedSearchParams = searchParamsCache?.parse(searchParams) ?? {};
+
+    const search = await fetchFacetedSearch(
+      {
+        ...searchParams,
+        ...parsedSearchParams,
+      },
+      currencyCode,
+      customerAccessToken,
+    );
+
+    return search;
+  });
+
+  const streamableProducts = Streamable.from(async () => {
+    const format = await getFormatter();
+
+    const searchParams = await props.searchParams;
+    const searchTerm = typeof searchParams.term === 'string' ? searchParams.term : '';
+
+    if (!searchTerm) {
+      return [];
+    }
+
+    const search = await streamableFacetedSearch;
+    const products = search.products.items;
+
+    return products.map((product) => ({
+      id: product.entityId.toString(),
+      title: product.name,
+      href: product.path,
+      image: product.defaultImage
+        ? { src: product.defaultImage.url, alt: product.defaultImage.altText }
+        : undefined,
+      price: pricesTransformer(product.prices, format),
+      subtitle: product.brand?.name ?? undefined,
+    }));
+  });
+
+  const streamableTitle = Streamable.from(async () => {
+    const searchParams = await props.searchParams;
+    const searchTerm = typeof searchParams.term === 'string' ? searchParams.term : '';
+
+    return `${t('Search.searchResults')} "${searchTerm}"`;
+  });
+
+  const streamableTotalCount = Streamable.from(async () => {
+    const searchParams = await props.searchParams;
+    const searchTerm = typeof searchParams.term === 'string' ? searchParams.term : '';
+
+    if (!searchTerm) {
+      return 0;
+    }
+
+    const search = await streamableFacetedSearch;
+
+    return search.products.collectionInfo?.totalItems ?? 0;
+  });
+
+  const streamableEmptyStateTitle = Streamable.from(async () => {
+    const searchParams = await props.searchParams;
+    const searchTerm = typeof searchParams.term === 'string' ? searchParams.term : '';
+
+    return t('Search.Empty.title', { term: searchTerm });
+  });
+
+  const streamablePagination = Streamable.from(async () => {
+    const searchParams = await props.searchParams;
+    const searchTerm = typeof searchParams.term === 'string' ? searchParams.term : '';
+
+    if (!searchTerm) {
+      return {
+        startCursorParamName: 'before',
+        endCursorParamName: 'after',
+        endCursor: null,
+        startCursor: null,
+      };
+    }
+
+    const search = await streamableFacetedSearch;
+
+    return pageInfoTransformer(search.products.pageInfo);
+  });
+
+  const streamableFilters = Streamable.from(async () => {
+    const searchParams = await props.searchParams;
+    const searchTerm = typeof searchParams.term === 'string' ? searchParams.term : '';
+
+    if (!searchTerm) {
+      return [];
+    }
+
+    const searchParamsCache = await createSearchSearchParamsCache();
+    const parsedSearchParams = searchParamsCache?.parse(searchParams) ?? {};
+    const search = await streamableFacetedSearch;
+
+    const allFacets = search.facets.items.filter(
+      (facet) => facet.__typename !== 'CategorySearchFilter',
+    );
+    const refinedFacets = search.facets.items.filter(
+      (facet) => facet.__typename !== 'CategorySearchFilter',
+    );
+
+    const transformedFacets = await facetsTransformer({
+      refinedFacets,
+      allFacets,
+      searchParams: { ...searchParams, ...parsedSearchParams },
+    });
+
+    return transformedFacets.filter((facet) => facet != null);
+  });
+
+  const streamableCompareProducts = Streamable.from(async () => {
+    const searchParams = await props.searchParams;
+    const customerAccessToken = await getSessionCustomerAccessToken();
+    const currencyCode = await getPreferredCurrencyCode();
+
+    if (!productComparisonsEnabled) {
+      return [];
+    }
+
+    const compareLoader = createCompareLoader();
+
+    const { compare } = compareLoader(searchParams);
+
+    const compareIds = { entityIds: compare ? compare.map((id: string) => Number(id)) : [] };
+
+    const products = await getCompareProductsData(compareIds, currencyCode, customerAccessToken);
+
+    return products.map((product) => ({
+      id: product.entityId.toString(),
+      title: product.name,
+      image: product.defaultImage
+        ? { src: product.defaultImage.url, alt: product.defaultImage.altText }
+        : undefined,
+      href: product.path,
+    }));
+  });
+
   return (
     <ProductsListSection
-      breadcrumbs={Streamable.from(getBreadcrumbs)}
-      compareLabel={Streamable.from(getCompareLabel)}
-      compareProducts={Streamable.from(() => getCompareProducts(props))}
-      emptyStateSubtitle={Streamable.from(getEmptyStateSubtitle)}
-      emptyStateTitle={Streamable.from(() => getEmptyStateTitle(props))}
-      filterLabel={await getFilterLabel()}
-      filters={Streamable.from(() => getFilters(props))}
-      filtersPanelTitle={Streamable.from(getFiltersPanelTitle)}
-      maxCompareLimitMessage={Streamable.from(getMaxCompareLimitMessage)}
+      breadcrumbs={[
+        { label: t('Search.Breadcrumbs.home'), href: '/' },
+        { label: t('Search.Breadcrumbs.search'), href: `#` },
+      ]}
+      compareLabel={t('Compare.compare')}
+      compareProducts={streamableCompareProducts}
+      emptyStateSubtitle={t('Search.Empty.subtitle')}
+      emptyStateTitle={streamableEmptyStateTitle}
+      filterLabel={t('FacetedSearch.filters')}
+      filters={streamableFilters}
+      filtersPanelTitle={t('FacetedSearch.filters')}
+      maxCompareLimitMessage={t('Compare.maxCompareLimit')}
       maxItems={MAX_COMPARE_LIMIT}
-      paginationInfo={Streamable.from(() => getPaginationInfo(props))}
-      products={Streamable.from(() => getListProducts(props))}
-      rangeFilterApplyLabel={Streamable.from(getRangeFilterApplyLabel)}
-      removeLabel={Streamable.from(getRemoveLabel)}
-      resetFiltersLabel={Streamable.from(getResetFiltersLabel)}
-      showCompare={Streamable.from(getShowCompare)}
+      paginationInfo={streamablePagination}
+      products={streamableProducts}
+      rangeFilterApplyLabel={t('FacetedSearch.Range.apply')}
+      removeLabel={t('Compare.remove')}
+      resetFiltersLabel={t('FacetedSearch.resetFilters')}
+      showCompare={productComparisonsEnabled}
       sortDefaultValue="featured"
-      sortLabel={Streamable.from(getSortLabel)}
-      sortOptions={Streamable.from(getSortOptions)}
+      sortLabel={t('SortBy.sortBy')}
+      sortOptions={[
+        { value: 'featured', label: t('SortBy.featuredItems') },
+        { value: 'newest', label: t('SortBy.newestItems') },
+        { value: 'best_selling', label: t('SortBy.bestSellingItems') },
+        { value: 'a_to_z', label: t('SortBy.aToZ') },
+        { value: 'z_to_a', label: t('SortBy.zToA') },
+        { value: 'best_reviewed', label: t('SortBy.byReview') },
+        { value: 'lowest_price', label: t('SortBy.priceAscending') },
+        { value: 'highest_price', label: t('SortBy.priceDescending') },
+        { value: 'relevance', label: t('SortBy.relevance') },
+      ]}
       sortParamName="sort"
-      title={Streamable.from(() => getTitle(props))}
-      totalCount={Streamable.from(() => getTotalCount(props))}
+      title={streamableTitle}
+      totalCount={streamableTotalCount}
     />
   );
 }


### PR DESCRIPTION
## New

This refactor optimizes search PLP for caching and the eventual use of dynamicIO. With these changes we leverage data caching to hit mostly cache data for guest shoppers in different locales and with different currencies.

## Key modifications include:

- We don't stream in Search page data, instead it's a blocking call to get page data.
- Our query functions now take in all params required for fetching, instead of accessing dynamic variables internally. This is important to serialize arguments if we want to eventually `use cache`.
- Use `Streamable.from` to generate our streaming props that are passed to our UI components.
- Remove use of nuqs' `createSearchParamsCache` in favor of nuqs' `createLoader`.

## Migration instructions:

- Update `/(facted)/search/page.tsx`
  - For this page we are now doing a blocking request for brand page data. Instead of having functions that each would read from props, we share streamable functions that can be passed to our UI components. We still stream in filter and product data.

## Testing
Locally, page is faster, and requests are non blocking.