### PR TITLE
Fix Switch component labels

### DIFF
--- a/core/vibes/soul/form/switch/index.tsx
+++ b/core/vibes/soul/form/switch/index.tsx
@@ -136,7 +136,7 @@ function SwitchLabel({ id, label, size = 'medium', state, loading }: LabelProps)
     <div className="leading-[0]">
       <label
         className={clsx(
-          'mb-[-2px] group-has-data-[state=checked]/switch:block group-has-data-[state=unchecked]/switch:invisible',
+          'mb-[-2px] leading-[0] group-has-data-[state=checked]/switch:block group-has-data-[state=unchecked]/switch:invisible',
           baseClass,
           sizeClass,
         )}
@@ -147,7 +147,7 @@ function SwitchLabel({ id, label, size = 'medium', state, loading }: LabelProps)
       </label>
       <label
         className={clsx(
-          'group-has-data-[state=checked]/switch:invisible group-has-data-[state=unchecked]/switch:block',
+          'mt-[-1px] leading-[0] group-has-data-[state=checked]/switch:invisible group-has-data-[state=unchecked]/switch:block',
           baseClass,
           sizeClass,
         )}


### PR DESCRIPTION
## What/Why?
I noticed that after we updated TailwindCSS, the `Switch` component labels got broken. This is a quick PR to fix it.

## Testing
Confirmed the fix works:

https://github.com/user-attachments/assets/5c58cebb-b972-4968-9076-fe09355d2014

## Migration
1. Copy CSS classes over to Switch component
