### PR TITLE
fix: add /lib/makeswift/components folder to tailwind.config.js

### DIFF
--- a/.changeset/nine-bikes-hunt.md
+++ b/.changeset/nine-bikes-hunt.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Add core/lib/makeswift/components folder to tailwind config content property so that tailwind classes can be used in components there.

--- a/core/tailwind.config.js
+++ b/core/tailwind.config.js
@@ -3,6 +3,7 @@ const config = {
   content: [
     './app/**/*.{ts,tsx}',
     './components/**/*.{ts,tsx}',
+    './lib/makeswift/components/**/*.{ts,tsx}',
     './vibes/**/*.{ts,tsx}',
     '!./node_modules/**', // Exclude everything in node_modules to speed up builds
   ],


### PR DESCRIPTION
From PR https://github.com/bigcommerce/catalyst/pull/2215. An environment variable was missing on a [required CI check](https://github.com/bigcommerce/catalyst/actions/runs/14436770524/job/40732966176?pr=2215).

Thank you, @pvaladez!