### PR TITLE
Detect FinalizationRegistry and WeakRef features and fallback if they are not available

### DIFF
--- a/.changeset/chatty-keys-cover.md
+++ b/.changeset/chatty-keys-cover.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Provide fallback behavior for environments where FinalizationRegistry and WeakRef are not available

--- a/core/vibes/soul/lib/streamable.tsx
+++ b/core/vibes/soul/lib/streamable.tsx
@@ -34,9 +34,15 @@ function getCompositeKey(streamables: readonly unknown[]): string {
   return streamables.map(stableKeys.get).join('.');
 }
 
-function weakRefCache<K, T extends object>() {
-  const cache = new Map<K, WeakRef<T>>();
+// Interface for cache implementations
+interface Cache<K, V> {
+  get(key: K): V | undefined;
+  set(key: K, value: V): void;
+}
 
+// Implementation using WeakRef and FinalizationRegistry
+function createWeakRefCache<K, V extends object>(): Cache<K, V> {
+  const cache = new Map<K, WeakRef<V>>();
   const registry = new FinalizationRegistry((key: K) => {
     const valueRef = cache.get(key);
 
@@ -45,14 +51,72 @@ function weakRefCache<K, T extends object>() {
 
   return {
     get: (key: K) => cache.get(key)?.deref(),
-    set: (key: K, value: T) => {
+    set: (key: K, value: V) => {
       cache.set(key, new WeakRef(value));
       registry.register(value, key);
     },
   };
 }
 
-const promiseCache = weakRefCache<string, Promise<unknown>>();
+// Fallback implementation using LRU strategy
+function createLRUCache<K, V>(maxSize = 1000): Cache<K, V> {
+  const cache = new Map<K, V>();
+  const accessOrder = new Map<K, number>(); // Track last access time
+  let accessCounter = 0;
+
+  const cleanup = () => {
+    if (cache.size <= maxSize) return;
+
+    // Find the least recently used entries
+    const entries = Array.from(accessOrder.entries());
+
+    entries.sort((a, b) => a[1] - b[1]);
+
+    // Remove oldest entries until we're under the limit
+    const entriesToRemove = entries.slice(0, entries.length - maxSize);
+
+    // Replace for...of loop with forEach to avoid linter error
+    entriesToRemove.forEach(([key]) => {
+      cache.delete(key);
+      accessOrder.delete(key);
+    });
+  };
+
+  return {
+    get: (key: K) => {
+      const value = cache.get(key);
+
+      if (value !== undefined) {
+        // Update access time - avoid ++ operator
+        accessCounter += 1;
+        accessOrder.set(key, accessCounter);
+      }
+
+      return value;
+    },
+    set: (key: K, value: V) => {
+      cache.set(key, value);
+      // Avoid ++ operator
+      accessCounter += 1;
+      accessOrder.set(key, accessCounter);
+      cleanup();
+    },
+  };
+}
+
+// Create the appropriate cache based on feature detection
+function createCache<K, V extends object>(): Cache<K, V> {
+  const hasWeakRef = typeof WeakRef !== 'undefined';
+  const hasFinalizationRegistry = typeof FinalizationRegistry !== 'undefined';
+
+  if (hasWeakRef && hasFinalizationRegistry) {
+    return createWeakRefCache<K, V>();
+  }
+
+  return createLRUCache<K, V>();
+}
+
+const promiseCache = createCache<string, Promise<unknown>>();
 
 // eslint-disable-next-line valid-jsdoc
 /**


### PR DESCRIPTION
## What/Why?
Per title

Not all environments support FinalizationRegistry and WeakRef; this change to the Streamable pattern uses feature detection and a fallback in this case. This has the tradeoff of potentially leaking memory, so we use an LRU approach to evict the cache naively as it grows large.

## Testing
In addition to the preview deployment on this PR, I created an arbitrary deployment where I forced LRU on and set `maxSize` to `2` to test exhaustion behavior, and I observed no breakage.

https://catalyst-canary-p74486ofb-bigcommerce-platform.vercel.app/
