### PR TITLE
feat: add locale override parameter to client.fetch

### DIFF
--- a/.changeset/metal-owls-travel.md
+++ b/.changeset/metal-owls-travel.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-client": minor
+---
+
+Allow passing a `locale` that will be used to set the outgoing `"Accept-Language"` header sent to the BigCommerce Storefront GraphQL API. This additional, optional paramter gives you more explicit control over what language you'd like responses to be translated into, [leveraging BigCommerce's resolved locale feature](https://developer.bigcommerce.com/docs/storefront/graphql/multi-language-support#returned-data). To incorporate these changes into your fork, either update your `@bigcommerce/catalyst-client` dependency to `0.16.0` or use the diff associated with this commit as a reference if using the workspace version of the Catalyst client.

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -86,6 +86,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     customerAccessToken?: string;
     fetchOptions?: FetcherRequestInit;
     channelId?: string;
+    locale?: string;
     errorPolicy?: GraphQLErrorPolicy;
     validateCustomerAccessToken?: boolean;
   }): Promise<BigCommerceResponse<TResult>>;
@@ -97,6 +98,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     customerAccessToken?: string;
     fetchOptions?: FetcherRequestInit;
     channelId?: string;
+    locale?: string;
     errorPolicy?: GraphQLErrorPolicy;
     validateCustomerAccessToken?: boolean;
   }): Promise<BigCommerceResponse<TResult>>;
@@ -107,6 +109,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     customerAccessToken,
     fetchOptions = {} as FetcherRequestInit,
     channelId,
+    locale,
     errorPolicy = 'none',
     validateCustomerAccessToken = true,
   }: {
@@ -115,6 +118,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     customerAccessToken?: string;
     fetchOptions?: FetcherRequestInit;
     channelId?: string;
+    locale?: string;
     errorPolicy?: GraphQLErrorPolicy;
     validateCustomerAccessToken?: boolean;
   }): Promise<BigCommerceResponse<TResult>> {
@@ -142,6 +146,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
           'X-Bc-Error-On-Invalid-Customer-Access-Token': 'true',
         }),
         ...(this.trustedProxySecret && { 'X-BC-Trusted-Proxy-Secret': this.trustedProxySecret }),
+        ...(locale && { 'Accept-Language': locale }),
         ...Object.fromEntries(new Headers(additionalFetchHeaders).entries()),
         ...Object.fromEntries(new Headers(headers).entries()),
       },


### PR DESCRIPTION
## What/Why?
Allows passing a `locale` that will be used to set the outgoing `"Accept-Language"` header sent to the BigCommerce Storefront GraphQL API. This additional, optional parameter gives you more explicit control over what language you'd like responses to be translated into, [leveraging BigCommerce's resolved locale feature](https://developer.bigcommerce.com/docs/storefront/graphql/multi-language-support#returned-data).

> [!NOTE]
> This PR originated from #2286 

## Testing
N/A - Additive change

## Migration
* For those consuming the package from the NPM registry, this feature will be available in version `0.16` or higher, so a simple version bump should suffice. 
* For those using the package via `pnpm` workspaces, simply cherry-pick the additive diff from this PR into your branch.
