### PR TITLE
feat: update NotFound and SectionLayout

### DIFF
--- a/core/app/[locale]/layout.tsx
+++ b/core/app/[locale]/layout.tsx
@@ -94,7 +94,7 @@ export default async function RootLayout({ params, children }: Props) {
 
   return (
     <html className={clsx(fonts.map((f) => f.variable))} lang={locale}>
-      <body>
+      <body className="flex min-h-screen flex-col">
         <NextIntlClientProvider>
           <NuqsAdapter>
             <Providers>

--- a/core/app/[locale]/not-found.tsx
+++ b/core/app/[locale]/not-found.tsx
@@ -11,7 +11,11 @@ export default async function NotFound() {
     <>
       <Header />
 
-      <NotFoundSection subtitle={t('subtitle')} title={t('title')} />
+      <NotFoundSection
+        className="flex-1 place-content-center"
+        subtitle={t('subtitle')}
+        title={t('title')}
+      />
 
       <Footer />
     </>

--- a/core/vibes/soul/sections/not-found/index.tsx
+++ b/core/vibes/soul/sections/not-found/index.tsx
@@ -1,20 +1,40 @@
-interface Props {
+import { SectionLayout } from '@/vibes/soul/sections/section-layout';
+
+export interface NotFoundProps {
   title?: string;
   subtitle?: string;
+  className?: string;
 }
 
+// eslint-disable-next-line valid-jsdoc
+/**
+ * This component supports various CSS variables for theming. Here's a comprehensive list, along
+ * with their default values:
+ *
+ * ```css
+ * :root {
+ *   --not-found-font-family: var(--font-family-body);
+ *   --not-found-title-font-family: var(--font-family-heading);
+ *   --not-found-title: hsl(var(--foreground));
+ *   --not-found-subtitle: hsl(var(--contrast-500));
+ * }
+ * ```
+ */
 export function NotFound({
   title = 'Not found',
   subtitle = "Take a look around if you're lost.",
-}: Props) {
+  className = '',
+}: NotFoundProps) {
   return (
-    <section className="@container pb-20">
-      <div className="mx-auto max-w-3xl px-4 pt-10 @xl:px-6 @xl:pt-14 @4xl:px-8 @4xl:pt-20">
-        <h1 className="font-heading mb-3 text-3xl leading-none font-medium @xl:text-4xl @4xl:text-5xl">
+    <SectionLayout className={className} containerSize="2xl">
+      <header className="font-[family-name:var(--not-found-font-family,var(--font-family-body))]">
+        <h1 className="mb-3 font-[family-name:var(--not-found-title-font-family,var(--font-family-heading))] text-3xl leading-none font-medium text-[var(--not-found-title,hsl(var(--foreground)))] @xl:text-4xl @4xl:text-5xl">
           {title}
         </h1>
-        <p className="text-contrast-500 text-lg">{subtitle}</p>
-      </div>
-    </section>
+        <p className="text-lg text-[var(--not-found-subtitle,hsl(var(--contrast-500)))]">
+          {subtitle}
+        </p>
+      </header>
+    </SectionLayout>
   );
 }

--- a/core/vibes/soul/sections/section-layout/index.tsx
+++ b/core/vibes/soul/sections/section-layout/index.tsx
@@ -1,4 +1,11 @@
 import { clsx } from 'clsx';
+import { ReactNode } from 'react';
+
+export interface SectionLayoutProps {
+  className?: string;
+  children: ReactNode;
+  containerSize?: 'md' | 'lg' | 'xl' | '2xl' | 'full';
+}
 
 // eslint-disable-next-line valid-jsdoc
 /**
@@ -14,19 +21,9 @@ import { clsx } from 'clsx';
  * }
  * ```
  */
-export function SectionLayout({
-  className,
-  children,
-  containerSize = '2xl',
-  hideOverflow = false,
-}: {
-  className?: string;
-  children: React.ReactNode;
-  containerSize?: 'md' | 'lg' | 'xl' | '2xl';
-  hideOverflow?: boolean;
-}) {
+export function SectionLayout({ className, children, containerSize = '2xl' }: SectionLayoutProps) {
   return (
-    <section className={clsx('@container', hideOverflow && 'overflow-hidden', className)}>
+    <section className={clsx('@container overflow-hidden', className)}>
       <div
         className={clsx(
           'mx-auto px-4 py-10 @xl:px-6 @xl:py-14 @4xl:px-8 @4xl:py-20',
@@ -35,6 +32,7 @@ export function SectionLayout({
             lg: 'max-w-[var(--section-max-width-lg,1024px)]',
             xl: 'max-w-[var(--section-max-width-xl,1280px)]',
             '2xl': 'max-w-[var(--section-max-width-2xl,1536px)]',
+            full: 'max-w-none',
           }[containerSize],
         )}
       >


### PR DESCRIPTION
## What/Why?
- updates NotFound Soul component
- adds `min-h-screen`, `flex`, & `flex-col` to the body to allow full-screen content when not enough content fills the page
- updates `SectionLayout` component

## Testing
https://github.com/user-attachments/assets/e0ad1a71-70a0-4412-8b07-71cd957857ff

