### PR TITLE
fix: toast & cart updates on "add to cart"

### DIFF
--- a/.changeset/seven-banks-bow.md
+++ b/.changeset/seven-banks-bow.md
@@ -1,0 +1,8 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Fix: missing **Add-to-cart** feedback on `integrations/makeswift` branch:
+
+- Toast success notification now appears when **Add to cart** is clicked.
+- Cart button badge in the header now updates to show `1` when the first item is added.

--- a/core/lib/makeswift/component.tsx
+++ b/core/lib/makeswift/component.tsx
@@ -1,6 +1,6 @@
-import { MakeswiftComponent } from '@makeswift/runtime/next';
-
 import { getComponentSnapshot } from '~/lib/makeswift/client';
+
+import { MakeswiftComponentShim } from './makeswift-component-shim';
 
 export const Component = async ({
   snapshotId,
@@ -13,5 +13,5 @@ export const Component = async ({
 }) => {
   const snapshot = await getComponentSnapshot(snapshotId);
 
-  return <MakeswiftComponent label={await label} snapshot={snapshot} {...props} />;
+  return <MakeswiftComponentShim label={await label} snapshot={snapshot} {...props} />;
 };

--- a/core/lib/makeswift/makeswift-component-shim.tsx
+++ b/core/lib/makeswift/makeswift-component-shim.tsx
@@ -1,0 +1,16 @@
+/**
+ * Temporary shim to avoid React/Next.js remount bug when a memoised
+ * client component is rendered directly by an RSC.
+ * See: https://github.com/vercel/next.js/issues/44901 and
+ *      https://github.com/vercel/next.js/issues/73507
+ *
+ * Remove once the upstream fix ships.
+ */
+'use client';
+
+import { MakeswiftComponent } from '@makeswift/runtime/next';
+import { ComponentPropsWithoutRef } from 'react';
+
+export function MakeswiftComponentShim(props: ComponentPropsWithoutRef<typeof MakeswiftComponent>) {
+  return <MakeswiftComponent {...props} />;
+}

--- a/core/lib/makeswift/makeswift-page-shim.tsx
+++ b/core/lib/makeswift/makeswift-page-shim.tsx
@@ -1,0 +1,16 @@
+/**
+ * Temporary shim to avoid React/Next.js remount bug when a memoised
+ * client component is rendered directly by an RSC.
+ * See: https://github.com/vercel/next.js/issues/44901 and
+ *      https://github.com/vercel/next.js/issues/73507
+ *
+ * Remove once the upstream fix ships.
+ */
+'use client';
+
+import { Page as MakeswiftPage } from '@makeswift/runtime/next';
+import { ComponentPropsWithoutRef } from 'react';
+
+export function MakeswiftPageShim(props: ComponentPropsWithoutRef<typeof MakeswiftPage>) {
+  return <MakeswiftPage {...props} />;
+}

--- a/core/lib/makeswift/page.tsx
+++ b/core/lib/makeswift/page.tsx
@@ -1,8 +1,8 @@
-import { Page as MakeswiftPage } from '@makeswift/runtime/next';
 import { notFound } from 'next/navigation';
 import { connection } from 'next/server';
 
 import { getPageSnapshot } from './client';
+import { MakeswiftPageShim } from './makeswift-page-shim';
 
 export async function Page({ path, locale }: { path: string; locale: string }) {
   const snapshot = await getPageSnapshot({ path, locale });
@@ -14,5 +14,5 @@ export async function Page({ path, locale }: { path: string; locale: string }) {
     return notFound();
   }
 
-  return <MakeswiftPage snapshot={snapshot} />;
+  return <MakeswiftPageShim snapshot={snapshot} />;
 }


### PR DESCRIPTION
## What/Why?

React / Next.js bug remounts a memoised client component rendered directly by an RSC. This caused the `ProductDetail` to remount before it can show the toast and update the cart.

https://github.com/vercel/next.js/issues/44901
https://github.com/vercel/next.js/issues/73507


### Fix
Introduce a non-memo shims around `MakeswiftComponent` and `MakeswiftPage` that prevent the unwanted remount.

## Testing

https://github.com/user-attachments/assets/23831b75-2d5e-45ab-83be-2dbe67434d9f

Test on the preview branch vs the `integrations/makeswift` branch:

https://catalyst-canary-git-fikri-eng-8075-3c0f42-bigcommerce-platform.vercel.app/smith-journal-13/

https://integrations-makeswift.catalyst-canary.store/spray-bottle/
