### PR TITLE
Fix incorrect/missing translation messages, separate defaultLocale in to a separate file, remove caching in /account pages

### DIFF
--- a/.changeset/shiny-cooks-travel.md
+++ b/.changeset/shiny-cooks-travel.md
@@ -1,0 +1,18 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+- Fix incorrect/missing translation messages
+- Separate defaultLocale in to a separate file
+- Remove caching in `/account` pages
+- Update `WishlistListItem` for better accessibility
+
+## Migration
+
+Use this PR as a reference: https://github.com/bigcommerce/catalyst/pull/2341
+
+1. Update your `messages/en.json` file with the translation keys added in this PR
+2. Ensure that all components are being passed the correct translation keys
+3. Update all references to `defaultLocale` to point to the `~/i18n/locales` file created in this PR
+4. Update all pages in `/core/app/[locale]/(default)/account/` and ensure that `cache: 'no-store'` is set on the `client.fetch` calls
+5. Update the `WishlistListItem` component to use the new accessibility features/tags as shown in the PR

--- a/core/app/[locale]/(default)/(auth)/login/page.tsx
+++ b/core/app/[locale]/(default)/(auth)/login/page.tsx
@@ -43,8 +43,10 @@ export default async function Login({ params, searchParams }: Props) {
       <ForceRefresh />
       <SignInSection
         action={login.bind(null, { redirectTo: redirectTarget })}
+        emailLabel={t('email')}
         forgotPasswordHref="/login/forgot-password"
         forgotPasswordLabel={t('forgotPassword')}
+        passwordLabel={t('password')}
         submitLabel={t('cta')}
         title={t('heading')}
       >

--- a/core/app/[locale]/(default)/account/orders/page.tsx
+++ b/core/app/[locale]/(default)/account/orders/page.tsx
@@ -50,6 +50,8 @@ export default async function Orders({ params, searchParams }: Props) {
 
   return (
     <OrderList
+      emptyStateActionLabel={t('emptyState.cta')}
+      emptyStateTitle={t('emptyState.title')}
       orderNumberLabel={t('orderNumber')}
       orders={getOrders(after, before)}
       paginationInfo={getPaginationInfo(after, before)}

--- a/core/app/[locale]/(default)/account/settings/_actions/update-customer.ts
+++ b/core/app/[locale]/(default)/account/settings/_actions/update-customer.ts
@@ -79,7 +79,7 @@ export const updateCustomer: UpdateAccountAction = async (prevState, formData) =
 
     return {
       account: submission.value,
-      successMessage: t('passwordUpdated'),
+      successMessage: t('settingsUpdated'),
       lastResult: submission.reply(),
     };
   } catch (error) {

--- a/core/app/[locale]/(default)/account/wishlists/[id]/_components/wishlist-actions.tsx
+++ b/core/app/[locale]/(default)/account/wishlists/[id]/_components/wishlist-actions.tsx
@@ -16,6 +16,7 @@ interface Props {
   isMobileUser: Streamable<boolean>;
   shareLabel: string;
   shareCloseLabel: string;
+  shareCopyLabel: string;
   shareModalTitle: string;
   shareSuccessMessage: string;
   shareCopiedMessage: string;
@@ -28,6 +29,7 @@ export const WishlistActions = ({
   isMobileUser,
   shareLabel,
   shareCloseLabel,
+  shareCopyLabel,
   shareModalTitle,
   shareSuccessMessage,
   shareCopiedMessage,
@@ -47,6 +49,7 @@ export const WishlistActions = ({
             <WishlistShareButton
               closeLabel={shareCloseLabel}
               copiedMessage={shareCopiedMessage}
+              copyLabel={shareCopyLabel}
               disabledTooltip={shareDisabledTooltip}
               isMobileUser={isMobileUser}
               isPublic={wishlist.visibility.isPublic}

--- a/core/app/[locale]/(default)/account/wishlists/[id]/page-data.ts
+++ b/core/app/[locale]/(default)/account/wishlists/[id]/page-data.ts
@@ -3,7 +3,6 @@ import { cache } from 'react';
 import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
-import { revalidate } from '~/client/revalidate-target';
 import { TAGS } from '~/client/tags';
 import { WishlistPaginatedItemsFragment } from '~/components/wishlist/fragment';
 import { getPreferredCurrencyCode } from '~/lib/currency';
@@ -47,7 +46,7 @@ export const getCustomerWishlist = cache(async (entityId: number, pagination: Pa
     document: WishlistDetailsQuery,
     variables: { ...paginationArgs, currencyCode, entityId },
     customerAccessToken,
-    fetchOptions: { next: { revalidate, tags: [TAGS.customer] } },
+    fetchOptions: { cache: 'no-store', next: { tags: [TAGS.customer] } },
   });
 
   const wishlist = response.data.customer?.wishlists.edges?.[0]?.node;

--- a/core/app/[locale]/(default)/account/wishlists/[id]/page.tsx
+++ b/core/app/[locale]/(default)/account/wishlists/[id]/page.tsx
@@ -114,6 +114,7 @@ export default async function WishlistPage({ params, searchParams }: Props) {
         ]}
         shareCloseLabel={t('Modal.close')}
         shareCopiedMessage={t('shareCopied')}
+        shareCopyLabel={t('Modal.copy')}
         shareDisabledTooltip={t('shareDisabled')}
         shareLabel={t('share')}
         shareModalTitle={t('Modal.shareTitle', { name: wishlist.name })}

--- a/core/app/[locale]/(default)/account/wishlists/_components/wishlist-actions-menu.tsx
+++ b/core/app/[locale]/(default)/account/wishlists/_components/wishlist-actions-menu.tsx
@@ -37,18 +37,19 @@ interface WishlistMenuAction extends WishlistActionBase {
 export type WishlistAction = WishlistModalAction | WishlistMenuAction;
 
 interface Props {
+  actionsTitle?: string;
   share?: {
     wishlistName: string;
     label: string;
     publicUrl: string;
     modalTitle: string;
-    modalCloseLabel: string;
     copiedMessage: string;
     isMobileUser: boolean;
     isPublic: boolean;
     successMessage: string;
     disabledTooltip: string;
     closeLabel: string;
+    copyLabel: string;
   };
   items: WishlistAction[];
 }
@@ -84,13 +85,19 @@ function getShareMenuItemProps(
     label: share.label,
     disabled: !share.isPublic,
     key,
-    modal: getShareWishlistModal(share.modalTitle, share.modalCloseLabel, share.publicUrl, () => {
-      void copyToClipboard(share.publicUrl);
-    }),
+    modal: getShareWishlistModal(
+      share.modalTitle,
+      share.copyLabel,
+      share.closeLabel,
+      share.publicUrl,
+      () => {
+        void copyToClipboard(share.publicUrl);
+      },
+    ),
   };
 }
 
-export const WishlistActionsMenu = ({ items, share }: Props) => {
+export const WishlistActionsMenu = ({ actionsTitle, items, share }: Props) => {
   const [state, dispatch] = useReducer(reducer, {});
   const shareModalKey = 'share-dropdown-modal';
   const getShareUrl = (publicUrl: string) => String(new URL(publicUrl, window.location.origin));
@@ -149,7 +156,9 @@ export const WishlistActionsMenu = ({ items, share }: Props) => {
           size="small"
           variant="tertiary"
         >
-          <EllipsisIcon size={20} />
+          <EllipsisIcon size={20}>
+            <title>{actionsTitle}</title>
+          </EllipsisIcon>
         </Button>
       </DropdownMenu>
       {modals.map(({ key, modal: { formAction: action, ...modalProps } }) => (

--- a/core/app/[locale]/(default)/account/wishlists/modals.tsx
+++ b/core/app/[locale]/(default)/account/wishlists/modals.tsx
@@ -94,6 +94,7 @@ export const getChangeWishlistVisibilityModal = (
 
 export const getShareWishlistModal = (
   title: string,
+  copyLabel: string,
   closeLabel: string,
   publicUrl: string,
   action: () => void | Promise<void>,
@@ -102,7 +103,7 @@ export const getShareWishlistModal = (
   title,
   buttons: [
     { type: 'cancel', label: closeLabel },
-    { label: 'Copy', variant: 'primary', action },
+    { label: copyLabel, variant: 'primary', action },
   ],
 });
 

--- a/core/app/[locale]/(default)/account/wishlists/page-data.ts
+++ b/core/app/[locale]/(default)/account/wishlists/page-data.ts
@@ -3,7 +3,6 @@ import { cache } from 'react';
 import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
-import { revalidate } from '~/client/revalidate-target';
 import { TAGS } from '~/client/tags';
 import { WishlistsFragment } from '~/components/wishlist/fragment';
 import { getPreferredCurrencyCode } from '~/lib/currency';
@@ -42,7 +41,7 @@ export const getCustomerWishlists = cache(async ({ limit = 9, before, after }: P
     document: WishlistsPageQuery,
     variables: { ...paginationArgs, currencyCode },
     customerAccessToken,
-    fetchOptions: { next: { revalidate, tags: [TAGS.customer] } },
+    fetchOptions: { cache: 'no-store', next: { tags: [TAGS.customer] } },
   });
 
   const wishlists = response.data.customer?.wishlists;

--- a/core/app/[locale]/(default)/account/wishlists/page.tsx
+++ b/core/app/[locale]/(default)/account/wishlists/page.tsx
@@ -85,6 +85,7 @@ export default async function Wishlists({ params, searchParams }: Props) {
 
           return (
             <WishlistActionsMenu
+              actionsTitle={t('actionsTitle')}
               items={[
                 {
                   label: t('rename'),
@@ -107,12 +108,12 @@ export default async function Wishlists({ params, searchParams }: Props) {
                       modalTitle: t('Modal.shareTitle', { name: wishlist.name }),
                       publicUrl: wishlist.publicUrl,
                       closeLabel: t('Modal.close'),
+                      copyLabel: t('Modal.copy'),
                       copiedMessage: t('shareCopied'),
                       disabledTooltip: t('shareDisabled'),
                       label: t('share'),
                       successMessage: t('shareSuccess'),
                       isPublic: wishlist.visibility.isPublic,
-                      modalCloseLabel: t('Modal.close'),
                       isMobileUser: isMobile,
                     }
                   : undefined

--- a/core/app/[locale]/(default)/wishlist/[token]/page.tsx
+++ b/core/app/[locale]/(default)/wishlist/[token]/page.tsx
@@ -141,6 +141,7 @@ export default async function PublicWishlist({ params, searchParams }: Props) {
         <WishlistShareButton
           closeLabel={t('Modal.close')}
           copiedMessage={t('shareCopied')}
+          copyLabel={t('Modal.copy')}
           disabledTooltip={t('shareDisabled')}
           isMobileUser={Streamable.from(isMobileUser)}
           isPublic={wishlist.visibility.isPublic}

--- a/core/app/admin/route.ts
+++ b/core/app/admin/route.ts
@@ -1,4 +1,5 @@
-import { defaultLocale, redirect } from '~/i18n/routing';
+import { defaultLocale } from '~/i18n/locales';
+import { redirect } from '~/i18n/routing';
 
 const canonicalDomain: string = process.env.BIGCOMMERCE_GRAPHQL_API_DOMAIN ?? 'mybigcommerce.com';
 const BIGCOMMERCE_STORE_HASH = process.env.BIGCOMMERCE_STORE_HASH;

--- a/core/app/favicon.ico/route.ts
+++ b/core/app/favicon.ico/route.ts
@@ -12,7 +12,7 @@
 import { getChannelIdFromLocale } from '~/channels.config';
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
-import { defaultLocale } from '~/i18n/routing';
+import { defaultLocale } from '~/i18n/locales';
 
 const GetFaviconQuery = graphql(`
   query GetFaviconQuery {

--- a/core/app/robots.txt/route.ts
+++ b/core/app/robots.txt/route.ts
@@ -13,7 +13,7 @@
 import { getChannelIdFromLocale } from '~/channels.config';
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
-import { defaultLocale } from '~/i18n/routing';
+import { defaultLocale } from '~/i18n/locales';
 
 const RobotsTxtQuery = graphql(`
   query RobotsTxtQuery {

--- a/core/app/sitemap.xml/route.ts
+++ b/core/app/sitemap.xml/route.ts
@@ -5,7 +5,7 @@
 
 import { getChannelIdFromLocale } from '~/channels.config';
 import { client } from '~/client';
-import { defaultLocale } from '~/i18n/routing';
+import { defaultLocale } from '~/i18n/locales';
 
 export const GET = async () => {
   const sitemapIndex = await client.fetchSitemapIndex(getChannelIdFromLocale(defaultLocale));

--- a/core/app/xmlsitemap.php/route.ts
+++ b/core/app/xmlsitemap.php/route.ts
@@ -1,5 +1,6 @@
 /* eslint-disable check-file/folder-naming-convention */
-import { defaultLocale, permanentRedirect } from '~/i18n/routing';
+import { defaultLocale } from '~/i18n/locales';
+import { permanentRedirect } from '~/i18n/routing';
 
 /*
  * This route is used to redirect the legacy Stencil sitemap that lives on /xmlsitemap.php

--- a/core/components/wishlist/share-button.tsx
+++ b/core/components/wishlist/share-button.tsx
@@ -25,6 +25,7 @@ interface Props {
   copiedMessage: string;
   disabledTooltip: string;
   closeLabel: string;
+  copyLabel: string;
   size?: ButtonProps['size'];
 }
 
@@ -39,6 +40,7 @@ export const WishlistShareButton = ({
   copiedMessage,
   disabledTooltip,
   closeLabel,
+  copyLabel,
   size = 'small',
 }: Props) => {
   const [open, setOpen] = useState(false);
@@ -100,7 +102,13 @@ export const WishlistShareButton = ({
               isOpen={open}
               setOpen={setOpen}
               trigger={ShareButton}
-              {...getShareWishlistModal(modalTitle, closeLabel, publicUrl, copyToClipboard)}
+              {...getShareWishlistModal(
+                modalTitle,
+                copyLabel,
+                closeLabel,
+                publicUrl,
+                copyToClipboard,
+              )}
             >
               <ShareWishlistModal publicUrl={publicUrl} />
             </Modal>

--- a/core/i18n/locales.ts
+++ b/core/i18n/locales.ts
@@ -1,0 +1,6 @@
+import { buildConfig } from '~/build-config/reader';
+
+const localeNodes = buildConfig.get('locales');
+
+export const locales = localeNodes.map((locale) => locale.code);
+export const defaultLocale = localeNodes.find((locale) => locale.isDefault)?.code ?? 'en';

--- a/core/i18n/request.ts
+++ b/core/i18n/request.ts
@@ -2,7 +2,7 @@ import deepmerge from 'deepmerge';
 import { notFound } from 'next/navigation';
 import { getRequestConfig } from 'next-intl/server';
 
-import { locales } from './routing';
+import { locales } from './locales';
 
 // The language to fall back to if the requested message string is not available.
 const fallbackLocale = 'en';

--- a/core/i18n/routing.ts
+++ b/core/i18n/routing.ts
@@ -1,12 +1,7 @@
 import { createNavigation } from 'next-intl/navigation';
 import { defineRouting } from 'next-intl/routing';
 
-import { buildConfig } from '~/build-config/reader';
-
-const localeNodes = buildConfig.get('locales');
-
-export const locales = localeNodes.map((locale) => locale.code);
-export const defaultLocale = localeNodes.find((locale) => locale.isDefault)?.code ?? 'en';
+import { defaultLocale, locales } from './locales';
 
 interface LocaleEntry {
   id: string;

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -50,6 +50,8 @@
       "heading": "Log in",
       "forgotPassword": "Forgot your password?",
       "cta": "Log in",
+      "email": "Email",
+      "password": "Password",
       "invalidCredentials": "Your email address or password is incorrect. Try signing in again or reset your password",
       "somethingWentWrong": "Something went wrong. Please try again later.",
       "CreateAccount": {
@@ -146,6 +148,10 @@
       "orderNumber": "Order #",
       "totalPrice": "Total",
       "viewDetails": "View Details",
+      "emptyState": {
+        "title": "You don't have any orders",
+        "cta": "Shop now"
+      },
       "Details": {
         "title": "Order #{orderNumber}",
         "shippingAddress": "Shipping address",
@@ -174,6 +180,7 @@
       "title": "Account settings",
       "changePassword": "Change password",
       "passwordUpdated": "Password has been updated successfully!",
+      "settingsUpdated": "Account settings have been updated successfully!",
       "somethingWentWrong": "Something went wrong. Please try again later.",
       "currentPassword": "Current password",
       "newPassword": "New password",
@@ -182,6 +189,7 @@
     }
   },
   "Wishlist": {
+    "actionsTitle": "Wishlist actions",
     "title": "Wish Lists",
     "new": "New wish list",
     "items": "{count, plural, =1 {1 item} other {# items}}",

--- a/core/vibes/soul/sections/wishlist-list-item/index.tsx
+++ b/core/vibes/soul/sections/wishlist-list-item/index.tsx
@@ -44,19 +44,27 @@ export const WishlistListItem = ({
       value={streamableWishlist}
     >
       {(wishlist) => {
-        const { name, visibility, items, totalItems, href } = wishlist;
+        const { name, visibility, items, totalItems, href, id } = wishlist;
 
         return (
-          <div className={clsx('@container my-4 flex flex-col', className)}>
+          <section
+            aria-describedby={`wishlist-description-${id}`}
+            aria-labelledby={`wishlist-title-${id}`}
+            className={clsx('@container my-4 flex flex-col', className)}
+          >
             <div className="flex flex-1 flex-col justify-between @sm:flex-row @sm:items-center">
               <div className="flex flex-col">
                 <div className="flex items-center gap-2">
-                  <span className="text-lg font-semibold">{name}</span>
+                  <h2 className="text-lg font-semibold" id={`wishlist-title-${id}`}>
+                    {name}
+                  </h2>
                   <Badge variant={visibility.isPublic ? 'primary' : 'info'}>
                     {visibility.label}
                   </Badge>
                 </div>
-                <div className="text-contrast-500 text-sm">{totalItems.label}</div>
+                <div className="text-contrast-500 text-sm" id={`wishlist-description-${id}`}>
+                  {totalItems.label}
+                </div>
               </div>
               <div className="my-4 flex gap-2 whitespace-nowrap @sm:my-0 @sm:ml-2 @sm:items-center">
                 {actionsPosition === 'left' && actionsComponent?.(wishlist)}
@@ -71,7 +79,7 @@ export const WishlistListItem = ({
               items={items}
               placeholderCount={placeholderCount}
             />
-          </div>
+          </section>
         );
       }}
     </Stream>


### PR DESCRIPTION
## What/Why?
To prepare for the subsequent e2e testing PRs I'm going to make, I had to make some changes to some core components first:
1. Fix incorrect/missing translation messages, as this is needed for locale-based testing. I did not capture all of the missing ones, just the easy ones. We will follow up on this.
2. Separate `defaultLocale` into it's own file. This needs to be done because `i18n/routing.ts` imports server-only NextJS components which prevents importing `defaultLocale` in tests. Splitting `defaultLocale` into a separate file allows us to use it in the test environment.
3. I noticed caching issues on account pages in my e2e tests, and we decided that it's best not to cache the data on these pages.
4. Update `WishlistListItem` for better accessibility

## Testing
Tested locally, local build, and vercel deployment to personal project

## Migration

Use this PR as a reference.

1. Update your `messages/en.json` file with the translation keys added in this PR
2. Ensure that all components are being passed the correct translation keys
3. Update all references to `defaultLocale` to point to the `~/i18n/locales` file created in this PR
5. Update all pages in `/core/app/[locale]/(default)/account/` and ensure that `cache: 'no-store'` is set on the `client.fetch` calls
6. Update the `WishlistListItem` component to use the new accessibility features/tags as shown in the PR
