### PR TITLE
fix(core): set min-height for navigation fallback

### DIFF
--- a/.changeset/every-pets-sneeze.md
+++ b/.changeset/every-pets-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Set a min-height for the Navigation fallback skeleton to prevent layout shift.

--- a/core/vibes/soul/primitives/navigation/index.tsx
+++ b/core/vibes/soul/primitives/navigation/index.tsx
@@ -432,7 +432,7 @@ export const Navigation = forwardRef(function Navigation<S extends SearchResult>
         >
           <Stream
             fallback={
-              <ul className="flex animate-pulse flex-row @4xl:gap-6 @4xl:p-2.5">
+              <ul className="flex min-h-[41px] animate-pulse flex-row items-center @4xl:gap-6 @4xl:p-2.5">
                 <li>
                   <span className="block h-4 w-10 rounded-md bg-contrast-100" />
                 </li>


### PR DESCRIPTION
## What/Why?
Set a min-height for the Navigation fallback skeleton to prevent layout shift.

Reason why it's `41px` is because this is the value of the menu links.

<img width="454" alt="Screenshot 2025-06-12 at 3 32 52 PM" src="https://github.com/user-attachments/assets/d2965692-ef21-42e3-80c2-ba1a87e271da" />

<img width="214" alt="Screenshot 2025-06-12 at 3 32 55 PM" src="https://github.com/user-attachments/assets/fb9106d7-6318-4a13-a061-75dbb16d8d80" />

## Testing
Tested locally and no longer see a layout shift when swapping locales.

## Migration
Add `min-h-[41px]` & `items-center` to fallback.
