### PR TITLE
Add deepwiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 [![MIT License](https://img.shields.io/github/license/bigcommerce/catalyst)](LICENSE.md)
 [![Lighthouse Report](https://github.com/bigcommerce/catalyst/actions/workflows/lighthouse.yml/badge.svg)](https://github.com/bigcommerce/catalyst/actions/workflows/lighthouse.yml) [![Lint, Typecheck, gql.tada](https://github.com/bigcommerce/catalyst/actions/workflows/basic.yml/badge.svg)](https://github.com/bigcommerce/catalyst/actions/workflows/basic.yml)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/bigcommerce/catalyst)
 
 </div>
 


### PR DESCRIPTION
## What/Why?
We've seen a lot of value in DeepWiki for asking questions about Catalyst and getting some nice AI-generated documentation:

https://deepwiki.com/bigcommerce/catalyst

In support of this project, and also to get the benefit of the wiki refreshing weekly as we push new code, adding a badge to the README.

![image](https://github.com/user-attachments/assets/0a4ec8a1-e61b-4f5f-8265-9ee761685cda)


## Testing

![image](https://github.com/user-attachments/assets/02d571b2-973d-4a48-8839-91bc7d611402)

