### PR TITLE
Set minimum address count to 0

### DIFF
--- a/.changeset/silver-spiders-sing.md
+++ b/.changeset/silver-spiders-sing.md
@@ -1,0 +1,30 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Fix issue where delete button is not displayed if you have only 1 address
+
+## Migration steps:
+
+Update `/core/app/[locale]/(default)/account/addresses/page.tsx` and pass the `minimumAddressCount={0}` prop to the AddressListSection component.
+
+Example:
+
+```tsx
+return (
+  <AddressListSection
+    addressAction={addressAction}
+    addresses={addresses}
+    cancelLabel={t('cancel')}
+    createLabel={t('create')}
+    deleteLabel={t('delete')}
+    editLabel={t('edit')}
+    fields={[...fields, { name: 'id', type: 'hidden', label: 'ID' }]}
+    minimumAddressCount={0}
+    setDefaultLabel={t('setDefault')}
+    showAddFormLabel={t('cta')}
+    title={t('title')}
+    updateLabel={t('update')}
+  />
+);
+```

--- a/core/app/[locale]/(default)/account/addresses/page.tsx
+++ b/core/app/[locale]/(default)/account/addresses/page.tsx
@@ -111,6 +111,7 @@ export default async function Addresses({ params, searchParams }: Props) {
       deleteLabel={t('delete')}
       editLabel={t('edit')}
       fields={[...fields, { name: 'id', type: 'hidden', label: 'ID' }]}
+      minimumAddressCount={0}
       setDefaultLabel={t('setDefault')}
       showAddFormLabel={t('cta')}
       title={t('title')}


### PR DESCRIPTION
## What/Why?
Pass `minimumAddressCount={0}` to the AddressListSection component.

We should allow customers to delete addresses even if it is their last one.

## Testing
Tested locally

## Migration

Update `/core/app/[locale]/(default)/account/addresses/page.tsx` and pass the `minimumAddressCount={0}` prop to the AddressListSection component.

Example:

```tsx
return (
  <AddressListSection
    addressAction={addressAction}
    addresses={addresses}
    cancelLabel={t('cancel')}
    createLabel={t('create')}
    deleteLabel={t('delete')}
    editLabel={t('edit')}
    fields={[...fields, { name: 'id', type: 'hidden', label: 'ID' }]}
    minimumAddressCount={0}
    setDefaultLabel={t('setDefault')}
    showAddFormLabel={t('cta')}
    title={t('title')}
    updateLabel={t('update')}
  />
);
```

