### PR TITLE
Update GQL client and auth middleware to handle invalid tokens and invalidate session

### DIFF
--- a/.changeset/little-hornets-stand.md
+++ b/.changeset/little-hornets-stand.md
@@ -1,0 +1,20 @@
+---
+"@bigcommerce/catalyst-client": patch
+"@bigcommerce/catalyst-core": patch
+---
+
+Update GQL client and auth middleware to handle invalid tokens and invalidate session.
+
+### Summary
+
+This will ensure that if a user is logged out elsewhere, they will be redirected to the /login page when they try to access a protected route.
+
+Previously, the pages would 404 which is misleading.
+
+### Migration
+
+1. Copy all changes from the `/core/client` directory and the `/packages/client` directory
+2. Copy logic from withAuth middleware to handle the `?invalidate-session` query param
+3. Copy translation values
+4. Copy all changes from the `/core/app/[locale]/(default)/account/` directory server actions
+5. Copy all changes from the `/core/app/[locale]/(default)/checkout/route.ts` file

--- a/core/app/[locale]/(default)/account/layout.tsx
+++ b/core/app/[locale]/(default)/account/layout.tsx
@@ -3,8 +3,6 @@ import { PropsWithChildren } from 'react';
 
 import { SidebarMenu } from '@/vibes/soul/sections/sidebar-menu';
 import { StickySidebarLayout } from '@/vibes/soul/sections/sticky-sidebar-layout';
-import { isLoggedIn } from '~/auth';
-import { redirect } from '~/i18n/routing';
 
 interface Props extends PropsWithChildren {
   params: Promise<{ locale: string }>;
@@ -12,15 +10,10 @@ interface Props extends PropsWithChildren {
 
 export default async function Layout({ children, params }: Props) {
   const { locale } = await params;
-  const loggedIn = await isLoggedIn();
 
   setRequestLocale(locale);
 
   const t = await getTranslations('Account.Layout');
-
-  if (!loggedIn) {
-    redirect({ href: '/login', locale });
-  }
 
   return (
     <StickySidebarLayout

--- a/core/app/[locale]/(default)/account/orders/[id]/page-data.tsx
+++ b/core/app/[locale]/(default)/account/orders/[id]/page-data.tsx
@@ -133,7 +133,7 @@ export const getCustomerOrderDetails = cache(async ({ id }: CustomerOrderDetails
     },
     fetchOptions: { cache: 'no-store', next: { tags: [TAGS.customer] } },
     customerAccessToken,
-    errorPolicy: 'ignore',
+    errorPolicy: 'auth',
   });
 
   const order = response.data.site.order;

--- a/core/app/[locale]/(default)/account/orders/page-data.ts
+++ b/core/app/[locale]/(default)/account/orders/page-data.ts
@@ -94,7 +94,7 @@ export const getCustomerOrders = cache(
       variables: { ...paginationArgs, ...filtersArgs },
       customerAccessToken,
       fetchOptions: { cache: 'no-store', next: { tags: [TAGS.customer] } },
-      errorPolicy: 'ignore',
+      errorPolicy: 'auth',
     });
 
     const orders = response.data.customer?.orders;

--- a/core/app/[locale]/(default)/account/wishlists/_actions/change-wishlist-visibility.ts
+++ b/core/app/[locale]/(default)/account/wishlists/_actions/change-wishlist-visibility.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { BigCommerceAPIError, BigCommerceGQLError } from '@bigcommerce/catalyst-client';
+import { BigCommerceAuthError } from '@bigcommerce/catalyst-client';
 import { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
 import { revalidateTag } from 'next/cache';
@@ -73,28 +73,22 @@ export async function toggleWishlistVisibility(
     // eslint-disable-next-line no-console
     console.error(error);
 
-    if (error instanceof BigCommerceGQLError) {
+    if (error instanceof BigCommerceAuthError) {
+      const authErrorMessage = t('Errors.unauthorized');
+
       return {
         ...prevState,
-        lastResult: submission.reply({ formErrors: [t('Errors.unexpected')] }),
-        errorMessage: error.message.includes('Please sign in')
-          ? t('Errors.unauthorized')
-          : t('Errors.unexpected'),
+        lastResult: submission.reply({ formErrors: [authErrorMessage] }),
+        errorMessage: authErrorMessage,
       };
     }
 
-    if (error instanceof BigCommerceAPIError) {
-      return {
-        ...prevState,
-        lastResult: submission.reply({ formErrors: [t('Errors.unexpected')] }),
-        errorMessage: t('Errors.unexpected'),
-      };
-    }
+    const errorMessage = t('Errors.unexpected');
 
     return {
       ...prevState,
-      lastResult: submission.reply({ formErrors: [t('Errors.unexpected')] }),
-      errorMessage: t('Errors.unexpected'),
+      lastResult: submission.reply({ formErrors: [errorMessage] }),
+      errorMessage,
     };
   }
 }

--- a/core/app/[locale]/(default)/account/wishlists/_actions/delete-wishlist.ts
+++ b/core/app/[locale]/(default)/account/wishlists/_actions/delete-wishlist.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { BigCommerceAPIError, BigCommerceGQLError } from '@bigcommerce/catalyst-client';
+import { BigCommerceAuthError } from '@bigcommerce/catalyst-client';
 import { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
 import { revalidateTag } from 'next/cache';
@@ -73,17 +73,10 @@ export async function deleteWishlist(
     // eslint-disable-next-line no-console
     console.error(error);
 
-    if (error instanceof BigCommerceGQLError) {
+    if (error instanceof BigCommerceAuthError) {
       return {
         ...prevState,
-        lastResult: submission.reply({ formErrors: [t('Errors.unexpected')] }),
-      };
-    }
-
-    if (error instanceof BigCommerceAPIError) {
-      return {
-        ...prevState,
-        lastResult: submission.reply({ formErrors: [t('Errors.unexpected')] }),
+        lastResult: submission.reply({ formErrors: [t('Errors.unauthorized')] }),
       };
     }
 

--- a/core/app/[locale]/(default)/account/wishlists/_actions/new-wishlist.ts
+++ b/core/app/[locale]/(default)/account/wishlists/_actions/new-wishlist.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { BigCommerceAPIError, BigCommerceGQLError } from '@bigcommerce/catalyst-client';
+import { BigCommerceAuthError } from '@bigcommerce/catalyst-client';
 import { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
 import { revalidateTag } from 'next/cache';
@@ -68,21 +68,10 @@ export async function newWishlist(prevState: Awaited<State>, formData: FormData)
     // eslint-disable-next-line no-console
     console.error(error);
 
-    if (error instanceof BigCommerceGQLError) {
-      const formError = error.message.includes('Please sign in')
-        ? t('Errors.unauthorized')
-        : t('Errors.unexpected');
-
+    if (error instanceof BigCommerceAuthError) {
       return {
         ...prevState,
-        lastResult: submission.reply({ formErrors: [formError] }),
-      };
-    }
-
-    if (error instanceof BigCommerceAPIError) {
-      return {
-        ...prevState,
-        lastResult: submission.reply({ formErrors: [t('Errors.unexpected')] }),
+        lastResult: submission.reply({ formErrors: [t('Errors.unauthorized')] }),
       };
     }
 

--- a/core/app/[locale]/(default)/account/wishlists/_actions/remove-wishlist-item.ts
+++ b/core/app/[locale]/(default)/account/wishlists/_actions/remove-wishlist-item.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { BigCommerceAPIError, BigCommerceGQLError } from '@bigcommerce/catalyst-client';
+import { BigCommerceAuthError } from '@bigcommerce/catalyst-client';
 import { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
 import { revalidateTag } from 'next/cache';
@@ -76,21 +76,11 @@ export async function removeWishlistItem(
     // eslint-disable-next-line no-console
     console.error(error);
 
-    if (error instanceof BigCommerceGQLError) {
+    if (error instanceof BigCommerceAuthError) {
       return {
         ...prevState,
         lastResult: { status: 'error' },
-        errorMessage: error.message.includes('Please sign in')
-          ? t('Errors.unauthorized')
-          : t('Errors.unexpected'),
-      };
-    }
-
-    if (error instanceof BigCommerceAPIError) {
-      return {
-        ...prevState,
-        lastResult: { status: 'error' },
-        errorMessage: t('Errors.unexpected'),
+        errorMessage: t('Errors.unauthorized'),
       };
     }
 

--- a/core/app/[locale]/(default)/account/wishlists/_actions/rename-wishlist.ts
+++ b/core/app/[locale]/(default)/account/wishlists/_actions/rename-wishlist.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { BigCommerceAPIError, BigCommerceGQLError } from '@bigcommerce/catalyst-client';
+import { BigCommerceAuthError } from '@bigcommerce/catalyst-client';
 import { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
 import { revalidateTag } from 'next/cache';
@@ -70,17 +70,10 @@ export async function renameWishlist(
     // eslint-disable-next-line no-console
     console.error(error);
 
-    if (error instanceof BigCommerceGQLError) {
+    if (error instanceof BigCommerceAuthError) {
       return {
         ...prevState,
-        lastResult: submission.reply({ formErrors: [t('Errors.unexpected')] }),
-      };
-    }
-
-    if (error instanceof BigCommerceAPIError) {
-      return {
-        ...prevState,
-        lastResult: submission.reply({ formErrors: [t('Errors.unexpected')] }),
+        lastResult: submission.reply({ formErrors: [t('Errors.unauthorized')] }),
       };
     }
 

--- a/core/app/[locale]/(default)/checkout/route.ts
+++ b/core/app/[locale]/(default)/checkout/route.ts
@@ -1,3 +1,4 @@
+import { BigCommerceAuthError } from '@bigcommerce/catalyst-client';
 import { unstable_rethrow as rethrow } from 'next/navigation';
 import { NextRequest, NextResponse } from 'next/server';
 
@@ -57,6 +58,10 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ loca
     });
   } catch (error) {
     rethrow(error);
+
+    if (error instanceof BigCommerceAuthError) {
+      return redirect({ href: '/logout?redirectTo=/checkout/', locale });
+    }
 
     // eslint-disable-next-line no-console
     console.error(error);

--- a/core/client/index.ts
+++ b/core/client/index.ts
@@ -1,5 +1,7 @@
-import { createClient } from '@bigcommerce/catalyst-client';
+import { BigCommerceAuthError, createClient } from '@bigcommerce/catalyst-client';
 import { headers } from 'next/headers';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import { redirect } from 'next/navigation';
 import { getLocale as getServerLocale } from 'next-intl/server';
 
 import { getChannelIdFromLocale } from '../channels.config';
@@ -59,5 +61,10 @@ export const client = createClient({
     return {
       headers: requestHeaders,
     };
+  },
+  onError: (error, queryType) => {
+    if (error instanceof BigCommerceAuthError && queryType === 'query') {
+      redirect('?invalidate-session');
+    }
   },
 });

--- a/core/middlewares/with-auth.ts
+++ b/core/middlewares/with-auth.ts
@@ -1,20 +1,51 @@
-import { auth, signIn } from '~/auth';
+import { NextResponse, URLPattern } from 'next/server';
+
+import { auth, signIn, signOut } from '~/auth';
 
 import { type MiddlewareFactory } from './compose-middlewares';
+
+// Path matcher for any routes that require authentication
+const protectedPathPattern = new URLPattern({ pathname: '/(account)/*' });
+const sessionInvalidateParam = 'invalidate-session';
+
+function redirectToLogin(url: string) {
+  return NextResponse.redirect(new URL('/login', url), { status: 302 });
+}
 
 export const withAuth: MiddlewareFactory = (next) => {
   return async (request, event) => {
     // @ts-expect-error: The `auth` function doesn't have the correct type to support it as a MiddlewareFactory.
     const authWithCallback = auth(async (req) => {
+      const isProtectedRoute = protectedPathPattern.test(req.nextUrl.toString().toLowerCase());
+      const isGetRequest = req.method === 'GET';
+
       if (!req.auth) {
         await signIn('anonymous', { redirect: false });
 
+        if (isProtectedRoute && isGetRequest) {
+          return redirectToLogin(req.url);
+        }
+
         return next(req, event);
+      }
+
+      const { customerAccessToken } = req.auth.user ?? {};
+
+      if (isProtectedRoute && isGetRequest && !customerAccessToken) {
+        return redirectToLogin(req.url);
       }
 
       // Continue the middleware chain
       return next(req, event);
     });
+
+    if (request.nextUrl.searchParams.has(sessionInvalidateParam)) {
+      await signOut({ redirect: false });
+
+      request.nextUrl.searchParams.delete(sessionInvalidateParam);
+
+      return NextResponse.redirect(request.nextUrl, { status: 302 });
+    }
 
     // @ts-expect-error: The `auth` function doesn't have the correct type to support it as a MiddlewareFactory.
     return authWithCallback(request, event);

--- a/packages/client/src/gql-auth-error.ts
+++ b/packages/client/src/gql-auth-error.ts
@@ -1,0 +1,15 @@
+import { BigCommerceGQLError, GQLError, GQLErrorCode } from './gql-error';
+
+export class BigCommerceAuthError extends BigCommerceGQLError {
+  readonly code: GQLErrorCode;
+
+  constructor(
+    errorCode: GQLErrorCode,
+    public errors: GQLError[] = [],
+  ) {
+    super(errors);
+
+    this.name = 'BigCommerceAuthError';
+    this.code = errorCode;
+  }
+}

--- a/packages/client/src/gql-error.ts
+++ b/packages/client/src/gql-error.ts
@@ -1,7 +1,16 @@
-interface GQLError {
+export enum GQLErrorCode {
+  INVALID_CAT = 'INVALID_CUSTOMER_ACCESS_TOKEN',
+  MISSING_CAT = 'MISSING_CUSTOMER_ACCESS_TOKEN',
+}
+
+export interface GQLError {
   message: string;
   path: string[];
   locations: Array<{ line: number; column: number }>;
+  extensions?: {
+    [key: string]: unknown;
+    code?: GQLErrorCode;
+  };
 }
 
 export class BigCommerceGQLError extends Error {
@@ -10,29 +19,5 @@ export class BigCommerceGQLError extends Error {
 
     super(message);
     this.name = 'BigCommerceGQLError';
-  }
-
-  static createFromResult(result: unknown) {
-    try {
-      assertIsGQLErrorResponse(result);
-
-      return new BigCommerceGQLError(result);
-    } catch {
-      return new BigCommerceGQLError([{ message: 'Unknown error', path: [], locations: [] }]);
-    }
-  }
-}
-
-function assertIsGQLErrorResponse(value: unknown): asserts value is GQLError[] {
-  if (!Array.isArray(value)) {
-    throw new Error('Expected maybeError to be an array');
-  }
-
-  if (value.some((error) => typeof error !== 'object' || error === null)) {
-    throw new Error('Expected maybeError to be an array of objects');
-  }
-
-  if (value.some((error) => !('message' in error))) {
-    throw new Error('Expected maybeError to have a message property');
   }
 }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,4 +1,7 @@
 export { BigCommerceAPIError } from './api-error';
 export { BigCommerceGQLError } from './gql-error';
+export { BigCommerceAuthError } from './gql-auth-error';
+export { MissingCustomerAccessTokenError } from './missing-cat-error';
+export { InvalidCustomerAccessTokenError } from './invalid-cat-error';
 export { createClient } from './client';
 export { removeEdgesAndNodes } from './utils/removeEdgesAndNodes';

--- a/packages/client/src/invalid-cat-error.ts
+++ b/packages/client/src/invalid-cat-error.ts
@@ -1,0 +1,10 @@
+import { BigCommerceAuthError } from './gql-auth-error';
+import { GQLError, GQLErrorCode } from './gql-error';
+
+export class InvalidCustomerAccessTokenError extends BigCommerceAuthError {
+  constructor(public errors: GQLError[] = []) {
+    super(GQLErrorCode.INVALID_CAT, errors);
+
+    this.name = 'InvalidCustomerAccessTokenError';
+  }
+}

--- a/packages/client/src/lib/error.ts
+++ b/packages/client/src/lib/error.ts
@@ -1,0 +1,39 @@
+import { BigCommerceGQLError, GQLError, GQLErrorCode } from '../gql-error';
+import { InvalidCustomerAccessTokenError } from '../invalid-cat-error';
+import { MissingCustomerAccessTokenError } from '../missing-cat-error';
+
+export function parseGraphQLError(result: unknown) {
+  try {
+    assertIsGQLErrorResponse(result);
+
+    const extendedError = result.find((error) => error.extensions && 'code' in error.extensions);
+
+    if (extendedError) {
+      switch (extendedError.extensions?.code) {
+        case GQLErrorCode.MISSING_CAT:
+          return new MissingCustomerAccessTokenError(result);
+
+        case GQLErrorCode.INVALID_CAT:
+          return new InvalidCustomerAccessTokenError(result);
+      }
+    }
+
+    return new BigCommerceGQLError(result);
+  } catch {
+    return new BigCommerceGQLError([{ message: 'Unknown error', path: [], locations: [] }]);
+  }
+}
+
+function assertIsGQLErrorResponse(value: unknown): asserts value is GQLError[] {
+  if (!Array.isArray(value)) {
+    throw new Error('Expected maybeError to be an array');
+  }
+
+  if (value.some((error) => typeof error !== 'object' || error === null)) {
+    throw new Error('Expected maybeError to be an array of objects');
+  }
+
+  if (value.some((error) => !('message' in error))) {
+    throw new Error('Expected maybeError to have a message property');
+  }
+}

--- a/packages/client/src/missing-cat-error.ts
+++ b/packages/client/src/missing-cat-error.ts
@@ -1,0 +1,10 @@
+import { BigCommerceAuthError } from './gql-auth-error';
+import { GQLError, GQLErrorCode } from './gql-error';
+
+export class MissingCustomerAccessTokenError extends BigCommerceAuthError {
+  constructor(public errors: GQLError[] = []) {
+    super(GQLErrorCode.MISSING_CAT, errors);
+
+    this.name = 'MissingCustomerAccessTokenError';
+  }
+}


### PR DESCRIPTION
## What/Why?
- Update `withAuth` middleware to redirect protected routes to `/login` page when user is unauthorized
- Add customer access token validation on protected routes
- Minor updates to end-user error messages on unauthorized GQL requests to stop returning raw GQL error and use our translated error message instead.
- Add `onError` event to GraphQL client
- Use the `onError` callback to invalidate user session when GQL returns an invalid or missing token error

## Testing


https://github.com/user-attachments/assets/d3c519dd-1655-4a15-8801-cd0ef368711d

## Migration

1. Copy all changes from the `/core/client` directory and the `/packages/client` directory
2. Copy logic from withAuth middleware to handle the `?invalidate-session` query param
3. Copy translation values
4. Copy all changes from the `/core/app/[locale]/(default)/account/` directory server actions
5. Copy all changes from the `/core/app/[locale]/(default)/checkout/route.ts` file
