### PR TITLE
feat: add search button cta to 404 page

### DIFF
--- a/.changeset/legal-ends-judge.md
+++ b/.changeset/legal-ends-judge.md
@@ -1,0 +1,13 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+In order to maintain parity with Stencil's 404 page, we wanted to allow the user to search from the 404 page. Since the search included with the header component is fully featured, we included a CTA to open the same search that you get when clicking the search icon in the header.
+
+**Migration**
+Most changes are additive, so they should hopefully be easy to resolve if flagged for merge conflicts. Change #3 below replaces the Search state with the new search context, be sure to pay attention to the new
+
+1. This change adds a new directory under `core/` called `context/` containing a `search-context.tsx` file. Since this is a new file, there shouldn't be any merge conflicts
+2. `SearchProvider` is imported into `core/app/providers` and replaces the React fragment (`<>`) that currently wraps `<Toaster>` and `{children}`
+3. In `core/vibes/soul/primitives/navigation`, replace `useState` with `useSearch` imported from the new context file, and update the dependency arrays for the `useEffect`'s in the `Navigation component`
+4. Add search `Button` that calls `setIsSearchOpen(true)` to the `NotFound` component in `core/vibes/sections/not-found/index.tsx`

--- a/core/app/providers.tsx
+++ b/core/app/providers.tsx
@@ -3,12 +3,13 @@
 import { PropsWithChildren } from 'react';
 
 import { Toaster } from '@/vibes/soul/primitives/toaster';
+import { SearchProvider } from '~/context/search-context';
 
 export function Providers({ children }: PropsWithChildren) {
   return (
-    <>
+    <SearchProvider>
       <Toaster position="top-right" />
       {children}
-    </>
+    </SearchProvider>
   );
 }

--- a/core/context/search-context.tsx
+++ b/core/context/search-context.tsx
@@ -1,0 +1,35 @@
+import React, {
+  createContext,
+  Dispatch,
+  ReactNode,
+  SetStateAction,
+  useContext,
+  useState,
+} from 'react';
+
+interface SearchContextProps {
+  isSearchOpen: boolean;
+  setIsSearchOpen: Dispatch<SetStateAction<boolean>>;
+}
+
+const SearchContext = createContext<SearchContextProps | undefined>(undefined);
+
+export const SearchProvider = ({ children }: { children: ReactNode }) => {
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
+
+  return (
+    <SearchContext.Provider value={{ isSearchOpen, setIsSearchOpen }}>
+      {children}
+    </SearchContext.Provider>
+  );
+};
+
+export const useSearch = (): SearchContextProps => {
+  const context = useContext(SearchContext);
+
+  if (context === undefined) {
+    throw new Error('useSearch must be used within a SearchProvider');
+  }
+
+  return context;
+};

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -401,7 +401,7 @@
   },
   "NotFound": {
     "title": "We couldn't find that page!",
-    "subtitle": "It looks like the page you requested has moved or no longer exists.",
+    "subtitle": "Try searching for something else or go back to the home page.",
     "featuredProducts": "Featured products"
   },
   "Components": {

--- a/core/vibes/soul/primitives/navigation/index.tsx
+++ b/core/vibes/soul/primitives/navigation/index.tsx
@@ -27,6 +27,7 @@ import { Logo } from '@/vibes/soul/primitives/logo';
 import { Price } from '@/vibes/soul/primitives/price-label';
 import { ProductCard } from '@/vibes/soul/primitives/product-card';
 import { Link } from '~/components/link';
+import { useSearch } from '~/context/search-context';
 import { usePathname, useRouter } from '~/i18n/routing';
 
 interface Link {
@@ -287,14 +288,14 @@ export const Navigation = forwardRef(function Navigation<S extends SearchResult>
   ref: Ref<HTMLDivElement>,
 ) {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
-  const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const { isSearchOpen, setIsSearchOpen } = useSearch();
 
   const pathname = usePathname();
 
   useEffect(() => {
     setIsMobileMenuOpen(false);
     setIsSearchOpen(false);
-  }, [pathname]);
+  }, [pathname, setIsSearchOpen]);
 
   useEffect(() => {
     function handleScroll() {
@@ -305,7 +306,7 @@ export const Navigation = forwardRef(function Navigation<S extends SearchResult>
     window.addEventListener('scroll', handleScroll);
 
     return () => window.removeEventListener('scroll', handleScroll);
-  }, []);
+  }, [setIsSearchOpen]);
 
   return (
     <NavigationMenu.Root

--- a/core/vibes/soul/sections/not-found/index.tsx
+++ b/core/vibes/soul/sections/not-found/index.tsx
@@ -1,4 +1,8 @@
+'use client';
+
+import { Button } from '@/vibes/soul/primitives/button';
 import { SectionLayout } from '@/vibes/soul/sections/section-layout';
+import { useSearch } from '~/context/search-context';
 
 export interface NotFoundProps {
   title?: string;
@@ -25,15 +29,22 @@ export function NotFound({
   subtitle = "Take a look around if you're lost.",
   className = '',
 }: NotFoundProps) {
+  const { setIsSearchOpen } = useSearch();
+
+  const handleOpenSearch = () => {
+    setIsSearchOpen(true);
+  };
+
   return (
     <SectionLayout className={className} containerSize="2xl">
       <header className="font-[family-name:var(--not-found-font-family,var(--font-family-body))]">
         <h1 className="mb-3 font-[family-name:var(--not-found-title-font-family,var(--font-family-heading))] text-3xl leading-none font-medium text-[var(--not-found-title,hsl(var(--foreground)))] @xl:text-4xl @4xl:text-5xl">
           {title}
         </h1>
-        <p className="text-lg text-[var(--not-found-subtitle,hsl(var(--contrast-500)))]">
+        <p className="mb-4 text-lg text-[var(--not-found-subtitle,hsl(var(--contrast-500)))]">
           {subtitle}
         </p>
+        <Button onClick={handleOpenSearch}>Search</Button>
       </header>
     </SectionLayout>
   );


### PR DESCRIPTION
## What/Why?
In order to maintain parity with Stencil's 404 page, we wanted to allow the user to search from the 404 page. Since the search included with the header component is fully featured, we included a CTA to open the same search that you get when clicking the search icon in the header.

## Testing
* Pull down branch locally, navigate to `localhost:3000/foo`
* Check preview deployment: https://catalyst-canary-git-add-search-cta-to-404-bigcommerce-platform.vercel.app/foo/

## Migration
Most changes are additive, so they should hopefully be easy to resolve if flagged for merge conflicts. Change #3 below replaces the Search state with the new search context, be sure to pay attention to the new 
1. This change adds a new directory under `core/` called `context/` containing a `search-context.tsx` file. Since this is a new file, there shouldn't be any merge conflicts
2. `SearchProvider` is imported into `core/app/providers` and replaces the React fragment (`<>`) that currently wraps `<Toaster>` and `{children}`
3. In `core/vibes/soul/primitives/navigation`, replace `useState` with `useSearch` imported from the new context file, and update the dependency arrays for the `useEffect`'s in the `Navigation component`
4. Add search `Button` that calls `setIsSearchOpen(true)` to the `NotFound` component in `core/vibes/sections/not-found/index.tsx`
