### PR TITLE
Fix persistent cart behavior

### DIFF
--- a/.changeset/solid-bees-type.md
+++ b/.changeset/solid-bees-type.md
@@ -1,0 +1,43 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Fix persistent cart behavior during login.
+
+## Migration
+
+In `core/auth/index.ts`, create the `cartIdSchema` variable:
+
+```ts
+const cartIdSchema = z
+  .string()
+  .uuid()
+  .or(z.literal('undefined')) // auth.js seems to pass the cart id as a string literal 'undefined' when not set.
+  .optional()
+  .transform((val) => (val === 'undefined' ? undefined : val));
+```
+
+Then, update all `Credentials` schemas to use this new `cartIdSchema`:
+
+```ts
+const PasswordCredentials = z.object({
+  email: z.string().email(),
+  password: z.string().min(1),
+  cartId: cartIdSchema,
+});
+
+const AnonymousCredentials = z.object({
+  cartId: cartIdSchema,
+});
+
+const JwtCredentials = z.object({
+  jwt: z.string(),
+  cartId: cartIdSchema,
+});
+
+const SessionUpdate = z.object({
+  user: z.object({
+    cartId: cartIdSchema,
+  }),
+});
+```

--- a/core/auth/index.ts
+++ b/core/auth/index.ts
@@ -56,24 +56,31 @@ const LogoutMutation = graphql(`
   }
 `);
 
+const cartIdSchema = z
+  .string()
+  .uuid()
+  .or(z.literal('undefined')) // auth.js seems to pass the cart id as a string literal 'undefined' when not set.
+  .optional()
+  .transform((val) => (val === 'undefined' ? undefined : val));
+
 const PasswordCredentials = z.object({
   email: z.string().email(),
   password: z.string().min(1),
-  cartId: z.string().optional(),
+  cartId: cartIdSchema,
 });
 
 const AnonymousCredentials = z.object({
-  cartId: z.string().optional(),
+  cartId: cartIdSchema,
 });
 
 const JwtCredentials = z.object({
   jwt: z.string(),
-  cartId: z.string().optional(),
+  cartId: cartIdSchema,
 });
 
 const SessionUpdate = z.object({
   user: z.object({
-    cartId: z.string().nullable().optional(),
+    cartId: cartIdSchema,
   }),
 });
 


### PR DESCRIPTION
## What/Why?
Resolve persistent cart behavior not working during login. I found that the auth.js credentials providers were passing `cartId` as a literal `"undefined"` string, rather than an `undefined` type, causing the GraphQL query to not restore carts correctly.

## Testing
Tested locally, confirmed fix works:
![image](https://github.com/user-attachments/assets/3664c0a0-7940-4a96-8b2a-036a975edcab)


## Migration

In `core/auth/index.ts`, create the `cartIdSchema` variable:

```ts
const cartIdSchema = z
  .string()
  .uuid()
  .or(z.literal('undefined')) // auth.js seems to pass the cart id as a string literal 'undefined' when not set.
  .optional()
  .transform((val) => (val === 'undefined' ? undefined : val));
```

Then, update all `Credentials` schemas to use this new `cartIdSchema`:

```ts
const PasswordCredentials = z.object({
  email: z.string().email(),
  password: z.string().min(1),
  cartId: cartIdSchema,
});

const AnonymousCredentials = z.object({
  cartId: cartIdSchema,
});

const JwtCredentials = z.object({
  jwt: z.string(),
  cartId: cartIdSchema,
});

const SessionUpdate = z.object({
  user: z.object({
    cartId: cartIdSchema,
  }),
});
```

