### PR TITLE
fix(tests): ensure the session file exists before running tests

### DIFF
--- a/core/tests/fixtures/customer/index.ts
+++ b/core/tests/fixtures/customer/index.ts
@@ -152,12 +152,12 @@ export class CustomerFixture extends Fixture {
     const searchParams = redirectTo ? `?${new URLSearchParams({ redirectTo }).toString()}` : '';
     const url = `/login${searchParams}`;
 
-    if (
-      !redirectTo &&
-      this.reuseCustomerSession &&
-      (await customerSessionStore.useExistingSession(this, customer.id))
-    ) {
-      return;
+    if (!redirectTo && this.reuseCustomerSession) {
+      const usedExistingSession = await customerSessionStore.useExistingSession(this, customer.id);
+
+      if (usedExistingSession) {
+        return;
+      }
     }
 
     await this.page.goto(url);

--- a/core/tests/fixtures/customer/session.ts
+++ b/core/tests/fixtures/customer/session.ts
@@ -1,27 +1,10 @@
-/* eslint-disable valid-jsdoc */
-import fs from 'node:fs';
-import { readFile, writeFile } from 'node:fs/promises';
+import { access, readFile, writeFile } from 'node:fs/promises';
 import { z } from 'zod';
 
 import { CustomerFixture } from '.';
 
-const storageFilePath = '.tests/customer-session.json';
 const fileSchema = z.record(
-  z.string().transform((val, ctx) => {
-    const parsed = Number(val);
-
-    if (Number.isNaN(parsed)) {
-      ctx.addIssue({
-        code: 'invalid_type',
-        expected: 'number',
-        received: 'nan',
-      });
-
-      return z.NEVER;
-    }
-
-    return parsed;
-  }),
+  z.coerce.number(),
   z.array(
     z.object({
       name: z.string(),
@@ -37,34 +20,36 @@ const fileSchema = z.record(
 );
 
 class CustomerSessionStore {
-  constructor() {
-    if (!fs.existsSync(storageFilePath)) {
-      fs.writeFileSync(storageFilePath, JSON.stringify({}));
-    }
-  }
+  private storageFilePath = '.tests/customer-session.json';
 
   async updateCustomerSession(fixture: CustomerFixture, customerId: number): Promise<void> {
-    const cookies = (await fixture.page.context().cookies()).filter((cookie) =>
-      cookie.name.includes('authjs'),
-    );
+    await this.ensureStorageFileExists();
 
-    const storage = fileSchema.parse(JSON.parse(fs.readFileSync(storageFilePath, 'utf-8')));
+    const cookieJar = await fixture.page.context().cookies();
+    const cookies = cookieJar.filter((cookie) => cookie.name.includes('authjs'));
+
+    const file = await readFile(this.storageFilePath, 'utf-8');
+    const storage = fileSchema.parse(JSON.parse(file));
 
     storage[customerId] = cookies;
 
-    await writeFile(storageFilePath, JSON.stringify(storage, null, 2));
+    await writeFile(this.storageFilePath, JSON.stringify(storage, null, 2));
   }
 
-  /** Uses an existing session for a customer ID if it exists. Returns true if successful and false if not found */
+  // Uses an existing session for a customer ID if it exists. Returns true if successful and false if not found
   async useExistingSession(fixture: CustomerFixture, customerId: number): Promise<boolean> {
-    const storage = fileSchema.parse(JSON.parse(await readFile(storageFilePath, 'utf-8')));
-    const customerSession = storage[customerId];
+    await this.ensureStorageFileExists();
 
     fixture.page.on('response', async (resp) => {
       if (resp.url().includes('/logout')) {
         await this.removeCustomerSession(customerId);
       }
     });
+
+    const file = await readFile(this.storageFilePath, 'utf-8');
+
+    const storage = fileSchema.parse(JSON.parse(file));
+    const customerSession = storage[customerId];
 
     if (!customerSession) {
       return false;
@@ -85,15 +70,23 @@ class CustomerSessionStore {
   }
 
   private async removeCustomerSession(customerId: number): Promise<void> {
-    const storage = fileSchema.parse(JSON.parse(fs.readFileSync(storageFilePath, 'utf-8')));
-    const customerSession = storage[customerId];
+    await this.ensureStorageFileExists();
 
-    if (customerSession) {
-      const updatedStorage = Object.fromEntries(
-        Object.entries(storage).filter(([key]) => key !== String(customerId)),
-      );
+    const file = await readFile(this.storageFilePath, 'utf-8');
 
-      await writeFile(storageFilePath, JSON.stringify(updatedStorage, null, 2));
+    const storage = fileSchema.parse(JSON.parse(file));
+    const updatedStorage = Object.fromEntries(
+      Object.entries(storage).filter(([key]) => key !== String(customerId)),
+    );
+
+    await writeFile(this.storageFilePath, JSON.stringify(updatedStorage, null, 2));
+  }
+
+  private async ensureStorageFileExists(): Promise<void> {
+    try {
+      await access(this.storageFilePath);
+    } catch {
+      await writeFile(this.storageFilePath, JSON.stringify({}));
     }
   }
 }


### PR DESCRIPTION
## What/Why?
Refactors the customer fixture to account for the `.tests` directory to not exist + simplify the code a bit. For every public method that gets invoked, we check and create the file if it doesn't exists before we consume it.

## Testing
Ran the tests locally.

## Migration
N/A
