### PR TITLE
fix: disable locale detection in the builder

### DIFF
--- a/.changeset/wise-humans-serve.md
+++ b/.changeset/wise-humans-serve.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+fix: disable cookie- and language-based locale detection in the builder

--- a/core/middlewares/with-intl.ts
+++ b/core/middlewares/with-intl.ts
@@ -4,10 +4,15 @@ import { routing } from '~/i18n/routing';
 
 import { type MiddlewareFactory } from './compose-middlewares';
 
-const intlMiddleware = createMiddleware(routing);
-
 export const withIntl: MiddlewareFactory = (next) => {
   return async (request, event) => {
+    const disableLocaleDetection = request.headers.get('x-bc-disable-locale-detection') === 'true';
+
+    const intlMiddleware = createMiddleware({
+      ...routing,
+      ...(disableLocaleDetection ? { localeDetection: false } : {}),
+    });
+
     const intlResponse = intlMiddleware(request);
 
     // If intlMiddleware redirects, or returns a non-200 return it immediately

--- a/core/middlewares/with-makeswift.ts
+++ b/core/middlewares/with-makeswift.ts
@@ -1,8 +1,4 @@
 import { unstable_createMakeswiftDraftRequest } from '@makeswift/runtime/next/middleware';
-import { NextResponse } from 'next/server';
-import { splitCookiesString } from 'set-cookie-parser';
-
-import { routing } from '~/i18n/routing';
 
 import { MiddlewareFactory } from './compose-middlewares';
 
@@ -12,35 +8,6 @@ if (!process.env.MAKESWIFT_SITE_API_KEY) {
 
 const MAKESWIFT_SITE_API_KEY = process.env.MAKESWIFT_SITE_API_KEY;
 
-const localeCookieName = ({ localeCookie }: { localeCookie?: boolean | { name?: string } }) =>
-  (typeof localeCookie === 'object' ? localeCookie.name : undefined) ?? 'NEXT_LOCALE';
-
-const stripSetLocaleCookieHeaders = (response: NextResponse | Response) => {
-  const cookieName = localeCookieName(routing);
-  const isLocaleCookie = (value: string) => value.startsWith(`${cookieName}=`);
-
-  response.headers.forEach((value, name) => {
-    if (name === 'set-cookie') {
-      if (isLocaleCookie(value)) {
-        response.headers.delete(name);
-      }
-    }
-
-    if (name === 'x-middleware-set-cookie') {
-      // In contrast to the 'set-cookie' header, Next.js' 'x-middleware-set-cookie' header may
-      // contain multiple comma-separated cookie values in a single header--see
-      // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/spec-extension/response.ts#L60
-      const values = splitCookiesString(value).filter((v) => !isLocaleCookie(v));
-
-      if (values.length > 0) {
-        response.headers.set(name, values.join(','));
-      } else {
-        response.headers.delete(name);
-      }
-    }
-  });
-};
-
 export const withMakeswift: MiddlewareFactory = (middleware) => {
   return async (request, event) => {
     const draftRequest = await unstable_createMakeswiftDraftRequest(
@@ -49,16 +16,12 @@ export const withMakeswift: MiddlewareFactory = (middleware) => {
     );
 
     if (draftRequest != null) {
-      const response = await middleware(draftRequest, event);
+      // Makeswift Builder's locale switcher expects the host to derive locale strictly from
+      // the URL. Disable cookie- and language-based locale detection when in draft mode to
+      // meet this expectation.
+      draftRequest.headers.set('x-bc-disable-locale-detection', 'true');
 
-      // If the i18n middleware is configured to use a cookie, it will first try to derive the
-      // locale from the existing request cookie before attempting to match the URL against the
-      // locale routes. The locale switcher in the Makeswift Builder expects the host to always
-      // determine the locale from the URL, though. To enable that behavior, we prevent the
-      // locale cookie from being set in response to all draft requests.
-      if (response != null) stripSetLocaleCookieHeaders(response);
-
-      return response;
+      return await middleware(draftRequest, event);
     }
 
     return middleware(request, event);


### PR DESCRIPTION
## What/Why?

Makeswift Builder's locale switcher expects the host to derive locale strictly from the URL. Disable cookie- and language-based locale detection when in draft mode to meet this expectation. Rework of https://github.com/bigcommerce/catalyst/pull/2213 and https://github.com/bigcommerce/catalyst/pull/1984.


## Testing

https://github.com/user-attachments/assets/a3e1aac0-5cd6-475d-90f3-b5c19ac750f3
