### PR TITLE
fix: memoize GetCartCountQuery with react cache

### DIFF
--- a/.changeset/fruity-dingos-sip.md
+++ b/.changeset/fruity-dingos-sip.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Memoize `GetCartCountQuery` using React.js `cache()` so that it only hits the GraphQL API once per render, instead of twice.

--- a/core/components/header/index.tsx
+++ b/core/components/header/index.tsx
@@ -31,7 +31,7 @@ const GetCartCountQuery = graphql(`
   }
 `);
 
-const getCartCount = async (cartId: string, customerAccessToken?: string) => {
+const getCartCount = cache(async (cartId: string, customerAccessToken?: string) => {
   const response = await client.fetch({
     document: GetCartCountQuery,
     variables: { cartId },
@@ -45,7 +45,7 @@ const getCartCount = async (cartId: string, customerAccessToken?: string) => {
   });
 
   return response.data.site.cart?.lineItems.totalQuantity ?? null;
-};
+});
 
 const getHeaderLinks = cache(async (customerAccessToken?: string) => {
   const { data: response } = await client.fetch({


### PR DESCRIPTION
## What/Why?
* As part of the low cache hit rate investigation, we found that `GetCartCountQuery` is sent twice per render when navigating not using client cache (e.g., pressing browser reload button, clicking a link to a page)
* This PR wraps it in React `cache()` to prevent the behavior
* ✅ The `cache()` function does not do anything to cache the fetch request in data cache or otherwise, the cache options are still set to `'no-store'`. 

## Testing
#### BEFORE:

https://github.com/user-attachments/assets/c359de4d-a6ba-4952-811c-32ec25119eac

#### AFTER:

https://github.com/user-attachments/assets/38a3a0e1-7944-44a2-ba8b-195bed7d5776

## Migration
Simply wrap `getCartCount` in `core/components/header/index.tsx` with React `cache()`
