### PR TITLE
fix(core): translate home breadcrumb in contact us page

### DIFF
--- a/.changeset/cuddly-seals-exist.md
+++ b/.changeset/cuddly-seals-exist.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Translate home breadcrumb in Contact Us page.

--- a/core/app/[locale]/(default)/webpages/[id]/contact/page.tsx
+++ b/core/app/[locale]/(default)/webpages/[id]/contact/page.tsx
@@ -67,11 +67,13 @@ const getWebPage = cache(async (id: string): Promise<ContactPage> => {
 });
 
 async function getWebPageBreadcrumbs(id: string): Promise<Breadcrumb[]> {
+  const t = await getTranslations('WebPages.ContactUs');
+
   const webpage = await getWebPage(id);
   const [, ...rest] = webpage.breadcrumbs.reverse();
   const breadcrumbs = [
     {
-      label: 'Home',
+      label: t('home'),
       href: '/',
     },
     ...rest.reverse(),

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -385,6 +385,7 @@
       "home": "Home"
     },
     "ContactUs": {
+      "home": "Home",
       "Form": {
         "success": "Thanks for reaching out. We'll get back to you soon.",
         "successCta": "Continue shopping",


### PR DESCRIPTION
## What/Why?
Adds missing translation.

## Testing
Translated label shows up.

## Migration
Add missing translation.
