### PR TITLE
Add aria labels to currency selector and PDP wishlist favorite button

### DIFF
--- a/.changeset/soft-emus-drive.md
+++ b/.changeset/soft-emus-drive.md
@@ -1,0 +1,13 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Add aria-label to currency selector and PDP wishlist buttons
+
+## Migration
+1. Copy all changes from the `/messages/en.json` file to get updated translation keys
+2. Add the `label` prop to the `Heart` component in `/core/vibes/soul/primitives/favorite/heart.tsx`
+3. Add the `label` prop to the `Favorite` component in `/core/vibes/soul/primitives/favorite/index.tsx` and pass it to the `Heart` component
+4. Copy all changes in the `/core/vibes/soul/navigation/index.tsx` file to add the `switchCurrencyLabel` property
+5. Update `/core/components/header/index.tsx` file to pass the `switchCurrencyLabel` to the `HeaderSection` component
+6. Update `/core/app/[locale]/(default)/product/[slug]/_components/wishlist-button/index.tsx` to pass the `label` prop to the `Favorite` component

--- a/core/app/[locale]/(default)/product/[slug]/_components/wishlist-button/index.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/_components/wishlist-button/index.tsx
@@ -146,7 +146,7 @@ export const WishlistButton = async ({ productId, productSku, formId }: Props) =
       newWishlistLabel={t('addToNewWishlist')}
       wishlists={wishlists}
     >
-      <Favorite checked={isProductInWishlist} />
+      <Favorite checked={isProductInWishlist} label={t('label')} />
     </WishlistButtonDropdown>
   );
 };

--- a/core/components/header/index.tsx
+++ b/core/components/header/index.tsx
@@ -160,6 +160,7 @@ export const Header = async () => {
         currencies,
         activeCurrencyId: streamableActiveCurrencyId,
         currencyAction: switchCurrency,
+        switchCurrencyLabel: t('SwitchCurrency.label'),
       }}
     />
   );

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -246,6 +246,7 @@
       "removeItemSuccess": "Item has been removed from your wish list."
     },
     "Button": {
+      "label": "Add to wish list",
       "addToNewWishlist": "Add to new wish list",
       "defaultWishlistName": "My wish list",
       "addSuccessMessage": "Product has been added to your wish list",
@@ -437,6 +438,7 @@
         "search": "Open search popup"
       },
       "SwitchCurrency": {
+        "label": "Switch currency",
         "invalidCurrency": "Invalid currency",
         "errorUpdatingCurrency": "Error updating currency for your cart. Please try again."
       },

--- a/core/vibes/soul/primitives/favorite/heart.tsx
+++ b/core/vibes/soul/primitives/favorite/heart.tsx
@@ -2,7 +2,7 @@ import { clsx } from 'clsx';
 
 import './styles.css';
 
-export function Heart({ filled = false }: { filled?: boolean }) {
+export function Heart({ filled = false, title = 'Heart' }: { filled?: boolean; title?: string }) {
   return (
     <svg
       className="group-active:heart-pulse transform-gpu transition-transform duration-300 ease-out group-active:scale-75 sm:group-hover:scale-110"
@@ -12,6 +12,7 @@ export function Heart({ filled = false }: { filled?: boolean }) {
       width="20"
       xmlns="http://www.w3.org/2000/svg"
     >
+      <title>{title}</title>
       {/* Line Heart */}
       <path
         className={clsx({

--- a/core/vibes/soul/primitives/favorite/index.tsx
+++ b/core/vibes/soul/primitives/favorite/index.tsx
@@ -3,6 +3,7 @@ import * as Toggle from '@radix-ui/react-toggle';
 import { Heart } from '@/vibes/soul/primitives/favorite/heart';
 
 export interface FavoriteProps {
+  label?: string;
   checked?: boolean;
   setChecked?: (liked: boolean) => void;
 }
@@ -22,14 +23,14 @@ export interface FavoriteProps {
  * }
  * ```
  */
-export const Favorite = ({ checked = false, setChecked }: FavoriteProps) => {
+export const Favorite = ({ checked = false, setChecked, label = 'Favorite' }: FavoriteProps) => {
   return (
     <Toggle.Root
       className="group relative flex h-[50px] w-[50px] shrink-0 cursor-pointer items-center justify-center rounded-full border border-[var(--favorite-border,hsl(var(--contrast-100)))] text-[var(--favorite-icon,hsl(var(--foreground)))] ring-[var(--favorite-focus,hsl(var(--primary)))] transition-[colors,transform] duration-300 focus-within:outline-none focus-within:ring-2 data-[state=on]:bg-[var(--favorite-on-background,hsl(var(--contrast-100)))] data-[state=off]:hover:border-[var(--favorite-off-border,hsl(var(--contrast-200)))]"
       onPressedChange={setChecked}
       pressed={checked}
     >
-      <Heart filled={checked} />
+      <Heart filled={checked} title={label} />
     </Toggle.Root>
   );
 };

--- a/core/vibes/soul/primitives/navigation/index.tsx
+++ b/core/vibes/soul/primitives/navigation/index.tsx
@@ -118,6 +118,7 @@ interface Props<S extends SearchResult> {
   openSearchPopupLabel?: string;
   searchLabel?: string;
   mobileMenuTriggerLabel?: string;
+  switchCurrencyLabel?: string;
 }
 
 const MobileMenuButton = forwardRef<
@@ -284,6 +285,7 @@ export const Navigation = forwardRef(function Navigation<S extends SearchResult>
     openSearchPopupLabel = 'Open search popup',
     searchLabel = 'Search',
     mobileMenuTriggerLabel = 'Toggle navigation',
+    switchCurrencyLabel,
   }: Props<S>,
   ref: Ref<HTMLDivElement>,
 ) {
@@ -582,6 +584,7 @@ export const Navigation = forwardRef(function Navigation<S extends SearchResult>
                   activeCurrencyId={activeCurrencyId}
                   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
                   currencies={currencies as [Currency, ...Currency[]]}
+                  switchCurrencyLabel={switchCurrencyLabel}
                 />
               ) : null
             }
@@ -898,10 +901,12 @@ function CurrencyForm({
   action,
   currencies,
   activeCurrencyId,
+  switchCurrencyLabel = 'Switch currency',
 }: {
   activeCurrencyId?: string;
   action: CurrencyAction;
   currencies: [Currency, ...Currency[]];
+  switchCurrencyLabel?: string;
 }) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
@@ -923,7 +928,9 @@ function CurrencyForm({
         disabled={isPending}
       >
         {activeCurrency?.label ?? currencies[0].label}
-        <ChevronDown size={16} strokeWidth={1.5} />
+        <ChevronDown size={16} strokeWidth={1.5}>
+          <title>{switchCurrencyLabel}</title>
+        </ChevronDown>
       </DropdownMenu.Trigger>
       <DropdownMenu.Portal>
         <DropdownMenu.Content


### PR DESCRIPTION
## What/Why?
Add title to currency selector and PDP wishlist buttons. This is good for accessibility but also allows e2e tests to find the elements.

## Testing
Build passes locally

## Migration
1. Copy all changes from the `/messages/en.json` file to get updated translation keys
2. Add the `title` prop to the `Heart` component in `/core/vibes/soul/primitives/favorite/heart.tsx`
3. Add the `title` prop to the `Favorite` component in `/core/vibes/soul/primitives/favorite/index.tsx` and pass it to the `Heart` component
4. Copy all changes in the `/core/vibes/soul/navigation/index.tsx` file to add the `switchCurrencyLabel` property
5. Update `/core/components/header/index.tsx` file to pass the `switchCurrencyLabel` to the `HeaderSection` component
6. Update `/core/app/[locale]/(default)/product/[slug]/_components/wishlist-button/index.tsx` to pass the `label` prop to the `Favorite` component

