### PR TITLE
Update readme for integrations/makeswift branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 
 </div>
 
+> **Note:** This is the `integrations/makeswift` branch of Catalyst, which includes an integration with Makeswift for visual editing. This is the version of Catalyst deployed by default by the One-Click Catalyst functionality in the BigCommerce control panel. If you wish to use a version of Catalyst without a pre-integrated visual editor, consider the code on the `canary` branch or refer to the [tags](https://github.com/bigcommerce/catalyst/tags) for the version that's best for you.
+
 **Catalyst** is the composable, fully customizable headless commerce framework for
 [BigCommerce](https://www.bigcommerce.com/). Catalyst is built with [Next.js](https://nextjs.org/), uses
 our [React](https://react.dev/) storefront components, and is backed by the

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-⚠️ **IMPORTANT:** As of January 6, 2025, the `main` branch is frozen. The default branch is now `canary`. Please make sure to work with and submit PRs to the `canary` branch.
-
-
 <a href="https://catalyst.dev" target="_blank" rel="noopener norerrer">
   <img src="https://storage.googleapis.com/bigcommerce-developers/images/catalyst_readme_banner.png" alt="Catalyst for Composable Commerce Image Banner" title="Catalyst">
 </a>
@@ -12,6 +9,7 @@
 
 [![MIT License](https://img.shields.io/github/license/bigcommerce/catalyst)](LICENSE.md)
 [![Lighthouse Report](https://github.com/bigcommerce/catalyst/actions/workflows/lighthouse.yml/badge.svg)](https://github.com/bigcommerce/catalyst/actions/workflows/lighthouse.yml) [![Lint, Typecheck, gql.tada](https://github.com/bigcommerce/catalyst/actions/workflows/basic.yml/badge.svg)](https://github.com/bigcommerce/catalyst/actions/workflows/basic.yml)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/bigcommerce/catalyst)
 
 </div>
 
@@ -39,45 +37,35 @@ times before. You can instead go straight to work building your brand and making
 
 ![-----------------------------------------------------](https://storage.googleapis.com/bigcommerce-developers/images/catalyst_readme_hr.png)
 
+## Deploy via One-Click Catalyst App
 
-## Deploy on Vercel
+The easiest way to deploy your Catalyst Storefront is to use the [One-Click Catalyst App](https://login.bigcommerce.com/deep-links/app/53284) available in the BigCommerce App Marketplace.
 
-The easiest way to deploy your Catalyst Storefront is to use the [Vercel Platform](https://vercel.com/new) from the creators of Next.js.
+Check out the [Catalyst.dev One-Click Catalyst Documentation](https://www.catalyst.dev/docs/getting-started) for more details.
 
-Check out the [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+## Getting Started
 
-<div align="left">
-  <a href="https://vercel.com/new/clone?repository-url=https://github.com/bigcommerce/catalyst&root-directory=core&project-name=my-catalyst-storefront&repository-name=my-catalyst-storefront&integration-ids=oac_nsrwzogJLEFglVwt2060kB0y&external-id=catalyst&demo-title=BigCommerce+Catalyst+with+Vercel&demo-description=Create+a+BigCommerce+Catalyst+Storefront+and+Deploy+to+Vercel&demo-url=catalyst-demo.site&demo-image=https://storage.googleapis.com/s.mkswft.com/RmlsZTozODgzZmY3Yy1hNmVlLTQ1MGUtYjRkMS1mMjEyNzgxNjk5MTY%3D/Social-image-Catalyst.png"><img src="https://vercel.com/button" alt="Deploy with Vercel"/></a>
-</div>
+**Requirements:**
 
-## Quickstart
+- A [BigCommerce account](https://www.bigcommerce.com/start-your-trial)
+- Node.js version 20 or 22
+- Corepack-enabled `pnpm`
 
-Create a new project interactively by running:
+  ```bash
+  corepack enable pnpm
+  ```
 
-```bash
-npm create @bigcommerce/catalyst@latest
-```
+1. Install the latest version of Catalyst:
 
-You'll then get the following prompts:
+   ```bash
+   pnpm create @bigcommerce/catalyst@latest
+   ```
 
-```console
-? What would you like to call your project?  my-faster-storefront
-? Which would you like?
-❯ Link Catalyst to a BigCommerce Store
-  Use sample data
+2. Run the local development server:
 
-? Would you like to create a new channel? y
-
-? What would you like to name the new channel? My Faster Storefront
-
-Success! Created 'my-faster-storefront' at '/Users/first.last/Documents/GitHub/my-faster-storefront'
-```
-
-Next steps:
-
-```bash
-cd my-faster-storefront && npm run dev
-```
+   ```bash
+   pnpm run dev
+   ```
 
 Learn more about Catalyst at [catalyst.dev](https://catalyst.dev).
 
@@ -87,9 +75,3 @@ Learn more about Catalyst at [catalyst.dev](https://catalyst.dev).
 - [GraphQL Storefront API Playground](https://developer.bigcommerce.com/graphql-storefront/playground)
 - [GraphQL Storefront API Explorer](https://developer.bigcommerce.com/graphql-storefront/explorer)
 - [BigCommerce DevDocs](https://developer.bigcommerce.com/docs/build)
-
-![-----------------------------------------------------](https://storage.googleapis.com/bigcommerce-developers/images/catalyst_readme_hr.png)
-
-> [!IMPORTANT]
-> If you just want to build a storefront, start with the [CLI](#quickstart) which will install the Next.js application in [/core](/core/).
-> If you wish to contribute back to Catalyst or create a fork of Catalyst, you can check the [docs for this monorepo](https://catalyst.dev/docs/monorepo) to get started.


### PR DESCRIPTION
## What/Why?
Two changes:
1. Sync the readme with `canary` for `integrations/makeswift`; somehow it had the readme from `main`.
2. Add a specific notice to this readme as to which version of Catalyst it's from

## Testing
N/A
