### PR TITLE
chore(eslint): add eslint rule for expect and test imports

### DIFF
--- a/.changeset/wicked-dingos-doubt.md
+++ b/.changeset/wicked-dingos-doubt.md
@@ -1,0 +1,16 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Adds an eslint rule to import expect and test from ~/tests/fixtures instead of the @playwright/test module. This is to create a more consistent testing experience across the codebase.
+
+### Migration
+
+Any import statements that import `expect` and `test` from `@playwright/test` should be updated to import from `~/tests/fixtures` instead. All other imports from `@playwright/test` should remain unchanged.
+
+```diff
+-import { expect, type Page, test } from '@playwright/test';
++import { type Page } from '@playwright/test';
++
++import { expect, test } from '~/tests/fixtures';
+```

--- a/core/.eslintrc.cjs
+++ b/core/.eslintrc.cjs
@@ -47,6 +47,11 @@ const config = {
             importNames: ['redirect', 'permanentRedirect', 'useRouter', 'usePathname'],
             message: 'Please import from `~/i18n/routing` instead.',
           },
+          {
+            name: '@playwright/test',
+            importNames: ['expect', 'test'],
+            message: 'Please import from `~/tests/fixtures` instead.',
+          },
         ],
       },
     ],

--- a/core/tests/fixtures/index.ts
+++ b/core/tests/fixtures/index.ts
@@ -1,3 +1,5 @@
+// Disabling the rule as this should be the only place where we import test and expect from Playwright
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { expect as baseExpect, test as baseTest } from '@playwright/test';
 import { validate as isUuid } from 'uuid';
 
@@ -52,5 +54,3 @@ export const expect = baseExpect.extend({
     };
   },
 });
-
-export { type Page } from '@playwright/test';

--- a/core/tests/ui/e2e/addresses.spec.ts
+++ b/core/tests/ui/e2e/addresses.spec.ts
@@ -1,6 +1,7 @@
 import { faker } from '@faker-js/faker';
+import { type Page } from '@playwright/test';
 
-import { expect, type Page, test } from '~/tests/fixtures';
+import { expect, test } from '~/tests/fixtures';
 
 const streetAddress: string = faker.location.streetAddress();
 const state: string = faker.location.state();

--- a/core/tests/ui/e2e/checkout.spec.ts
+++ b/core/tests/ui/e2e/checkout.spec.ts
@@ -1,6 +1,7 @@
 import { faker } from '@faker-js/faker';
+import { type Page } from '@playwright/test';
 
-import { expect, Page, test } from '~/tests/fixtures';
+import { expect, test } from '~/tests/fixtures';
 
 const firstName = faker.person.firstName();
 const lastName = faker.person.lastName();

--- a/core/tests/ui/e2e/product.spec.ts
+++ b/core/tests/ui/e2e/product.spec.ts
@@ -1,4 +1,6 @@
-import { expect, Page, test } from '~/tests/fixtures';
+import { type Page } from '@playwright/test';
+
+import { expect, test } from '~/tests/fixtures';
 
 async function selectProductForComparison(page: Page, name: string) {
   const productInformation = page.getByRole('heading', { name }).locator('..');

--- a/core/tests/ui/e2e/shipping.spec.ts
+++ b/core/tests/ui/e2e/shipping.spec.ts
@@ -1,4 +1,6 @@
-import { expect, Page, test } from '~/tests/fixtures';
+import { type Page } from '@playwright/test';
+
+import { expect, test } from '~/tests/fixtures';
 
 async function addEstimatedShippingCosts(
   page: Page,

--- a/core/tests/visual-regression/components/accordion.spec.ts
+++ b/core/tests/visual-regression/components/accordion.spec.ts
@@ -1,5 +1,4 @@
-import { expect, test } from '@playwright/test';
-
+import { expect, test } from '~/tests/fixtures';
 import routes from '~/tests/routes';
 
 test('accordion expanded', async ({ page }) => {

--- a/core/tests/visual-regression/components/badge.spec.ts
+++ b/core/tests/visual-regression/components/badge.spec.ts
@@ -1,5 +1,4 @@
-import { expect, test } from '@playwright/test';
-
+import { expect, test } from '~/tests/fixtures';
 import routes from '~/tests/routes';
 
 test('badge with icon', async ({ page }) => {

--- a/core/tests/visual-regression/components/blog-post-card.spec.ts
+++ b/core/tests/visual-regression/components/blog-post-card.spec.ts
@@ -1,5 +1,4 @@
-import { expect, test } from '@playwright/test';
-
+import { expect, test } from '~/tests/fixtures';
 import routes from '~/tests/routes';
 
 test('blog post card', async ({ page }) => {

--- a/core/tests/visual-regression/components/breadcrumbs.spec.ts
+++ b/core/tests/visual-regression/components/breadcrumbs.spec.ts
@@ -1,5 +1,4 @@
-import { expect, test } from '@playwright/test';
-
+import { expect, test } from '~/tests/fixtures';
 import routes from '~/tests/routes';
 
 test('breadcrumbs', async ({ page }) => {

--- a/core/tests/visual-regression/components/button.spec.ts
+++ b/core/tests/visual-regression/components/button.spec.ts
@@ -1,5 +1,4 @@
-import { expect, test } from '@playwright/test';
-
+import { expect, test } from '~/tests/fixtures';
 import routes from '~/tests/routes';
 
 test('Primary button', async ({ page }) => {

--- a/core/tests/visual-regression/components/carousel.spec.ts
+++ b/core/tests/visual-regression/components/carousel.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from '~/tests/fixtures';
 
 test('Carousel', async ({ page }) => {
   // Arrange

--- a/core/tests/visual-regression/components/checkbox.spec.ts
+++ b/core/tests/visual-regression/components/checkbox.spec.ts
@@ -1,5 +1,4 @@
-import { expect, test } from '@playwright/test';
-
+import { expect, test } from '~/tests/fixtures';
 import routes from '~/tests/routes';
 
 test('Checked checkbox with label', async ({ page }) => {

--- a/core/tests/visual-regression/components/counter.spec.ts
+++ b/core/tests/visual-regression/components/counter.spec.ts
@@ -1,5 +1,4 @@
-import { expect, test } from '@playwright/test';
-
+import { expect, test } from '~/tests/fixtures';
 import routes from '~/tests/routes';
 
 test('Counter default', async ({ page }) => {

--- a/core/tests/visual-regression/components/datepicker.spec.ts
+++ b/core/tests/visual-regression/components/datepicker.spec.ts
@@ -1,5 +1,4 @@
-import { expect, test } from '@playwright/test';
-
+import { expect, test } from '~/tests/fixtures';
 import routes from '~/tests/routes';
 
 test('Date picker', async ({ page }) => {

--- a/core/tests/visual-regression/components/footer.spec.ts
+++ b/core/tests/visual-regression/components/footer.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from '~/tests/fixtures';
 
 test('Footer', async ({ page }) => {
   // Arrange

--- a/core/tests/visual-regression/components/form.spec.ts
+++ b/core/tests/visual-regression/components/form.spec.ts
@@ -1,5 +1,4 @@
-import { expect, test } from '@playwright/test';
-
+import { expect, test } from '~/tests/fixtures';
 import routes from '~/tests/routes';
 
 test('Form', async ({ page }) => {

--- a/core/tests/visual-regression/components/gallery.spec.ts
+++ b/core/tests/visual-regression/components/gallery.spec.ts
@@ -1,5 +1,4 @@
-import { expect, test } from '@playwright/test';
-
+import { expect, test } from '~/tests/fixtures';
 import routes from '~/tests/routes';
 
 test('Gallery image', async ({ page }) => {

--- a/core/tests/visual-regression/components/header.spec.ts
+++ b/core/tests/visual-regression/components/header.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from '~/tests/fixtures';
 
 test('Header', async ({ page }) => {
   // Arrange

--- a/core/tests/visual-regression/components/input.spec.ts
+++ b/core/tests/visual-regression/components/input.spec.ts
@@ -1,5 +1,4 @@
-import { expect, test } from '@playwright/test';
-
+import { expect, test } from '~/tests/fixtures';
 import routes from '~/tests/routes';
 
 test('Input with placeholder', async ({ page }) => {

--- a/core/tests/visual-regression/components/label.spec.ts
+++ b/core/tests/visual-regression/components/label.spec.ts
@@ -1,5 +1,4 @@
-import { expect, test } from '@playwright/test';
-
+import { expect, test } from '~/tests/fixtures';
 import routes from '~/tests/routes';
 
 test('Label with input', async ({ page }) => {

--- a/core/tests/visual-regression/components/picklist.spec.ts
+++ b/core/tests/visual-regression/components/picklist.spec.ts
@@ -1,5 +1,4 @@
-import { expect, test } from '@playwright/test';
-
+import { expect, test } from '~/tests/fixtures';
 import routes from '~/tests/routes';
 
 test('Pick list', async ({ page }) => {

--- a/core/tests/visual-regression/components/radio-group.spec.ts
+++ b/core/tests/visual-regression/components/radio-group.spec.ts
@@ -1,5 +1,4 @@
-import { expect, test } from '@playwright/test';
-
+import { expect, test } from '~/tests/fixtures';
 import routes from '~/tests/routes';
 
 test('Default radio group', async ({ page }) => {

--- a/core/tests/visual-regression/components/rating.spec.ts
+++ b/core/tests/visual-regression/components/rating.spec.ts
@@ -1,5 +1,4 @@
-import { expect, test } from '@playwright/test';
-
+import { expect, test } from '~/tests/fixtures';
 import routes from '~/tests/routes';
 
 test('Zero star rating', async ({ page }) => {

--- a/core/tests/visual-regression/components/rectangle-list.spec.ts
+++ b/core/tests/visual-regression/components/rectangle-list.spec.ts
@@ -1,5 +1,4 @@
-import { expect, test } from '@playwright/test';
-
+import { expect, test } from '~/tests/fixtures';
 import routes from '~/tests/routes';
 
 test('Rectangle list', async ({ page }) => {

--- a/core/tests/visual-regression/components/select.spec.ts
+++ b/core/tests/visual-regression/components/select.spec.ts
@@ -1,5 +1,4 @@
-import { expect, test } from '@playwright/test';
-
+import { expect, test } from '~/tests/fixtures';
 import routes from '~/tests/routes';
 
 test('Select default', async ({ page }) => {

--- a/core/tests/visual-regression/components/slideshow.spec.ts
+++ b/core/tests/visual-regression/components/slideshow.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from '~/tests/fixtures';
 
 test('Slideshow multiple slides', async ({ page }) => {
   // Arrange

--- a/core/tests/visual-regression/components/swatch.spec.ts
+++ b/core/tests/visual-regression/components/swatch.spec.ts
@@ -1,5 +1,4 @@
-import { expect, test } from '@playwright/test';
-
+import { expect, test } from '~/tests/fixtures';
 import routes from '~/tests/routes';
 
 test('Swatch basic', async ({ page }) => {

--- a/core/tests/visual-regression/components/tags.spec.ts
+++ b/core/tests/visual-regression/components/tags.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from '~/tests/fixtures';
 
 test('Tags', async ({ page }) => {
   await page.goto('/shop-all/?brand=37');

--- a/core/tests/visual-regression/components/textarea.spec.ts
+++ b/core/tests/visual-regression/components/textarea.spec.ts
@@ -1,5 +1,4 @@
-import { expect, test } from '@playwright/test';
-
+import { expect, test } from '~/tests/fixtures';
 import routes from '~/tests/routes';
 
 test('Textarea basic', async ({ page }) => {


### PR DESCRIPTION
## What/Why?
Adds an eslint rule to import from the fixtures instead of the `@playwright/test` library.

## Testing
See CI.

## Migration

Any import statements that import `expect` and `test` from `@playwright/test` should be updated to import from `~/tests/fixtures` instead. All other imports from `@playwright/test` should remain unchanged.

```diff
-import { expect, type Page, test } from '@playwright/test';
+import { type Page } from '@playwright/test';
+
+import { expect, test } from '~/tests/fixtures';
```
