### PR TITLE
fix: remove `await connection()` workaround on 404 pages

### DIFF
--- a/.changeset/evil-dogs-shine.md
+++ b/.changeset/evil-dogs-shine.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Remove `await connection()` workaround on 404 pages

--- a/core/lib/makeswift/page.tsx
+++ b/core/lib/makeswift/page.tsx
@@ -1,5 +1,4 @@
 import { notFound } from 'next/navigation';
-import { connection } from 'next/server';
 
 import { getPageSnapshot } from './client';
 import { MakeswiftPageShim } from './makeswift-page-shim';
@@ -8,9 +7,6 @@ export async function Page({ path, locale }: { path: string; locale: string }) {
   const snapshot = await getPageSnapshot({ path, locale });
 
   if (snapshot == null) {
-    // This is a temporary solution to fix the issue where non-published pages are not editable in the builder.
-    await connection();
-
     return notFound();
   }
 


### PR DESCRIPTION
## What/Why?

This was originally put in place to work around the issue of non-published pages not being editable in the builder. That issue has long since been resolved, so the workaround is no longer necessary.

## Testing

As an extra test, here's a demo of a 404 page with an editable Makeswift component on it:

https://github.com/user-attachments/assets/21a264d7-00e4-4f90-b676-8739da43fc7f


