### PR TITLE
feat: pass analytics cookies to external checkout

### DIFF
--- a/.changeset/rotten-badgers-spend.md
+++ b/.changeset/rotten-badgers-spend.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Pass analytics cookies to checkout mutation to preserve the analytics session whenever shopper redirects to the external checkout

--- a/core/tests/ui/e2e/checkout.spec.ts
+++ b/core/tests/ui/e2e/checkout.spec.ts
@@ -152,3 +152,39 @@ test.describe('mobile', () => {
     ).toBeVisible();
   });
 });
+
+test.describe('Analytics Cookies synchronization', () => {
+  test('Checkout route redirects to external checkout with analytics cookies', async ({
+    page,
+    context,
+  }) => {
+    await page.goto('/laundry-detergent/');
+    await expect(
+      page.getByRole('heading', { level: 1, name: '[Sample] Laundry Detergent' }),
+    ).toBeVisible();
+
+    const cookies = await context.cookies();
+    const visitorId = cookies.find((c) => c.name === 'catalyst.visitorId');
+    const visitId = cookies.find((c) => c.name === 'catalyst.visitId');
+
+    await page.getByRole('button', { name: 'Add to Cart' }).first().click();
+    await page.getByRole('button', { name: 'Add to Cart' }).first().isEnabled();
+    await page.getByRole('link', { name: 'Cart Items 1' }).click();
+    await page.getByRole('heading', { level: 1, name: 'Your cart' }).click();
+    await page.getByRole('button', { name: 'Proceed to checkout' }).click();
+
+    await page.waitForLoadState('networkidle');
+
+    const externalCheckoutUrl = page.url();
+
+    const checkoutCookies = await context.cookies(externalCheckoutUrl);
+
+    const externalVisitorId = checkoutCookies.find((c) => c.name === 'catalyst.visitorId');
+    const externalVisitId = checkoutCookies.find((c) => c.name === 'catalyst.visitId');
+
+    expect(externalVisitorId).toBeDefined();
+    expect(externalVisitorId?.value).toBe(visitorId?.value);
+    expect(externalVisitId).toBeDefined();
+    expect(externalVisitId?.value).toBe(visitId?.value);
+  });
+});


### PR DESCRIPTION
## What/Why?
Pass analytics cookies to checkout mutation, so whenever shopper redirected to the external checkout we preserve the analytics session

## Testing
Added e2e test case

Also, manually
Catalyst cart page with analytics cookies
![image](https://github.com/user-attachments/assets/79badc8b-e3c5-4ad9-bde6-d442fdbf3bf8)

BigCommerce checkout page, analytics cookies has been correctly transferred and preserved
`short_athena_visit_id` matches with `catalyst.visitId` and `fornax_anonymousId` matches with `visitorId`
![image](https://github.com/user-attachments/assets/40fce0d8-3790-48e1-838d-1a88652962c4)


## Migration
None