### PR TITLE
Fix breadcrumb keys

### DIFF
--- a/.changeset/busy-snakes-agree.md
+++ b/.changeset/busy-snakes-agree.md
@@ -1,0 +1,9 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Fix possibility of duplicate `key` error in Breadcrumbs component for truncated breadcrumbs.
+
+## Migration
+Update `core/vibes/soul/sections/breadcrumbs/index.tsx` to use `index` as the `key` property instead of `href`
+

--- a/core/vibes/soul/sections/breadcrumbs/index.tsx
+++ b/core/vibes/soul/sections/breadcrumbs/index.tsx
@@ -45,7 +45,7 @@ export function Breadcrumbs({ breadcrumbs: streamableBreadcrumbs, className }: B
               {breadcrumbs.map(({ label, href }, index) => {
                 if (index < breadcrumbs.length - 1) {
                   return (
-                    <li className="inline-flex items-center gap-x-1.5" key={href}>
+                    <li className="inline-flex items-center gap-x-1.5" key={index}>
                       <Link className="group/underline focus:outline-none" href={href}>
                         <AnimatedUnderline className="font-[family-name:var(--breadcrumbs-font-family,var(--font-family-body))] text-[var(--breadcrumbs-primary-text,hsl(var(--foreground)))] [background:linear-gradient(0deg,var(--breadcrumbs-hover,hsl(var(--primary))),var(--breadcrumbs-hover,hsl(var(--primary))))_no-repeat_left_bottom_/_0_2px]">
                           {label}
@@ -64,7 +64,7 @@ export function Breadcrumbs({ breadcrumbs: streamableBreadcrumbs, className }: B
                 return (
                   <li
                     className="inline-flex items-center font-[family-name:var(--breadcrumbs-font-family,var(--font-family-body))] text-[var(--breadcrumbs-secondary-text,hsl(var(--contrast-500)))]"
-                    key={href}
+                    key={index}
                   >
                     <span aria-current="page" aria-disabled="true" role="link">
                       {label}


### PR DESCRIPTION
## What/Why?
Alter `Breadcrumb` component to use `index` instead of `href` for the key. When using large breadcrumbs for nested pages or categories, we truncate the breadcrumbs to put a `...` (e.g. `Home > Page 1 > ... > Page 5`), Where the `...` and `Page 5` will both use `#` for the href property.

This means that if you have a deeply nested page, you will get a duplicate key error.

This was previously fixed, but had a regression when we sync'd the Breadcrumbs component from VIBES.

## Testing
Tested locally

## Migration
Update `core/vibes/soul/sections/breadcrumbs/index.tsx` to use `index` as the `key` property instead of `href`
