### PR TITLE
feat: re-enable Customer Group Slot component

### DIFF
--- a/.changeset/lovely-comics-wear.md
+++ b/.changeset/lovely-comics-wear.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Re-enable Customer Group Slot component

--- a/core/app/api/customer/groups/route.ts
+++ b/core/app/api/customer/groups/route.ts
@@ -1,8 +1,10 @@
 import { NextResponse } from 'next/server';
 
 export async function GET(): Promise<NextResponse> {
-  if (!process.env.BIGCOMMERCE_ACCESS_TOKEN) {
-    throw new Error('BIGCOMMERCE_ACCESS_TOKEN is not set');
+  const authToken = process.env.BIGCOMMERCE_ACCESS_TOKEN;
+
+  if (!authToken) {
+    return NextResponse.json(null);
   }
 
   const response = await fetch(
@@ -12,13 +14,18 @@ export async function GET(): Promise<NextResponse> {
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json',
-        'X-Auth-Token': process.env.BIGCOMMERCE_ACCESS_TOKEN,
+        'X-Auth-Token': authToken,
       },
     },
   );
 
   if (!response.ok) {
     throw new Error(`Failed to fetch customer groups: ${response.statusText}`);
+  }
+
+  // `/v2/customer_groups` endpoint returns a `204 No Content` response if there are no customer groups
+  if (response.status === 204) {
+    return NextResponse.json([]);
   }
 
   const jsonResponse: unknown = await response.json();

--- a/core/lib/makeswift/components.ts
+++ b/core/lib/makeswift/components.ts
@@ -3,6 +3,7 @@ import './components/button-link/button-link.makeswift';
 import './components/card-carousel/card-carousel.makeswift';
 import './components/card/card.makeswift';
 import './components/carousel/carousel.makeswift';
+import './components/customer-group-slot/customer-group-slot.makeswift';
 import './components/product-card/product-card.makeswift';
 import './components/products-carousel/products-carousel.makeswift';
 import './components/products-list/products-list.makeswift';

--- a/core/lib/makeswift/components/customer-group-slot/customer-group-slot.makeswift.ts
+++ b/core/lib/makeswift/components/customer-group-slot/customer-group-slot.makeswift.ts
@@ -64,7 +64,16 @@ runtime.registerComponent(CustomerGroupSlot, {
         try {
           const data = await getAllCustomerGroups();
 
-          if (!data) return [];
+          if (!data) {
+            // nullish data means we don't have access to the customer groups API
+            return [
+              {
+                id: NO_GROUP_ID,
+                label: 'Setup needed. See docs.',
+                value: NO_GROUP_ID,
+              },
+            ];
+          }
 
           return [
             {

--- a/core/lib/makeswift/components/customer-group-slot/schema.ts
+++ b/core/lib/makeswift/components/customer-group-slot/schema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const CustomerGroupsSchema = z.optional(
+export const CustomerGroupsSchema = z.nullable(
   z
     .object({
       id: z.number(),


### PR DESCRIPTION
## What/Why?

We initially unregistered this component because fetching customer groups requires the BigCommerce authentication token, which we don't expose in the default OCC configuration. However, removing the component entirely reduced discoverability and led to more confusion about its availability.

This PR re-enables the component by default, while providing a notice to inform users that it's not fully functional and requires additional configuration.

## Testing

https://github.com/user-attachments/assets/af8303e5-2797-45bc-839f-a62a4310ab47

