### PR TITLE
refactor(core): hook up new analytics provider

### DIFF
--- a/.changeset/red-otters-wave.md
+++ b/.changeset/red-otters-wave.md
@@ -1,0 +1,9 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Implement the new analytics provider, utilizing the GoogleAnalytics provider as the first analytics solution.
+
+
+Most changes are additive so merge conflicts should be easy to resolve. In order to use the new provider from the previous provider, if it's already not setup in the BigCommerce control panel for checkout analytics, you'll need to add the GA4 property ID. This will automatically be used by the new GoogleAnalytics provider.
+

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/_components/category-viewed.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/_components/category-viewed.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { FragmentOf } from '~/client/graphql';
 import { ProductCardFragment } from '~/components/product-card/fragment';
-import { bodl } from '~/lib/bodl';
+import { useAnalytics } from '~/lib/analytics/react';
 
 import { getCategoryPageData } from '../page-data';
 
@@ -13,35 +13,36 @@ type Category = Awaited<ReturnType<typeof getCategoryPageData>>['category'];
 type productSearchItem = FragmentOf<typeof ProductCardFragment>;
 
 interface Props {
-  categoryId: number;
-  category: Category;
+  category: NonNullable<Category>;
   products: productSearchItem[];
 }
 
-const productItemTransform = (p: productSearchItem, c: Category) => {
-  const breadcrumbs = c ? removeEdgesAndNodes(c.breadcrumbs) : [];
+export const CategoryViewed = ({ category, products }: Props) => {
+  const isMounted = useRef(false);
+  const analytics = useAnalytics();
 
-  return {
-    product_id: p.entityId.toString(),
-    product_name: p.name,
-    brand_name: p.brand?.name,
-    sale_price: p.prices?.salePrice?.value,
-    purchase_price: p.prices?.salePrice?.value || p.prices?.price.value || 0,
-    base_price: p.prices?.price.value,
-    retail_price: p.prices?.retailPrice?.value,
-    currency: p.prices?.price.currencyCode || 'USD',
-    category_names: breadcrumbs.map(({ name }) => name),
-  };
-};
-
-export const CategoryViewed = ({ categoryId, category, products }: Props) => {
   useEffect(() => {
-    bodl.navigation.categoryViewed({
-      category_id: categoryId,
-      category_name: category?.name ?? '',
-      line_items: products.map((p) => productItemTransform(p, category)),
+    if (isMounted.current) {
+      return;
+    }
+
+    isMounted.current = true;
+
+    analytics?.navigation.categoryViewed({
+      id: category.entityId,
+      name: category.name,
+      currency: products[0]?.prices?.price.currencyCode || 'USD',
+      items: products.map((p) => {
+        return {
+          id: p.entityId.toString(),
+          name: p.name,
+          brand: p.brand?.name,
+          price: p.prices?.price.value,
+          categories: removeEdgesAndNodes(category.breadcrumbs).map(({ name }) => name),
+        };
+      }),
     });
-  }, [category, categoryId, products]);
+  }, [analytics, category, products]);
 
   return null;
 };

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -274,13 +274,7 @@ export default async function Category(props: Props) {
         totalCount={streamableTotalCount}
       />
       <Stream value={streamableFacetedSearch}>
-        {(search) => (
-          <CategoryViewed
-            category={category}
-            categoryId={category.entityId}
-            products={search.products.items}
-          />
-        )}
+        {(search) => <CategoryViewed category={category} products={search.products.items} />}
       </Stream>
     </>
   );

--- a/core/app/[locale]/(default)/account/wishlists/[id]/_components/wishlist-analytics-provider.tsx
+++ b/core/app/[locale]/(default)/account/wishlists/[id]/_components/wishlist-analytics-provider.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { PropsWithChildren, Suspense } from 'react';
+import { z } from 'zod';
+
+import { Streamable, useStreamable } from '@/vibes/soul/lib/streamable';
+import { EventsProvider } from '~/components/analytics/events';
+import { useAnalytics } from '~/lib/analytics/react';
+
+interface AddToCartContext {
+  id: number;
+  name: string;
+  brand: string;
+  sku?: string;
+  currency: string;
+  price: number;
+}
+
+const AddToCartSchema = z.object({
+  productId: z.number({ coerce: true }),
+  variantId: z.number({ coerce: true }),
+});
+
+export function WishlistAnalyticsProvider(
+  props: PropsWithChildren<{ data: Streamable<AddToCartContext[]> }>,
+) {
+  return (
+    <Suspense fallback={<div />}>
+      <WishlistAnalyticsProviderResolved {...props} />
+    </Suspense>
+  );
+}
+
+export function WishlistAnalyticsProviderResolved({
+  children,
+  data,
+}: PropsWithChildren<{ data: Streamable<AddToCartContext[]> }>) {
+  const analytics = useAnalytics();
+  const products = useStreamable(data);
+
+  const onAddToCart = (payload?: FormData) => {
+    const parsedPayload = AddToCartSchema.safeParse(Object.fromEntries(payload?.entries() ?? []));
+
+    if (parsedPayload.success) {
+      const { productId, variantId: variant_id } = parsedPayload.data;
+      const product = products.find(({ id }) => id === productId);
+
+      if (product) {
+        const { id, name, brand, sku, price, currency } = product;
+
+        analytics?.cart.productAdded({
+          currency,
+          value: 1 * price,
+          items: [
+            {
+              id: id.toString(),
+              name,
+              brand,
+              sku,
+              price,
+              quantity: 1,
+              variant_id,
+            },
+          ],
+        });
+      }
+    }
+  };
+
+  return <EventsProvider onAddToCart={onAddToCart}>{children}</EventsProvider>;
+}

--- a/core/app/[locale]/(default)/account/wishlists/[id]/page.tsx
+++ b/core/app/[locale]/(default)/account/wishlists/[id]/page.tsx
@@ -1,3 +1,4 @@
+import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
 import { notFound } from 'next/navigation';
 import { getFormatter, getTranslations, setRequestLocale } from 'next-intl/server';
 import { SearchParams } from 'nuqs';
@@ -16,6 +17,7 @@ import { getDeleteWishlistModal, getRenameWishlistModal } from '../modals';
 
 import { addWishlistItemToCart } from './_actions/add-to-cart';
 import { WishlistActions, WishlistActionsSkeleton } from './_components/wishlist-actions';
+import { WishlistAnalyticsProvider } from './_components/wishlist-analytics-provider';
 import { getCustomerWishlist } from './page-data';
 
 interface Props {
@@ -48,6 +50,30 @@ async function getWishlist(
 
   return wishlistDetailsTransformer(wishlist, t, pt, formatter);
 }
+
+const getAnalyticsData = async (id: string, searchParamsPromise: Promise<SearchParams>) => {
+  const entityId = Number(id);
+  const searchParamsParsed = searchParamsCache.parse(await searchParamsPromise);
+  const wishlist = await getCustomerWishlist(entityId, searchParamsParsed);
+
+  if (!wishlist) {
+    return [];
+  }
+
+  return removeEdgesAndNodes(wishlist.items)
+    .map(({ product }) => product)
+    .filter((product) => product !== null)
+    .map((product) => {
+      return {
+        id: product.entityId,
+        name: product.name,
+        sku: product.sku,
+        brand: product.brand?.name ?? '',
+        price: product.prices?.price.value ?? 0,
+        currency: product.prices?.price.currencyCode ?? '',
+      };
+    });
+};
 
 async function getPaginationInfo(
   id: string,
@@ -98,14 +124,16 @@ export default async function WishlistPage({ params, searchParams }: Props) {
   };
 
   return (
-    <WishlistDetails
-      action={addWishlistItemToCart}
-      emptyStateText={t('emptyWishlist')}
-      headerActions={wishlistActions}
-      paginationInfo={Streamable.from(() => getPaginationInfo(id, searchParams))}
-      prevHref="/account/wishlists"
-      removeAction={removeWishlistItem}
-      wishlist={Streamable.from(() => getWishlist(id, t, pt, searchParams))}
-    />
+    <WishlistAnalyticsProvider data={Streamable.from(() => getAnalyticsData(id, searchParams))}>
+      <WishlistDetails
+        action={addWishlistItemToCart}
+        emptyStateText={t('emptyWishlist')}
+        headerActions={wishlistActions}
+        paginationInfo={Streamable.from(() => getPaginationInfo(id, searchParams))}
+        prevHref="/account/wishlists"
+        removeAction={removeWishlistItem}
+        wishlist={Streamable.from(() => getWishlist(id, t, pt, searchParams))}
+      />
+    </WishlistAnalyticsProvider>
   );
 }

--- a/core/app/[locale]/(default)/cart/_actions/update-line-item.ts
+++ b/core/app/[locale]/(default)/cart/_actions/update-line-item.ts
@@ -386,13 +386,6 @@ export const updateLineItem = async (
 
       const deletedItem = submission.value;
 
-      // TODO: add bodl
-      // bodl.cart.productRemoved({
-      //   currency,
-      //   product_value: product.listPrice.value * product.quantity,
-      //   line_items: [lineItemTransform(product)],
-      // });
-
       return {
         lineItems: prevState.lineItems.filter((item) => item.id !== deletedItem.id),
         lastResult: submission.reply({ resetForm: true }),

--- a/core/app/[locale]/(default)/cart/_components/cart-analytics-provider.tsx
+++ b/core/app/[locale]/(default)/cart/_components/cart-analytics-provider.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { PropsWithChildren, Suspense } from 'react';
+import { z } from 'zod';
+
+import { Streamable, useStreamable } from '@/vibes/soul/lib/streamable';
+import { EventsProvider } from '~/components/analytics/events';
+import { useAnalytics } from '~/lib/analytics/react';
+
+interface AddToCartContext {
+  entityId: string;
+  id: number;
+  name: string;
+  brand: string;
+  sku?: string;
+  currency: string;
+  price: number;
+}
+
+const AddToCartSchema = z.object({
+  id: z.string(),
+  quantity: z.number({ coerce: true }).default(1),
+});
+
+export function CartAnalyticsProvider(
+  props: PropsWithChildren<{ data: Streamable<AddToCartContext[]> }>,
+) {
+  return (
+    <Suspense fallback={<div />}>
+      <CartAnalyticsProviderResolved {...props} />
+    </Suspense>
+  );
+}
+
+export function CartAnalyticsProviderResolved({
+  children,
+  data,
+}: PropsWithChildren<{ data: Streamable<AddToCartContext[]> }>) {
+  const analytics = useAnalytics();
+  const products = useStreamable(data);
+
+  const onAddToCart = (payload?: FormData) => {
+    const parsedPayload = AddToCartSchema.safeParse(Object.fromEntries(payload?.entries() ?? []));
+
+    if (parsedPayload.success) {
+      const { id, quantity } = parsedPayload.data;
+
+      const product = products.find(({ entityId }) => entityId === id);
+
+      if (product) {
+        const { id: productId, name, brand, sku, price, currency } = product;
+
+        analytics?.cart.productAdded({
+          currency,
+          value: quantity * price,
+          items: [
+            {
+              id: productId.toString(),
+              name,
+              brand,
+              sku,
+              price,
+              quantity,
+            },
+          ],
+        });
+      }
+    }
+  };
+
+  const onRemoveFromCart = (payload?: FormData) => {
+    const parsedPayload = AddToCartSchema.safeParse(Object.fromEntries(payload?.entries() ?? []));
+
+    if (parsedPayload.success) {
+      const { id, quantity } = parsedPayload.data;
+
+      const product = products.find(({ entityId }) => entityId === id);
+
+      if (product) {
+        const { id: productId, name, brand, sku, price, currency } = product;
+
+        analytics?.cart.productRemoved({
+          currency,
+          value: quantity * price,
+          items: [
+            {
+              id: productId.toString(),
+              name,
+              brand,
+              sku,
+              price,
+              quantity,
+            },
+          ],
+        });
+      }
+    }
+  };
+
+  return (
+    <EventsProvider onAddToCart={onAddToCart} onRemoveFromCart={onRemoveFromCart}>
+      {children}
+    </EventsProvider>
+  );
+}

--- a/core/app/[locale]/(default)/cart/_components/cart-viewed.tsx
+++ b/core/app/[locale]/(default)/cart/_components/cart-viewed.tsx
@@ -1,46 +1,49 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { FragmentOf } from '~/client/graphql';
-import { bodl } from '~/lib/bodl';
+import { useAnalytics } from '~/lib/analytics/react';
 
 import { DigitalItemFragment, PhysicalItemFragment } from '../page-data';
 
 type PhysicalItem = FragmentOf<typeof PhysicalItemFragment>;
 type DigitalItem = FragmentOf<typeof DigitalItemFragment>;
-type lineItem = PhysicalItem | DigitalItem;
+type LineItem = PhysicalItem | DigitalItem;
 
 interface Props {
   subtotal?: number;
   currencyCode: string;
-  lineItems: lineItem[];
+  lineItems: LineItem[];
 }
 
-const lineItemTransform = (item: lineItem) => {
-  return {
-    product_id: item.productEntityId.toString(),
-    product_name: item.name,
-    brand_name: item.brand ?? undefined,
-    sku: item.sku ?? undefined,
-    sale_price: item.extendedSalePrice.value,
-    purchase_price: item.listPrice.value,
-    base_price: item.originalPrice.value,
-    retail_price: item.listPrice.value,
-    currency: item.listPrice.currencyCode,
-    variant_id: item.variantEntityId ? [item.variantEntityId] : undefined,
-    quantity: item.quantity,
-  };
-};
-
 export const CartViewed = ({ subtotal, currencyCode, lineItems }: Props) => {
+  const isMounted = useRef(false);
+  const analytics = useAnalytics();
+
   useEffect(() => {
-    bodl.cart.cartViewed({
+    if (isMounted.current) {
+      return;
+    }
+
+    isMounted.current = true;
+
+    analytics?.cart.cartViewed({
       currency: currencyCode,
-      cart_value: subtotal ?? 0,
-      line_items: lineItems.map(lineItemTransform),
+      value: subtotal ?? 0,
+      items: lineItems.map((lineItem) => {
+        return {
+          id: lineItem.productEntityId.toString(),
+          name: lineItem.name,
+          brand: lineItem.brand ?? undefined,
+          sku: lineItem.sku ?? undefined,
+          price: lineItem.listPrice.value,
+          variant_id: lineItem.variantEntityId ?? undefined,
+          quantity: lineItem.quantity,
+        };
+      }),
     });
-  }, [currencyCode, lineItems, subtotal]);
+  }, [analytics, currencyCode, lineItems, subtotal]);
 
   return null;
 };

--- a/core/app/[locale]/(default)/cart/page.tsx
+++ b/core/app/[locale]/(default)/cart/page.tsx
@@ -1,7 +1,9 @@
 import { Metadata } from 'next';
 import { getFormatter, getTranslations, setRequestLocale } from 'next-intl/server';
 
+import { Streamable } from '@/vibes/soul/lib/streamable';
 import { Cart as CartComponent, CartEmptyState } from '@/vibes/soul/sections/cart';
+import { CartAnalyticsProvider } from '~/app/[locale]/(default)/cart/_components/cart-analytics-provider';
 import { getCartId } from '~/lib/cart';
 import { exists } from '~/lib/utils';
 
@@ -25,6 +27,31 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     title: t('title'),
   };
 }
+
+const getAnalyticsData = async (cartId: string) => {
+  const data = await getCart({ cartId });
+
+  const cart = data.site.cart;
+
+  if (!cart) {
+    return [];
+  }
+
+  const lineItems = [...cart.lineItems.physicalItems, ...cart.lineItems.digitalItems];
+
+  return lineItems.map((item) => {
+    return {
+      entityId: item.entityId,
+      id: item.productEntityId,
+      name: item.name,
+      brand: item.brand ?? '',
+      sku: item.sku ?? '',
+      price: item.listPrice.value,
+      quantity: item.quantity,
+      currency: item.listPrice.currencyCode,
+    };
+  });
+};
 
 // eslint-disable-next-line complexity
 export default async function Cart({ params }: Props) {
@@ -127,129 +154,131 @@ export default async function Cart({ params }: Props) {
 
   return (
     <>
-      <CartComponent
-        cart={{
-          lineItems: formattedLineItems,
-          total: format.number(checkout?.grandTotal?.value || 0, {
-            style: 'currency',
-            currency: cart.currencyCode,
-          }),
-          totalLabel: t('CheckoutSummary.total'),
-          summaryItems: [
-            {
-              label: t('CheckoutSummary.subTotal'),
-              value: format.number(checkout?.subtotal?.value ?? 0, {
-                style: 'currency',
-                currency: cart.currencyCode,
-              }),
-            },
-            cart.discountedAmount.value > 0
-              ? {
-                  label: t('CheckoutSummary.discounts'),
-                  value: `-${format.number(cart.discountedAmount.value, {
-                    style: 'currency',
-                    currency: cart.currencyCode,
-                  })}`,
-                }
-              : null,
-            totalCouponDiscount > 0
-              ? {
-                  label: t('CheckoutSummary.CouponCode.couponCode'),
-                  value: `-${format.number(totalCouponDiscount, {
-                    style: 'currency',
-                    currency: cart.currencyCode,
-                  })}`,
-                }
-              : null,
-            checkout?.taxTotal && {
-              label: t('CheckoutSummary.tax'),
-              value: format.number(checkout.taxTotal.value, {
-                style: 'currency',
-                currency: cart.currencyCode,
-              }),
-            },
-          ].filter(exists),
-        }}
-        checkoutAction={redirectToCheckout}
-        checkoutLabel={t('proceedToCheckout')}
-        couponCode={{
-          action: updateCouponCode,
-          couponCodes: checkout?.coupons.map((coupon) => coupon.code) ?? [],
-          ctaLabel: t('CheckoutSummary.CouponCode.apply'),
-          label: t('CheckoutSummary.CouponCode.couponCode'),
-          removeLabel: t('CheckoutSummary.CouponCode.removeCouponCode'),
-        }}
-        decrementLineItemLabel={t('decrement')}
-        deleteLineItemLabel={t('removeItem')}
-        emptyState={{
-          title: t('Empty.title'),
-          subtitle: t('Empty.subtitle'),
-          cta: { label: t('Empty.cta'), href: '/shop-all' },
-        }}
-        incrementLineItemLabel={t('increment')}
-        key={`${cart.entityId}-${cart.version}`}
-        lineItemAction={updateLineItem}
-        shipping={{
-          action: updateShippingInfo,
-          countries,
-          states: statesOrProvinces,
-          address: shippingConsignment?.address
-            ? {
-                country: shippingConsignment.address.countryCode,
-                city:
-                  shippingConsignment.address.city !== ''
-                    ? (shippingConsignment.address.city ?? undefined)
-                    : undefined,
-                state:
-                  shippingConsignment.address.stateOrProvince !== ''
-                    ? (shippingConsignment.address.stateOrProvince ?? undefined)
-                    : undefined,
-                postalCode:
-                  shippingConsignment.address.postalCode !== ''
-                    ? (shippingConsignment.address.postalCode ?? undefined)
-                    : undefined,
-              }
-            : undefined,
-          shippingOptions: shippingConsignment?.availableShippingOptions
-            ? shippingConsignment.availableShippingOptions.map((option) => ({
-                label: option.description,
-                value: option.entityId,
-                price: format.number(option.cost.value, {
+      <CartAnalyticsProvider data={Streamable.from(() => getAnalyticsData(cartId))}>
+        <CartComponent
+          cart={{
+            lineItems: formattedLineItems,
+            total: format.number(checkout?.grandTotal?.value || 0, {
+              style: 'currency',
+              currency: cart.currencyCode,
+            }),
+            totalLabel: t('CheckoutSummary.total'),
+            summaryItems: [
+              {
+                label: t('CheckoutSummary.subTotal'),
+                value: format.number(checkout?.subtotal?.value ?? 0, {
                   style: 'currency',
-                  currency: checkout?.cart?.currencyCode,
+                  currency: cart.currencyCode,
                 }),
-              }))
-            : undefined,
-          shippingOption: shippingConsignment?.selectedShippingOption
-            ? {
-                value: shippingConsignment.selectedShippingOption.entityId,
-                label: shippingConsignment.selectedShippingOption.description,
-                price: format.number(shippingConsignment.selectedShippingOption.cost.value, {
+              },
+              cart.discountedAmount.value > 0
+                ? {
+                    label: t('CheckoutSummary.discounts'),
+                    value: `-${format.number(cart.discountedAmount.value, {
+                      style: 'currency',
+                      currency: cart.currencyCode,
+                    })}`,
+                  }
+                : null,
+              totalCouponDiscount > 0
+                ? {
+                    label: t('CheckoutSummary.CouponCode.couponCode'),
+                    value: `-${format.number(totalCouponDiscount, {
+                      style: 'currency',
+                      currency: cart.currencyCode,
+                    })}`,
+                  }
+                : null,
+              checkout?.taxTotal && {
+                label: t('CheckoutSummary.tax'),
+                value: format.number(checkout.taxTotal.value, {
                   style: 'currency',
-                  currency: checkout?.cart?.currencyCode,
+                  currency: cart.currencyCode,
                 }),
-              }
-            : undefined,
-          showShippingForm,
-          shippingLabel: t('CheckoutSummary.Shipping.shipping'),
-          addLabel: t('CheckoutSummary.Shipping.add'),
-          changeLabel: t('CheckoutSummary.Shipping.change'),
-          countryLabel: t('CheckoutSummary.Shipping.country'),
-          cityLabel: t('CheckoutSummary.Shipping.city'),
-          stateLabel: t('CheckoutSummary.Shipping.state'),
-          postalCodeLabel: t('CheckoutSummary.Shipping.postalCode'),
-          updateShippingOptionsLabel: t('CheckoutSummary.Shipping.updatedShippingOptions'),
-          viewShippingOptionsLabel: t('CheckoutSummary.Shipping.viewShippingOptions'),
-          cancelLabel: t('CheckoutSummary.Shipping.cancel'),
-          editAddressLabel: t('CheckoutSummary.Shipping.editAddress'),
-          shippingOptionsLabel: t('CheckoutSummary.Shipping.shippingOptions'),
-          updateShippingLabel: t('CheckoutSummary.Shipping.updateShipping'),
-          addShippingLabel: t('CheckoutSummary.Shipping.addShipping'),
-          noShippingOptionsLabel: t('CheckoutSummary.Shipping.noShippingOptions'),
-        }}
-        summaryTitle={t('CheckoutSummary.title')}
-        title={t('title')}
-      />
+              },
+            ].filter(exists),
+          }}
+          checkoutAction={redirectToCheckout}
+          checkoutLabel={t('proceedToCheckout')}
+          couponCode={{
+            action: updateCouponCode,
+            couponCodes: checkout?.coupons.map((coupon) => coupon.code) ?? [],
+            ctaLabel: t('CheckoutSummary.CouponCode.apply'),
+            label: t('CheckoutSummary.CouponCode.couponCode'),
+            removeLabel: t('CheckoutSummary.CouponCode.removeCouponCode'),
+          }}
+          decrementLineItemLabel={t('decrement')}
+          deleteLineItemLabel={t('removeItem')}
+          emptyState={{
+            title: t('Empty.title'),
+            subtitle: t('Empty.subtitle'),
+            cta: { label: t('Empty.cta'), href: '/shop-all' },
+          }}
+          incrementLineItemLabel={t('increment')}
+          key={`${cart.entityId}-${cart.version}`}
+          lineItemAction={updateLineItem}
+          shipping={{
+            action: updateShippingInfo,
+            countries,
+            states: statesOrProvinces,
+            address: shippingConsignment?.address
+              ? {
+                  country: shippingConsignment.address.countryCode,
+                  city:
+                    shippingConsignment.address.city !== ''
+                      ? (shippingConsignment.address.city ?? undefined)
+                      : undefined,
+                  state:
+                    shippingConsignment.address.stateOrProvince !== ''
+                      ? (shippingConsignment.address.stateOrProvince ?? undefined)
+                      : undefined,
+                  postalCode:
+                    shippingConsignment.address.postalCode !== ''
+                      ? (shippingConsignment.address.postalCode ?? undefined)
+                      : undefined,
+                }
+              : undefined,
+            shippingOptions: shippingConsignment?.availableShippingOptions
+              ? shippingConsignment.availableShippingOptions.map((option) => ({
+                  label: option.description,
+                  value: option.entityId,
+                  price: format.number(option.cost.value, {
+                    style: 'currency',
+                    currency: checkout?.cart?.currencyCode,
+                  }),
+                }))
+              : undefined,
+            shippingOption: shippingConsignment?.selectedShippingOption
+              ? {
+                  value: shippingConsignment.selectedShippingOption.entityId,
+                  label: shippingConsignment.selectedShippingOption.description,
+                  price: format.number(shippingConsignment.selectedShippingOption.cost.value, {
+                    style: 'currency',
+                    currency: checkout?.cart?.currencyCode,
+                  }),
+                }
+              : undefined,
+            showShippingForm,
+            shippingLabel: t('CheckoutSummary.Shipping.shipping'),
+            addLabel: t('CheckoutSummary.Shipping.add'),
+            changeLabel: t('CheckoutSummary.Shipping.change'),
+            countryLabel: t('CheckoutSummary.Shipping.country'),
+            cityLabel: t('CheckoutSummary.Shipping.city'),
+            stateLabel: t('CheckoutSummary.Shipping.state'),
+            postalCodeLabel: t('CheckoutSummary.Shipping.postalCode'),
+            updateShippingOptionsLabel: t('CheckoutSummary.Shipping.updatedShippingOptions'),
+            viewShippingOptionsLabel: t('CheckoutSummary.Shipping.viewShippingOptions'),
+            cancelLabel: t('CheckoutSummary.Shipping.cancel'),
+            editAddressLabel: t('CheckoutSummary.Shipping.editAddress'),
+            shippingOptionsLabel: t('CheckoutSummary.Shipping.shippingOptions'),
+            updateShippingLabel: t('CheckoutSummary.Shipping.updateShipping'),
+            addShippingLabel: t('CheckoutSummary.Shipping.addShipping'),
+            noShippingOptionsLabel: t('CheckoutSummary.Shipping.noShippingOptions'),
+          }}
+          summaryTitle={t('CheckoutSummary.title')}
+          title={t('title')}
+        />
+      </CartAnalyticsProvider>
       <CartViewed
         currencyCode={cart.currencyCode}
         lineItems={lineItems}

--- a/core/app/[locale]/(default)/compare/_components/compare-analytics-provider.tsx
+++ b/core/app/[locale]/(default)/compare/_components/compare-analytics-provider.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { PropsWithChildren, Suspense } from 'react';
+import { z } from 'zod';
+
+import { Streamable, useStreamable } from '@/vibes/soul/lib/streamable';
+import { EventsProvider } from '~/components/analytics/events';
+import { useAnalytics } from '~/lib/analytics/react';
+
+interface AddToCartContext {
+  id: number;
+  name: string;
+  brand: string;
+  sku?: string;
+  currency: string;
+  price: number;
+}
+
+const AddToCartSchema = z.object({
+  id: z.number({ coerce: true }),
+  quantity: z.number({ coerce: true }).default(1),
+});
+
+export function CompareAnalyticsProvider(
+  props: PropsWithChildren<{ data: Streamable<AddToCartContext[]> }>,
+) {
+  return (
+    <Suspense fallback={<div />}>
+      <CompareAnalyticsProviderResolved {...props} />
+    </Suspense>
+  );
+}
+
+export function CompareAnalyticsProviderResolved({
+  children,
+  data,
+}: PropsWithChildren<{ data: Streamable<AddToCartContext[]> }>) {
+  const analytics = useAnalytics();
+  const products = useStreamable(data);
+
+  const onAddToCart = (payload?: FormData) => {
+    const parsedPayload = AddToCartSchema.safeParse(Object.fromEntries(payload?.entries() ?? []));
+
+    if (parsedPayload.success) {
+      const { id: productId, quantity } = parsedPayload.data;
+      const product = products.find(({ id }) => id === productId);
+
+      if (product) {
+        const { id, name, brand, sku, price, currency } = product;
+
+        analytics?.cart.productAdded({
+          currency,
+          value: 1 * price,
+          items: [
+            {
+              id: id.toString(),
+              name,
+              brand,
+              sku,
+              price,
+              quantity,
+            },
+          ],
+        });
+      }
+    }
+  };
+
+  return <EventsProvider onAddToCart={onAddToCart}>{children}</EventsProvider>;
+}

--- a/core/app/[locale]/(default)/compare/page.tsx
+++ b/core/app/[locale]/(default)/compare/page.tsx
@@ -10,6 +10,7 @@ import { CompareSection } from '@/vibes/soul/sections/compare-section';
 import { pricesTransformer } from '~/data-transformers/prices-transformer';
 
 import { addToCart } from './_actions/add-to-cart';
+import { CompareAnalyticsProvider } from './_components/compare-analytics-provider';
 import { getCompareData } from './page-data';
 
 const CompareParamsSchema = z.object({
@@ -57,6 +58,21 @@ const getProducts = cache(async (productIds: number[] = []): Promise<CompareProd
   }));
 });
 
+const getAnalyticsData = async (productIds: number[] = []) => {
+  const products = await getCompareData(productIds);
+
+  return products.map((product) => {
+    return {
+      id: product.entityId,
+      name: product.name,
+      sku: product.sku,
+      brand: product.brand?.name ?? '',
+      price: product.prices?.price.value ?? 0,
+      currency: product.prices?.price.currencyCode ?? '',
+    };
+  });
+};
+
 interface Props {
   params: Promise<{ locale: string }>;
   searchParams: Promise<{
@@ -86,22 +102,24 @@ export default async function Compare(props: Props) {
   const productIds = parsed.ids?.filter((id) => !Number.isNaN(id));
 
   return (
-    <CompareSection
-      addToCartAction={addToCart}
-      addToCartLabel={t('addToCart')}
-      descriptionLabel={t('description')}
-      emptyStateTitle={t('noProductsToCompare')}
-      nextLabel={t('next')}
-      noDescriptionLabel={t('noDescription')}
-      noOtherDetailsLabel={t('noOtherDetails')}
-      noRatingsLabel={t('noRatings')}
-      otherDetailsLabel={t('otherDetails')}
-      previousLabel={t('previous')}
-      products={Streamable.from(() => getProducts(productIds))}
-      ratingLabel={t('rating')}
-      title={t('title')}
-      viewOptionsLabel={t('viewOptions')}
-    />
+    <CompareAnalyticsProvider data={Streamable.from(() => getAnalyticsData(productIds))}>
+      <CompareSection
+        addToCartAction={addToCart}
+        addToCartLabel={t('addToCart')}
+        descriptionLabel={t('description')}
+        emptyStateTitle={t('noProductsToCompare')}
+        nextLabel={t('next')}
+        noDescriptionLabel={t('noDescription')}
+        noOtherDetailsLabel={t('noOtherDetails')}
+        noRatingsLabel={t('noRatings')}
+        otherDetailsLabel={t('otherDetails')}
+        previousLabel={t('previous')}
+        products={Streamable.from(() => getProducts(productIds))}
+        ratingLabel={t('rating')}
+        title={t('title')}
+        viewOptionsLabel={t('viewOptions')}
+      />
+    </CompareAnalyticsProvider>
   );
 }
 

--- a/core/app/[locale]/(default)/product/[slug]/_components/product-analytics-provider/index.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/_components/product-analytics-provider/index.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { PropsWithChildren, Suspense } from 'react';
+import { z } from 'zod';
+
+import { Streamable, useStreamable } from '@/vibes/soul/lib/streamable';
+import { EventsProvider } from '~/components/analytics/events';
+import { useAnalytics } from '~/lib/analytics/react';
+
+interface AddToCartContext {
+  id: number;
+  name: string;
+  brand: string;
+  sku?: string;
+  currency: string;
+  price: number;
+}
+
+const AddToCartSchema = z.object({
+  quantity: z.number({ coerce: true }).default(1),
+});
+
+export function ProductAnalyticsProvider(
+  props: PropsWithChildren<{ data: Streamable<AddToCartContext> }>,
+) {
+  return (
+    <Suspense fallback={<div />}>
+      <ProductAnalyticsProviderResolved {...props} />
+    </Suspense>
+  );
+}
+
+export function ProductAnalyticsProviderResolved({
+  children,
+  data,
+}: PropsWithChildren<{ data: Streamable<AddToCartContext> }>) {
+  const analytics = useAnalytics();
+  const { id, name, brand, sku, currency, price } = useStreamable(data);
+
+  const onAddToCart = (payload?: FormData) => {
+    const parsedPayload = AddToCartSchema.safeParse(Object.fromEntries(payload?.entries() ?? []));
+
+    if (parsedPayload.success) {
+      const { quantity } = parsedPayload.data;
+
+      analytics?.cart.productAdded({
+        currency,
+        value: quantity * price,
+        items: [
+          {
+            id: id.toString(),
+            name,
+            brand,
+            sku,
+            price,
+            quantity,
+          },
+        ],
+      });
+    }
+  };
+
+  return <EventsProvider onAddToCart={onAddToCart}>{children}</EventsProvider>;
+}

--- a/core/app/[locale]/(default)/product/[slug]/_components/product-viewed/index.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/_components/product-viewed/index.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { PricingFragment } from '~/client/fragments/pricing';
 import { FragmentOf } from '~/client/graphql';
-import { bodl } from '~/lib/bodl';
+import { useAnalytics } from '~/lib/analytics/react';
 
 import { ProductViewedFragment } from './fragment';
 
@@ -12,31 +12,31 @@ interface Props {
   product: FragmentOf<typeof ProductViewedFragment> & FragmentOf<typeof PricingFragment>;
 }
 
-const productItemTransform = (p: Props['product']) => {
-  return {
-    product_id: p.entityId.toString(),
-    product_name: p.name,
-    brand_name: p.brand?.name,
-    sku: p.sku,
-    sale_price: p.prices?.salePrice?.value,
-    purchase_price: p.prices?.salePrice?.value || p.prices?.price.value || 0,
-    base_price: p.prices?.price.value,
-    retail_price: p.prices?.retailPrice?.value,
-    currency: p.prices?.price.currencyCode || 'USD',
-    variant_id: p.variants.edges?.map((variant) => variant.node.entityId),
-  };
-};
-
 export const ProductViewed = ({ product }: Props) => {
-  useEffect(() => {
-    const transformedProduct = productItemTransform(product);
+  const isMounted = useRef(false);
+  const analytics = useAnalytics();
 
-    bodl.navigation.productViewed({
-      product_value: transformedProduct.purchase_price,
-      currency: transformedProduct.currency,
-      line_items: [transformedProduct],
+  useEffect(() => {
+    if (isMounted.current) {
+      return;
+    }
+
+    isMounted.current = true;
+
+    analytics?.navigation.productViewed({
+      value: product.prices?.price.value ?? 0,
+      currency: product.prices?.price.currencyCode ?? 'USD',
+      items: [
+        {
+          id: product.entityId.toString(),
+          name: product.name,
+          brand: product.brand?.name,
+          sku: product.sku,
+          price: product.prices?.salePrice?.value,
+        },
+      ],
     });
-  }, [product]);
+  }, [analytics, product]);
 
   return null;
 };

--- a/core/app/[locale]/(default)/product/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/page.tsx
@@ -14,6 +14,7 @@ import { productOptionsTransformer } from '~/data-transformers/product-options-t
 import { getPreferredCurrencyCode } from '~/lib/currency';
 
 import { addToCart } from './_actions/add-to-cart';
+import { ProductAnalyticsProvider } from './_components/product-analytics-provider';
 import { ProductSchema } from './_components/product-schema';
 import { ProductViewed } from './_components/product-viewed';
 import { Reviews } from './_components/reviews';
@@ -266,39 +267,57 @@ export default async function Product(props: Props) {
     return productCardTransformer(relatedProducts, format);
   });
 
+  const streamableAnalyticsData = Streamable.from(async () => {
+    const [extendedProduct, pricingProduct] = await Streamable.all([
+      streamableProduct,
+      streamableProductPricingAndRelatedProducts,
+    ]);
+
+    return {
+      id: extendedProduct.entityId,
+      name: extendedProduct.name,
+      sku: extendedProduct.sku,
+      brand: extendedProduct.brand?.name ?? '',
+      price: pricingProduct?.prices?.price.value ?? 0,
+      currency: pricingProduct?.prices?.price.currencyCode ?? '',
+    };
+  });
+
   return (
     <>
-      <ProductDetail
-        action={addToCart}
-        additionalActions={
-          <WishlistButton
-            formId={detachedWishlistFormId}
-            productId={productId}
-            productSku={streamableProductSku}
-          />
-        }
-        additionalInformationTitle={t('ProductDetails.additionalInformation')}
-        ctaDisabled={streameableCtaDisabled}
-        ctaLabel={streameableCtaLabel}
-        decrementLabel={t('ProductDetails.decreaseQuantity')}
-        emptySelectPlaceholder={t('ProductDetails.emptySelectPlaceholder')}
-        fields={productOptionsTransformer(baseProduct.productOptions)}
-        incrementLabel={t('ProductDetails.increaseQuantity')}
-        prefetch={true}
-        product={{
-          id: baseProduct.entityId.toString(),
-          title: baseProduct.name,
-          description: <div dangerouslySetInnerHTML={{ __html: baseProduct.description }} />,
-          href: baseProduct.path,
-          images: streamableImages,
-          price: streamablePrices,
-          subtitle: baseProduct.brand?.name,
-          rating: baseProduct.reviewSummary.averageRating,
-          accordions: streameableAccordions,
-        }}
-        quantityLabel={t('ProductDetails.quantity')}
-        thumbnailLabel={t('ProductDetails.thumbnail')}
-      />
+      <ProductAnalyticsProvider data={streamableAnalyticsData}>
+        <ProductDetail
+          action={addToCart}
+          additionalActions={
+            <WishlistButton
+              formId={detachedWishlistFormId}
+              productId={productId}
+              productSku={streamableProductSku}
+            />
+          }
+          additionalInformationTitle={t('ProductDetails.additionalInformation')}
+          ctaDisabled={streameableCtaDisabled}
+          ctaLabel={streameableCtaLabel}
+          decrementLabel={t('ProductDetails.decreaseQuantity')}
+          emptySelectPlaceholder={t('ProductDetails.emptySelectPlaceholder')}
+          fields={productOptionsTransformer(baseProduct.productOptions)}
+          incrementLabel={t('ProductDetails.increaseQuantity')}
+          prefetch={true}
+          product={{
+            id: baseProduct.entityId.toString(),
+            title: baseProduct.name,
+            description: <div dangerouslySetInnerHTML={{ __html: baseProduct.description }} />,
+            href: baseProduct.path,
+            images: streamableImages,
+            price: streamablePrices,
+            subtitle: baseProduct.brand?.name,
+            rating: baseProduct.reviewSummary.averageRating,
+            accordions: streameableAccordions,
+          }}
+          quantityLabel={t('ProductDetails.quantity')}
+          thumbnailLabel={t('ProductDetails.thumbnail')}
+        />
+      </ProductAnalyticsProvider>
 
       <FeaturedProductCarousel
         cta={{ label: t('RelatedProducts.cta'), href: '/shop-all' }}

--- a/core/components/analytics/events.tsx
+++ b/core/components/analytics/events.tsx
@@ -1,0 +1,22 @@
+import { createContext, PropsWithChildren, useContext } from 'react';
+
+interface EventsContext {
+  onAddToCart?: (formData?: FormData) => void;
+  onRemoveFromCart?: (formData?: FormData) => void;
+}
+
+const EventsContext = createContext<EventsContext | null>(null);
+
+export const EventsProvider = ({ children, ...props }: PropsWithChildren<EventsContext>) => {
+  return <EventsContext.Provider value={props}>{children}</EventsContext.Provider>;
+};
+
+export const useEvents = () => {
+  const context = useContext(EventsContext);
+
+  if (!context) {
+    throw new Error('useEvents must be used within a EventsProvider');
+  }
+
+  return context;
+};

--- a/core/components/analytics/fragment.ts
+++ b/core/components/analytics/fragment.ts
@@ -1,0 +1,11 @@
+import { graphql } from '~/client/graphql';
+
+export const WebAnalyticsFragment = graphql(`
+  fragment WebAnalyticsFragment on Settings {
+    webAnalytics {
+      ga4 {
+        tagId
+      }
+    }
+  }
+`);

--- a/core/components/analytics/provider.tsx
+++ b/core/components/analytics/provider.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { PropsWithChildren } from 'react';
+
+import { FragmentOf } from '~/client/graphql';
+import { Analytics } from '~/lib/analytics';
+import { GoogleAnalyticsProvider } from '~/lib/analytics/providers/google-analytics';
+import { AnalyticsProvider as AnalyticsProviderLib } from '~/lib/analytics/react';
+
+import { WebAnalyticsFragment } from './fragment';
+
+interface Props {
+  channelId: number;
+  settings?: FragmentOf<typeof WebAnalyticsFragment> | null;
+}
+
+const getAnalytics = (
+  channelId: number,
+  settings?: FragmentOf<typeof WebAnalyticsFragment> | null,
+) => {
+  if (settings?.webAnalytics?.ga4?.tagId && channelId) {
+    const googleAnalytics = new GoogleAnalyticsProvider({
+      gaId: settings.webAnalytics.ga4.tagId,
+      // TODO: Need to implement consent mode
+      // https://github.com/bigcommerce/catalyst/issues/2066
+      consentModeEnabled: false,
+      developerId: 'dMjk3Nj',
+    });
+
+    return new Analytics({
+      channelId,
+      providers: [googleAnalytics],
+    });
+  }
+
+  return null;
+};
+
+export function AnalyticsProvider({ children, settings, channelId }: PropsWithChildren<Props>) {
+  const analytics = getAnalytics(channelId, settings);
+
+  return <AnalyticsProviderLib analytics={analytics ?? null}>{children}</AnalyticsProviderLib>;
+}

--- a/core/components/wishlist/fragment.ts
+++ b/core/components/wishlist/fragment.ts
@@ -6,6 +6,7 @@ export const WishlistItemProductFragment = graphql(
   `
     fragment WishlistItemProductFragment on Product {
       ...ProductCardFragment
+      sku
       showCartAction
       inventory {
         isInStock

--- a/core/vibes/soul/primitives/wishlist-item-card/wishlist-item-add-to-cart.tsx
+++ b/core/vibes/soul/primitives/wishlist-item-card/wishlist-item-add-to-cart.tsx
@@ -1,11 +1,13 @@
 'use client';
 
-import { SubmissionResult } from '@conform-to/react';
-import { useActionState, useEffect } from 'react';
-import { useFormStatus } from 'react-dom';
+import { getFormProps, SubmissionResult, useForm } from '@conform-to/react';
+import { startTransition, useActionState, useEffect } from 'react';
+import { requestFormReset, useFormStatus } from 'react-dom';
 
 import { Button } from '@/vibes/soul/primitives/button';
 import { toast } from '@/vibes/soul/primitives/toaster';
+import { useEvents } from '~/components/analytics/events';
+import { useRouter } from '~/i18n/routing';
 
 import { WishlistItem } from '.';
 
@@ -29,22 +31,42 @@ export const WishlistItemAddToCart = ({
   variantId,
   action,
 }: Props) => {
+  const events = useEvents();
+  const router = useRouter();
   const [{ lastResult, successMessage, errorMessage }, formAction] = useActionState(action, {
     lastResult: null,
+  });
+
+  const [form] = useForm({
+    lastResult,
+    onSubmit(event, { formData }) {
+      event.preventDefault();
+
+      startTransition(() => {
+        requestFormReset(event.currentTarget);
+        formAction(formData);
+
+        events.onAddToCart?.(formData);
+      });
+    },
   });
 
   useEffect(() => {
     if (lastResult?.status === 'success' && successMessage) {
       toast.success(successMessage);
+
+      // This is needed to refresh the Data Cache after the product has been added to the cart.
+      // The cart id is not picked up after the first time the cart is created/updated.
+      router.refresh();
     }
 
     if (lastResult?.status === 'error' && errorMessage) {
       toast.error(errorMessage);
     }
-  }, [lastResult, successMessage, errorMessage]);
+  }, [lastResult, successMessage, errorMessage, router]);
 
   return (
-    <form action={formAction} className="flex">
+    <form {...getFormProps(form)} action={formAction} className="flex">
       <input name="productId" type="hidden" value={productId} />
       <input name="variantId" type="hidden" value={variantId} />
       <SubmitButton ctaLabel={callToAction.label} disabled={callToAction.disabled} />

--- a/core/vibes/soul/sections/cart/client.tsx
+++ b/core/vibes/soul/sections/cart/client.tsx
@@ -16,6 +16,7 @@ import { useFormStatus } from 'react-dom';
 import { Button } from '@/vibes/soul/primitives/button';
 import { toast } from '@/vibes/soul/primitives/toaster';
 import { StickySidebarLayout } from '@/vibes/soul/sections/sticky-sidebar-layout';
+import { useEvents } from '~/components/analytics/events';
 import { Image } from '~/components/image';
 
 import { CouponCodeForm, CouponCodeFormState } from './coupon-code-form';
@@ -173,6 +174,7 @@ export function CartClient<LineItem extends CartLineItem>({
   summaryTitle,
   shipping,
 }: CartProps<LineItem>) {
+  const events = useEvents();
   const [state, formAction] = useActionState(lineItemAction, {
     lineItems: cart.lineItems,
     lastResult: null,
@@ -314,6 +316,26 @@ export function CartClient<LineItem extends CartLineItem>({
                     startTransition(() => {
                       formAction(formData);
                       setOptimisticLineItems(formData);
+
+                      const intent = formData.get('intent');
+
+                      if (intent === 'increment') {
+                        formData.set('quantity', '1');
+
+                        events.onAddToCart?.(formData);
+                      }
+
+                      if (intent === 'decrement') {
+                        formData.set('quantity', '1');
+
+                        events.onRemoveFromCart?.(formData);
+                      }
+
+                      if (intent === 'delete') {
+                        formData.set('quantity', lineItem.quantity.toString());
+
+                        events.onRemoveFromCart?.(formData);
+                      }
                     });
                   }}
                 />

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,4 @@
 packages:
   - core
   - packages/*
-onlyBuiltDependencies:
-  - '@vercel/speed-insights'
+neverBuiltDependencies: null


### PR DESCRIPTION
## What/Why?
Implements the new analytics provide and replaces consumption of the old one. The new provider now fetches your GA4 ID from the Bigcommerce Control Panel settings, removing the need of setting the environment variable. It also comes with new  events bindings to work more easily with VIBES components.

## Testing
![Screenshot 2025-04-22 at 16 18 50](https://github.com/user-attachments/assets/c581639e-a922-4100-8809-8bbd0d7cd78e)


## Migration
Most changes are additive so merge conflicts should be easy to resolve. In order to use the new provider from the previous provider, if it's already not setup in the BigCommerce control panel for checkout analytics, you'll need to add the GA4 property ID. This will automatically be used by the new `GoogleAnalytics` provider.