### PR TITLE
feat(core): update ProductListSection totalCount prop to string

### DIFF
--- a/.changeset/free-chicken-hammer.md
+++ b/.changeset/free-chicken-hammer.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Update ProductListSection's and ReviewsSection's `totalCount` prop to string.

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
@@ -147,7 +147,7 @@ export default async function Brand(props: Props) {
   const streamableTotalCount = Streamable.from(async () => {
     const search = await streamableFacetedSearch;
 
-    return search.products.collectionInfo?.totalItems ?? 0;
+    return String(search.products.collectionInfo?.totalItems ?? 0);
   });
 
   const streamablePagination = Streamable.from(async () => {

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -160,7 +160,7 @@ export default async function Category(props: Props) {
   const streamableTotalCount = Streamable.from(async () => {
     const search = await streamableFacetedSearch;
 
-    return search.products.collectionInfo?.totalItems ?? 0;
+    return String(search.products.collectionInfo?.totalItems ?? 0);
   });
 
   const streamablePagination = Streamable.from(async () => {

--- a/core/app/[locale]/(default)/(faceted)/search/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/search/page.tsx
@@ -141,12 +141,12 @@ export default async function Search(props: Props) {
     const searchTerm = typeof searchParams.term === 'string' ? searchParams.term : '';
 
     if (!searchTerm) {
-      return 0;
+      return '0';
     }
 
     const search = await streamableFacetedSearch;
 
-    return search.products.collectionInfo?.totalItems ?? 0;
+    return String(search.products.collectionInfo?.totalItems ?? 0);
   });
 
   const streamableEmptyStateTitle = Streamable.from(async () => {

--- a/core/vibes/soul/sections/products-list-section/index.tsx
+++ b/core/vibes/soul/sections/products-list-section/index.tsx
@@ -18,7 +18,7 @@ import {
 interface Props {
   breadcrumbs?: Streamable<Breadcrumb[]>;
   title?: Streamable<string | null>;
-  totalCount: Streamable<number>;
+  totalCount: Streamable<string>;
   products: Streamable<Product[]>;
   filters: Streamable<Filter[]>;
   sortOptions: Streamable<SortOption[]>;

--- a/core/vibes/soul/sections/reviews/index.tsx
+++ b/core/vibes/soul/sections/reviews/index.tsx
@@ -14,7 +14,7 @@ interface Review {
 interface Props {
   reviews: Streamable<Review[]>;
   averageRating: Streamable<number>;
-  totalCount?: Streamable<number>;
+  totalCount?: Streamable<string>;
   paginationInfo?: Streamable<CursorPaginationInfo>;
   nextLabel?: Streamable<string>;
   previousLabel?: Streamable<string>;


### PR DESCRIPTION
## What/Why?
Update ProductListSection's and ReviewsSection's `totalCount` prop to string.

## Testing
`totalCount` still displays count number.

## Migration
Since the prop has changed for these components, you need to update the type of the prop passed down to these sections.
