### PR TITLE
fix: soft fail analytics events

### DIFF
--- a/.changeset/fluffy-oranges-act.md
+++ b/.changeset/fluffy-oranges-act.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Soft fail analytics events if the provider is not rendered

--- a/core/components/analytics/events.tsx
+++ b/core/components/analytics/events.tsx
@@ -5,7 +5,10 @@ interface EventsContext {
   onRemoveFromCart?: (formData?: FormData) => void;
 }
 
-const EventsContext = createContext<EventsContext | null>(null);
+const EventsContext = createContext<EventsContext>({
+  onAddToCart: undefined,
+  onRemoveFromCart: undefined,
+});
 
 export const EventsProvider = ({ children, ...props }: PropsWithChildren<EventsContext>) => {
   return <EventsContext.Provider value={props}>{children}</EventsContext.Provider>;
@@ -13,10 +16,6 @@ export const EventsProvider = ({ children, ...props }: PropsWithChildren<EventsC
 
 export const useEvents = () => {
   const context = useContext(EventsContext);
-
-  if (!context) {
-    throw new Error('useEvents must be used within a EventsProvider');
-  }
 
   return context;
 };


### PR DESCRIPTION
## What/Why?
Softly fails the `useEvents` hook if not rendered within a context.

## Testing

https://github.com/user-attachments/assets/e021ce06-66d1-4bc8-81d7-f5994fe47292

## Migration
Pull in changes with a merge/rebase.