### PR TITLE
fix: deletion of `NEXT_LOCALE` cookie triggers page rerender

### DIFF
--- a/.changeset/tired-places-build.md
+++ b/.changeset/tired-places-build.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+fix: deletion of `NEXT_LOCALE` cookie triggers page rerender

--- a/core/middlewares/with-makeswift.ts
+++ b/core/middlewares/with-makeswift.ts
@@ -1,4 +1,6 @@
 import { unstable_createMakeswiftDraftRequest } from '@makeswift/runtime/next/middleware';
+import { NextResponse } from 'next/server';
+import { splitCookiesString } from 'set-cookie-parser';
 
 import { routing } from '~/i18n/routing';
 
@@ -13,6 +15,32 @@ const MAKESWIFT_SITE_API_KEY = process.env.MAKESWIFT_SITE_API_KEY;
 const localeCookieName = ({ localeCookie }: { localeCookie?: boolean | { name?: string } }) =>
   (typeof localeCookie === 'object' ? localeCookie.name : undefined) ?? 'NEXT_LOCALE';
 
+const stripSetLocaleCookieHeaders = (response: NextResponse | Response) => {
+  const cookieName = localeCookieName(routing);
+  const isLocaleCookie = (value: string) => value.startsWith(`${cookieName}=`);
+
+  response.headers.forEach((value, name) => {
+    if (name === 'set-cookie') {
+      if (isLocaleCookie(value)) {
+        response.headers.delete(name);
+      }
+    }
+
+    if (name === 'x-middleware-set-cookie') {
+      // In contrast to the 'set-cookie' header, Next.js' 'x-middleware-set-cookie' header may
+      // contain multiple comma-separated cookie values in a single header--see
+      // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/spec-extension/response.ts#L60
+      const values = splitCookiesString(value).filter((v) => !isLocaleCookie(v));
+
+      if (values.length > 0) {
+        response.headers.set(name, values.join(','));
+      } else {
+        response.headers.delete(name);
+      }
+    }
+  });
+};
+
 export const withMakeswift: MiddlewareFactory = (middleware) => {
   return async (request, event) => {
     const draftRequest = await unstable_createMakeswiftDraftRequest(
@@ -21,16 +49,16 @@ export const withMakeswift: MiddlewareFactory = (middleware) => {
     );
 
     if (draftRequest != null) {
-      if (routing.localeCookie) {
-        // If the i18n middleware is configured to use a cookie, it will first try to derive the
-        // locale from the existing request cookie before attempting to match the URL against the
-        // locale routes. The locale switcher in the Makeswift Builder expects the host to always
-        // determine the locale from the URL, though, so we have to erase the cookie from the
-        // proxied request to force that behavior.
-        draftRequest.cookies.delete(localeCookieName(routing));
-      }
+      const response = await middleware(draftRequest, event);
 
-      return middleware(draftRequest, event);
+      // If the i18n middleware is configured to use a cookie, it will first try to derive the
+      // locale from the existing request cookie before attempting to match the URL against the
+      // locale routes. The locale switcher in the Makeswift Builder expects the host to always
+      // determine the locale from the URL, though. To enable that behavior, we prevent the
+      // locale cookie from being set in response to all draft requests.
+      if (response != null) stripSetLocaleCookieHeaders(response);
+
+      return response;
     }
 
     return middleware(request, event);

--- a/core/package.json
+++ b/core/package.json
@@ -67,6 +67,7 @@
     "react-hook-form": "^7.54.2",
     "schema-dts": "^1.1.5",
     "server-only": "^0.0.1",
+    "set-cookie-parser": "^2.7.1",
     "sharp": "^0.33.5",
     "sonner": "^1.7.4",
     "swr": "^2.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
+      set-cookie-parser:
+        specifier: ^2.7.1
+        version: 2.7.1
       sharp:
         specifier: ^0.33.5
         version: 0.33.5
@@ -309,7 +312,7 @@ importers:
     devDependencies:
       '@bigcommerce/eslint-config':
         specifier: ^2.11.0
-        version: 2.11.0(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0(babel-plugin-macros@3.1.0))(typescript@5.8.2)
+        version: 2.11.0(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0(@types/node@22.13.13)(babel-plugin-macros@3.1.0))(typescript@5.8.2)
       '@bigcommerce/eslint-config-catalyst':
         specifier: workspace:^
         version: link:../eslint-config-catalyst
@@ -349,7 +352,7 @@ importers:
     devDependencies:
       '@bigcommerce/eslint-config':
         specifier: ^2.11.0
-        version: 2.11.0(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0(babel-plugin-macros@3.1.0))(typescript@5.8.2)
+        version: 2.11.0(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0(@types/node@22.13.13)(babel-plugin-macros@3.1.0))(typescript@5.8.2)
       '@bigcommerce/eslint-config-catalyst':
         specifier: workspace:^
         version: link:../eslint-config-catalyst
@@ -446,7 +449,7 @@ importers:
     devDependencies:
       '@bigcommerce/eslint-config':
         specifier: ^2.11.0
-        version: 2.11.0(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0(babel-plugin-macros@3.1.0))(typescript@5.8.2)
+        version: 2.11.0(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0(@types/node@22.13.13)(babel-plugin-macros@3.1.0))(typescript@5.8.2)
       '@bigcommerce/eslint-config-catalyst':
         specifier: workspace:^
         version: link:../eslint-config-catalyst
@@ -500,7 +503,7 @@ importers:
     dependencies:
       '@bigcommerce/eslint-config':
         specifier: ^2.11.0
-        version: 2.11.0(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0(babel-plugin-macros@3.1.0))(typescript@5.8.2)
+        version: 2.11.0(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0(@types/node@22.13.13)(babel-plugin-macros@3.1.0))(typescript@5.8.2)
       '@next/eslint-plugin-next':
         specifier: ^15.2.3
         version: 15.2.3
@@ -6728,7 +6731,7 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@bigcommerce/eslint-config@2.11.0(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0(babel-plugin-macros@3.1.0))(typescript@5.8.2)':
+  '@bigcommerce/eslint-config@2.11.0(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0(@types/node@22.13.13)(babel-plugin-macros@3.1.0))(typescript@5.8.2)':
     dependencies:
       '@bigcommerce/eslint-plugin': 1.4.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2)
       '@rushstack/eslint-patch': 1.10.5
@@ -6740,7 +6743,7 @@ snapshots:
       eslint-import-resolver-typescript: 3.9.1(eslint-plugin-import@2.31.0)(eslint@8.57.1)
       eslint-plugin-gettext: 1.2.0
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.9.1)(eslint@8.57.1)
-      eslint-plugin-jest: 28.11.0(@typescript-eslint/eslint-plugin@8.28.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(jest@29.7.0(babel-plugin-macros@3.1.0))(typescript@5.8.2)
+      eslint-plugin-jest: 28.11.0(@typescript-eslint/eslint-plugin@8.28.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(jest@29.7.0(@types/node@22.13.13)(babel-plugin-macros@3.1.0))(typescript@5.8.2)
       eslint-plugin-jest-dom: 5.5.0(eslint@8.57.1)
       eslint-plugin-jest-formatting: 3.1.0(eslint@8.57.1)
       eslint-plugin-jsdoc: 50.6.9(eslint@8.57.1)
@@ -9965,7 +9968,7 @@ snapshots:
     dependencies:
       eslint: 8.57.1
 
-  eslint-plugin-jest@28.11.0(@typescript-eslint/eslint-plugin@8.28.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(jest@29.7.0(babel-plugin-macros@3.1.0))(typescript@5.8.2):
+  eslint-plugin-jest@28.11.0(@typescript-eslint/eslint-plugin@8.28.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(jest@29.7.0(@types/node@22.13.13)(babel-plugin-macros@3.1.0))(typescript@5.8.2):
     dependencies:
       '@typescript-eslint/utils': 8.28.0(eslint@8.57.1)(typescript@5.8.2)
       eslint: 8.57.1


### PR DESCRIPTION
## What/Why?

This is a rework of https://github.com/bigcommerce/catalyst/pull/1984 that fixes the unintended page reload introduced by that PR. See [ENG-7924](https://linear.app/makeswift/issue/ENG-7924/unconditional-deletion-of-next-locale-cookie-triggers-page-rerender) for more details.

## Testing

https://github.com/user-attachments/assets/8caf3611-4b6d-40db-9e61-b880e1ade156



