### PR TITLE
feat(core): update empty states for account pages

### DIFF
--- a/.changeset/some-aliens-punch.md
+++ b/.changeset/some-aliens-punch.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Update empty state for account pages, adjusting headers and empty designs.

--- a/core/app/[locale]/(default)/account/addresses/page.tsx
+++ b/core/app/[locale]/(default)/account/addresses/page.tsx
@@ -101,6 +101,7 @@ export default async function Addresses({ params, searchParams }: Props) {
       createLabel={t('create')}
       deleteLabel={t('delete')}
       editLabel={t('edit')}
+      emptyStateTitle={t('EmptyState.title')}
       fields={[...fields, { name: 'id', type: 'hidden', label: 'ID' }]}
       minimumAddressCount={0}
       setDefaultLabel={t('setDefault')}

--- a/core/app/[locale]/(default)/account/orders/page.tsx
+++ b/core/app/[locale]/(default)/account/orders/page.tsx
@@ -50,8 +50,8 @@ export default async function Orders({ params, searchParams }: Props) {
 
   return (
     <OrderList
-      emptyStateActionLabel={t('emptyState.cta')}
-      emptyStateTitle={t('emptyState.title')}
+      emptyStateActionLabel={t('EmptyState.cta')}
+      emptyStateTitle={t('EmptyState.title')}
       orderNumberLabel={t('orderNumber')}
       orders={getOrders(after, before)}
       paginationInfo={getPaginationInfo(after, before)}

--- a/core/app/[locale]/(default)/account/wishlists/page.tsx
+++ b/core/app/[locale]/(default)/account/wishlists/page.tsx
@@ -74,7 +74,6 @@ export default async function Wishlists({ params, searchParams }: Props) {
       emptyStateCallToAction={
         <NewWishlistButton label={t('noWishlistsCallToAction')} modal={newWishlistModal} />
       }
-      emptyStateSubtitle={t('noWishlistsSubtitle')}
       emptyStateTitle={t('noWishlists')}
       emptyWishlistStateText={t('emptyWishlist')}
       itemActions={{
@@ -123,7 +122,6 @@ export default async function Wishlists({ params, searchParams }: Props) {
         },
       }}
       paginationInfo={Streamable.from(() => getPaginationInfo(searchParams))}
-      placeholderCount={1}
       title={t('title')}
       viewWishlistLabel={t('viewWishlist')}
       wishlists={Streamable.from(() => listWishlists(searchParams, t))}

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -148,7 +148,7 @@
       "orderNumber": "Order #",
       "totalPrice": "Total",
       "viewDetails": "View Details",
-      "emptyState": {
+      "EmptyState": {
         "title": "You don't have any orders",
         "cta": "Shop now"
       },
@@ -174,7 +174,10 @@
       "create": "Create",
       "update": "Update",
       "setDefault": "Set as default",
-      "somethingWentWrong": "Something went wrong. Please try again later."
+      "somethingWentWrong": "Something went wrong. Please try again later.",
+      "EmptyState": {
+        "title": "You don't have any addresses"
+      }
     },
     "Settings": {
       "title": "Account settings",
@@ -195,7 +198,6 @@
     "items": "{count, plural, =1 {1 item} other {# items}}",
     "viewWishlist": "View list",
     "noWishlists": "You don't have any wish lists",
-    "noWishlistsSubtitle": "Create a wishlist to save your favorite products.",
     "noWishlistsCallToAction": "Create a wishlist",
     "emptyWishlist": "You haven't added products to this wish list.",
     "share": "Share",

--- a/core/tests/ui/e2e/account/orders.spec.ts
+++ b/core/tests/ui/e2e/account/orders.spec.ts
@@ -16,8 +16,8 @@ test('Orders page has an empty state when no orders exist', async ({ page, custo
     page.getByRole('heading', { name: t('Account.Orders.title'), exact: true }),
   ).toBeVisible();
 
-  await expect(page.getByText(t('Account.Orders.emptyState.title'))).toBeVisible();
-  await expect(page.getByRole('link', { name: t('Account.Orders.emptyState.cta') })).toBeVisible();
+  await expect(page.getByText(t('Account.Orders.EmptyState.title'))).toBeVisible();
+  await expect(page.getByRole('link', { name: t('Account.Orders.EmptyState.cta') })).toBeVisible();
 });
 
 test('Order details are displayed and use correct formatting', async ({

--- a/core/tests/ui/e2e/account/wishlists.spec.ts
+++ b/core/tests/ui/e2e/account/wishlists.spec.ts
@@ -79,7 +79,6 @@ test('Wishlists page displays empty state when there are no wishlists', async ({
   await expect(page.getByRole('heading', { name: t('title'), exact: true })).toBeVisible();
   await expect(page.getByRole('heading', { name: t('noWishlists'), exact: true })).toBeVisible();
   await expect(page.getByRole('button', { name: t('new'), exact: true })).toBeVisible();
-  await expect(page.getByText(t('noWishlistsSubtitle'), { exact: true })).toBeVisible();
   await expect(
     page.getByRole('button', { name: t('noWishlistsCallToAction'), exact: true }),
   ).toBeVisible();

--- a/core/vibes/soul/sections/account-settings/index.tsx
+++ b/core/vibes/soul/sections/account-settings/index.tsx
@@ -21,6 +21,7 @@ export interface AccountSettingsSectionProps {
  *
  * ```css
  * :root {
+ *   --account-settings-section-title-font-family: var(--font-family-heading);
  *   --account-settings-section-font-family: var(--font-family-heading);
  *   --account-settings-section-text: hsl(var(--foreground));
  *   --account-settings-section-border: hsl(var(--contrast-100));
@@ -41,10 +42,10 @@ export function AccountSettingsSection({
 }: AccountSettingsSectionProps) {
   return (
     <section className="w-full @container">
-      <header className="mb-4 border-b border-b-contrast-100">
-        <div className="mb-4 flex min-h-[42px] items-center justify-between">
-          <h1 className="font-heading text-4xl font-medium leading-none">{title}</h1>
-        </div>
+      <header className="mb-4 border-[var(--account-settings-section-border,hsl(var(--contrast-100)))] @2xl:min-h-[72px] @2xl:border-b">
+        <h1 className="hidden font-[family-name:var(--account-settings-section-title-font-family,var(--font-family-heading))] text-4xl font-medium leading-none tracking-tight text-[var(--account-settings-section-title,hsl(var(--foreground)))] @2xl:block">
+          {title}
+        </h1>
       </header>
       <div className="flex flex-col gap-y-24 @xl:flex-row">
         <div className="my-4 flex w-full flex-col @xl:max-w-lg">

--- a/core/vibes/soul/sections/order-list/index.tsx
+++ b/core/vibes/soul/sections/order-list/index.tsx
@@ -68,8 +68,8 @@ export function OrderList({
 }: OrderListProps) {
   return (
     <section className="group/order-list w-full @container">
-      <header className="mb-4 border-b border-[var(--order-list-border,hsl(var(--contrast-100)))]">
-        <div className="mb-4 flex min-h-[42px] items-center justify-between">
+      <header className="mb-4 border-[var(--order-list-border,hsl(var(--contrast-100)))] @2xl:min-h-[72px] @2xl:border-b">
+        <div className="mb-4 flex items-center justify-between">
           <h1 className="hidden font-[family-name:var(--order-list-title-font-family,var(--font-family-heading))] text-4xl font-medium leading-none tracking-tight text-[var(--order-list-title,hsl(var(--foreground)))] @2xl:block">
             {title}
           </h1>

--- a/core/vibes/soul/sections/wishlist-list/index.tsx
+++ b/core/vibes/soul/sections/wishlist-list/index.tsx
@@ -1,5 +1,3 @@
-import { clsx } from 'clsx';
-
 import { Stream, Streamable } from '@/vibes/soul/lib/streamable';
 import { Wishlist } from '@/vibes/soul/sections/wishlist-details';
 import {
@@ -11,11 +9,9 @@ import {
 interface Props {
   wishlists: Streamable<Wishlist[]>;
   emptyStateCallToAction?: React.ReactNode;
-  emptyStateSubtitle?: Streamable<string | null>;
   emptyStateTitle?: Streamable<string | null>;
   emptyWishlistStateText?: Streamable<string | null>;
   viewWishlistLabel?: string;
-  placeholderCount?: number;
   itemActions?: WishlistItemActions;
 }
 
@@ -23,10 +19,8 @@ export const WishlistList = ({
   wishlists: streamableWishlists,
   emptyStateCallToAction,
   emptyStateTitle,
-  emptyStateSubtitle,
   emptyWishlistStateText,
   viewWishlistLabel,
-  placeholderCount,
   itemActions,
 }: Props) => {
   return (
@@ -40,10 +34,8 @@ export const WishlistList = ({
             return (
               <WishlistListEmptyState
                 emptyStateCallToAction={emptyStateCallToAction}
-                emptyStateSubtitle={emptyStateSubtitle}
                 emptyStateTitle={emptyStateTitle}
                 itemActions={itemActions}
-                placeholderCount={placeholderCount}
               />
             );
           }
@@ -65,26 +57,18 @@ export const WishlistList = ({
 };
 
 function WishlistListEmptyState({
-  className = '',
   emptyStateCallToAction,
-  emptyStateSubtitle = 'Create a new wish list to save your favorite products.',
   emptyStateTitle = "You don't have any wish list",
-  itemActions,
-  placeholderCount = 1,
-}: { className?: string } & Omit<Props, 'wishlists'>) {
+}: Omit<Props, 'wishlists'>) {
   return (
-    <div className={clsx('relative', className)}>
-      <div className="[mask-image:linear-gradient(to_bottom,_black_0%,_transparent_100%)]">
-        <WishlistListSkeleton itemActions={itemActions} placeholderCount={placeholderCount} />
-      </div>
-      <div className="absolute inset-0 mx-auto px-3 py-24 pb-3 @4xl:px-10 @4xl:pb-10 @4xl:pt-16">
-        <div className="mx-auto max-w-xl space-y-2 text-center @4xl:space-y-3">
-          <h3 className="@4x:leading-none font-heading text-2xl leading-tight text-foreground @4xl:text-4xl">
+    <div className="@container">
+      <div className="py-20">
+        <header className="mx-auto flex max-w-2xl flex-col items-center gap-5">
+          <h2 className="text-center text-lg font-semibold text-[var(--order-list-empty-state-title,hsl(var(--foreground)))]">
             {emptyStateTitle}
-          </h3>
-          <p className="text-sm text-contrast-500 @4xl:text-lg">{emptyStateSubtitle}</p>
+          </h2>
           {emptyStateCallToAction}
-        </div>
+        </header>
       </div>
     </div>
   );

--- a/core/vibes/soul/sections/wishlists-section/index.tsx
+++ b/core/vibes/soul/sections/wishlists-section/index.tsx
@@ -9,44 +9,53 @@ interface Props {
   wishlists: Streamable<Wishlist[]>;
   paginationInfo?: Streamable<CursorPaginationInfo>;
   emptyStateCallToAction?: React.ReactNode;
-  emptyStateSubtitle?: Streamable<string | null>;
   emptyStateTitle?: Streamable<string | null>;
   emptyWishlistStateText?: Streamable<string | null>;
   viewWishlistLabel?: string;
-  placeholderCount?: number;
   actions?: React.ReactNode;
   itemActions?: WishlistItemActions;
 }
+
+/**
+ * This component supports various CSS variables for theming. Here's a comprehensive list, along
+ * with their default values:
+ *
+ * ```css
+ * :root {
+ *   --wishlists-section-title-font-family: var(--font-family-heading);
+ *   --wishlists-section-title: hsl(var(--foreground));
+ *   --wishlists-section-border: hsl(var(--contrast-100));
+ * }
+ * ```
+ */
 
 export const WishlistsSection = ({
   title,
   wishlists,
   paginationInfo,
   emptyStateCallToAction,
-  emptyStateSubtitle,
   emptyStateTitle,
   emptyWishlistStateText,
   viewWishlistLabel,
-  placeholderCount,
   actions,
   itemActions,
 }: Props) => {
   return (
     <section className="w-full">
-      <header className="mb-4 border-b border-b-contrast-100">
+      <header className="mb-4 border-[var(--wishlists-section-border,hsl(var(--contrast-100)))] @2xl:min-h-[72px] @2xl:border-b">
         <div className="mb-4 flex items-center justify-between">
-          <h1 className="font-heading text-4xl font-medium leading-none">{title}</h1>
+          <h1 className="hidden font-[family-name:var(--wishlists-section-title-font-family,var(--font-family-heading))] text-4xl font-medium leading-none tracking-tight text-[var(--wishlists-section-title,hsl(var(--foreground)))] @2xl:block">
+            {title}
+          </h1>
           {actions}
         </div>
       </header>
 
       <WishlistList
         emptyStateCallToAction={emptyStateCallToAction}
-        emptyStateSubtitle={emptyStateSubtitle}
         emptyStateTitle={emptyStateTitle}
         emptyWishlistStateText={emptyWishlistStateText}
         itemActions={itemActions}
-        placeholderCount={placeholderCount}
         viewWishlistLabel={viewWishlistLabel}
         wishlists={wishlists}
       />


### PR DESCRIPTION
## What/Why?
Add empty state for AddressListSection.

## Testing

<img width="1108" alt="Screenshot 2025-06-13 at 12 48 54 PM" src="https://github.com/user-attachments/assets/5db0ff02-7083-417b-9836-9bd5e0fc62be" />

<img width="1086" alt="Screenshot 2025-06-13 at 12 48 41 PM" src="https://github.com/user-attachments/assets/5f4996ef-d6a1-4ee9-b261-e922c5e084e4" />

## Migration

- Add `AddressListEmptyState` and conditionally render it if the `addresses` array is empty.
- Add `emptyStateTitle` prop.
- Update header classes for all account pages
- Hide header in small viewport
