### PR TITLE
fix(core): select component properly errors when required and empty

### DIFF
--- a/.changeset/silent-times-nail.md
+++ b/.changeset/silent-times-nail.md
@@ -1,0 +1,11 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Updates `SelectField` to have a hidden input to pass the value of the select to the form. This is a workaround for a [Radix Select issue](https://github.com/radix-ui/primitives/issues/3198) that auto selects the first option in the select when submitting a form (even when no selection has been made).
+
+Additionally, fixes an issue of incorrectly adding an empty query param for product options when an option is empty.
+
+## Migration
+
+Migration is straighforward and requires adding the hidden input to the component and renaming the `name` prop for the `Select` component to something temporary.

--- a/core/vibes/soul/form/select-field/index.tsx
+++ b/core/vibes/soul/form/select-field/index.tsx
@@ -31,6 +31,7 @@ export function SelectField({
   onBlur,
   onOptionMouseEnter,
   onValueChange,
+  ...rest
 }: SelectFieldProps) {
   const id = React.useId();
 
@@ -43,12 +44,14 @@ export function SelectField({
       >
         {label}
       </Label>
+      {/* Workaround for https://github.com/radix-ui/primitives/issues/3198, remove when fixed */}
+      <input name={name} type="hidden" value={value} />
       <Select
         colorScheme={colorScheme}
         errors={errors}
         id={id}
         label={label}
-        name={name}
+        name={`${name}_display`} // Temp `_display` to avoid conflicts with the hidden input
         onBlur={onBlur}
         onFocus={onFocus}
         onOptionMouseEnter={onOptionMouseEnter}
@@ -58,6 +61,7 @@ export function SelectField({
         placeholder={placeholder}
         value={value}
         variant={variant}
+        {...rest}
       />
       {errors?.map((error) => (
         <FieldError className="mt-2" key={error}>

--- a/core/vibes/soul/sections/product-detail/product-detail-form.tsx
+++ b/core/vibes/soul/sections/product-detail/product-detail-form.tsx
@@ -96,7 +96,7 @@ export function ProductDetailForm<F extends Field>({
   }>(
     (acc, field) => ({
       ...acc,
-      [field.name]: params[field.name] ?? field.defaultValue ?? '',
+      [field.name]: params[field.name] ?? field.defaultValue,
     }),
     { quantity: 1 },
   );
@@ -224,9 +224,9 @@ function FormField({
   const handleChange = useCallback(
     (value: string) => {
       // Ensure that if page is reached without a full reload, we are still setting the selection properly based on query params.
-      const fieldValue = value || String(params[field.name] ?? '');
+      const fieldValue = value || String(params[field.name]);
 
-      void setParams({ [field.name]: fieldValue });
+      void setParams({ [field.name]: fieldValue || null }); // Passing `null` to remove the value from the query params if fieldValue is falsey
       controls.change(fieldValue);
     },
     [setParams, field, controls, params],


### PR DESCRIPTION
## What/Why?
Updates `SelectField` to have a hidden input to pass the value of the select to the form. This is a workaround for a [Radix Select issue](https://github.com/radix-ui/primitives/issues/3198) that auto selects the first option in the select when submitting a form (even when no selection has been made).

Additionally, fixes an issue of incorrectly adding an empty query param for product options when an option is empty.

## Testing
Locally, input error when it is required and no selection has been made.

<img width="759" alt="Screenshot 2025-06-05 at 2 20 04 PM" src="https://github.com/user-attachments/assets/c02a702a-4d8c-4082-86b2-d708eb216f77" />

## Migration
Migration is straighforward and requires adding the hidden input to the component and renaming the `name` prop for the `Select` component to something temporary.
