### PR TITLE
Remove unused variant fetch from query

### DIFF
--- a/.changeset/eighty-nails-juggle.md
+++ b/.changeset/eighty-nails-juggle.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Remove unused variants collection from query for PDP

--- a/core/app/[locale]/(default)/product/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/product/[slug]/page-data.ts
@@ -118,13 +118,6 @@ export const ProductFormFragment = graphql(
   `
     fragment ProductFormFragment on Product {
       entityId
-      variants {
-        edges {
-          node {
-            entityId
-          }
-        }
-      }
       productOptions(first: 50) {
         edges {
           node {


### PR DESCRIPTION
## What/Why?
Remove unused `variants` collection from the query used to build PDPs.

## Testing
Preview deployment