### PR TITLE
feat(core): add date field to product details form

### DIFF
--- a/.changeset/whole-papers-scream.md
+++ b/.changeset/whole-papers-scream.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Add date field to product details form.

--- a/core/vibes/soul/sections/product-detail/product-detail-form.tsx
+++ b/core/vibes/soul/sections/product-detail/product-detail-form.tsx
@@ -18,6 +18,7 @@ import { z } from 'zod';
 import { ButtonRadioGroup } from '@/vibes/soul/form/button-radio-group';
 import { CardRadioGroup } from '@/vibes/soul/form/card-radio-group';
 import { Checkbox } from '@/vibes/soul/form/checkbox';
+import { DatePicker } from '@/vibes/soul/form/date-picker';
 import { FormStatus } from '@/vibes/soul/form/form-status';
 import { Input } from '@/vibes/soul/form/input';
 import { NumberInput } from '@/vibes/soul/form/number-input';
@@ -251,6 +252,21 @@ function FormField({
           onFocus={controls.focus}
           required={formField.required}
           value={controls.value ?? ''}
+        />
+      );
+
+    case 'date':
+      return (
+        <DatePicker
+          defaultValue={controls.value}
+          errors={formField.errors}
+          key={formField.id}
+          label={field.label}
+          name={formField.name}
+          onBlur={controls.blur}
+          onChange={(e) => handleChange(e.currentTarget.value)}
+          onFocus={controls.focus}
+          required={formField.required}
         />
       );
 


### PR DESCRIPTION
## What/Why?
Add `date` field to product details form.

## Testing
Locally, tested with default values or no default values.

## Migration
Add missing date field switch case to product details form.

<img width="532" alt="Screenshot 2025-05-07 at 2 41 42 PM" src="https://github.com/user-attachments/assets/6efd2798-66ee-4d13-b627-b2e1d724cbfc" />

