### PR TITLE
chore: expand node.js version required to run CLI

### DIFF
--- a/.changeset/pretty-coats-accept.md
+++ b/.changeset/pretty-coats-accept.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": minor
+---
+
+Expands the supported Node.js version of the `create-catalyst` CLI to `^20` and `^22`. The version of Node.js required to run the CLI is not necessarily tied to the version of Node.js required to run Catalyst; the CLI requires at least version 18 to run because it depends on global Fetch API support being enabled by default. More context in [#2296](https://github.com/bigcommerce/catalyst/pull/2296).

--- a/packages/create-catalyst/bin/index.cjs
+++ b/packages/create-catalyst/bin/index.cjs
@@ -2,12 +2,22 @@
 
 const semver = require('semver');
 
-const catalystRequiredNodeVersion = '^20';
+/**
+ * Discourage use of odd-numbered versions of Node.js
+ * @see https://nodejs.org/en/about/previous-releases#nodejs-releases
+ */
+const catalystRequiredNodeVersions = ['^20', '^22'];
 const userNodeVersion = process.version;
 
-if (!semver.satisfies(userNodeVersion, catalystRequiredNodeVersion)) {
+if (!catalystRequiredNodeVersions.some((version) => semver.satisfies(userNodeVersion, version))) {
+  const prettyRequiredNodeVersions = catalystRequiredNodeVersions
+    .map((version) => semver.coerce(version).major)
+    .join(', ');
+
   console.error(`\n\x1b[31mYou are using Node.js ${userNodeVersion}.`);
-  console.error(`Catalyst requires Node.js version ${catalystRequiredNodeVersion}.\x1b[0m\n`);
+  console.error(
+    `You must use one of the following Node.js versions: ${prettyRequiredNodeVersions}\x1b[0m\n`,
+  );
   process.exit(1);
 }
 


### PR DESCRIPTION
## What/Why?
* The Catalyst CLI is currently powered by the package `packages/create-catalyst`
* Before running the CLI, we check what version of Node.js you are running the CLI with
* **⚠️ This check is done only to ensure that the version of Node.js you using to run the CLI supports all of the native Node.js features that the CLI depends on**. It does not need to be concerned with what version of Node.js is required to run Catalyst, those are two separate things.
* The minimum required Node version for the CLI to function is 18, because that's when [global Fetch was enabled by default](https://nodejs.org/en/blog/announcements/v18-release-announce), and global Fetch is the most recently released feature that the CLI depends on.
* Therefore, as long as the user is running Node 18+, they should have no problem running the CLI. However, since Node.js 18 is EOL, we'll support 19+... finally, [since odd-numbered releases become supported after 6 months](https://nodejs.org/en/about/previous-releases#nodejs-releases), we'll discourage their use by explicitly requiring Node.js `^20` or `^22` to run the CLI.
* The CLI's version check does not necessarily need to match the version of Node.js required to run Catalyst, which is instead dictated by `.nvmrc`: https://github.com/bigcommerce/catalyst/blob/45bbd92fcb7aba476fb1ee97c1f13bcc30f8ba1e/.nvmrc#L1

So, it's totally valid for someone to have Node 20 installed by default on their machine, run the CLI successfully, and then to switch to Node.js 22 to run Catalyst once the CLI installation is complete.

In the past, we just tied the version the CLI requires to the version of Node.js required by Catalyst for convenience; we figured it would be more convenient to run the CLI with a Node.js version that you wouldn't have to upgrade a few steps later. So alternatively, if we don't want to set the CLI to require version `^20`/`^22`, we can require `^22` just like `.nvmrc`. 

## Testing
Manual:

https://github.com/user-attachments/assets/3d9b6c43-f638-4625-88f7-11a0963efd96

## Migration
No migration needed, as this is a package run from NPM directly.
