### PR TITLE
Add e2e tests for coupon codes

### DIFF
--- a/core/tests/fixtures/index.ts
+++ b/core/tests/fixtures/index.ts
@@ -13,6 +13,7 @@ import { CurrencyFixture } from './currency';
 import { CustomerFixture } from './customer';
 import { OrderFixture } from './order';
 import { extendedPage, toHaveURL } from './page';
+import { PromotionFixture } from './promotion';
 import { WebPageFixture } from './webpage';
 
 interface Fixtures {
@@ -21,6 +22,7 @@ interface Fixtures {
   catalog: CatalogFixture;
   customer: CustomerFixture;
   currency: CurrencyFixture;
+  promotion: PromotionFixture;
   webPage: WebPageFixture;
   /**
    * 'reuseCustomerSession' sets the the configuration for the customer fixture and determines whether to reuse the customer session.
@@ -92,6 +94,16 @@ export const test = baseTest.extend<Fixtures>({
       await use(currencyFixture);
 
       await currencyFixture.cleanup();
+    },
+    { scope: 'test' },
+  ],
+  promotion: [
+    async ({ page }, use, currentTest) => {
+      const promotionFixture = new PromotionFixture(page, currentTest);
+
+      await use(promotionFixture);
+
+      await promotionFixture.cleanup();
     },
     { scope: 'test' },
   ],

--- a/core/tests/fixtures/promotion/index.ts
+++ b/core/tests/fixtures/promotion/index.ts
@@ -1,0 +1,24 @@
+import { Fixture } from '~/tests/fixtures/fixture';
+import { Coupon, PromotionWithCoupon } from '~/tests/fixtures/utils/api/promotions';
+
+export class PromotionFixture extends Fixture {
+  coupons: PromotionWithCoupon[] = [];
+
+  async createCouponCode(): Promise<Coupon> {
+    this.skipIfReadonly();
+
+    const promoWithCoupon = await this.api.promotions.createCouponCode();
+
+    this.coupons.push(promoWithCoupon);
+
+    return promoWithCoupon.coupon;
+  }
+
+  async cleanup() {
+    await Promise.all(
+      this.coupons.map(({ promotionId, coupon }) =>
+        this.api.promotions.deleteCouponCode(promotionId, coupon.id),
+      ),
+    );
+  }
+}

--- a/core/tests/fixtures/utils/api/index.ts
+++ b/core/tests/fixtures/utils/api/index.ts
@@ -3,6 +3,7 @@ import { CatalogApi, catalogHttpClient } from '~/tests/fixtures/utils/api/catalo
 import { CurrenciesApi, currenciesHttpClient } from '~/tests/fixtures/utils/api/currencies';
 import { CustomersApi, customersHttpClient } from '~/tests/fixtures/utils/api/customers';
 import { OrdersApi, ordersHttpClient } from '~/tests/fixtures/utils/api/orders';
+import { PromotionsApi, promotionsHttpClient } from '~/tests/fixtures/utils/api/promotions';
 import { WebPagesApi, webPagesHttpClient } from '~/tests/fixtures/utils/api/webpages';
 
 export interface ApiClient {
@@ -11,6 +12,7 @@ export interface ApiClient {
   customers: CustomersApi;
   currencies: CurrenciesApi;
   orders: OrdersApi;
+  promotions: PromotionsApi;
   webPages: WebPagesApi;
 }
 
@@ -20,5 +22,6 @@ export const httpApiClient: ApiClient = {
   customers: customersHttpClient,
   currencies: currenciesHttpClient,
   orders: ordersHttpClient,
+  promotions: promotionsHttpClient,
   webPages: webPagesHttpClient,
 };

--- a/core/tests/fixtures/utils/api/promotions/http.ts
+++ b/core/tests/fixtures/utils/api/promotions/http.ts
@@ -1,0 +1,61 @@
+import { faker } from '@faker-js/faker';
+import { z } from 'zod';
+
+import { testEnv } from '~/tests/environment';
+
+import { httpClient } from '../client';
+import { apiResponseSchema } from '../schema';
+
+import { Coupon, PromotionsApi } from '.';
+
+const CouponSchema = z
+  .object({
+    id: z.number(),
+    code: z.string(),
+  })
+  .transform(
+    (data): Coupon => ({
+      id: data.id,
+      code: data.code,
+    }),
+  );
+
+export const promotionsHttpClient: PromotionsApi = {
+  createCouponCode: async () => {
+    const promotion = await httpClient
+      .post('/v3/promotions', {
+        name: `Catalyst Test Promotion ${faker.string.alpha(10)}`,
+        channels: [{ id: testEnv.BIGCOMMERCE_CHANNEL_ID ?? 1 }],
+        rules: [
+          {
+            action: {
+              cart_value: {
+                discount: {
+                  percentage_amount: 10,
+                },
+              },
+            },
+          },
+        ],
+        redemption_type: 'COUPON',
+        status: 'ENABLED',
+      })
+      .parse(apiResponseSchema(z.object({ id: z.number() }).passthrough()));
+
+    const coupon = await httpClient
+      .post(`/v3/promotions/${promotion.data.id}/codes`, {
+        code: `CATALYST-TEST-${faker.string.alpha(10).toUpperCase()}`,
+        max_uses: 1,
+      })
+      .parse(apiResponseSchema(CouponSchema));
+
+    return {
+      promotionId: promotion.data.id,
+      coupon: coupon.data,
+    };
+  },
+  deleteCouponCode: async (promotionId: number, couponId: number) => {
+    await httpClient.delete(`/v3/promotions/${promotionId}/codes/${couponId}`);
+    await httpClient.delete(`/v3/promotions/${promotionId}`);
+  },
+};

--- a/core/tests/fixtures/utils/api/promotions/index.ts
+++ b/core/tests/fixtures/utils/api/promotions/index.ts
@@ -1,0 +1,16 @@
+export interface Coupon {
+  readonly id: number;
+  readonly code: string;
+}
+
+export interface PromotionWithCoupon {
+  promotionId: number;
+  coupon: Coupon;
+}
+
+export interface PromotionsApi {
+  createCouponCode: () => Promise<PromotionWithCoupon>;
+  deleteCouponCode: (promotionId: number, couponId: number) => Promise<void>;
+}
+
+export { promotionsHttpClient } from './http';


### PR DESCRIPTION
## What/Why?
Add e2e tests for coupon code functionality on the cart.

## Testing
![image](https://github.com/user-attachments/assets/b167d7c2-37c7-4c04-8adb-5d084a805feb)

## Migration
Copy changes from `/core/tests`
