### PR TITLE
Add PDP e2e tests, add currency fixture

### DIFF
--- a/core/tests/fixtures/catalog/index.ts
+++ b/core/tests/fixtures/catalog/index.ts
@@ -13,20 +13,36 @@ import {
 export class CatalogFixture extends Fixture {
   products: Product[] = [];
 
-  getDefaultOrCreateSimpleProduct(): Promise<Product> {
+  async getDefaultOrCreateSimpleProduct(): Promise<Product> {
     if (!testEnv.DEFAULT_PRODUCT_ID) {
       return this.createSimpleProduct();
     }
 
-    return this.api.catalog.getProductById(testEnv.DEFAULT_PRODUCT_ID);
+    const testProduct = await this.api.catalog.getProductById(testEnv.DEFAULT_PRODUCT_ID);
+
+    if (testProduct.inventoryLevel === 0 && testProduct.inventoryTracking !== 'none') {
+      throw new Error(
+        'Product for DEFAULT_PRODUCT_ID is out of stock and cannot be used in tests.',
+      );
+    }
+
+    return testProduct;
   }
 
-  getDefaultOrCreateComplexProduct(): Promise<Product> {
+  async getDefaultOrCreateComplexProduct(): Promise<Product> {
     if (!testEnv.DEFAULT_COMPLEX_PRODUCT_ID) {
       return this.createComplexProduct();
     }
 
-    return this.api.catalog.getProductById(testEnv.DEFAULT_COMPLEX_PRODUCT_ID);
+    const testProduct = await this.api.catalog.getProductById(testEnv.DEFAULT_COMPLEX_PRODUCT_ID);
+
+    if (testProduct.inventoryLevel === 0 && testProduct.inventoryTracking !== 'none') {
+      throw new Error(
+        'Product for DEFAULT_COMPLEX_PRODUCT_ID is out of stock and cannot be used in tests.',
+      );
+    }
+
+    return testProduct;
   }
 
   getCategories(filters?: { nameLike?: string; ids?: number[] }): Promise<Category[]> {
@@ -85,9 +101,9 @@ export class CatalogFixture extends Fixture {
       type: 'physical',
       description: faker.lorem.paragraph({ min: 3, max: 50 }),
       isVisible: true,
-      inventoryLevel: faker.number.int({ min: 1, max: 100 }),
+      inventoryLevel: faker.number.int({ min: 10, max: 100 }),
       inventoryWarningLevel: faker.number.int({ min: 1, max: 50 }),
-      inventoryTracking: 'product',
+      inventoryTracking: 'none',
       ...data,
     };
   }

--- a/core/tests/fixtures/currency/index.ts
+++ b/core/tests/fixtures/currency/index.ts
@@ -1,0 +1,39 @@
+import { Fixture } from '~/tests/fixtures/fixture';
+import { getTranslations } from '~/tests/lib/i18n';
+
+export class CurrencyFixture extends Fixture {
+  async getDefaultCurrency(): Promise<string> {
+    const currencyAssignments = await this.api.currencies.getCurrencyAssignments();
+
+    return currencyAssignments.defaultCurrency;
+  }
+
+  async getEnabledCurrencies(): Promise<string[]> {
+    const currencyAssignments = await this.api.currencies.getCurrencyAssignments();
+
+    return currencyAssignments.enabledCurrencies;
+  }
+
+  async convertWithExchangeRate(currencyCode: string, value: number): Promise<number> {
+    const currencies = await this.api.currencies.getCurrencies();
+    const currency = currencies.find((c) => c.currencyCode === currencyCode);
+
+    if (!currency) {
+      throw new Error(`Currency with code ${currencyCode} not found`);
+    }
+
+    return value * currency.exchangeRate;
+  }
+
+  async selectCurrency(currency: string): Promise<void> {
+    const t = await getTranslations('Components.Header.SwitchCurrency');
+
+    await this.page.getByRole('button', { name: t('label') }).click();
+    await this.page.getByRole('menuitem', { name: currency }).click();
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  async cleanup() {
+    // no cleanup needed
+  }
+}

--- a/core/tests/fixtures/customer/session.ts
+++ b/core/tests/fixtures/customer/session.ts
@@ -73,7 +73,7 @@ class CustomerSessionStore {
     await fixture.page.context().addCookies(customerSession);
     await fixture.page.goto('/login/', { waitUntil: 'networkidle' });
 
-    if (new URL(fixture.page.url()).pathname === '/login/') {
+    if (new URL(fixture.page.url()).pathname.includes('/login/')) {
       // If the session is no longer valid, the page will stay on the login page.
       // If this happens, the session should be removed so the test can login as normal.
       await this.removeCustomerSession(customerId);

--- a/core/tests/fixtures/index.ts
+++ b/core/tests/fixtures/index.ts
@@ -8,6 +8,7 @@ import { TAGS } from '~/tests/tags';
 
 import { extendedBrowser } from './browser';
 import { CatalogFixture } from './catalog';
+import { CurrencyFixture } from './currency';
 import { CustomerFixture } from './customer';
 import { OrderFixture } from './order';
 import { extendedPage, toHaveURL } from './page';
@@ -16,6 +17,7 @@ interface Fixtures {
   order: OrderFixture;
   catalog: CatalogFixture;
   customer: CustomerFixture;
+  currency: CurrencyFixture;
   /**
    * 'reuseCustomerSession' sets the the configuration for the customer fixture and determines whether to reuse the customer session.
    * For example, in login tests we do not want to reuse the session so we call `test.use({ reuseCustomerSession: false });`
@@ -66,6 +68,16 @@ export const test = baseTest.extend<Fixtures>({
       await use(customerFixture);
 
       await customerFixture.cleanup();
+    },
+    { scope: 'test' },
+  ],
+  currency: [
+    async ({ page }, use, currentTest) => {
+      const currencyFixture = new CurrencyFixture(page, currentTest);
+
+      await use(currencyFixture);
+
+      await currencyFixture.cleanup();
     },
     { scope: 'test' },
   ],

--- a/core/tests/fixtures/utils/api/catalog/http.ts
+++ b/core/tests/fixtures/utils/api/catalog/http.ts
@@ -72,6 +72,7 @@ const ProductSchema = z
   .object({
     id: z.number(),
     name: z.string(),
+    description: z.string(),
     sku: z.string(),
     price: z.number(),
     retail_price: z.number(),
@@ -89,6 +90,7 @@ const ProductSchema = z
     (data): Product => ({
       id: data.id,
       name: data.name,
+      description: data.description,
       sku: data.sku,
       price: data.price,
       retailPrice: data.retail_price,

--- a/core/tests/fixtures/utils/api/catalog/index.ts
+++ b/core/tests/fixtures/utils/api/catalog/index.ts
@@ -17,6 +17,7 @@ export interface Variant {
 export interface Product {
   readonly id: number;
   readonly name: string;
+  readonly description: string;
   readonly sku: string;
   readonly price: number;
   readonly retailPrice: number;

--- a/core/tests/fixtures/utils/api/currencies/http.ts
+++ b/core/tests/fixtures/utils/api/currencies/http.ts
@@ -1,0 +1,55 @@
+import { z } from 'zod';
+
+import { testEnv } from '~/tests/environment';
+
+import { httpClient } from '../client';
+import { apiResponseSchema } from '../schema';
+
+import { CurrenciesApi, Currency, CurrencyAssignments } from '.';
+
+const CurrencyAssignmentSchema = z
+  .object({
+    enabled_currencies: z.array(z.string()),
+    default_currency: z.string(),
+  })
+  .transform(
+    (data): CurrencyAssignments => ({
+      enabledCurrencies: data.enabled_currencies,
+      defaultCurrency: data.default_currency,
+    }),
+  );
+
+const CurrencySchema = z
+  .object({
+    id: z.number(),
+    is_default: z.boolean(),
+    enabled: z.boolean(),
+    decimal_places: z.number(),
+    currency_exchange_rate: z.coerce.number(),
+    currency_code: z.string(),
+  })
+  .transform(
+    (data): Currency => ({
+      id: data.id,
+      isDefault: data.is_default,
+      isEnabled: data.enabled,
+      decimalPlaces: data.decimal_places,
+      exchangeRate: data.currency_exchange_rate,
+      currencyCode: data.currency_code,
+    }),
+  );
+
+export const currenciesHttpClient: CurrenciesApi = {
+  getCurrencyAssignments: async (): Promise<CurrencyAssignments> => {
+    const resp = await httpClient
+      .get(`/v3/channels/${testEnv.BIGCOMMERCE_CHANNEL_ID ?? 1}/currency-assignments`)
+      .parse(apiResponseSchema(CurrencyAssignmentSchema));
+
+    return resp.data;
+  },
+  getCurrencies: async (): Promise<Currency[]> => {
+    const resp = await httpClient.get(`/v2/currencies?limit=250`).parse(z.array(CurrencySchema));
+
+    return resp;
+  },
+};

--- a/core/tests/fixtures/utils/api/currencies/index.ts
+++ b/core/tests/fixtures/utils/api/currencies/index.ts
@@ -1,0 +1,20 @@
+export interface CurrencyAssignments {
+  readonly enabledCurrencies: string[];
+  readonly defaultCurrency: string;
+}
+
+export interface Currency {
+  readonly id: number;
+  readonly isDefault: boolean;
+  readonly isEnabled: boolean;
+  readonly decimalPlaces: number;
+  readonly exchangeRate: number;
+  readonly currencyCode: string;
+}
+
+export interface CurrenciesApi {
+  getCurrencyAssignments: () => Promise<CurrencyAssignments>;
+  getCurrencies: () => Promise<Currency[]>;
+}
+
+export { currenciesHttpClient } from './http';

--- a/core/tests/fixtures/utils/api/index.ts
+++ b/core/tests/fixtures/utils/api/index.ts
@@ -1,15 +1,18 @@
 import { CatalogApi, catalogHttpClient } from '~/tests/fixtures/utils/api/catalog';
+import { CurrenciesApi, currenciesHttpClient } from '~/tests/fixtures/utils/api/currencies';
 import { CustomersApi, customersHttpClient } from '~/tests/fixtures/utils/api/customers';
 import { OrdersApi, ordersHttpClient } from '~/tests/fixtures/utils/api/orders';
 
 export interface ApiClient {
   catalog: CatalogApi;
   customers: CustomersApi;
+  currencies: CurrenciesApi;
   orders: OrdersApi;
 }
 
 export const httpApiClient: ApiClient = {
   catalog: catalogHttpClient,
   customers: customersHttpClient,
+  currencies: currenciesHttpClient,
   orders: ordersHttpClient,
 };

--- a/core/tests/ui/e2e/account/wishlist-details.spec.ts
+++ b/core/tests/ui/e2e/account/wishlist-details.spec.ts
@@ -45,14 +45,6 @@ test('Wishlist details displays a product correctly with "Add to Cart" button', 
   customer,
 }) => {
   const product = await catalog.getDefaultOrCreateSimpleProduct();
-
-  if (product.inventoryLevel === 0 && product.inventoryTracking !== 'none') {
-    test.skip(
-      true,
-      'Product is out of stock, skipping test. This means that the DEFAULT_PRODUCT_ID points to an out of stock product.',
-    );
-  }
-
   const t = await getTranslations();
   const { id: customerId } = await customer.login();
   const { id: wishlistId, name } = await customer.createWishlist({
@@ -76,14 +68,6 @@ test('Wishlist details displays a product correctly with "Add to Cart" button', 
 
 test('Wishlist product is able to be added to the cart', async ({ page, catalog, customer }) => {
   const product = await catalog.getDefaultOrCreateSimpleProduct();
-
-  if (product.inventoryLevel === 0 && product.inventoryTracking !== 'none') {
-    test.skip(
-      true,
-      'Product is out of stock, skipping test. This means that the DEFAULT_PRODUCT_ID points to an out of stock product.',
-    );
-  }
-
   const t = await getTranslations();
   const { id: customerId } = await customer.login();
   const { id: wishlistId, name } = await customer.createWishlist({

--- a/core/tests/ui/e2e/product.spec.ts
+++ b/core/tests/ui/e2e/product.spec.ts
@@ -1,78 +1,237 @@
-import { type Page } from '@playwright/test';
+import { faker } from '@faker-js/faker';
 
 import { expect, test } from '~/tests/fixtures';
+import { getFormatter } from '~/tests/lib/formatter';
+import { getTranslations } from '~/tests/lib/i18n';
+import { TAGS } from '~/tests/tags';
 
-async function selectProductForComparison(page: Page, name: string) {
-  const productInformation = page.getByRole('heading', { name }).locator('..');
-  const compareButton = productInformation.getByLabel('Compare');
+test('Displays a simple product and can add it to the cart', async ({
+  page,
+  catalog,
+  currency,
+}) => {
+  const t = await getTranslations('Product.ProductDetails');
+  const format = getFormatter();
+  const product = await catalog.getDefaultOrCreateSimpleProduct();
 
-  await compareButton.scrollIntoViewIfNeeded();
+  await page.goto(product.path);
+  await page.waitForLoadState('networkidle');
 
-  await compareButton.click();
-}
+  await expect(page.getByRole('heading', { name: product.name })).toBeVisible();
+  await expect(
+    page.getByText(
+      format.number(product.price, {
+        style: 'currency',
+        currency: await currency.getDefaultCurrency(),
+      }),
+    ),
+  ).toBeVisible();
 
-test.beforeEach(async ({ page }) => {
-  await page.goto('/');
-  await page.getByLabel('Main').getByRole('link', { name: 'Shop All' }).click();
+  await expect(page.getByRole('button', { name: t('Submit.addToCart') })).toBeVisible();
 
-  await expect(page.getByRole('heading', { level: 1, name: 'Shop all' })).toBeVisible();
+  await page.getByRole('button', { name: t('Submit.addToCart') }).click();
 });
 
-test('Validate product page', async ({ page }) => {
-  await expect(page.getByRole('button', { name: 'Brand' })).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Brand' })).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Color' })).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Size' })).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Price', exact: true })).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Rating' })).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Other' })).toBeVisible();
-  await expect(page.getByLabel('Sort by:')).toBeVisible();
+test('Displays out of stock product correctly', async ({ page, catalog }) => {
+  const t = await getTranslations('Product.ProductDetails');
+  const product = await catalog.createSimpleProduct({
+    inventoryTracking: 'product',
+    inventoryLevel: 0,
+  });
+
+  await page.goto(product.path);
+  await page.waitForLoadState('networkidle');
+
+  await expect(page.getByRole('heading', { name: product.name })).toBeVisible();
+  await expect(page.getByRole('button', { name: t('Submit.outOfStock') })).toBeVisible();
 });
 
-test('Compare products', async ({ page }) => {
-  await selectProductForComparison(page, 'Smith Journal 13');
-  await selectProductForComparison(page, 'Utility Caddy');
-  await selectProductForComparison(page, 'Laundry Detergent');
+test('Displays product price correctly for an alternate currency', async ({
+  page,
+  catalog,
+  currency,
+}) => {
+  const format = getFormatter();
+  const product = await catalog.getDefaultOrCreateSimpleProduct();
+  const defaultCurrency = await currency.getDefaultCurrency();
+  const alternateCurrency = (await currency.getEnabledCurrencies()).find(
+    (c) => c !== defaultCurrency,
+  );
 
-  await expect(page.getByRole('link', { name: 'Compare (3)' })).toBeVisible();
-  await expect(
-    page.getByRole('button', { name: 'Remove [Sample] Smith Journal 13 from compare list' }),
-  ).toBeAttached();
-  await expect(
-    page.getByRole('button', { name: 'Remove [Sample] Utility Caddy from compare list' }),
-  ).toBeAttached();
-  await expect(
-    page.getByRole('button', { name: 'Remove [Sample] Laundry Detergent from compare list' }),
-  ).toBeAttached();
+  if (!alternateCurrency) {
+    test.skip(true, 'No alternative currencies found.');
 
-  await page.getByRole('link', { name: 'Compare (3)' }).click();
-  await expect(page.getByRole('heading', { name: 'Comparing 3 products' })).toBeVisible();
+    return;
+  }
+
+  await page.goto(product.path);
+  await page.waitForLoadState('networkidle');
+  await expect(
+    page.getByText(
+      format.number(product.price, {
+        style: 'currency',
+        currency: defaultCurrency,
+      }),
+    ),
+  ).toBeVisible();
+
+  await currency.selectCurrency(alternateCurrency);
+
+  const productPriceConverted = await currency.convertWithExchangeRate(
+    alternateCurrency,
+    product.price,
+  );
+
+  const formatted = format.number(productPriceConverted, {
+    style: 'currency',
+    currency: alternateCurrency,
+  });
+
+  await expect(page.getByText(formatted)).toBeVisible();
 });
 
-test('Add and remove products to compare', async ({ page }) => {
-  await selectProductForComparison(page, 'Smith Journal 13');
-  await selectProductForComparison(page, 'Utility Caddy');
-  await selectProductForComparison(page, 'Laundry Detergent');
+test('Quantity buttons work and adds the correct amount to the cart', async ({ page, catalog }) => {
+  const t = await getTranslations('Product.ProductDetails');
+  const product = await catalog.getDefaultOrCreateSimpleProduct();
 
-  await expect(page.getByRole('link', { name: 'Compare (3)' })).toBeVisible();
-  await expect(
-    page.getByRole('button', { name: 'Remove [Sample] Smith Journal 13 from compare list' }),
-  ).toBeAttached();
-  await expect(
-    page.getByRole('button', { name: 'Remove [Sample] Utility Caddy from compare list' }),
-  ).toBeAttached();
-  await expect(
-    page.getByRole('button', { name: 'Remove [Sample] Laundry Detergent from compare list' }),
-  ).toBeAttached();
+  await page.goto(product.path);
+  await page.waitForLoadState('networkidle');
 
-  await page
-    .getByRole('button', { name: `Remove [Sample] Smith Journal 13 from compare list` })
-    .click();
-  await expect(page.getByRole('link', { name: 'Compare (2)' })).toBeVisible();
+  await page.getByLabel(t('increaseQuantity')).click();
+  await page.getByLabel(t('increaseQuantity')).click();
+  await page.getByLabel(t('increaseQuantity')).click();
+  await expect(page.getByRole('spinbutton', { name: t('quantity') })).toHaveValue('4');
+  await page.getByLabel(t('decreaseQuantity')).click();
+  await expect(page.getByRole('spinbutton', { name: t('quantity') })).toHaveValue('3');
+
+  await page.getByRole('button', { name: t('Submit.addToCart') }).click();
+
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  const addToCartSuccessMessage = t.rich('successMessage', {
+    cartItems: 3,
+    cartLink: (chunks: React.ReactNode) => chunks,
+  }) as string;
+
+  await expect(page.getByText(addToCartSuccessMessage)).toBeVisible();
 });
 
-test('Out of stock products show disabled "Out of stock" button', async ({ page }) => {
-  await page.goto('1-l-le-parfait-jar/?112=117&111=113');
+test('Quantity input works and adds the correct amount to the cart', async ({ page, catalog }) => {
+  const t = await getTranslations('Product.ProductDetails');
+  const product = await catalog.getDefaultOrCreateSimpleProduct();
 
-  await expect(page.getByRole('button', { name: 'Out of stock' })).toBeDisabled();
+  await page.goto(product.path);
+  await page.waitForLoadState('networkidle');
+  await page.getByRole('spinbutton', { name: t('quantity') }).fill('5');
+
+  await page.getByRole('button', { name: t('Submit.addToCart') }).click();
+
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  const addToCartSuccessMessage = t.rich('successMessage', {
+    cartItems: 5,
+    cartLink: (chunks: React.ReactNode) => chunks,
+  }) as string;
+
+  await expect(page.getByText(addToCartSuccessMessage)).toBeVisible();
 });
+
+test('Displays the wishlist button with default menu items', async ({ page, catalog }) => {
+  const t = await getTranslations();
+  const product = await catalog.getDefaultOrCreateSimpleProduct();
+
+  await page.goto(product.path);
+  await page.waitForLoadState('networkidle');
+
+  await page.getByRole('button', { name: t('Wishlist.Button.label') }).click();
+
+  await expect(
+    page.getByRole('menuitem', { name: t('Wishlist.Button.addToNewWishlist') }),
+  ).toBeVisible();
+
+  await expect(
+    page.getByRole('menuitem', { name: t('Wishlist.Button.defaultWishlistName') }),
+  ).toBeVisible();
+});
+
+test(
+  'Adding to a new wishlist as a guest user redirects to login, and redirects back to PDP to finish adding to the new wishlist',
+  { tag: [TAGS.writesData] },
+  async ({ page, catalog, customer }) => {
+    const t = await getTranslations();
+    const { id: customerId, email, password } = await customer.getOrCreateTestCustomer();
+
+    if (!password) {
+      test.skip(true, 'No password set for the customer, skipping test.');
+
+      return;
+    }
+
+    const product = await catalog.getDefaultOrCreateSimpleProduct();
+
+    await page.goto(product.path);
+    await page.waitForLoadState('networkidle');
+
+    await page.getByRole('button', { name: t('Wishlist.Button.label') }).click();
+    await page.getByRole('menuitem', { name: t('Wishlist.Button.addToNewWishlist') }).click();
+    await page.waitForLoadState('networkidle');
+
+    await page.getByLabel(t('Auth.Login.email')).fill(email);
+    await page.getByLabel(t('Auth.Login.password')).fill(password);
+    await page.getByRole('button', { name: t('Auth.Login.cta') }).click();
+    await page.waitForURL(`${product.path}?action=addToNewWishlist`);
+
+    const wishlistName = `Wishlist ${faker.string.alpha(10)}`;
+
+    await page.getByLabel(t('Wishlist.Form.nameLabel')).fill(wishlistName);
+    await page.getByRole('button', { name: t('Wishlist.Modal.create') }).click();
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText(t('Wishlist.Button.addSuccessMessage'))).toBeVisible();
+
+    await customer.deleteAllWishlists(customerId);
+  },
+);
+
+test(
+  'Wishlist button adds to the default wishlist if a customer does not have any wishlists',
+  { tag: [TAGS.writesData] },
+  async ({ page, customer, catalog }) => {
+    const t = await getTranslations();
+    const { id: customerId } = await customer.login();
+
+    // Ensure the customer has no wishlists before starting the test
+    await customer.deleteAllWishlists(customerId);
+
+    const product = await catalog.getDefaultOrCreateSimpleProduct();
+
+    await page.goto(product.path);
+    await page.waitForLoadState('networkidle');
+
+    await page.getByRole('button', { name: t('Wishlist.Button.label') }).click();
+    await page.getByRole('menuitem', { name: t('Wishlist.Button.defaultWishlistName') }).click();
+
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText(t('Wishlist.Button.addSuccessMessage'))).toBeVisible();
+  },
+);
+
+test(
+  'Wishlist button adds the product to an existing wishlist',
+  { tag: [TAGS.writesData] },
+  async ({ page, customer, catalog }) => {
+    const t = await getTranslations();
+    const { id: customerId } = await customer.login();
+    const { name } = await customer.createWishlist({ customerId });
+
+    const product = await catalog.getDefaultOrCreateSimpleProduct();
+
+    await page.goto(product.path);
+    await page.waitForLoadState('networkidle');
+
+    await page.getByRole('button', { name: t('Wishlist.Button.label') }).click();
+    await page.getByRole('menuitem', { name }).click();
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText(t('Wishlist.Button.addSuccessMessage'))).toBeVisible();
+  },
+);


### PR DESCRIPTION
## What/Why?
- Add e2e tests for the product page
- Add currency fixture for tests that need alternate currency formatting and utilities

## Testing
![image](https://github.com/user-attachments/assets/dd8b3cd3-3cf6-4365-ab31-4e5457247a7a)

## Migration
1. Copy all changes from the `/core/tests` directory
