### PR TITLE
fix: remove featured products from 404 page, allowing the page to be static

### DIFF
--- a/.changeset/puny-radios-show.md
+++ b/.changeset/puny-radios-show.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Remove featured products panel from 404 page, allowing the page to be static in preparation for adding a search box

--- a/core/app/[locale]/not-found.tsx
+++ b/core/app/[locale]/not-found.tsx
@@ -1,48 +1,8 @@
-import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
-import { getFormatter, getTranslations } from 'next-intl/server';
+import { getTranslations } from 'next-intl/server';
 
-import { FeaturedProductCarousel } from '@/vibes/soul/sections/featured-product-carousel';
 import { NotFound as NotFoundSection } from '@/vibes/soul/sections/not-found';
-import { CarouselProduct } from '@/vibes/soul/sections/product-carousel';
-import { client } from '~/client';
-import { graphql } from '~/client/graphql';
-import { revalidate } from '~/client/revalidate-target';
 import { Footer } from '~/components/footer';
 import { Header } from '~/components/header';
-import { ProductCardFragment } from '~/components/product-card/fragment';
-import { productCardTransformer } from '~/data-transformers/product-card-transformer';
-import { getPreferredCurrencyCode } from '~/lib/currency';
-
-const NotFoundQuery = graphql(
-  `
-    query NotFoundQuery($currencyCode: currencyCode) {
-      site {
-        featuredProducts(first: 10) {
-          edges {
-            node {
-              ...ProductCardFragment
-            }
-          }
-        }
-      }
-    }
-  `,
-  [ProductCardFragment],
-);
-
-async function getFeaturedProducts(): Promise<CarouselProduct[]> {
-  const format = await getFormatter();
-  const currencyCode = await getPreferredCurrencyCode();
-  const { data } = await client.fetch({
-    document: NotFoundQuery,
-    variables: { currencyCode },
-    fetchOptions: { next: { revalidate } },
-  });
-
-  const featuredProducts = removeEdgesAndNodes(data.site.featuredProducts);
-
-  return productCardTransformer(featuredProducts, format);
-}
 
 export default async function NotFound() {
   const t = await getTranslations('NotFound');
@@ -52,8 +12,6 @@ export default async function NotFound() {
       <Header />
 
       <NotFoundSection subtitle={t('subtitle')} title={t('title')} />
-
-      <FeaturedProductCarousel products={getFeaturedProducts()} title={t('featuredProducts')} />
 
       <Footer />
     </>

--- a/core/vibes/soul/sections/not-found/index.tsx
+++ b/core/vibes/soul/sections/not-found/index.tsx
@@ -8,7 +8,7 @@ export function NotFound({
   subtitle = "Take a look around if you're lost.",
 }: Props) {
   return (
-    <section className="@container">
+    <section className="@container pb-20">
       <div className="mx-auto max-w-3xl px-4 pt-10 @xl:px-6 @xl:pt-14 @4xl:px-8 @4xl:pt-20">
         <h1 className="font-heading mb-3 text-3xl leading-none font-medium @xl:text-4xl @4xl:text-5xl">
           {title}


### PR DESCRIPTION
## What/Why?
We'd like to move in the direction of a static 404 page with just a search box instead of a featured products panel, in order to make 404 pages inexpensive to serve. This is particularly important because of [this issue.](https://github.com/vercel/next.js/issues/67532#issuecomment-2688292808)

This is the first step of that change which removes the featured products panel, the search box can be added in a separate PR.

## Testing
Preview deployment

<img width="1232" alt="image" src="https://github.com/user-attachments/assets/5299f19d-75b9-46ae-8509-384d56fb91a0" />

