### PR TITLE
feat: add disabled styles to checkbox input and label

### DIFF
--- a/.changeset/common-brooms-dress.md
+++ b/.changeset/common-brooms-dress.md
@@ -1,0 +1,8 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Adds Tailwind classes used to style the checkbox input and label based on the disabled state of the checkbox.
+
+Migration:
+Since this is a one-file change, you should be able to simply grab the diff from [this PR](https://github.com/bigcommerce/catalyst/pull/2399). The main changes to note are that we are [adding a `peer` class](https://v3.tailwindcss.com/docs/hover-focus-and-other-states#styling-based-on-sibling-state) to the CheckboxPrimitive.Root, explicitly styling the `enabled` pseudoclass, and only applying hover styles when the checkbox is enabled.

--- a/core/vibes/soul/form/checkbox/index.tsx
+++ b/core/vibes/soul/form/checkbox/index.tsx
@@ -32,6 +32,9 @@ export interface CheckboxProps extends ComponentPropsWithoutRef<typeof CheckboxP
  *    --checkbox-light-checked-border-hover: hsl(var(--foreground));
  *    --checkbox-light-checked-background: hsl(var(--foreground));
  *    --checkbox-light-checked-icon: hsl(var(--background));
+ *    --checkbox-light-disabled-border: hsl(var(--contrast-200));
+ *    --checkbox-light-disabled-background: hsl(var(--contrast-100));
+ *    --checkbox-light-disabled-icon: hsl(var(--contrast-300));
  *    --checkbox-dark-label: hsl(var(--background));
  *    --checkbox-dark-error: hsl(var(--error));
  *    --checkbox-dark-unchecked-border: hsl(var(--contrast-400));
@@ -42,6 +45,9 @@ export interface CheckboxProps extends ComponentPropsWithoutRef<typeof CheckboxP
  *    --checkbox-dark-checked-border-hover: hsl(var(--background));
  *    --checkbox-dark-checked-background: hsl(var(--foreground));
  *    --checkbox-dark-checked-icon: hsl(var(--foreground));
+ *    --checkbox-dark-disabled-border: hsl(var(--contrast-200));
+ *    --checkbox-dark-disabled-background: hsl(var(--contrast-100));
+ *    --checkbox-dark-disabled-icon: hsl(var(--contrast-300));
  *    --checkbox-font-family: var(--font-family-body);
  *  }
  * ```
@@ -68,16 +74,30 @@ export function Checkbox({
           {...props}
           aria-labelledby={id !== undefined ? `${id}-label` : `${generatedId}-label`}
           className={clsx(
-            'flex h-5 w-5 items-center justify-center rounded-md border transition-colors duration-150 focus-visible:outline-0 focus-visible:ring-2 focus-visible:ring-[var(--checkbox-focus,hsl(var(--primary)))]',
+            'peer flex h-5 w-5 items-center justify-center rounded-md border transition-colors duration-150 focus-visible:outline-0 focus-visible:ring-2 focus-visible:ring-[var(--checkbox-focus,hsl(var(--primary)))] disabled:cursor-not-allowed',
             {
               light:
                 errors && errors.length > 0
                   ? 'border-[var(--checkbox-light-error,hsl(var(--error)))]'
-                  : 'data-[state=checked]:border-[var(--checkbox-light-checked-border,hsl(var(--foreground)))] data-[state=unchecked]:border-[var(--checkbox-light-unchecked-border,hsl(var(--contrast-200)))] data-[state=checked]:bg-[var(--checkbox-light-checked-background,hsl(var(--foreground)))] data-[state=unchecked]:bg-[var(--checkbox-light-unchecked-background,hsl(var(--background)))] data-[state=checked]:text-[var(--checkbox-light-checked-text,hsl(var(--background)))] data-[state=unchecked]:text-[var(--checkbox-light-unchecked-text,hsl(var(--foreground)))] data-[state=checked]:hover:border-[var(--checkbox-light-checked-border-hover,hsl(var(--foreground)))] data-[state=unchecked]:hover:border-[var(--checkbox-light-unchecked-border-hover,hsl(var(--contrast-300)))]',
+                  : clsx(
+                      // Disabled states
+                      'disabled:border-[var(--checkbox-light-disabled-border,hsl(var(--contrast-200)))] disabled:bg-[var(--checkbox-light-disabled-background,hsl(var(--contrast-100)))] disabled:text-[var(--checkbox-light-disabled-icon,hsl(var(--contrast-300)))]',
+                      // Normal states
+                      'enabled:data-[state=checked]:border-[var(--checkbox-light-checked-border,hsl(var(--foreground)))] enabled:data-[state=unchecked]:border-[var(--checkbox-light-unchecked-border,hsl(var(--contrast-200)))] enabled:data-[state=checked]:bg-[var(--checkbox-light-checked-background,hsl(var(--foreground)))] enabled:data-[state=unchecked]:bg-[var(--checkbox-light-unchecked-background,hsl(var(--background)))] enabled:data-[state=checked]:text-[var(--checkbox-light-checked-text,hsl(var(--background)))] enabled:data-[state=unchecked]:text-[var(--checkbox-light-unchecked-text,hsl(var(--foreground)))]',
+                      // Hover states (only apply when checkbox is enabled)
+                      'enabled:data-[state=checked]:hover:border-[var(--checkbox-light-checked-border-hover,hsl(var(--foreground)))] enabled:data-[state=unchecked]:hover:border-[var(--checkbox-light-unchecked-border-hover,hsl(var(--contrast-300)))]',
+                    ),
               dark:
                 errors && errors.length > 0
                   ? 'border-[var(--checkbox-dark-error,hsl(var(--error)))]'
-                  : 'data-[state=checked]:border-[var(--checkbox-dark-checked-border,hsl(var(--background)))] data-[state=unchecked]:border-[var(--checkbox-dark-unchecked-border,hsl(var(--contrast-400)))] data-[state=checked]:bg-[var(--checkbox-dark-checked-background,hsl(var(--foreground)))] data-[state=unchecked]:bg-[var(--checkbox-dark-unchecked-background,hsl(var(--foreground)))] data-[state=checked]:text-[var(--checkbox-dark-checked-text,hsl(var(--background)))] data-[state=unchecked]:text-[var(--checkbox-dark-unchecked-text,hsl(var(--background)))] data-[state=checked]:hover:border-[var(--checkbox-dark-checked-border-hover,hsl(var(--background)))] data-[state=unchecked]:hover:border-[var(--checkbox-dark-unchecked-border-hover,hsl(var(--contrast-300)))]',
+                  : clsx(
+                      // Disabled states
+                      'disabled:border-[var(--checkbox-dark-disabled-border,hsl(var(--contrast-200)))] disabled:bg-[var(--checkbox-dark-disabled-background,hsl(var(--contrast-100)))] disabled:text-[var(--checkbox-dark-disabled-icon,hsl(var(--contrast-300)))]',
+                      // Normal states
+                      'enabled:data-[state=checked]:border-[var(--checkbox-dark-checked-border,hsl(var(--background)))] enabled:data-[state=unchecked]:border-[var(--checkbox-dark-unchecked-border,hsl(var(--contrast-400)))] enabled:data-[state=checked]:bg-[var(--checkbox-dark-checked-background,hsl(var(--foreground)))] enabled:data-[state=unchecked]:bg-[var(--checkbox-dark-unchecked-background,hsl(var(--foreground)))] enabled:data-[state=checked]:text-[var(--checkbox-dark-checked-text,hsl(var(--background)))] enabled:data-[state=unchecked]:text-[var(--checkbox-dark-unchecked-text,hsl(var(--background)))]',
+                      // Hover states (only apply when checkbox is enabled)
+                      'enabled:data-[state=checked]:hover:border-[var(--checkbox-dark-checked-border-hover,hsl(var(--background)))] enabled:data-[state=unchecked]:hover:border-[var(--checkbox-dark-unchecked-border-hover,hsl(var(--contrast-300)))]',
+                    ),
             }[colorScheme],
           )}
           id={id ?? generatedId}
@@ -90,7 +110,7 @@ export function Checkbox({
         {label != null && label !== '' && (
           <LabelPrimitive.Root
             className={clsx(
-              'cursor-pointer text-sm',
+              'cursor-pointer text-sm peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
               {
                 light: 'text-[var(--checkbox-light-label,hsl(var(--foreground)))]',
                 dark: 'text-[var(--checkbox-dark-label,hsl(var(--background)))]',


### PR DESCRIPTION
## What/Why?
<!--- 
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
--->
Adds Tailwind classes used to style the checkbox input and label based on the disabled state of the checkbox. 

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->
Default:

https://github.com/user-attachments/assets/e4fdfed8-930b-4ea5-8038-1ea71c63f6e5

Disabled:

https://github.com/user-attachments/assets/1a044ff6-1923-478e-ae36-07ca858afdf3

Checked + disabled:

https://github.com/user-attachments/assets/c17e4e3b-cecb-494b-b0eb-66ef47748159

## Migration
<!---
  If you have moved any files around, or made any breaking changes,
  please provide a migration guide for the developers to make rebases easier.
--->
Since this is a one-file change, you should be able to simply grab the diff from this PR. The main changes to note are that we are [adding a `peer` class](https://v3.tailwindcss.com/docs/hover-focus-and-other-states#styling-based-on-sibling-state) to the CheckboxPrimitive.Root, explicitly styling the `enabled` pseudoclass, and only applying hover styles when the checkbox is enabled.
