### PR TITLE
fix(core): makes image optional for PickList with no images

### DIFF
--- a/.changeset/bright-rabbits-joke.md
+++ b/.changeset/bright-rabbits-joke.md
@@ -1,0 +1,13 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Fixes the error warning by having a `ProductPickList` with no images, by making the `image` prop optional for when it is not needed.
+
+## Migration
+
+- Update `schema.ts` to allow optional `image` prop for `CardRadioField`
+- Update `productOptionsTransformer` switch to have two cases for `ProductPickList`
+  - `ProductPickList` with no image object
+  - `ProductPickListWithImages` with image object
+- Update ui component to make the `image` prop optional and conditionally render the image.

--- a/core/data-transformers/product-options-transformer.ts
+++ b/core/data-transformers/product-options-transformer.ts
@@ -93,7 +93,26 @@ export const productOptionsTransformer = async (
             };
           }
 
-          case 'ProductPickList':
+          case 'ProductPickList': {
+            return {
+              persist: option.isVariantOption,
+              type: 'card-radio-group',
+              label: option.displayName,
+              required: option.isRequired,
+              name: option.entityId.toString(),
+              defaultValue: values.find((value) => value.isDefault)?.entityId.toString(),
+              options: values
+                .filter(
+                  (value) =>
+                    '__typename' in value && value.__typename === 'ProductPickListOptionValue',
+                )
+                .map((value) => ({
+                  label: value.label,
+                  value: value.entityId.toString(),
+                })),
+            };
+          }
+
           case 'ProductPickListWithImages': {
             return {
               persist: option.isVariantOption,

--- a/core/vibes/soul/form/card-radio-group/index.tsx
+++ b/core/vibes/soul/form/card-radio-group/index.tsx
@@ -9,7 +9,7 @@ import { Image } from '~/components/image';
 interface Option {
   value: string;
   label: string;
-  image: { src: string; alt: string };
+  image?: { src: string; alt: string };
   disabled?: boolean;
 }
 
@@ -92,14 +92,16 @@ export const CardRadioGroup = React.forwardRef<
               }}
               value={option.value}
             >
-              <div className="relative aspect-square h-full">
-                <Image
-                  alt={option.image.alt}
-                  className="bg-background object-fill"
-                  fill
-                  src={option.image.src}
-                />
-              </div>
+              {option.image && (
+                <div className="relative aspect-square h-full">
+                  <Image
+                    alt={option.image.alt}
+                    className="bg-background object-fill"
+                    fill
+                    src={option.image.src}
+                  />
+                </div>
+              )}
 
               <span className="flex-1 truncate text-ellipsis px-4 text-left">{option.label}</span>
             </RadioGroupPrimitive.Item>

--- a/core/vibes/soul/sections/product-detail/schema.ts
+++ b/core/vibes/soul/sections/product-detail/schema.ts
@@ -82,7 +82,7 @@ type CardRadioField = {
   options: Array<{
     value: string;
     label: string;
-    image: { src: string; alt: string };
+    image?: { src: string; alt: string };
     disabled?: boolean;
   }>;
 } & FormField;


### PR DESCRIPTION
## What/Why?
Fixes the error warning of having a `ProductPickList` with no images, by making the `image` prop optional for when it is not needed.

## Testing
Locally, no issue on console.

<img width="759" alt="Screenshot 2025-06-06 at 10 42 01 AM" src="https://github.com/user-attachments/assets/d46e009d-892e-4aaa-b0dd-b9a37eb850d5" />

## Migration

- Update `schema.ts` to allow optional `image` prop for `CardRadioField`
- Update `productOptionsTransformer` switch to have two cases for `ProductPickList`
  - `ProductPickList` with no image object
  - `ProductPickListWithImages` with image object
- Update ui component to make the `image` prop optional and conditionally render the image.
