### PR TITLE
feat(core): B2B-2562 cart id as optional search param in checkout route

### DIFF
--- a/core/app/[locale]/(default)/checkout/route.ts
+++ b/core/app/[locale]/(default)/checkout/route.ts
@@ -25,9 +25,12 @@ const CheckoutRedirectMutation = graphql(`
   }
 `);
 
-export async function GET(_: NextRequest, { params }: { params: Promise<{ locale: string }> }) {
+export async function GET(req: NextRequest, { params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
-  const cartId = await getCartId();
+  const url = new URL(req.url);
+  const searchParams = url.searchParams;
+  const paramsCartId = searchParams.get('cartId'); 
+  const cartId = paramsCartId || await getCartId();
   const customerAccessToken = await getSessionCustomerAccessToken();
   const channelId = getChannelIdFromLocale(locale);
 

--- a/core/app/[locale]/(default)/checkout/route.ts
+++ b/core/app/[locale]/(default)/checkout/route.ts
@@ -27,10 +27,7 @@ const CheckoutRedirectMutation = graphql(`
 
 export async function GET(req: NextRequest, { params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
-  const url = new URL(req.url);
-  const searchParams = url.searchParams;
-  const paramsCartId = searchParams.get('cartId'); 
-  const cartId = paramsCartId || await getCartId();
+  const cartId = req.nextUrl.searchParams.get('cartId') ?? (await getCartId());
   const customerAccessToken = await getSessionCustomerAccessToken();
   const channelId = getChannelIdFromLocale(locale);
 


### PR DESCRIPTION
## What/Why?
Adding cart id as an optional search param in the checkout route - this will help with B2B payments of quotes and invoices since the buyer portal creates carts and checks out in the same submit event, this leads to issues with passing a cart id to the session in between. 

## Testing
Tested in B2B while paying a quote and redirecting to catalyst checkout route.

## Migration
No migration changes
