### PR TITLE
Fix test httpClient from breaking when BC returns empty body for a JSON response

### DIFF
--- a/core/tests/fixtures/utils/api/client.ts
+++ b/core/tests/fixtures/utils/api/client.ts
@@ -6,7 +6,9 @@ import { TestApiClientResponseError } from './errors';
 
 class ApiClientResponse extends Promise<Response> {
   async parse<Out, In = Out>(schema: z.ZodType<Out, z.ZodTypeDef, In>): Promise<Out> {
-    return schema.parse(await this.then((res) => res.json()));
+    const resp = await this.then((res) => res.text());
+
+    return schema.parse(resp.length ? JSON.parse(resp) : undefined);
   }
 }
 


### PR DESCRIPTION
## What/Why?
I noticed that after refactoring the httpClient for test fixtures, we forgot to account for the fact that the BC API returns an empty body for certain routes.

For example, with `GET /v2/orders`, if no orders are returned, instead of responding with an empty array `[]`, the endpoint will simply respond with `204 No Content` with an empty body. This causes an error when attempting to parse the response as a zod schema.

For usability, we should only parse as JSON when the body is not empty, otherwise attempt to use zod to parse an `undefined` value. This allows the API clients to define the intent when calling the API:

```
    const resp = await httpClient
      .get(`/v2/orders?${params}`)
      .parse(z.array(OrderSchema).optional());
```

## Testing

### Before fix, orders empty state test fails due to the API returning no content
![image](https://github.com/user-attachments/assets/cc2b5781-cd1f-464b-83ba-14db66d9a28c)

### After fix, the empty response is simply parsed with the zod `optional` type instead of failing
![image](https://github.com/user-attachments/assets/f8cb58cb-ce02-4ab4-b87c-c51cccf6df82)


## Migration
Copy changes from `/core/tests`
