### PR TITLE
feat(core): format totalCount value for i18n

### DIFF
--- a/.changeset/swift-geese-bake.md
+++ b/.changeset/swift-geese-bake.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Format totalCount value for i18n.

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
@@ -145,9 +145,10 @@ export default async function Brand(props: Props) {
   });
 
   const streamableTotalCount = Streamable.from(async () => {
+    const format = await getFormatter();
     const search = await streamableFacetedSearch;
 
-    return String(search.products.collectionInfo?.totalItems ?? 0);
+    return format.number(search.products.collectionInfo?.totalItems ?? 0);
   });
 
   const streamablePagination = Streamable.from(async () => {

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -158,9 +158,10 @@ export default async function Category(props: Props) {
   });
 
   const streamableTotalCount = Streamable.from(async () => {
+    const format = await getFormatter();
     const search = await streamableFacetedSearch;
 
-    return String(search.products.collectionInfo?.totalItems ?? 0);
+    return format.number(search.products.collectionInfo?.totalItems ?? 0);
   });
 
   const streamablePagination = Streamable.from(async () => {

--- a/core/app/[locale]/(default)/(faceted)/search/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/search/page.tsx
@@ -137,16 +137,17 @@ export default async function Search(props: Props) {
   });
 
   const streamableTotalCount = Streamable.from(async () => {
+    const format = await getFormatter();
     const searchParams = await props.searchParams;
     const searchTerm = typeof searchParams.term === 'string' ? searchParams.term : '';
 
     if (!searchTerm) {
-      return '0';
+      return format.number(0);
     }
 
     const search = await streamableFacetedSearch;
 
-    return String(search.products.collectionInfo?.totalItems ?? 0);
+    return format.number(search.products.collectionInfo?.totalItems ?? 0);
   });
 
   const streamableEmptyStateTitle = Streamable.from(async () => {


### PR DESCRIPTION
## What/Why?
Now that `totalCount` accepts strings, format the number to account for i18n.

## Testing
Number is formatted.

## Migration
Use `getFormatter` to `format.number` the values passed to the section component.
