### PR TITLE
chore: CATALYST-1117 remove outdated cli/monorepo guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,3 @@ Learn more about Catalyst at [catalyst.dev](https://catalyst.dev).
 - [GraphQL Storefront API Playground](https://developer.bigcommerce.com/graphql-storefront/playground)
 - [GraphQL Storefront API Explorer](https://developer.bigcommerce.com/graphql-storefront/explorer)
 - [BigCommerce DevDocs](https://developer.bigcommerce.com/docs/build)
-
-![-----------------------------------------------------](https://storage.googleapis.com/bigcommerce-developers/images/catalyst_readme_hr.png)
-
-> [!IMPORTANT]
-> If you just want to build a storefront, start with the [CLI](#quickstart) which will install the Next.js application in [/core](/core/).
-> If you wish to contribute back to Catalyst or create a fork of Catalyst, you can check the [docs for this monorepo](https://catalyst.dev/docs/monorepo) to get started.


### PR DESCRIPTION
> [!WARNING]
> This PR builds on #2305. Review by last commit on this branch

## What/Why?
- Removes the outdated guidance under `## Resources`. This guidance used to be relevant back when the CLI would install just the application inside of `core/`, however now the CLI installs the entire monorepo.

## Testing
N/A

## Migration
N/A