### PR TITLE
fix(core): pass searchParams when swapping locales

### DIFF
--- a/.changeset/rich-brooms-read.md
+++ b/.changeset/rich-brooms-read.md
@@ -1,0 +1,9 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Pass search params to router.redirect when swapping locales.
+
+## Migration
+
+Modify `useSwitchLocale` hook to include `Object.fromEntries(searchParams.entries())`.

--- a/core/vibes/soul/primitives/navigation/index.tsx
+++ b/core/vibes/soul/primitives/navigation/index.tsx
@@ -7,7 +7,7 @@ import * as Popover from '@radix-ui/react-popover';
 import { clsx } from 'clsx';
 import debounce from 'lodash.debounce';
 import { ArrowRight, ChevronDown, Search, SearchIcon, ShoppingBag, User } from 'lucide-react';
-import { useParams } from 'next/navigation';
+import { useParams, useSearchParams } from 'next/navigation';
 import React, {
   forwardRef,
   Ref,
@@ -833,6 +833,7 @@ const useSwitchLocale = () => {
   const pathname = usePathname();
   const router = useRouter();
   const params = useParams();
+  const searchParams = useSearchParams();
 
   return useCallback(
     (locale: string) =>
@@ -840,10 +841,10 @@ const useSwitchLocale = () => {
         // @ts-expect-error -- TypeScript will validate that only known `params`
         // are used in combination with a given `pathname`. Since the two will
         // always match for the current route, we can skip runtime checks.
-        { pathname, params },
+        { pathname, params, query: Object.fromEntries(searchParams.entries()) },
         { locale },
       ),
-    [pathname, params, router],
+    [pathname, params, router, searchParams],
   );
 };
 


### PR DESCRIPTION
## What/Why?
Noticed that when we switch locales, we lose the search params selection. In some cases (like compare and PDP), we want search params to be retained.

## Testing
Locally tested that the search params remain.

## Migration
Modify `useSwitchLocale` hook to include `Object.fromEntries(searchParams.entries())`.
