### PR TITLE
Add operation name and type to graphQL URL for easier logging

### DIFF
--- a/.changeset/swift-tips-wave.md
+++ b/.changeset/swift-tips-wave.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-client": patch
+---
+
+Add GraphQL operation name and type to GraphQL URL as query parameters to improve server logging of GraphQL operations


### PR DESCRIPTION
## What/Why?
Adds the name of the GraphQL operation as a query parameter on the GraphQL URL, such as:

`/graphql?operation=HomePageQuery&type=query`

This improves observability in server logs, making it easier to tell queries apart without parsing the body.

In the future we may add `locale` as well.

## Testing
Tested on preview deployment by observing logs.