### PR TITLE
fix: button disabled and loading styles

### DIFF
--- a/core/vibes/soul/primitives/button/index.tsx
+++ b/core/vibes/soul/primitives/button/index.tsx
@@ -58,7 +58,7 @@ export function Button({
       {...props}
       aria-busy={loading}
       className={clsx(
-        'relative z-0 inline-flex h-fit cursor-pointer items-center justify-center overflow-hidden border text-center font-[family-name:var(--button-font-family,var(--font-family-body))] leading-normal font-semibold select-none after:absolute after:inset-0 after:-z-10 after:-translate-x-[105%] after:duration-300 after:[animation-timing-function:cubic-bezier(0,0.25,0,1)] focus-visible:ring-2 focus-visible:ring-[var(--button-focus,hsl(var(--primary)))] focus-visible:ring-offset-2 focus-visible:outline-hidden',
+        'relative z-0 inline-flex h-fit cursor-pointer items-center justify-center overflow-hidden border text-center font-[family-name:var(--button-font-family,var(--font-family-body))] leading-normal font-semibold select-none after:absolute after:inset-0 after:-z-10 after:-translate-x-[105%] after:duration-300 after:[animation-timing-function:cubic-bezier(0,0.25,0,1)] focus-visible:ring-2 focus-visible:ring-[var(--button-focus,hsl(var(--primary)))] focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-30',
         {
           primary:
             'border-[var(--button-primary-border,hsl(var(--primary)))] bg-[var(--button-primary-background,hsl(var(--primary)))] text-[var(--button-primary-text,hsl(var(--foreground)))] after:bg-[var(--button-primary-background-hover,color-mix(in_oklab,hsl(var(--primary)),white_75%))]',
@@ -78,10 +78,10 @@ export function Button({
           circle: 'rounded-full after:rounded-full',
         }[shape],
         !loading && !disabled && 'hover:after:translate-x-0',
-        disabled && 'cursor-not-allowed opacity-30',
+        loading && 'pointer-events-none',
         className,
       )}
-      disabled={disabled || loading}
+      disabled={disabled}
       type={type}
     >
       <span


### PR DESCRIPTION
## What/Why?
- removes previous styles where loading and disabled states had the same styles
- moves disabled styles into the default classes with the correct `disabled:` Tailwind syntax

## Testing

https://github.com/user-attachments/assets/d8022d46-f9dc-4ee2-a2b4-78212cef5ff0


