### PR TITLE
fix: add /lib/makeswift/components folder to tailwind.config.js

### DIFF
--- a/.changeset/nine-bikes-hunt.md
+++ b/.changeset/nine-bikes-hunt.md
@@ -1,5 +1,5 @@
 ---
-"@bigcommerce/catalyst-core": minor
+"@bigcommerce/catalyst-core": patch
 ---
 
 Add core/lib/makeswift/components folder to tailwind config content property so that tailwind classes can be used in components there.

--- a/.changeset/nine-bikes-hunt.md
+++ b/.changeset/nine-bikes-hunt.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Add core/lib/makeswift/components folder to tailwind config content property so that tailwind classes can be used in components there.

--- a/core/tailwind.config.js
+++ b/core/tailwind.config.js
@@ -3,6 +3,7 @@ const config = {
   content: [
     './app/**/*.{ts,tsx}',
     './components/**/*.{ts,tsx}',
+    './lib/makeswift/components/**/*.{ts,tsx}',
     './vibes/**/*.{ts,tsx}',
     '!./node_modules/**', // Exclude everything in node_modules to speed up builds
   ],


### PR DESCRIPTION
## What/Why?
Add `core/lib/makeswift/components` folder to tailwind config content property so that tailwind classes can be used in components there. If you happen to write a tailwind class in a component in this folder that hasn't been used elsewhere in the codebase, the tailwind class won't work. Tailwind needs to watch this folder in order to include classes used in the compiled css.

There are other components in this folder already using tailwind classes; for example: [the Basic / Accordions component](https://github.com/bigcommerce/catalyst/blob/9d07a7160270d77c1e52ddfadef2325816d928fc/core/lib/makeswift/components/accordions/accordions.makeswift.tsx#L27). The only reason those classes worked is because they're already used in the folders tailwind is watching.

## Testing
Try using `p-10`(or another tailwind class that hasn't been used already) in a component in the `core/lib/makeswift/components` folder.

## Migration
n/a
