### PR TITLE
feat(core): use regex for image loader conditional

### DIFF
--- a/.changeset/long-bushes-hammer.md
+++ b/.changeset/long-bushes-hammer.md
@@ -1,0 +1,7 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Update the image loader conditional to allow subdomain matches for the cdn url.
+
+For example, setting `NEXT_PUBLIC_BIGCOMMERCE_CDN_HOSTNAME` to `store.test` will allow subomain to match, like `cdn.store.test`.

--- a/core/components/image/index.tsx
+++ b/core/components/image/index.tsx
@@ -7,10 +7,10 @@ import { buildConfig } from '~/build-config/reader';
 import bcCdnImageLoader from '~/lib/cdn-image-loader';
 
 function shouldUseLoaderProp(props: ImageProps): boolean {
-  return (
-    typeof props.src === 'string' &&
-    props.src.startsWith(`https://${buildConfig.get('urls').cdnUrl}`)
-  );
+  const domain = buildConfig.get('urls').cdnUrl.replace(/\./g, '\\.'); // Escape dots
+  const regex = new RegExp(`^https://([a-zA-Z0-9-]+\\.)*${domain}`); // Allows exact match or subdomains
+
+  return typeof props.src === 'string' && regex.test(props.src);
 }
 
 /**


### PR DESCRIPTION
## What/Why?
Changes image loader conditional to a regex that allows subdomains. This is needed to run Catalyst in a local environment that returns image urls with differing subdomains.

## Testing
In a local environment, I can set a domain in my env variables and allow different subdomains (for example, `cdn.store.dev` and `cluster.store.dev`).

## Migration
Update the image loader logic to use the new regex.
