### PR TITLE
feat(core): accept a list of CDNs for image loader

### DIFF
--- a/.changeset/dull-chairs-invite.md
+++ b/.changeset/dull-chairs-invite.md
@@ -1,0 +1,11 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Allow a list of CDN hostnames for cases when there can be more than one CDN available for image loader.
+
+Migration:
+
+- Update `build-config` schema to make `cndUrls` an array of strings.
+- Update `next.config.ts` to set `cdnUrls` as an array, and set multiple preconnected Link headers (one per CDN).
+- `shouldUseLoaderProp` function now reads from array.

--- a/core/build-config/schema.ts
+++ b/core/build-config/schema.ts
@@ -9,7 +9,7 @@ export const buildConfigSchema = z.object({
   ),
   urls: z.object({
     vanityUrl: z.string(),
-    cdnUrl: z.string().default('cdn11.bigcommerce.com'),
+    cdnUrls: z.array(z.string()).default(['cdn11.bigcommerce.com']),
     checkoutUrl: z.string(),
   }),
 });

--- a/core/components/image/index.tsx
+++ b/core/components/image/index.tsx
@@ -7,10 +7,11 @@ import { buildConfig } from '~/build-config/reader';
 import bcCdnImageLoader from '~/lib/cdn-image-loader';
 
 function shouldUseLoaderProp(props: ImageProps): boolean {
-  return (
-    typeof props.src === 'string' &&
-    props.src.startsWith(`https://${buildConfig.get('urls').cdnUrl}`)
-  );
+  if (typeof props.src !== 'string') return false;
+
+  const { src } = props;
+
+  return buildConfig.get('urls').cdnUrls.some((cdn) => src.startsWith(`https://${cdn}`));
 }
 
 /**


### PR DESCRIPTION
## What/Why?
Allow a list of CDN hostnames for cases when there can be more than one CDN available for image loader.

## Testing
Locally, I run two different CDNs and get no image loader errors.

## Migration
- Update `build-config` schema to make `cndUrls` an array of strings.
- Update `next.config.ts` to set `cdnUrls` as an array, and set multiple preconnected Link headers (one per CDN).
- `shouldUseLoaderProp` function now reads from array.
