### PR TITLE
Redirect to /account/wishlists when a wishlist isn't found, pass actionsTitle on WishlistDetails page

### DIFF
--- a/.changeset/hip-onions-dress.md
+++ b/.changeset/hip-onions-dress.md
@@ -1,0 +1,11 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+- Redirect to `/account/wishlists/` when a wishlist ID is not found
+- Pass `actionsTitle` to WishlistActionsMenu on WishlistDetails page
+
+## Migration
+1. Copy changes from `/core/app/[locale]/(default)/account/wishlists/[id]/_components/wishlist-actions.tsx` - Ensure that `actionsTitle` is an allowed property and that it is passed into the `WishlistActionsMenu` component
+2. Copy changes from `/core/app/[locale]/(default)/account/wishlists/[id]/page.tsx` - Redirect to `/account/wishlists/` on 404
+3. Ensure that the `removeButtonTitle` prop is passed down all the way to the `RemoveWishlistItemButton` component in the `WishlistItemCard` component

--- a/core/app/[locale]/(default)/account/wishlists/[id]/_components/wishlist-actions.tsx
+++ b/core/app/[locale]/(default)/account/wishlists/[id]/_components/wishlist-actions.tsx
@@ -22,6 +22,7 @@ interface Props {
   shareCopiedMessage: string;
   shareDisabledTooltip: string;
   menuActions: WishlistAction[];
+  actionsTitle?: string;
 }
 
 export const WishlistActions = ({
@@ -35,6 +36,7 @@ export const WishlistActions = ({
   shareCopiedMessage,
   shareDisabledTooltip,
   menuActions,
+  actionsTitle,
 }: Props) => {
   const { publicUrl } = wishlist;
 
@@ -60,7 +62,7 @@ export const WishlistActions = ({
               wishlistName={wishlist.name}
             />
           )}
-          <WishlistActionsMenu items={menuActions} />
+          <WishlistActionsMenu actionsTitle={actionsTitle} items={menuActions} />
         </div>
       </div>
     </div>

--- a/core/app/[locale]/(default)/account/wishlists/[id]/page.tsx
+++ b/core/app/[locale]/(default)/account/wishlists/[id]/page.tsx
@@ -1,5 +1,4 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
-import { notFound } from 'next/navigation';
 import { getFormatter, getTranslations, setRequestLocale } from 'next-intl/server';
 import { SearchParams } from 'nuqs';
 import { createSearchParamsCache, parseAsInteger, parseAsString } from 'nuqs/server';
@@ -10,6 +9,7 @@ import { Wishlist, WishlistDetails } from '@/vibes/soul/sections/wishlist-detail
 import { ExistingResultType } from '~/client/util';
 import { defaultPageInfo, pageInfoTransformer } from '~/data-transformers/page-info-transformer';
 import { wishlistDetailsTransformer } from '~/data-transformers/wishlists-transformer';
+import { redirect } from '~/i18n/routing';
 import { isMobileUser } from '~/lib/user-agent';
 
 import { removeWishlistItem } from '../_actions/remove-wishlist-item';
@@ -38,6 +38,7 @@ async function getWishlist(
   t: ExistingResultType<typeof getTranslations<'Wishlist'>>,
   pt: ExistingResultType<typeof getTranslations<'Product.ProductDetails'>>,
   searchParamsPromise: Promise<SearchParams>,
+  locale: string,
 ): Promise<Wishlist> {
   const entityId = Number(id);
   const searchParamsParsed = searchParamsCache.parse(await searchParamsPromise);
@@ -45,7 +46,7 @@ async function getWishlist(
   const wishlist = await getCustomerWishlist(entityId, searchParamsParsed);
 
   if (!wishlist) {
-    return notFound();
+    return redirect({ href: '/account/wishlists/', locale });
   }
 
   return wishlistDetailsTransformer(wishlist, t, pt, formatter);
@@ -100,6 +101,7 @@ export default async function WishlistPage({ params, searchParams }: Props) {
 
     return (
       <WishlistActions
+        actionsTitle={t('actionsTitle')}
         isMobileUser={isMobileUser()}
         menuActions={[
           {
@@ -133,7 +135,8 @@ export default async function WishlistPage({ params, searchParams }: Props) {
         paginationInfo={Streamable.from(() => getPaginationInfo(id, searchParams))}
         prevHref="/account/wishlists"
         removeAction={removeWishlistItem}
-        wishlist={Streamable.from(() => getWishlist(id, t, pt, searchParams))}
+        removeButtonTitle={t('removeButtonTitle')}
+        wishlist={Streamable.from(() => getWishlist(id, t, pt, searchParams, locale))}
       />
     </WishlistAnalyticsProvider>
   );

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -206,6 +206,7 @@
     "makePrivate": "Make private",
     "rename": "Rename",
     "delete": "Delete",
+    "removeButtonTitle": "Remove product from wish list",
     "Visibility": {
       "public": "Public",
       "private": "Private"

--- a/core/vibes/soul/primitives/wishlist-item-card/index.tsx
+++ b/core/vibes/soul/primitives/wishlist-item-card/index.tsx
@@ -27,6 +27,7 @@ interface WishlistItemCardProps extends Omit<ProductCardProps, 'product' | 'show
   item: WishlistItem;
   action: AddWishlistItemToCartAction;
   removeAction?: RemoveWishlistItemAction;
+  removeButtonTitle?: string;
 }
 
 export const WishlistItemCard = ({
@@ -34,6 +35,7 @@ export const WishlistItemCard = ({
   item: { itemId, productId, variantId, callToAction, product },
   action,
   removeAction,
+  removeButtonTitle,
   ...props
 }: WishlistItemCardProps) => {
   return (
@@ -52,7 +54,12 @@ export const WishlistItemCard = ({
       )}
       {removeAction && (
         <div className="absolute -right-3 -top-3 rounded-full transition-shadow duration-100 hover:shadow-md">
-          <RemoveWishlistItemButton action={removeAction} itemId={itemId} wishlistId={wishlistId} />
+          <RemoveWishlistItemButton
+            action={removeAction}
+            itemId={itemId}
+            removeButtonTitle={removeButtonTitle}
+            wishlistId={wishlistId}
+          />
         </div>
       )}
     </div>

--- a/core/vibes/soul/primitives/wishlist-item-card/remove-wishlist-item.tsx
+++ b/core/vibes/soul/primitives/wishlist-item-card/remove-wishlist-item.tsx
@@ -20,9 +20,15 @@ interface Props {
   wishlistId: string;
   itemId: string;
   action: RemoveWishlistItemAction;
+  removeButtonTitle?: string;
 }
 
-export const RemoveWishlistItemButton = ({ wishlistId, itemId, action }: Props) => {
+export const RemoveWishlistItemButton = ({
+  wishlistId,
+  itemId,
+  action,
+  removeButtonTitle = 'Remove product from wishlist',
+}: Props) => {
   const [isPending, startTransition] = useTransition();
   const [state, formAction] = useActionState(action, {
     lastResult: null,
@@ -39,7 +45,9 @@ export const RemoveWishlistItemButton = ({ wishlistId, itemId, action }: Props) 
       <input name="wishlistId" type="hidden" value={wishlistId} />
       <input name="wishlistItemId" type="hidden" value={itemId} />
       <Button loading={isPending} shape="circle" size="x-small" type="submit" variant="tertiary">
-        <XIcon size={20} />
+        <XIcon size={20}>
+          <title>{removeButtonTitle}</title>
+        </XIcon>
       </Button>
     </form>
   );

--- a/core/vibes/soul/sections/wishlist-details/index.tsx
+++ b/core/vibes/soul/sections/wishlist-details/index.tsx
@@ -41,6 +41,7 @@ interface Props {
   headerActions?: React.ReactNode | ((wishlist?: Wishlist) => React.ReactNode);
   action: AddWishlistItemToCartAction;
   removeAction?: RemoveWishlistItemAction;
+  removeButtonTitle?: string;
 }
 
 export const WishlistDetails = ({
@@ -53,6 +54,7 @@ export const WishlistDetails = ({
   placeholderCount,
   action,
   removeAction,
+  removeButtonTitle,
 }: Props) => {
   return (
     <Stream
@@ -94,6 +96,7 @@ export const WishlistDetails = ({
               items={items}
               placeholderCount={placeholderCount}
               removeAction={removeAction}
+              removeButtonTitle={removeButtonTitle}
               wishlistId={wishlist.id}
             />
 
@@ -112,6 +115,7 @@ function WishlistItems({
   placeholderCount,
   action,
   removeAction,
+  removeButtonTitle,
 }: {
   wishlistId: string;
   items: Streamable<WishlistItem[]>;
@@ -119,6 +123,7 @@ function WishlistItems({
   placeholderCount?: number;
   action: AddWishlistItemToCartAction;
   removeAction?: RemoveWishlistItemAction;
+  removeButtonTitle?: string;
 }) {
   return (
     <Stream
@@ -144,6 +149,7 @@ function WishlistItems({
                   item={item}
                   key={index}
                   removeAction={removeAction}
+                  removeButtonTitle={removeButtonTitle}
                   wishlistId={wishlistId}
                 />
               ))}


### PR DESCRIPTION
## What/Why?
- Redirect to `/account/wishlists/` when a wishlist ID is not found
- Pass `actionsTitle` to WishlistActionsMenu on WishlistDetails page

## Testing
Tested locally, e2e tests in following PR

## Migration
1. Copy changes from `/core/app/[locale]/(default)/account/wishlists/[id]/_components/wishlist-actions.tsx` - Ensure that `actionsTitle` is an allowed property and that it is passed into the `WishlistActionsMenu` component
2. Copy changes from `/core/app/[locale]/(default)/account/wishlists/[id]/page.tsx` - Redirect to `/account/wishlists/` on 404
3. Ensure that the `removeButtonTitle` prop is passed down all the way to the `RemoveWishlistItemButton` component in the `WishlistItemCard` component
