### PR TITLE
Fix blog date formatting

### DIFF
--- a/.changeset/rare-news-jump.md
+++ b/.changeset/rare-news-jump.md
@@ -1,0 +1,11 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Fix blog post card date formatting on alternate locales
+
+## Migration
+
+### `core/vibes/soul/primitives/blog-post-card/index.tsx`
+
+Update the component to use `<time dateTime={date}>{date}</time>` for the date, instead of calling `new Date(date).toLocaleDateString(...)`.

--- a/core/vibes/soul/primitives/blog-post-card/index.tsx
+++ b/core/vibes/soul/primitives/blog-post-card/index.tsx
@@ -51,13 +51,7 @@ export function BlogPostCard({ blogPost, className }: Props) {
       <div className="text-lg font-medium leading-snug">{title}</div>
       <p className="mb-3 mt-1.5 line-clamp-3 text-sm font-normal text-contrast-400">{content}</p>
       <div className="text-sm">
-        <time dateTime={date}>
-          {new Date(date).toLocaleDateString('en-US', {
-            year: 'numeric',
-            month: 'long',
-            day: 'numeric',
-          })}
-        </time>
+        <time dateTime={date}>{date}</time>
         {date !== '' && author != null && author !== '' && (
           <span className="after:mx-2 after:content-['•']" />
         )}


### PR DESCRIPTION
## What/Why?
Fix the blog date formatting to use the `date` property directly passed in. Currently, we're calling `new Date(date).toLocaleDateString('en-US', ...)` on the blog post card, which fails on alternate locales.

## Testing

### Before fix:
![image](https://github.com/user-attachments/assets/9fe8a0fb-e429-46d6-85a3-3946156b9065)

### After fix:
![image](https://github.com/user-attachments/assets/d8d54e66-c6aa-4eea-8e03-1a93ada9f29f)

## Migration

### `core/vibes/soul/primitives/blog-post-card/index.tsx`

Update the component to use `<time dateTime={date}>{date}</time>` for the date, instead of calling `new Date(date).toLocaleDateString(...)`.


