### PR TITLE
fix(core): prefix anonymous cookie with __Secure for https://

### DIFF
--- a/.changeset/silver-items-tie.md
+++ b/.changeset/silver-items-tie.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Adds the `__Secure-` prefix to the add additional broswer security policies around this cookie.


### PR DESCRIPTION
## What/Why?
This adds the `__Secure-` cookie prefix to the anonymous session cookie to add extra security measures. This logic follows the same behavior as Auth.js does for prefixing it's cookies with the `__Secure-` prefix.

## Testing
#### Local dev
![Screenshot 2025-06-06 at 13 41 10](https://github.com/user-attachments/assets/b9d89268-e205-4c31-ad4b-5c978bea0dcb)

#### Production
![Screenshot 2025-06-06 at 13 40 49](https://github.com/user-attachments/assets/128aae81-7ad8-470d-a3f5-006fdd373143)


## Migration
If you haven't merge the anonymous session code, pulling it in should just work ™️.
