### PR TITLE
Customer Access Token was missing in the getRoute Request

### DIFF
--- a/.changeset/vast-cooks-kneel.md
+++ b/.changeset/vast-cooks-kneel.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+FIX missing support for routes permissions

--- a/core/middlewares/with-routes.ts
+++ b/core/middlewares/with-routes.ts
@@ -9,6 +9,7 @@ import { kvKey, STORE_STATUS_KEY } from '~/lib/kv/keys';
 import { kv } from '../lib/kv';
 
 import { type MiddlewareFactory } from './compose-middlewares';
+import {getSessionCustomerAccessToken} from "~/auth";
 
 const GetRouteQuery = graphql(`
   query GetRouteQuery($path: String!) {
@@ -61,10 +62,13 @@ const GetRouteQuery = graphql(`
 `);
 
 const getRoute = async (path: string, channelId?: string) => {
+  const customerAccessToken = await getSessionCustomerAccessToken();
+
   const response = await client.fetch({
     document: GetRouteQuery,
     variables: { path },
     fetchOptions: { next: { revalidate } },
+    customerAccessToken,
     channelId,
   });
 


### PR DESCRIPTION
## What/Why?
When requesting route information, Catalyst does not send the Customer Access Token. If - for example - a category were hidden from the user, they would still see it.

## Testing
- Create a customer group
- Assign a customer to it
- Mark a category as hidden for the customer group
- Browse the category as a user belonging to another group: You should see it
- Browse the category as the customer belonging to the group you created: You should not see it