### PR TITLE
Add e2e tests for cart shipping quotes

### DIFF
--- a/core/tests/ui/e2e/shipping.spec.ts
+++ b/core/tests/ui/e2e/shipping.spec.ts
@@ -1,95 +1,152 @@
-import { type Page } from '@playwright/test';
+import { faker } from '@faker-js/faker';
 
-import { expect, test } from '~/tests/fixtures';
+import { expect, Page, test } from '~/tests/fixtures';
+import { CatalogFixture } from '~/tests/fixtures/catalog';
+import { getTranslations } from '~/tests/lib/i18n';
 
-async function addEstimatedShippingCosts(
-  page: Page,
-  country: string,
-  state: string,
-  city: string,
-  zip: string,
-): Promise<void> {
-  await page.getByRole('combobox', { name: 'Country' }).click();
-  await page.getByLabel(country).click();
+async function addProductAndGoToCart(page: Page, catalog: CatalogFixture) {
+  const t = await getTranslations();
+  const product = await catalog.getDefaultOrCreateSimpleProduct();
 
-  await page.getByRole('combobox', { name: 'State/province' }).click();
-  await page.getByLabel(state).click();
+  await page.goto(product.path);
+  await page.getByRole('button', { name: t('Product.ProductDetails.Submit.addToCart') }).click();
+  await page.waitForLoadState('networkidle');
 
-  await page.getByLabel('Suburb/city').fill(city);
-  await page.getByLabel('Zip/Postcode').fill(zip);
-
-  await page.getByRole('button', { name: 'Estimate shipping' }).click();
-  await page.getByRole('button', { name: 'Update shipping costs' }).click();
+  await page.goto('/cart');
+  await expect(page.getByRole('heading', { name: t('Cart.title') })).toBeVisible();
 }
 
-test.beforeEach(async ({ page }) => {
-  await page.goto('/sample-able-brewing-system/');
-  await expect(
-    page.getByRole('heading', { level: 1, name: '[Sample] Able Brewing System' }),
-  ).toBeVisible();
+async function fillOutShippingForm(page: Page) {
+  const t = await getTranslations('Cart.CheckoutSummary.Shipping');
 
-  await page.getByRole('button', { name: 'Add to Cart' }).first().click();
-  await page.getByRole('button', { name: 'Add to Cart' }).first().isEnabled();
-  await page.getByRole('link', { name: 'Cart Items 1' }).click();
+  await page.getByLabel(t('country')).click();
+  await page.getByRole('option').first().click();
+  await page.getByLabel(t('city')).fill(faker.location.city());
+  await page.getByLabel(t('state')).click();
 
-  await expect(page.getByRole('heading', { level: 1, name: 'Your cart' })).toBeVisible();
-  await expect(page.getByText('[Sample] Able Brewing System', { exact: true })).toBeVisible();
+  const states = await page.getByRole('option').allTextContents();
+
+  if (states.length >= 1) {
+    // Click a random state
+    const randomIndex = Math.floor(Math.random() * states.length);
+
+    await page.getByRole('option').nth(randomIndex).click();
+  } else {
+    await page.keyboard.press('Escape');
+  }
+
+  await page.getByLabel(t('postalCode')).click();
+  await page.getByLabel(t('postalCode')).fill(faker.location.zipCode('#####'));
+}
+
+async function selectRandomShippingOption(page: Page): Promise<string> {
+  const shippingOptions = await page.getByRole('radio').all();
+
+  let selectedOption = '';
+
+  if (shippingOptions.length >= 1) {
+    // Click a random state
+    const randomIndex = Math.floor(Math.random() * shippingOptions.length);
+    const shippingOption = shippingOptions[randomIndex];
+
+    selectedOption =
+      (await shippingOption?.locator('~ label > span[id*="label"]').innerText()) ?? '';
+
+    await shippingOption?.click();
+  }
+
+  return selectedOption;
+}
+
+test('Add shipping estimates', async ({ page, catalog }) => {
+  const t = await getTranslations('Cart.CheckoutSummary.Shipping');
+
+  await addProductAndGoToCart(page, catalog);
+
+  await page.getByRole('button', { name: t('add'), exact: true }).click();
+
+  await fillOutShippingForm(page);
+
+  await page.getByRole('button', { name: t('viewShippingOptions') }).click();
+  await expect(page.getByLabel(t('shippingOptions'))).toBeVisible();
+
+  const selectedOption = await selectRandomShippingOption(page);
+
+  await page.getByRole('button', { name: t('addShipping') }).click();
+  await page.waitForLoadState('networkidle');
+
+  await expect(page.getByText(`${selectedOption}${t('change')}`)).toBeVisible();
 });
 
-test('Add shipping estimates', async ({ page }) => {
-  await expect(page.getByText('Shipping cost')).toBeVisible();
-  await page.getByRole('button', { name: 'Add' }).first().click();
+test('Update shipping estimates', async ({ page, catalog }) => {
+  const t = await getTranslations('Cart.CheckoutSummary.Shipping');
 
-  await addEstimatedShippingCosts(page, 'United States', 'Texas', 'Austin', '76267');
-  await expect(page.getByRole('button', { name: 'Change' })).toBeVisible();
+  await addProductAndGoToCart(page, catalog);
+
+  await page.getByRole('button', { name: t('add'), exact: true }).click();
+
+  await fillOutShippingForm(page);
+
+  await page.getByRole('button', { name: t('viewShippingOptions') }).click();
+  await expect(page.getByLabel(t('shippingOptions'))).toBeVisible();
+
+  let selectedOption = await selectRandomShippingOption(page);
+
+  await page.getByRole('button', { name: t('addShipping') }).click();
+  await page.waitForLoadState('networkidle');
+
+  await page.getByText(t('change')).click();
+  await page.getByRole('button', { name: t('editAddress') }).click();
+
+  await fillOutShippingForm(page);
+
+  await page.getByRole('button', { name: t('updatedShippingOptions') }).click();
+  await expect(page.getByRole('button', { name: t('updatedShippingOptions') })).toBeHidden();
+
+  if (await page.getByLabel(t('shippingOptions')).isVisible()) {
+    selectedOption = await selectRandomShippingOption(page);
+    await page.getByRole('button', { name: t('updateShipping') }).click();
+    await page.waitForLoadState('networkidle');
+  }
+
+  await expect(page.getByText(`${selectedOption}${t('change')}`)).toBeVisible();
 });
 
-test('Update shipping estimates', async ({ page }) => {
-  await expect(page.getByText('Shipping cost')).toBeVisible();
-  await page.getByRole('button', { name: 'Add' }).first().click();
-
-  await addEstimatedShippingCosts(page, 'United States', 'Texas', 'Austin', '76267');
-
-  await expect(page.getByRole('button', { name: 'Change' })).toBeVisible();
-  await page.getByRole('button', { name: 'Change' }).click();
-
-  await addEstimatedShippingCosts(page, 'United States', 'Massachusetts', 'Boston', '01762');
-
-  await expect(page.getByRole('button', { name: 'Change' })).toBeVisible();
-});
-
-test('Add shipping estimates for Canada', async ({ page }) => {
-  await expect(page.getByText('Shipping cost')).toBeVisible();
-  await page.getByRole('button', { name: 'Add' }).first().click();
-
-  await addEstimatedShippingCosts(page, 'Canada', 'British Columbia', 'Vancouver', '98617');
-  await expect(page.getByRole('button', { name: 'Change' })).toBeVisible();
-});
-
-/**
- * @description When the item in cart is modified after shipping estimation is calculated, shipping estimation
- * is reset but shipping information is persisted.
- */
-test('Updating cart items should reset shipping costs but retain shipping information', async ({
+test('Updating cart quantity with a shipping estimate opens the shipping options for a new quote', async ({
   page,
+  catalog,
 }) => {
-  await expect(page.getByText('Shipping cost')).toBeVisible();
-  await page.getByRole('button', { name: 'Add' }).first().click();
+  const t = await getTranslations('Cart');
 
-  await addEstimatedShippingCosts(page, 'United States', 'Texas', 'Austin', '76267');
-  await page.getByRole('button', { name: 'Change' }).waitFor();
+  await addProductAndGoToCart(page, catalog);
 
-  await page.getByRole('button', { name: 'Increase count' }).click();
-  await page.getByRole('link', { name: 'Cart Items 2' }).waitFor();
+  await page.getByRole('button', { name: t('CheckoutSummary.Shipping.add'), exact: true }).click();
 
-  await page.getByRole('button', { name: 'Add' }).first().click();
+  await fillOutShippingForm(page);
+
+  await page
+    .getByRole('button', { name: t('CheckoutSummary.Shipping.viewShippingOptions') })
+    .click();
+  await expect(page.getByLabel(t('CheckoutSummary.Shipping.shippingOptions'))).toBeVisible();
+
+  let selectedOption = await selectRandomShippingOption(page);
+
+  await page.getByRole('button', { name: t('CheckoutSummary.Shipping.addShipping') }).click();
+  await page.waitForLoadState('networkidle');
 
   await expect(
-    page.getByRole('combobox', { name: 'Country' }).filter({ hasText: 'United States' }),
+    page.getByText(`${selectedOption}${t('CheckoutSummary.Shipping.change')}`),
   ).toBeVisible();
+
+  await page.getByLabel(t('increment')).click();
+  await page.waitForLoadState('networkidle');
+
+  await expect(page.getByLabel(t('CheckoutSummary.Shipping.shippingOptions'))).toBeVisible();
+
+  selectedOption = await selectRandomShippingOption(page);
+
+  await page.getByRole('button', { name: t('CheckoutSummary.Shipping.addShipping') }).click();
   await expect(
-    page.getByRole('combobox', { name: 'State/province' }).filter({ hasText: 'Texas' }),
+    page.getByText(`${selectedOption}${t('CheckoutSummary.Shipping.change')}`),
   ).toBeVisible();
-  await expect(page.getByPlaceholder('City')).toHaveValue('Austin');
-  await expect(page.getByPlaceholder('Postal code')).toHaveValue('76267');
 });


### PR DESCRIPTION
## What/Why?
Rewrite `shipping.spec.ts` e2e tests

## Testing
![image](https://github.com/user-attachments/assets/ab3d6d51-b6d8-4e58-8aca-c5560ddf1e8c)

## Migration
Copy changes from `/core/tests`
