### PR TITLE
feat: bump makeswift runtime to 0.24.0, simplify implementation

### DIFF
--- a/.changeset/shiny-worlds-type.md
+++ b/.changeset/shiny-worlds-type.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+fix: bump makeswift runtime version to `v0.24.0`, fixing issue with editing on SSGd pages

--- a/core/app/[locale]/layout.tsx
+++ b/core/app/[locale]/layout.tsx
@@ -1,4 +1,3 @@
-import { DraftModeScript } from '@makeswift/runtime/next/server';
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import { clsx } from 'clsx';
@@ -105,7 +104,6 @@ export default async function RootLayout({ params, children }: Props) {
       <html className={clsx(fonts.map((f) => f.variable))} lang={locale}>
         <head>
           <SiteTheme />
-          <DraftModeScript appOrigin={process.env.MAKESWIFT_APP_ORIGIN} />
         </head>
         <body>
           <NextIntlClientProvider locale={locale} messages={messages}>

--- a/core/middlewares/with-makeswift.ts
+++ b/core/middlewares/with-makeswift.ts
@@ -1,27 +1,18 @@
-import { unstable_createMakeswiftDraftRequest } from '@makeswift/runtime/next/middleware';
+import { unstable_isDraftModeRequest } from '@makeswift/runtime/next/middleware';
 
 import { MiddlewareFactory } from './compose-middlewares';
 
-if (!process.env.MAKESWIFT_SITE_API_KEY) {
-  throw new Error('MAKESWIFT_SITE_API_KEY is not set');
-}
-
-const MAKESWIFT_SITE_API_KEY = process.env.MAKESWIFT_SITE_API_KEY;
-
 export const withMakeswift: MiddlewareFactory = (middleware) => {
   return async (request, event) => {
-    const draftRequest = await unstable_createMakeswiftDraftRequest(
-      request,
-      MAKESWIFT_SITE_API_KEY,
-    );
+    const isDraftRequest = unstable_isDraftModeRequest(request);
 
-    if (draftRequest != null) {
+    if (isDraftRequest) {
       // Makeswift Builder's locale switcher expects the host to derive locale strictly from
       // the URL. Disable cookie- and language-based locale detection when in draft mode to
       // meet this expectation.
-      draftRequest.headers.set('x-bc-disable-locale-detection', 'true');
+      request.headers.set('x-bc-disable-locale-detection', 'true');
 
-      return await middleware(draftRequest, event);
+      return await middleware(request, event);
     }
 
     return middleware(request, event);

--- a/core/next.config.ts
+++ b/core/next.config.ts
@@ -8,7 +8,7 @@ import { client } from './client';
 import { graphql } from './client/graphql';
 import { cspHeader } from './lib/content-security-policy';
 
-const withMakeswift = createWithMakeswift({ previewMode: false });
+const withMakeswift = createWithMakeswift();
 const withNextIntl = createNextIntlPlugin();
 
 const LocaleQuery = graphql(`

--- a/core/package.json
+++ b/core/package.json
@@ -17,7 +17,7 @@
     "@conform-to/react": "^1.3.0",
     "@conform-to/zod": "^1.3.0",
     "@icons-pack/react-simple-icons": "^11.2.0",
-    "@makeswift/runtime": "^0.23.11",
+    "@makeswift/runtime": "^0.24.0",
     "@radix-ui/react-accordion": "^1.2.3",
     "@radix-ui/react-alert-dialog": "^1.1.6",
     "@radix-ui/react-checkbox": "^1.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^11.2.0
         version: 11.2.0(react@19.0.0)
       '@makeswift/runtime':
-        specifier: ^0.23.11
-        version: 0.23.11(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(next@15.3.0-canary.20(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: ^0.24.0
+        version: 0.24.0(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(next@15.3.0-canary.20(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-accordion':
         specifier: ^1.2.3
         version: 1.2.3(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -312,7 +312,7 @@ importers:
     devDependencies:
       '@bigcommerce/eslint-config':
         specifier: ^2.11.0
-        version: 2.11.0(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0(@types/node@22.13.13)(babel-plugin-macros@3.1.0))(typescript@5.8.2)
+        version: 2.11.0(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0(babel-plugin-macros@3.1.0))(typescript@5.8.2)
       '@bigcommerce/eslint-config-catalyst':
         specifier: workspace:^
         version: link:../eslint-config-catalyst
@@ -352,7 +352,7 @@ importers:
     devDependencies:
       '@bigcommerce/eslint-config':
         specifier: ^2.11.0
-        version: 2.11.0(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0(@types/node@22.13.13)(babel-plugin-macros@3.1.0))(typescript@5.8.2)
+        version: 2.11.0(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0(babel-plugin-macros@3.1.0))(typescript@5.8.2)
       '@bigcommerce/eslint-config-catalyst':
         specifier: workspace:^
         version: link:../eslint-config-catalyst
@@ -449,7 +449,7 @@ importers:
     devDependencies:
       '@bigcommerce/eslint-config':
         specifier: ^2.11.0
-        version: 2.11.0(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0(@types/node@22.13.13)(babel-plugin-macros@3.1.0))(typescript@5.8.2)
+        version: 2.11.0(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0(babel-plugin-macros@3.1.0))(typescript@5.8.2)
       '@bigcommerce/eslint-config-catalyst':
         specifier: workspace:^
         version: link:../eslint-config-catalyst
@@ -503,7 +503,7 @@ importers:
     dependencies:
       '@bigcommerce/eslint-config':
         specifier: ^2.11.0
-        version: 2.11.0(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0(@types/node@22.13.13)(babel-plugin-macros@3.1.0))(typescript@5.8.2)
+        version: 2.11.0(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0(babel-plugin-macros@3.1.0))(typescript@5.8.2)
       '@next/eslint-plugin-next':
         specifier: ^15.2.3
         version: 15.2.3
@@ -1536,16 +1536,16 @@ packages:
   '@makeswift/controls@0.1.8':
     resolution: {integrity: sha512-gCBNBPKXjVT4TqaBhG1C+XYfwmB06M5vr044yK7uabBiVk7SLaHn47rPDrBsco4P3yvaUvEYDsgcdfCaFamiNQ==}
 
-  '@makeswift/next-plugin@0.3.1':
-    resolution: {integrity: sha512-du4Z+0vw3FgGUEsE590gq5WaEeAIOeM2nv8STXpfMAzaTBvTV335RZNxm538d142JBy0SyD4EdNISJQTZ6X41g==}
+  '@makeswift/next-plugin@0.4.0':
+    resolution: {integrity: sha512-L26GCI6TokkLL5Zhb82Hzxhm1hhmuKmY3C8o/B/+hJwiNhUDQEnXYDVk+ZYiV5S7PipKYCEnmFw9J+9Y25ul5w==}
     peerDependencies:
       next: ^13.4.0 || ^14.0.0 || ^15.0.0
 
   '@makeswift/prop-controllers@0.4.1':
     resolution: {integrity: sha512-o9FkM0czODl1aXGxvnVOpx/KMLCJQ2wy5LUnUacPGXxZRW8fbsDaF3Y3dmM6tv2fJgIQbUG+bEpHBFQd1AxZJg==}
 
-  '@makeswift/runtime@0.23.11':
-    resolution: {integrity: sha512-+qPfnGxVF3AewQm/RQZ1PVOzkZ9F9hNDuBhK8rKqSUHboUBH2nJDsmgprR+edCkUPs8DoDkaCpA28rrrnwQcpA==}
+  '@makeswift/runtime@0.24.0':
+    resolution: {integrity: sha512-q4sjRgIQjMqNjQ7/YSTJ9YyhMYQBkNsvqUuT5dLxJD1mb4U5cMQYao+M3msAP71090L5oqzuPln8cfLqJCVi7w==}
     peerDependencies:
       '@types/react': ^18.0.0 || ^19.0.0
       '@types/react-dom': ^18.0.0 || ^19.0.0
@@ -6731,7 +6731,7 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@bigcommerce/eslint-config@2.11.0(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0(@types/node@22.13.13)(babel-plugin-macros@3.1.0))(typescript@5.8.2)':
+  '@bigcommerce/eslint-config@2.11.0(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0(babel-plugin-macros@3.1.0))(typescript@5.8.2)':
     dependencies:
       '@bigcommerce/eslint-plugin': 1.4.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2)
       '@rushstack/eslint-patch': 1.10.5
@@ -6743,7 +6743,7 @@ snapshots:
       eslint-import-resolver-typescript: 3.9.1(eslint-plugin-import@2.31.0)(eslint@8.57.1)
       eslint-plugin-gettext: 1.2.0
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.9.1)(eslint@8.57.1)
-      eslint-plugin-jest: 28.11.0(@typescript-eslint/eslint-plugin@8.28.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(jest@29.7.0(@types/node@22.13.13)(babel-plugin-macros@3.1.0))(typescript@5.8.2)
+      eslint-plugin-jest: 28.11.0(@typescript-eslint/eslint-plugin@8.28.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(jest@29.7.0(babel-plugin-macros@3.1.0))(typescript@5.8.2)
       eslint-plugin-jest-dom: 5.5.0(eslint@8.57.1)
       eslint-plugin-jest-formatting: 3.1.0(eslint@8.57.1)
       eslint-plugin-jsdoc: 50.6.9(eslint@8.57.1)
@@ -7663,12 +7663,12 @@ snapshots:
       uuid: 9.0.1
       zod: 3.24.2
 
-  '@makeswift/next-plugin@0.3.1(next@15.3.0-canary.20(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
+  '@makeswift/next-plugin@0.4.0(next@15.3.0-canary.20(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
     dependencies:
       enhanced-resolve: 5.10.0
       escalade: 3.1.1
       next: 15.3.0-canary.20(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      semver: 7.6.3
+      semver: 7.7.1
 
   '@makeswift/prop-controllers@0.4.1':
     dependencies:
@@ -7676,7 +7676,7 @@ snapshots:
       ts-pattern: 5.5.0
       zod: 3.24.2
 
-  '@makeswift/runtime@0.23.11(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(next@15.3.0-canary.20(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@makeswift/runtime@0.24.0(@types/react-dom@19.0.4(@types/react@19.0.12))(@types/react@19.0.12)(next@15.3.0-canary.20(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@emotion/cache': 11.14.0
       '@emotion/css': 11.13.5
@@ -7685,7 +7685,7 @@ snapshots:
       '@emotion/sheet': 1.4.0
       '@emotion/utils': 1.4.2
       '@makeswift/controls': 0.1.8
-      '@makeswift/next-plugin': 0.3.1(next@15.3.0-canary.20(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+      '@makeswift/next-plugin': 0.4.0(next@15.3.0-canary.20(@playwright/test@1.51.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       '@makeswift/prop-controllers': 0.4.1
       '@popmotion/popcorn': 0.4.4
       '@redux-devtools/extension': 3.3.0(redux@4.2.1)
@@ -9968,7 +9968,7 @@ snapshots:
     dependencies:
       eslint: 8.57.1
 
-  eslint-plugin-jest@28.11.0(@typescript-eslint/eslint-plugin@8.28.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(jest@29.7.0(@types/node@22.13.13)(babel-plugin-macros@3.1.0))(typescript@5.8.2):
+  eslint-plugin-jest@28.11.0(@typescript-eslint/eslint-plugin@8.28.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(jest@29.7.0(babel-plugin-macros@3.1.0))(typescript@5.8.2):
     dependencies:
       '@typescript-eslint/utils': 8.28.0(eslint@8.57.1)(typescript@5.8.2)
       eslint: 8.57.1


### PR DESCRIPTION
## What/Why?

Upgrades `@makeswift/runtime`, which resolves an issue with editing SSGd Catalyst pages in Makeswift.

## Testing

Manually tested locally and via Vercel deployments

## Migration
<!---
  If you have moved any files around, or made any breaking changes,
  please provide a migration guide for the developers to make rebases easier.
--->
