### PR TITLE
Add webpage e2e tests

### DIFF
--- a/core/tests/fixtures/index.ts
+++ b/core/tests/fixtures/index.ts
@@ -12,12 +12,14 @@ import { CurrencyFixture } from './currency';
 import { CustomerFixture } from './customer';
 import { OrderFixture } from './order';
 import { extendedPage, toHaveURL } from './page';
+import { WebPageFixture } from './webpage';
 
 interface Fixtures {
   order: OrderFixture;
   catalog: CatalogFixture;
   customer: CustomerFixture;
   currency: CurrencyFixture;
+  webPage: WebPageFixture;
   /**
    * 'reuseCustomerSession' sets the the configuration for the customer fixture and determines whether to reuse the customer session.
    * For example, in login tests we do not want to reuse the session so we call `test.use({ reuseCustomerSession: false });`
@@ -78,6 +80,16 @@ export const test = baseTest.extend<Fixtures>({
       await use(currencyFixture);
 
       await currencyFixture.cleanup();
+    },
+    { scope: 'test' },
+  ],
+  webPage: [
+    async ({ page }, use, currentTest) => {
+      const webPageFixture = new WebPageFixture(page, currentTest);
+
+      await use(webPageFixture);
+
+      await webPageFixture.cleanup();
     },
     { scope: 'test' },
   ],

--- a/core/tests/fixtures/utils/api/index.ts
+++ b/core/tests/fixtures/utils/api/index.ts
@@ -2,12 +2,14 @@ import { CatalogApi, catalogHttpClient } from '~/tests/fixtures/utils/api/catalo
 import { CurrenciesApi, currenciesHttpClient } from '~/tests/fixtures/utils/api/currencies';
 import { CustomersApi, customersHttpClient } from '~/tests/fixtures/utils/api/customers';
 import { OrdersApi, ordersHttpClient } from '~/tests/fixtures/utils/api/orders';
+import { WebPagesApi, webPagesHttpClient } from '~/tests/fixtures/utils/api/webpages';
 
 export interface ApiClient {
   catalog: CatalogApi;
   customers: CustomersApi;
   currencies: CurrenciesApi;
   orders: OrdersApi;
+  webPages: WebPagesApi;
 }
 
 export const httpApiClient: ApiClient = {
@@ -15,4 +17,5 @@ export const httpApiClient: ApiClient = {
   customers: customersHttpClient,
   currencies: currenciesHttpClient,
   orders: ordersHttpClient,
+  webPages: webPagesHttpClient,
 };

--- a/core/tests/fixtures/utils/api/webpages/http.ts
+++ b/core/tests/fixtures/utils/api/webpages/http.ts
@@ -1,0 +1,96 @@
+import { z } from 'zod';
+
+import { testEnv } from '~/tests/environment';
+
+import { httpClient } from '../client';
+import { apiResponseSchema } from '../schema';
+
+import { CreateWebPageData, WebPage, WebPagesApi } from '.';
+
+const WebPageTypeSchema = z.enum(['page', 'link', 'contact_form', 'raw']);
+const ContactFieldTypeSchema = z.array(
+  z.enum(['fullname', 'companyname', 'phone', 'orderno', 'rma']),
+);
+
+const WebPageSchema = z
+  .object({
+    id: z.number(),
+    parent_id: z.number(),
+    name: z.string(),
+    is_visible: z.boolean(),
+    is_customers_only: z.boolean(),
+    type: WebPageTypeSchema,
+    url: z.string().nullable().optional(),
+    email: z.string().nullable().optional(),
+    link: z.string().nullable().optional(),
+    body: z.string().nullable().optional(),
+    contact_fields: z.string().nullable().optional(),
+  })
+  .transform(
+    (data): WebPage => ({
+      id: data.id,
+      parentId: data.parent_id,
+      name: data.name,
+      isVisibleInNavigation: data.is_visible,
+      isCustomersOnly: data.is_customers_only,
+      type: data.type,
+      path: data.url ?? undefined,
+      email: data.email ?? undefined,
+      link: data.link ?? undefined,
+      body: data.body ?? undefined,
+      contactFields: ContactFieldTypeSchema.parse(data.contact_fields?.split(',') ?? []),
+    }),
+  );
+
+const WebPageCreateSchema = z.object({
+  name: z.string(),
+  type: WebPageTypeSchema,
+  channel_id: z.number(),
+  parent_id: z.number().optional(),
+  is_visible: z.boolean().optional(),
+  is_customers_only: z.boolean().optional(),
+  url: z.string().optional(),
+  email: z.string().optional(),
+  link: z.string().optional(),
+  body: z.string().optional(),
+  contact_fields: z.string().optional(),
+});
+
+const transformCreateWebPageData = (data: CreateWebPageData) =>
+  WebPageCreateSchema.parse({
+    name: data.name,
+    type: data.type,
+    channel_id: testEnv.BIGCOMMERCE_CHANNEL_ID ?? 1,
+    parent_id: data.parentId,
+    is_visible: data.isVisibleInNavigation,
+    is_customers_only: data.isCustomersOnly,
+    url: data.path,
+    email: data.email,
+    link: data.link,
+    body: data.body,
+    contact_fields: data.contactFields?.join(','),
+  });
+
+export const webPagesHttpClient: WebPagesApi = {
+  getById: async (id) => {
+    const resp = await httpClient
+      .get(`/v3/content/pages/${id}?include=body`)
+      .parse(apiResponseSchema(WebPageSchema));
+
+    return resp.data;
+  },
+  create: async (data) => {
+    const resp = await httpClient
+      .post('/v3/content/pages?include=body', transformCreateWebPageData(data))
+      .parse(apiResponseSchema(WebPageSchema));
+
+    return resp.data;
+  },
+  delete: async (ids) => {
+    if (ids.length > 0) {
+      // TODO: Switch to the bulk delete v3 endpoint when the DELETE /v3/content/pages API endpoint is fixed.
+      // Currently, it does not reliably delete pages.
+      await Promise.all(ids.map((id) => httpClient.delete(`/v2/pages/${id}`)));
+    }
+  },
+};

--- a/core/tests/fixtures/utils/api/webpages/index.ts
+++ b/core/tests/fixtures/utils/api/webpages/index.ts
@@ -1,0 +1,37 @@
+export type WebPageType = 'page' | 'link' | 'contact_form' | 'raw';
+export type ContactFieldType = 'fullname' | 'companyname' | 'phone' | 'orderno' | 'rma';
+
+export interface WebPage {
+  readonly id: number;
+  readonly parentId: number;
+  readonly name: string;
+  readonly isVisibleInNavigation: boolean;
+  readonly isCustomersOnly: boolean;
+  readonly type: WebPageType;
+  readonly path?: string;
+  readonly email?: string;
+  readonly link?: string;
+  readonly body?: string;
+  readonly contactFields?: ContactFieldType[];
+}
+
+export interface CreateWebPageData {
+  name: string;
+  type: WebPageType;
+  parentId?: number;
+  isVisibleInNavigation?: boolean;
+  isCustomersOnly?: boolean;
+  path?: string;
+  email?: string;
+  link?: string;
+  body?: string;
+  contactFields?: ContactFieldType[];
+}
+
+export interface WebPagesApi {
+  getById: (id: number) => Promise<WebPage>;
+  create: (data: CreateWebPageData) => Promise<WebPage>;
+  delete: (ids: number[]) => Promise<void>;
+}
+
+export { webPagesHttpClient } from './http';

--- a/core/tests/fixtures/webpage/index.ts
+++ b/core/tests/fixtures/webpage/index.ts
@@ -1,0 +1,38 @@
+import { faker } from '@faker-js/faker';
+
+import { Fixture } from '~/tests/fixtures/fixture';
+import { CreateWebPageData, WebPage } from '~/tests/fixtures/utils/api/webpages';
+
+export class WebPageFixture extends Fixture {
+  webPages: WebPage[] = [];
+
+  getById(id: number): Promise<WebPage> {
+    return this.api.webPages.getById(id);
+  }
+
+  async create(data?: Partial<CreateWebPageData>): Promise<WebPage> {
+    this.skipIfReadonly();
+
+    const webPage = await this.api.webPages.create(this.fakeCreatePageData(data));
+
+    this.webPages.push(webPage);
+
+    return webPage;
+  }
+
+  async cleanup() {
+    await this.api.webPages.delete(this.webPages.map(({ id }) => id));
+  }
+
+  private fakeCreatePageData(data?: Partial<CreateWebPageData>): CreateWebPageData {
+    return {
+      parentId: 0,
+      name: `Catalyst Test Page ${faker.string.alpha(5)}`,
+      type: 'page',
+      body: faker.lorem.paragraphs({ min: 1, max: 5 }),
+      isVisibleInNavigation: true,
+      isCustomersOnly: false,
+      ...data,
+    };
+  }
+}

--- a/core/tests/ui/e2e/webpages.spec.ts
+++ b/core/tests/ui/e2e/webpages.spec.ts
@@ -1,0 +1,104 @@
+import { faker } from '@faker-js/faker';
+
+import { expect, test } from '~/tests/fixtures';
+import { getTranslations } from '~/tests/lib/i18n';
+
+test('Normal web page works and displays the HTML content', async ({ page, webPage }) => {
+  const t = await getTranslations('WebPages.Normal');
+  const { name, path } = await webPage.create({
+    body: `
+      <h1>I am some testing page content</h1>
+      <p>This is a paragraph of text to test the web page rendering.</p>
+      <p>It should be visible when the page is loaded.</p>
+      <p>
+        <a href="https://example.com">Do links work too?</a>
+      </p>
+      <div>Testing div element</div>
+    `,
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  await page.goto(path!);
+  await page.waitForLoadState('networkidle');
+
+  const breadcrumbs = page.getByLabel('breadcrumb');
+
+  await expect(breadcrumbs.getByText(t('home'))).toBeVisible();
+  await expect(breadcrumbs.getByText(name)).toBeVisible();
+
+  await expect(page.getByRole('heading', { name })).toBeVisible();
+  await expect(page.getByText('I am some testing page content')).toBeVisible();
+  await expect(
+    page.getByText('This is a paragraph of text to test the web page rendering.'),
+  ).toBeVisible();
+  await expect(page.getByText('It should be visible when the page is loaded.')).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Do links work too?' })).toHaveAttribute(
+    'href',
+    'https://example.com',
+  );
+  await expect(page.getByText('Testing div element')).toBeVisible();
+});
+
+test('Nested web pages display the children in the side menu, navigate correctly, and truncate breadcrumbs', async ({
+  page,
+  webPage,
+}) => {
+  const t = await getTranslations('WebPages.Normal');
+  const parent = await webPage.create();
+  const child1 = await webPage.create({ parentId: parent.id });
+  const child2 = await webPage.create({ parentId: parent.id });
+  const nestedChild = await webPage.create({ parentId: child1.id });
+  const nestedChild2 = await webPage.create({ parentId: nestedChild.id });
+
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  await page.goto(parent.path!);
+  await page.waitForLoadState('networkidle');
+
+  await expect(page.getByRole('heading', { name: parent.name })).toBeVisible();
+  await expect(page.getByRole('link', { name: child1.name })).toBeVisible();
+  await expect(page.getByRole('link', { name: child2.name })).toBeVisible();
+
+  await page.getByRole('link', { name: child1.name }).click();
+  await page.getByRole('link', { name: nestedChild.name }).click();
+  await page.getByRole('link', { name: nestedChild2.name }).click();
+  await page.waitForLoadState('networkidle');
+
+  await expect(page.getByRole('heading', { name: nestedChild2.name })).toBeVisible();
+
+  const breadcrumbs = page.getByLabel('breadcrumb');
+
+  await expect(breadcrumbs.getByText(t('home'))).toBeVisible();
+  await expect(breadcrumbs.getByText(parent.name)).toBeVisible();
+  await expect(breadcrumbs.getByText('...')).toBeVisible();
+  await expect(breadcrumbs.getByText(nestedChild.name)).toBeVisible();
+  await expect(breadcrumbs.getByText(nestedChild2.name)).toBeVisible();
+});
+
+test('Contact page works with all fields and submits successfully', async ({ page, webPage }) => {
+  const t = await getTranslations('WebPages.ContactUs');
+  const contactPage = await webPage.create({
+    type: 'contact_form',
+    body: '<p>Reach out to us with any questions!</p>',
+    email: faker.internet.email({ provider: 'catalyst-example.catalyst' }),
+    contactFields: ['fullname', 'phone', 'companyname', 'orderno', 'rma'],
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  await page.goto(contactPage.path!);
+  await page.waitForLoadState('networkidle');
+
+  await expect(page.getByRole('heading', { name: contactPage.name })).toBeVisible();
+
+  await page.getByLabel(t('Form.email')).fill(faker.internet.email());
+  await page.getByLabel(t('Form.fullName')).fill(faker.person.fullName());
+  await page.getByLabel(t('Form.phone')).fill(faker.phone.number());
+  await page.getByLabel(t('Form.companyName')).fill(faker.company.name());
+  await page.getByLabel(t('Form.orderNo')).fill(faker.string.numeric(10));
+  await page.getByLabel(t('Form.rma')).fill(faker.string.numeric(10));
+  await page.getByLabel(t('Form.comments')).fill(faker.lorem.paragraph());
+
+  await page.getByRole('button', { name: t('Form.cta') }).click();
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByText(t('Form.success'))).toBeVisible();
+  await expect(page.getByRole('link', { name: t('Form.successCta') })).toBeVisible();
+});


### PR DESCRIPTION
## What/Why?
Add e2e tests for core functionality on Web Pages

## Testing
![image](https://github.com/user-attachments/assets/c5416764-7277-4649-a8f9-8ea6ea14b860)

## Migration
Copy all changes from `/core/tests`
