### PR TITLE
fix(ci): update security for translations changeset action

### DIFF
--- a/.github/workflows/translations-changeset.yml
+++ b/.github/workflows/translations-changeset.yml
@@ -48,4 +48,4 @@ jobs:
         env:
           TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }} HEAD:${{ github.event.pull_request.head.ref }}
+          git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }} HEAD:$GITHUB_HEAD_REF


### PR DESCRIPTION
## What/Why?
Improves the security of the github action by using the escaped environment variable rather than using Githubs action context. The context values are not escaped but we have the same information in default environment variables: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables

## Testing
N/A

## Migration
N/A