### PR TITLE
fix: incorrect css vars for border and contrast-gray

### DIFF
--- a/core/vibes/soul/form/swatch-radio-group/index.tsx
+++ b/core/vibes/soul/form/swatch-radio-group/index.tsx
@@ -32,14 +32,14 @@ type SwatchOption =
  *    --swatch-radio-group-focus: hsl(var(--primary));
  *    --swatch-radio-group-light-icon: hsl(var(--foreground));
  *    --swatch-radio-group-light-unchecked-border: transparent;
- *    --swatch-radio-group-light-unchecked-border-hover: hsl(var(--border-contrast-200));
+ *    --swatch-radio-group-light-unchecked-border-hover: hsl(var(--contrast-200));
  *    --swatch-radio-group-light-disabled-border: transparent;
  *    --swatch-radio-group-light-border-error: hsl(var(--error));
  *    --swatch-radio-group-light-checked-border: hsl(var(--foreground));
  *    --swatch-radio-group-light-option-border: hsl(var(--foreground) / 10%);
  *    --swatch-radio-group-dark-icon: hsl(var(--background));
  *    --swatch-radio-group-dark-unchecked-border: transparent;
- *    --swatch-radio-group-dark-unchecked-border-hover: hsl(var(--border-contrast-400));
+ *    --swatch-radio-group-dark-unchecked-border-hover: hsl(var(--contrast-400));
  *    --swatch-radio-group-dark-disabled-border: transparent;
  *    --swatch-radio-group-dark-border-error: hsl(var(--error));
  *    --swatch-radio-group-dark-checked-border: hsl(var(--background));
@@ -83,8 +83,8 @@ export const SwatchRadioGroup = React.forwardRef<
                 'group relative box-content h-8 w-8 rounded-full border p-0.5 transition-colors focus-visible:ring-2 focus-visible:ring-[var(--swatch-radio-group-focus,hsl(var(--primary)))] focus-visible:outline-hidden data-disabled:pointer-events-none [&:disabled>.disabled-icon]:grid',
                 {
                   light:
-                    'hover:border-[var(--swatch-radio-group-light-unchecked-border-hover,hsl(var(--border-contrast-200)))] data-[state=checked]:border-[var(--swatch-radio-group-light-checked-border,hsl(var(--foreground)))]',
-                  dark: 'hover:border-[var(--swatch-radio-group-dark-unchecked-border-hover,hsl(var(--border-contrast-400)))] data-[state=checked]:border-[var(--swatch-radio-group-dark-checked-border,hsl(var(--background)))]',
+                    'hover:border-[var(--swatch-radio-group-light-unchecked-border-hover,hsl(var(--contrast-200)))] data-[state=checked]:border-[var(--swatch-radio-group-light-checked-border,hsl(var(--foreground)))]',
+                  dark: 'hover:border-[var(--swatch-radio-group-dark-unchecked-border-hover,hsl(var(--contrast-400)))] data-[state=checked]:border-[var(--swatch-radio-group-dark-checked-border,hsl(var(--background)))]',
                 }[colorScheme],
                 {
                   light:

--- a/core/vibes/soul/form/textarea/index.tsx
+++ b/core/vibes/soul/form/textarea/index.tsx
@@ -12,14 +12,14 @@ import { Label } from '@/vibes/soul/form/label';
  *  :root {
  *    --textarea-light-background: hsl(var(--background));
  *    --textarea-light-text: hsl(var(--foreground));
- *    --textarea-light-placeholder: hsl(var(--contrast-gray-500));
- *    --textarea-light-border: hsl(var(--border-contrast-100));
+ *    --textarea-light-placeholder: hsl(var(--contrast-500));
+ *    --textarea-light-border: hsl(var(--contrast-100));
  *    --textarea-light-border-focus: hsl(var(--foreground));
  *    --textarea-light-border-error: hsl(var(--error));
  *    --textarea-dark-background: hsl(var(--foreground));
  *    --textarea-dark-text: hsl(var(--background));
- *    --textarea-dark-placeholder: hsl(var(--contrast-gray-100));
- *    --textarea-dark-border: hsl(var(--border-contrast-500));
+ *    --textarea-dark-placeholder: hsl(var(--contrast-100));
+ *    --textarea-dark-border: hsl(var(--contrast-500));
  *    --textarea-dark-border-focus: hsl(var(--background));
  *    --textarea-dark-border-error: hsl(var(--error));
  *  }
@@ -49,18 +49,18 @@ export const Textarea = React.forwardRef<
           'w-full rounded-lg border p-3 transition-colors duration-200 placeholder:font-normal focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
           {
             light:
-              'bg-[var(--textarea-light-background,hsl(var(--background)))] text-[var(--textarea-light-text,hsl(var(--foreground)))] placeholder-[var(--textarea-light-placeholder,hsl(var(--contrast-gray-500)))] focus:border-[var(--textarea-light-border-focus,hsl(var(--foreground)))]',
-            dark: 'bg-[var(--textarea-dark-background,hsl(var(--foreground)))] text-[var(--textarea-dark-text,hsl(var(--background)))] placeholder-[var(--textarea-dark-placeholder,hsl(var(--contrast-gray-100)))] focus:border-[var(--textarea-dark-border-focus,hsl(var(--background)))]',
+              'bg-[var(--textarea-light-background,hsl(var(--background)))] text-[var(--textarea-light-text,hsl(var(--foreground)))] placeholder-[var(--textarea-light-placeholder,hsl(var(--contrast-500)))] focus:border-[var(--textarea-light-border-focus,hsl(var(--foreground)))]',
+            dark: 'bg-[var(--textarea-dark-background,hsl(var(--foreground)))] text-[var(--textarea-dark-text,hsl(var(--background)))] placeholder-[var(--textarea-dark-placeholder,hsl(var(--contrast-100)))] focus:border-[var(--textarea-dark-border-focus,hsl(var(--background)))]',
           }[colorScheme],
           {
             light:
               errors && errors.length > 0
                 ? 'border-[var(--textarea-light-border-error,hsl(var(--error)))]'
-                : 'border-[var(--textarea-light-border,hsl(var(--border-contrast-100)))]',
+                : 'border-[var(--textarea-light-border,hsl(var(--contrast-100)))]',
             dark:
               errors && errors.length > 0
                 ? 'border-[var(--textarea-dark-border-error,hsl(var(--error)))]'
-                : 'border-[var(--textarea-dark-border,hsl(var(--border-contrast-500)))]',
+                : 'border-[var(--textarea-dark-border,hsl(var(--contrast-500)))]',
           }[colorScheme],
         )}
         id={id}

--- a/core/vibes/soul/form/toggle-group/index.tsx
+++ b/core/vibes/soul/form/toggle-group/index.tsx
@@ -20,7 +20,7 @@ interface Option {
  * ```css
  *  :root {
  *   --toggle-group-light-focus: hsl(var(--primary));
- *   --toggle-group-light-border: hsl(var(--border-contrast-100));
+ *   --toggle-group-light-border: hsl(var(--contrast-100));
  *   --toggle-group-light-on-border: hsl(var(--foreground));
  *   --toggle-group-light-on-background: hsl(var(--foreground));
  *   --toggle-group-light-off-background: hsl(var(--background));
@@ -29,7 +29,7 @@ interface Option {
  *   --toggle-group-light-off-border-hover: hsl(var(--contrast-200));
  *   --toggle-group-light-off-background-hover: hsl(var(--contrast-100));
  *   --toggle-group-dark-focus: hsl(var(--primary));
- *   --toggle-group-dark-border: hsl(var(--border-contrast-500));
+ *   --toggle-group-dark-border: hsl(var(--contrast-500));
  *   --toggle-group-dark-on-border: hsl(var(--background));
  *   --toggle-group-dark-on-background: hsl(var(--background));
  *   --toggle-group-dark-off-background: hsl(var(--foreground));
@@ -70,8 +70,8 @@ export const ToggleGroup = React.forwardRef<
               'font-body h-12 rounded-full border px-4 text-sm leading-normal font-normal whitespace-nowrap transition-colors focus-visible:ring-2 focus-visible:outline-0 data-disabled:pointer-events-none data-disabled:opacity-50',
               {
                 light:
-                  'border-[var(--toggle-group-light-border,hsl(var(--border-contrast-100)))] ring-[var(--toggle-group-light-focus,hsl(var(--primary)))] data-[state=off]:bg-[var(--toggle-group-light-off-background,hsl(var(--background)))] data-[state=off]:text-[var(--toggle-group-light-off-text,hsl(var(--foreground)))] data-[state=off]:hover:border-[var(--toggle-group-light-off-border-hover,hsl(var(--contrast-200)))] data-[state=off]:hover:bg-[var(--toggle-group-light-off-background-hover,hsl(var(--contrast-100)))] data-[state=on]:border-[var(--toggle-group-light-on-border,hsl(var(--foreground)))] data-[state=on]:bg-[var(--toggle-group-light-on-background,hsl(var(--foreground)))] data-[state=on]:text-[var(--toggle-group-light-on-text,hsl(var(--background)))]',
-                dark: 'border-[var(--toggle-group-dark-border,hsl(var(--border-contrast-500)))] ring-[var(--toggle-group-dark-focus,hsl(var(--primary)))] data-[state=off]:bg-[var(--toggle-group-dark-off-background,hsl(var(--foreground)))] data-[state=off]:text-[var(--toggle-group-dark-off-text,hsl(var(--background)))] data-[state=off]:hover:border-[var(--toggle-group-dark-off-border-hover,hsl(var(--contrast-400)))] data-[state=off]:hover:bg-[var(--toggle-group-dark-off-background-hover,hsl(var(--contrast-500)))] data-[state=on]:border-[var(--toggle-group-dark-on-border,hsl(var(--background)))] data-[state=on]:bg-[var(--toggle-group-dark-on-background,hsl(var(--background)))] data-[state=on]:text-[var(--toggle-group-dark-on-text,hsl(var(--foreground)))]',
+                  'border-[var(--toggle-group-light-border,hsl(var(--contrast-100)))] ring-[var(--toggle-group-light-focus,hsl(var(--primary)))] data-[state=off]:bg-[var(--toggle-group-light-off-background,hsl(var(--background)))] data-[state=off]:text-[var(--toggle-group-light-off-text,hsl(var(--foreground)))] data-[state=off]:hover:border-[var(--toggle-group-light-off-border-hover,hsl(var(--contrast-200)))] data-[state=off]:hover:bg-[var(--toggle-group-light-off-background-hover,hsl(var(--contrast-100)))] data-[state=on]:border-[var(--toggle-group-light-on-border,hsl(var(--foreground)))] data-[state=on]:bg-[var(--toggle-group-light-on-background,hsl(var(--foreground)))] data-[state=on]:text-[var(--toggle-group-light-on-text,hsl(var(--background)))]',
+                dark: 'border-[var(--toggle-group-dark-border,hsl(var(--contrast-500)))] ring-[var(--toggle-group-dark-focus,hsl(var(--primary)))] data-[state=off]:bg-[var(--toggle-group-dark-off-background,hsl(var(--foreground)))] data-[state=off]:text-[var(--toggle-group-dark-off-text,hsl(var(--background)))] data-[state=off]:hover:border-[var(--toggle-group-dark-off-border-hover,hsl(var(--contrast-400)))] data-[state=off]:hover:bg-[var(--toggle-group-dark-off-background-hover,hsl(var(--contrast-500)))] data-[state=on]:border-[var(--toggle-group-dark-on-border,hsl(var(--background)))] data-[state=on]:bg-[var(--toggle-group-dark-on-background,hsl(var(--background)))] data-[state=on]:text-[var(--toggle-group-dark-on-text,hsl(var(--foreground)))]',
               }[colorScheme],
             )}
             disabled={option.disabled}


### PR DESCRIPTION
## What/Why?
- renames CSS vars that incorrectly start with `--border-contrast` to `--border`
- renames CSS vars that incorrectly use `--contrast-gray` to `--contrast`