### PR TITLE
refactor: simplify session logout logic

### DIFF
--- a/.changeset/little-hornets-stand.md
+++ b/.changeset/little-hornets-stand.md
@@ -13,7 +13,6 @@ Previously, the pages would 404 which is misleading.
 ### Migration
 
 1. Copy all changes from the `/core/client` directory and the `/packages/client` directory
-2. Copy logic from withAuth middleware to handle the `?invalidate-session` query param
 3. Copy translation values
 4. Copy all changes from the `/core/app/[locale]/(default)/account/` directory server actions
 5. Copy all changes from the `/core/app/[locale]/(default)/checkout/route.ts` file

--- a/core/client/index.ts
+++ b/core/client/index.ts
@@ -64,7 +64,7 @@ export const client = createClient({
   },
   onError: (error, queryType) => {
     if (error instanceof BigCommerceAuthError && queryType === 'query') {
-      redirect('?invalidate-session');
+      redirect('/api/auth/signout');
     }
   },
 });

--- a/core/middlewares/with-auth.ts
+++ b/core/middlewares/with-auth.ts
@@ -1,12 +1,11 @@
 import { NextResponse, URLPattern } from 'next/server';
 
-import { auth, signIn, signOut } from '~/auth';
+import { auth, signIn } from '~/auth';
 
 import { type MiddlewareFactory } from './compose-middlewares';
 
 // Path matcher for any routes that require authentication
 const protectedPathPattern = new URLPattern({ pathname: `{/:locale}?/(account)/*` });
-const sessionInvalidateParam = 'invalidate-session';
 
 function redirectToLogin(url: string) {
   return NextResponse.redirect(new URL('/login', url), { status: 302 });
@@ -38,14 +37,6 @@ export const withAuth: MiddlewareFactory = (next) => {
       // Continue the middleware chain
       return next(req, event);
     });
-
-    if (request.nextUrl.searchParams.has(sessionInvalidateParam)) {
-      await signOut({ redirect: false });
-
-      request.nextUrl.searchParams.delete(sessionInvalidateParam);
-
-      return NextResponse.redirect(request.nextUrl, { status: 302 });
-    }
 
     // @ts-expect-error: The `auth` function doesn't have the correct type to support it as a MiddlewareFactory.
     return authWithCallback(request, event);


### PR DESCRIPTION
## What/Why?
Remove using a query param to handle session invalidation logic and instead hit the internal auth endpoint to trigger the signout.

## Testing

https://github.com/user-attachments/assets/e3d9043e-01f9-4d3f-9e9e-1aecc4c208b2

## Migration
N/A
