### PR TITLE
fix: usability/terminology fix, Accordions -> Accordion

### DIFF
--- a/.changeset/open-hotels-fetch.md
+++ b/.changeset/open-hotels-fetch.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Usability/terminology fix, Accordions -> Accordion

--- a/core/lib/makeswift/components.ts
+++ b/core/lib/makeswift/components.ts
@@ -1,4 +1,4 @@
-import './components/accordions/accordions.makeswift';
+import './components/accordion/accordion.makeswift';
 import './components/button-link/button-link.makeswift';
 import './components/card-carousel/card-carousel.makeswift';
 import './components/card/card.makeswift';

--- a/core/lib/makeswift/components/accordion/accordion.makeswift.tsx
+++ b/core/lib/makeswift/components/accordion/accordion.makeswift.tsx
@@ -3,7 +3,7 @@ import { Group, List, Select, Slot, Style, TextInput } from '@makeswift/runtime/
 import { Accordion, AccordionItem } from '@/vibes/soul/primitives/accordion';
 import { runtime } from '~/lib/makeswift/runtime';
 
-interface MSAccordion {
+interface MSAccordionItem {
   title: string;
   children: React.ReactNode;
 }
@@ -12,21 +12,21 @@ interface MSAccordionsProps {
   className: string;
   type: 'single' | 'multiple';
   colorScheme: 'light' | 'dark';
-  accordions: MSAccordion[];
+  items: MSAccordionItem[];
 }
 
 runtime.registerComponent(
-  function MSAccordions({ className, accordions, colorScheme, type }: MSAccordionsProps) {
+  function MSAccordion({ className, items, colorScheme, type }: MSAccordionsProps) {
     return (
       <Accordion
         className={className}
         collapsible={type === 'single' ? true : undefined}
         type={type}
       >
-        {accordions.length < 1 && (
-          <div className="p-4 text-center text-lg text-gray-400">Add accordions</div>
+        {items.length < 1 && (
+          <div className="p-4 text-center text-lg text-gray-400">Add accordion items</div>
         )}
-        {accordions.map(({ title, children }, index) => (
+        {items.map(({ title, children }, index) => (
           <AccordionItem
             colorScheme={colorScheme}
             key={index}
@@ -41,21 +41,21 @@ runtime.registerComponent(
   },
   {
     type: 'primitive-accordions',
-    label: 'Basic / Accordions',
+    label: 'Basic / Accordion',
     icon: 'carousel',
     props: {
       className: Style(),
-      accordions: List({
-        label: 'Accordions',
+      items: List({
+        label: 'Items',
         type: Group({
           label: 'Accordion item',
           props: {
-            title: TextInput({ label: 'Title', defaultValue: 'This is an accordion title' }),
+            title: TextInput({ label: 'Title', defaultValue: 'This is an item title' }),
             children: Slot(),
           },
         }),
         getItemLabel(accordion) {
-          return accordion?.title || 'Accordion';
+          return accordion?.title || 'Untitled item';
         },
       }),
       type: Select({


### PR DESCRIPTION
## What/Why?

Rename `Accordions` to `Accordion` to avoid confusion and align with [standard UX terminology](https://chatgpt.com/share/676758f0-d0b0-8012-968f-4b0949cc6826). Note that the underlying Soul component is already correctly named, this change only affects the Makeswift component and builder naming.

Aside from the terminology update, this change is fully backward compatible and does not affect user-visible component behavior.

## Testing

https://github.com/user-attachments/assets/65a1d834-50b9-43f3-a755-78ed5a19d0d0
