### PR TITLE
fix(core): check for error.type for login auth error

### DIFF
--- a/.changeset/plenty-buttons-know.md
+++ b/.changeset/plenty-buttons-know.md
@@ -1,0 +1,9 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Remove `error.name` check for auth error in Login, since `error.name` gets minified in production and the check never returns `true`.
+
+Migration:
+
+- Remove `error.name === 'CallbackRouteError'` check in the error handling of the login action.

--- a/.changeset/plenty-buttons-know.md
+++ b/.changeset/plenty-buttons-know.md
@@ -2,8 +2,8 @@
 "@bigcommerce/catalyst-core": patch
 ---
 
-Remove `error.name` check for auth error in Login, since `error.name` gets minified in production and the check never returns `true`.
+Check for `error.type` instead of `error.name` auth error in Login, since `error.name` gets minified in production and the check never returns `true`. Additionally, add a check for the `cause.err` to be of type `BigcommerceGQLError`.
 
 Migration:
 
-- Remove `error.name === 'CallbackRouteError'` check in the error handling of the login action.
+- Change `error.name === 'CallbackRouteError'` to `error.type === 'CallbackRouteError'` check in the error handling of the login action and include `error.cause.err instanceof BigCommerceGQLError`.

--- a/core/app/[locale]/(default)/(auth)/login/_actions/login.ts
+++ b/core/app/[locale]/(default)/(auth)/login/_actions/login.ts
@@ -45,6 +45,7 @@ export const login = async (
 
     if (
       error instanceof AuthError &&
+      error.type === 'CallbackRouteError' &&
       error.cause &&
       error.cause.err?.message.includes('Invalid credentials')
     ) {

--- a/core/app/[locale]/(default)/(auth)/login/_actions/login.ts
+++ b/core/app/[locale]/(default)/(auth)/login/_actions/login.ts
@@ -45,7 +45,6 @@ export const login = async (
 
     if (
       error instanceof AuthError &&
-      error.name === 'CallbackRouteError' &&
       error.cause &&
       error.cause.err?.message.includes('Invalid credentials')
     ) {

--- a/core/app/[locale]/(default)/(auth)/login/_actions/login.ts
+++ b/core/app/[locale]/(default)/(auth)/login/_actions/login.ts
@@ -47,7 +47,8 @@ export const login = async (
       error instanceof AuthError &&
       error.type === 'CallbackRouteError' &&
       error.cause &&
-      error.cause.err?.message.includes('Invalid credentials')
+      error.cause.err instanceof BigCommerceGQLError &&
+      error.cause.err.message.includes('Invalid credentials')
     ) {
       return submission.reply({ formErrors: [t('invalidCredentials')] });
     }


### PR DESCRIPTION
## What/Why?
Check for `error.type` instead of `error.name` auth error in Login, since `error.name` gets minified in production and the check never returns `true`. Additionally, add a check for the `cause.err` to be of type `BigcommerceGQLError`.

## Testing
In production:
<img width="497" alt="Screenshot 2025-05-01 at 11 31 21 AM" src="https://github.com/user-attachments/assets/b048decd-c30a-4903-89a6-04f58b8d2040" />

## Migration
Change `error.name === 'CallbackRouteError'` to `error.type === 'CallbackRouteError'` check in the error handling of the login action and include `error.cause.err instanceof BigCommerceGQLError`.
