### PR TITLE
fix(core): fix custom filters regex to include spaces

### DIFF
--- a/.changeset/giant-teams-film.md
+++ b/.changeset/giant-teams-film.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Fix the faceted search pages to account for facets with spaces or other special characters in the name.

--- a/core/app/[locale]/(default)/(faceted)/fetch-faceted-search.ts
+++ b/core/app/[locale]/(default)/(faceted)/fetch-faceted-search.ts
@@ -330,7 +330,7 @@ export const PublicSearchParamsSchema = z.object({
 });
 
 const AttributeKey = z.custom<`attr_${string}`>((val) => {
-  return typeof val === 'string' ? /^attr_\w+$/.test(val) : false;
+  return typeof val === 'string' ? /^attr_.+$/.test(val) : false;
 });
 
 export const PublicToPrivateParams = PublicSearchParamsSchema.catchall(SearchParamToArray.nullish())


### PR DESCRIPTION
## What/Why?
Changes the `AttributeKey` regex to include custom facets with spaces or other special characters within the name.

## Testing
![Screenshot 2025-06-11 at 15 51 16](https://github.com/user-attachments/assets/ffffd52f-5811-4300-a0c2-87ae17c9de2a)
![Screenshot 2025-06-11 at 15 51 09](https://github.com/user-attachments/assets/bd24aaa2-98e4-4e92-81e4-e1e84d9e3f8d)


## Migration
Replace `/^attr_\w+$/` with `/^attr_.+$/`.
