### PR TITLE
refactor: move anonymous session to its own cookie

### DIFF
--- a/.changeset/wild-cows-notice.md
+++ b/.changeset/wild-cows-notice.md
@@ -1,0 +1,9 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Move the anonymous session into it's own cookie, separate from Auth.js in order to have better non-persistent cart support.
+
+### Migration
+
+If you were using `await signIn('anonymous', { redirect: false });`, you'll need to migrate over to using the `await anonymousSignIn()` function. Otherwise, we am only changing the underlying logic in existing API's so pulling in the changes should immediately pick this up.

--- a/core/auth/anonymous-session.ts
+++ b/core/auth/anonymous-session.ts
@@ -1,0 +1,70 @@
+import { cookies } from 'next/headers';
+import { AnonymousUser } from 'next-auth';
+import { decode, encode } from 'next-auth/jwt';
+
+const anonymousCookieName = 'authjs.anonymous-session-token';
+
+export const anonymousSignIn = async (user: Partial<AnonymousUser> = { cartId: null }) => {
+  const secret = process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET;
+
+  if (!secret) {
+    throw new Error('AUTH_SECRET is not set');
+  }
+
+  const cookieJar = await cookies();
+  const jwt = await encode({
+    salt: anonymousCookieName,
+    secret,
+    token: {
+      user,
+    },
+  });
+
+  cookieJar.set(anonymousCookieName, jwt, {
+    secure: true,
+    sameSite: 'lax',
+    // We set the maxAge to 7 days as a good default for anonymous sessions.
+    // This can be adjusted based on your application's needs.
+    maxAge: 60 * 60 * 7, // 7 days
+    httpOnly: true,
+  });
+};
+
+export const getAnonymousSession = async () => {
+  const cookieJar = await cookies();
+  const jwt = cookieJar.get(anonymousCookieName);
+
+  if (!jwt) {
+    return null;
+  }
+
+  const secret = process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET;
+
+  if (!secret) {
+    throw new Error('AUTH_SECRET is not set');
+  }
+
+  const session = await decode({
+    secret,
+    salt: anonymousCookieName,
+    token: jwt.value,
+  });
+
+  return session;
+};
+
+export const clearAnonymousSession = async () => {
+  const cookieJar = await cookies();
+
+  cookieJar.delete(anonymousCookieName);
+};
+
+export const updateAnonymousSession = async (user: AnonymousUser) => {
+  const session = await getAnonymousSession();
+
+  if (!session) {
+    return null;
+  }
+
+  await anonymousSignIn(user);
+};

--- a/core/auth/types.ts
+++ b/core/auth/types.ts
@@ -1,8 +1,8 @@
-import { DefaultSession } from 'next-auth';
+import { User } from 'next-auth';
 
 declare module 'next-auth' {
   interface Session {
-    user?: DefaultSession['user'];
+    user?: User;
   }
 
   interface User {
@@ -12,11 +12,15 @@ declare module 'next-auth' {
     customerAccessToken?: string;
     impersonatorId?: string | null;
   }
+
+  interface AnonymousUser {
+    cartId?: string | null;
+  }
 }
 
 declare module 'next-auth/jwt' {
   interface JWT {
     id?: string;
-    user?: DefaultSession['user'];
+    user?: User;
   }
 }

--- a/core/lib/cart/index.ts
+++ b/core/lib/cart/index.ts
@@ -2,7 +2,7 @@
 
 import { unstable_expireTag } from 'next/cache';
 
-import { auth, updateSession } from '~/auth';
+import { auth, getAnonymousSession, updateAnonymousSession, updateSession } from '~/auth';
 import { addCartLineItem, AddCartLineItemsInput } from '~/client/mutations/add-cart-line-item';
 import { createCart, CreateCartInput } from '~/client/mutations/create-cart';
 import { getCart } from '~/client/queries/get-cart';
@@ -11,16 +11,38 @@ import { TAGS } from '~/client/tags';
 import { MissingCartError } from './error';
 
 export async function getCartId(): Promise<string | undefined> {
+  const anonymousSession = await getAnonymousSession();
+
+  if (anonymousSession) {
+    return anonymousSession.user?.cartId ?? undefined;
+  }
+
   const session = await auth();
 
   return session?.user?.cartId ?? undefined;
 }
 
 export async function setCartId(cartId: string): Promise<void> {
+  const anonymousSession = await getAnonymousSession();
+
+  if (anonymousSession) {
+    await updateAnonymousSession({ cartId });
+
+    return;
+  }
+
   await updateSession({ user: { cartId } });
 }
 
 export async function clearCartId(): Promise<void> {
+  const anonymousSession = await getAnonymousSession();
+
+  if (anonymousSession) {
+    await updateAnonymousSession({ cartId: null });
+
+    return;
+  }
+
   await updateSession({ user: { cartId: null } });
 }
 


### PR DESCRIPTION
## What/Why?
Builds off https://github.com/bigcommerce/catalyst/pull/2349

This is a series of PRs that is aimed to fix being able to have a non-persistent cart store be able to restore the cart back to an anonymous session. 

### Current Approach
We are generating a Auth.js session whenever you first visit a site. With this anonymous session, you can add products to the cart in which we update the session with the `cartId`. When a user signs in, we essentially "upgrade" that session to a logged in user session. This "upgrade" just adds information to the anonymous session, e.g. `customerAccessToken`, `name`, etc... so the `cartId` will be carried over.

Where this approach starts to degrade is when we sign out. There's the `signOut` callback in Auth.js in which we can hook onto the session before it's destroyed, assuming we can utilize that to pass information back into the anonymous session. Calling the `signIn` method for the new anonymous session within that `signOut` event creates the cookies, however Auth.js runs that invocation, then removes all the auth cookies. This leaves us in a state where we had the `cartId` tied to that anonymous cookies, then it's cleared, then middleware runs and returns a new anonymous cookie.

We tried a few workarounds, trying to utilize a different cookies but it would leave exposing the `cartId` as an unencrypted value in user-land. This should be avoided at all costs.

### Proposed Approach
Auth.js exposes the encryption methods they use to `encode`/`decode` their JWT for normal logged in sessions. We can utilize these methods to build our own anonymous session cookie that is separate from the logged in user session. The caveat with this approach is now we are leaking new session logic into application code. However this enables us to pass the `cartId` back into the anonymous session. It also comes with the benefit that it prevents leaking sensitive data back into the anonymous session, e.g. we accidentally pass the `customerAccessToken` back down (hypothetically).

In this PR I am proposing to utilize these `encode` and `decode` methods to create a new session cookie to handle the anonymous session. Most of the utilization of these methods are taken from how the Auth.js library uses them to construct their own session token. It also changes some of the underlying logic of `lib/` methods to fetch either from the anonymous session or the logged in session if they exist. Alongside this, middleware handles making sure there is only one type of session at a time.

## Testing
TBD...

## Migration
If you were using `await signIn('anonymous', { redirect: false });`, you'll need to migrate over to using the `await anonymousSignIn()` function. Otherwise, we am only changing the underlying logic in existing API's so pulling in the changes should immediately pick this up.
