### PR TITLE
fix(core): product form retains state when submitted

### DIFF
--- a/.changeset/proud-masks-read.md
+++ b/.changeset/proud-masks-read.md
@@ -1,0 +1,12 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+We want state to be persitent on the `ProductDetailForm`, even after submit. This change will allow the API error messages to properly show when the form is submitted. Additionally, other form fields will retain state (like item quantity).
+
+## Migration
+
+- Update `ProductDetailForm` to prevent reset on submit, by removing `requestFormReset` in the `onSubmit`.
+- Remove `router.refresh()` call and instead call new `revalidateCart` action.
+  - `revalidateCart` is an action that `revalidateTag(TAGS.cart)`
+  - This prevents the form from fully refreshing on success.

--- a/core/vibes/soul/sections/product-detail/actions/revalidate-cart.ts
+++ b/core/vibes/soul/sections/product-detail/actions/revalidate-cart.ts
@@ -1,0 +1,8 @@
+'use server';
+
+import { revalidateTag } from 'next/cache';
+
+import { TAGS } from '~/client/tags';
+
+// eslint-disable-next-line @typescript-eslint/require-await
+export const revalidateCart = async () => revalidateTag(TAGS.cart);


### PR DESCRIPTION
## What/Why?
We want state to be persitent on the `ProductDetailForm`, even after submit. This change will allow the API error messages to properly show when the form is submitted. Additionally, other form fields will retain state (like item quantity).

## Testing
State is retained when form is submitted.

## Migration
- Update `ProductDetailForm` to prevent reset on submit, by removing `requestFormReset` in the `onSubmit`.
- Remove `router.refresh()` call and instead call new `revalidateCart` action.
  - `revalidateCart` is an action that `revalidateTag(TAGS.cart)`
  - This prevents the form from fully refreshing on success.
