### PR TITLE
feat(core): render address fields for customer registration

### DIFF
--- a/.changeset/fancy-clowns-shout.md
+++ b/.changeset/fancy-clowns-shout.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Render address fields for customer registration form.

--- a/core/app/[locale]/(default)/(auth)/register/_actions/prefixes.ts
+++ b/core/app/[locale]/(default)/(auth)/register/_actions/prefixes.ts
@@ -1,0 +1,2 @@
+export const ADDRESS_FIELDS_NAME_PREFIX = 'customAddress_';
+export const CUSTOMER_FIELDS_NAME_PREFIX = 'customCustomer_';

--- a/core/app/[locale]/(default)/(auth)/register/page-data.ts
+++ b/core/app/[locale]/(default)/(auth)/register/page-data.ts
@@ -32,6 +32,12 @@ const RegisterCustomerQuery = graphql(
           }
         }
       }
+      geography {
+        countries {
+          code
+          name
+        }
+      }
     }
   `,
   [FormFieldsFragment],
@@ -68,6 +74,7 @@ export const getRegisterCustomerQuery = cache(async ({ address, customer }: Prop
 
   const addressFields = response.data.site.settings?.formFields.shippingAddress;
   const customerFields = response.data.site.settings?.formFields.customer;
+  const countries = response.data.geography.countries;
 
   const reCaptchaSettings = await bypassReCaptcha(response.data.site.settings?.reCaptcha);
 
@@ -79,5 +86,6 @@ export const getRegisterCustomerQuery = cache(async ({ address, customer }: Prop
     addressFields,
     customerFields,
     reCaptchaSettings,
+    countries,
   };
 });

--- a/core/app/[locale]/(default)/(auth)/register/page.tsx
+++ b/core/app/[locale]/(default)/(auth)/register/page.tsx
@@ -6,13 +6,18 @@ import { getTranslations, setRequestLocale } from 'next-intl/server';
 // import { bypassReCaptcha } from '~/lib/bypass-recaptcha';
 
 import { DynamicFormSection } from '@/vibes/soul/sections/dynamic-form-section';
-import { formFieldTransformer } from '~/data-transformers/form-field-transformer';
+import {
+  formFieldTransformer,
+  injectCountryCodeOptions,
+} from '~/data-transformers/form-field-transformer';
 import {
   CUSTOMER_FIELDS_TO_EXCLUDE,
-  FULL_NAME_FIELDS,
+  REGISTER_CUSTOMER_FORM_LAYOUT,
+  transformFieldsToLayout,
 } from '~/data-transformers/form-field-transformer/utils';
 import { exists } from '~/lib/utils';
 
+import { ADDRESS_FIELDS_NAME_PREFIX, CUSTOMER_FIELDS_NAME_PREFIX } from './_actions/prefixes';
 import { registerCustomer } from './_actions/register-customer';
 import { getRegisterCustomerQuery } from './page-data';
 
@@ -46,22 +51,55 @@ export default async function Register({ params }: Props) {
     notFound();
   }
 
-  const { addressFields, customerFields } = registerCustomerData;
+  const { addressFields, customerFields, countries } = registerCustomerData;
   // const reCaptcha = await bypassReCaptcha(reCaptchaSettings);
+
+  const fields = transformFieldsToLayout(
+    [
+      ...addressFields.map((field) => {
+        if (!field.isBuiltIn) {
+          return {
+            ...field,
+            name: `${ADDRESS_FIELDS_NAME_PREFIX}${field.label}`,
+          };
+        }
+
+        return field;
+      }),
+      ...customerFields.map((field) => {
+        if (!field.isBuiltIn) {
+          return {
+            ...field,
+            name: `${CUSTOMER_FIELDS_NAME_PREFIX}${field.label}`,
+          };
+        }
+
+        return field;
+      }),
+    ].filter((field) => !CUSTOMER_FIELDS_TO_EXCLUDE.includes(field.entityId)),
+    REGISTER_CUSTOMER_FORM_LAYOUT,
+  )
+    .map((field) => {
+      if (Array.isArray(field)) {
+        return field.map(formFieldTransformer).filter(exists);
+      }
+
+      return formFieldTransformer(field);
+    })
+    .filter(exists)
+    .map((field) => {
+      if (Array.isArray(field)) {
+        return field.map((f) => injectCountryCodeOptions(f, countries ?? []));
+      }
+
+      return injectCountryCodeOptions(field, countries ?? []);
+    })
+    .filter(exists);
 
   return (
     <DynamicFormSection
       action={registerCustomer}
-      fields={[
-        addressFields
-          .filter((field) => FULL_NAME_FIELDS.includes(field.entityId))
-          .map(formFieldTransformer)
-          .filter(exists),
-        ...customerFields
-          .filter((field) => !CUSTOMER_FIELDS_TO_EXCLUDE.includes(field.entityId))
-          .map(formFieldTransformer)
-          .filter(exists),
-      ]}
+      fields={fields}
       submitLabel={t('cta')}
       title={t('heading')}
     />

--- a/core/app/[locale]/(default)/account/addresses/page.tsx
+++ b/core/app/[locale]/(default)/account/addresses/page.tsx
@@ -4,7 +4,6 @@ import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { Address, AddressListSection } from '@/vibes/soul/sections/address-list-section';
 import {
-  fieldToFieldNameTransformer,
   formFieldTransformer,
   injectCountryCodeOptions,
 } from '~/data-transformers/form-field-transformer';
@@ -91,14 +90,6 @@ export default async function Addresses({ params, searchParams }: Props) {
       }
 
       return injectCountryCodeOptions(field, countries ?? []);
-    })
-    .filter(exists)
-    .map((field) => {
-      if (Array.isArray(field)) {
-        return field.map(fieldToFieldNameTransformer);
-      }
-
-      return fieldToFieldNameTransformer(field);
     })
     .filter(exists);
 

--- a/core/data-transformers/form-field-transformer/index.ts
+++ b/core/data-transformers/form-field-transformer/index.ts
@@ -6,14 +6,17 @@ import { FormFieldsFragment } from './fragment';
 import { FieldNameToFieldId } from './utils';
 
 export const formFieldTransformer = (
-  field: FragmentOf<typeof FormFieldsFragment>,
+  field: FragmentOf<typeof FormFieldsFragment> & { name?: string },
 ): Field | null => {
+  // If the field name is provided, use it; otherwise, fallback to the entityId mapped name or label.
+  const name = field.name ?? FieldNameToFieldId[Number(field.entityId)] ?? field.label;
+
   switch (field.__typename) {
     case 'CheckboxesFormField':
       return {
         id: String(field.entityId),
         type: 'checkbox-group',
-        name: String(field.entityId),
+        name,
         label: field.label,
         required: field.isRequired,
         options: field.options.map((option) => ({
@@ -26,7 +29,7 @@ export const formFieldTransformer = (
       return {
         id: String(field.entityId),
         type: 'date',
-        name: String(field.entityId),
+        name,
         label: field.label,
         required: field.isRequired,
         minDate: field.minDate ?? undefined,
@@ -37,7 +40,7 @@ export const formFieldTransformer = (
       return {
         id: String(field.entityId),
         type: 'textarea',
-        name: String(field.entityId),
+        name,
         label: field.label,
         required: field.isRequired,
       };
@@ -46,7 +49,7 @@ export const formFieldTransformer = (
       return {
         id: String(field.entityId),
         type: 'number',
-        name: String(field.entityId),
+        name,
         label: field.label,
         required: field.isRequired,
       };
@@ -56,7 +59,7 @@ export const formFieldTransformer = (
         id: String(field.entityId),
         type:
           field.entityId === FieldNameToFieldId.confirmPassword ? 'confirm-password' : 'password',
-        name: String(field.entityId),
+        name,
         label: field.label,
         required: field.isRequired,
       };
@@ -66,7 +69,7 @@ export const formFieldTransformer = (
         return {
           id: String(field.entityId),
           type: 'select',
-          name: String(field.entityId),
+          name,
           label: field.label,
           required: field.isRequired,
           options: field.options.map((option) => ({
@@ -79,7 +82,7 @@ export const formFieldTransformer = (
       return {
         id: String(field.entityId),
         type: 'button-radio-group',
-        name: String(field.entityId),
+        name,
         label: field.label,
         required: field.isRequired,
         options: field.options.map((option) => ({
@@ -92,7 +95,7 @@ export const formFieldTransformer = (
       return {
         id: String(field.entityId),
         type: 'radio-group',
-        name: String(field.entityId),
+        name,
         label: field.label,
         required: field.isRequired,
         options: field.options.map((option) => ({
@@ -106,7 +109,7 @@ export const formFieldTransformer = (
       return {
         id: String(field.entityId),
         type: field.entityId === FieldNameToFieldId.email ? 'email' : 'text',
-        name: String(field.entityId),
+        name,
         label: field.label,
         required: field.isRequired,
       };
@@ -114,17 +117,6 @@ export const formFieldTransformer = (
     default:
       return null;
   }
-};
-
-// TODO: See if we can merge this is with the above function
-// Will require testing and refactoring of register customer functionality
-export const fieldToFieldNameTransformer = (field: Field): Field => {
-  const name = FieldNameToFieldId[Number(field.name)];
-
-  return {
-    ...field,
-    name: name ?? (field.label || field.name),
-  };
 };
 
 export const injectCountryCodeOptions = (

--- a/core/data-transformers/form-field-transformer/utils.ts
+++ b/core/data-transformers/form-field-transformer/utils.ts
@@ -33,19 +33,20 @@ export enum FieldTypeToFieldInput {
   'MultilineTextFormField' = 'multilineTexts',
 }
 
-export const CUSTOMER_FIELDS_TO_EXCLUDE = [
-  FieldNameToFieldId.currentPassword,
-  FieldNameToFieldId.exclusiveOffers,
-];
+export const CUSTOMER_FIELDS_TO_EXCLUDE = [FieldNameToFieldId.currentPassword];
 
-export const BOTH_CUSTOMER_ADDRESS_FIELDS = [
-  FieldNameToFieldId.firstName,
-  FieldNameToFieldId.lastName,
+export const REGISTER_CUSTOMER_FORM_LAYOUT = [
+  [FieldNameToFieldId.firstName, FieldNameToFieldId.lastName],
+  FieldNameToFieldId.email,
+  FieldNameToFieldId.password,
+  FieldNameToFieldId.confirmPassword,
   FieldNameToFieldId.company,
   FieldNameToFieldId.phone,
+  FieldNameToFieldId.address1,
+  FieldNameToFieldId.address2,
+  [FieldNameToFieldId.city, FieldNameToFieldId.stateOrProvince],
+  [FieldNameToFieldId.postalCode, FieldNameToFieldId.countryCode],
 ];
-
-export const FULL_NAME_FIELDS = [FieldNameToFieldId.firstName, FieldNameToFieldId.lastName];
 
 export const ADDRESS_FORM_LAYOUT = [
   [FieldNameToFieldId.firstName, FieldNameToFieldId.lastName],
@@ -56,29 +57,6 @@ export const ADDRESS_FORM_LAYOUT = [
   [FieldNameToFieldId.city, FieldNameToFieldId.stateOrProvince],
   [FieldNameToFieldId.postalCode, FieldNameToFieldId.countryCode],
 ];
-
-export const createFieldName = (field: FormField, fieldOrigin: 'customer' | 'address') => {
-  const { isBuiltIn, entityId: fieldId, __typename: fieldType } = field;
-  const isCustomField = !isBuiltIn;
-  let secondFieldType = fieldOrigin;
-
-  if (isCustomField && fieldType !== 'PicklistOrTextFormField') {
-    const customFieldInputType =
-      fieldType === 'PicklistFormField' ? 'multipleChoices' : FieldTypeToFieldInput[fieldType];
-
-    return `custom_${fieldOrigin}-${customFieldInputType}-${fieldId}`;
-  }
-
-  if (fieldOrigin === 'address') {
-    secondFieldType = 'customer';
-  }
-
-  if (fieldOrigin === 'customer') {
-    secondFieldType = 'address';
-  }
-
-  return `${fieldOrigin}-${BOTH_CUSTOMER_ADDRESS_FIELDS.includes(fieldId) ? `${secondFieldType}-` : ''}${FieldNameToFieldId[fieldId] || fieldId}`;
-};
 
 export const getPreviouslySubmittedValue = (fieldValue?: FormFieldValue) => {
   if (!fieldValue) {

--- a/core/tests/ui/e2e/auth/register.spec.ts
+++ b/core/tests/ui/e2e/auth/register.spec.ts
@@ -14,6 +14,11 @@ test('Registration works as expected', { tag: [TAGS.writesData] }, async ({ page
     prefix: '1At!',
     length: 10,
   });
+  const phone = faker.phone.number({ style: 'national' });
+  const streetAddress = faker.location.streetAddress();
+  const city = faker.location.city();
+  const state = faker.location.state();
+  const postalCode = faker.location.zipCode();
 
   await page.goto('/register');
   await page.getByRole('heading', { name: t('Auth.Register.heading') }).waitFor();
@@ -24,6 +29,15 @@ test('Registration works as expected', { tag: [TAGS.writesData] }, async ({ page
   await page.getByLabel('Email Address').fill(email);
   await page.getByLabel('Password', { exact: true }).fill(password);
   await page.getByLabel('Confirm Password').fill(password);
+  await page.getByLabel('Phone').fill(phone);
+  await page.getByLabel('Address Line 1').fill(streetAddress);
+  await page.getByLabel('Suburb/City').fill(city);
+  await page.getByLabel('State/Province').fill(state);
+  await page.getByLabel('Zip/Postcode').fill(postalCode);
+  await page.getByRole('combobox', { name: 'Country' }).click();
+  await page.keyboard.type('United States');
+  await page.keyboard.press('Enter');
+  await page.getByRole('radio', { name: 'Home' }).click();
   await page.getByRole('button', { name: t('Auth.Register.cta') }).click();
 
   await expect(page).toHaveURL('/account/orders/');
@@ -47,6 +61,11 @@ test('Registration fails if email is already in use', async ({ page, customer })
     prefix: '1At!',
     length: 10,
   });
+  const phone = faker.phone.number({ style: 'national' });
+  const streetAddress = faker.location.streetAddress();
+  const city = faker.location.city();
+  const state = faker.location.state();
+  const postalCode = faker.location.zipCode();
 
   await page.goto('/register');
   await page.getByRole('heading', { name: t('heading') }).waitFor();
@@ -57,6 +76,15 @@ test('Registration fails if email is already in use', async ({ page, customer })
   await page.getByLabel('Email Address').fill(email);
   await page.getByLabel('Password', { exact: true }).fill(password);
   await page.getByLabel('Confirm Password').fill(password);
+  await page.getByLabel('Phone').fill(phone);
+  await page.getByLabel('Address Line 1').fill(streetAddress);
+  await page.getByLabel('Suburb/City').fill(city);
+  await page.getByLabel('State/Province').fill(state);
+  await page.getByLabel('Zip/Postcode').fill(postalCode);
+  await page.getByRole('combobox', { name: 'Country' }).click();
+  await page.keyboard.type('United States');
+  await page.keyboard.press('Enter');
+  await page.getByRole('radio', { name: 'Home' }).click();
   await page.getByRole('button', { name: t('cta') }).click();
 
   await expect(page).not.toHaveURL('/account/orders/');


### PR DESCRIPTION
## What/Why?

As part of the update with VIBES, we decided to slim down the account creation from. Part of this we added a custom hardcoded list of form fields we rendered within the form based on the form fields provided from the API. We'd then filter out the form fields provided by the API with this hardcoded list. Where this broke down is when you set a field on the address fields, e.g. `Phone number`, as required and tried to submit the form, you'd get API errors because the form field was not present on the form submission. A developer would need to go in and manually add the form field as part of the hard coded list.

As a solution to this problem, we are now taking all the form fields from the API and dynamically rendering them (still) with the `DynamicForm` component. This also aligns the logic to be the same as the customer address creation/update logic (was copied over). We can probably abstract this logic a bit as it's quite duplicative, but for the interim we can leave it separate in case functionality diverges in the future.

The alternative to this solution would be to create a new API to handle separating the customer form fields and the address field collection. However, that would require a lot more work. Alternatively, the following solution follows what Stencil follows which aligns with "feature parity".

## Testing
![screencapture-localhost-3000-register-2025-06-04-16_49_30](https://github.com/user-attachments/assets/ccb5e43d-d787-4b0f-95f8-81e5ebc653f8)

https://github.com/user-attachments/assets/7d0aa499-198d-41c8-8b6e-5a3a0b204767

## Migration

Unfortunately the migration for the work is not straight-forward if the customer registrations logic has been customized. Otherwise, it's mostly additive changes, so rebasing should pull in the changes needed.
