### PR TITLE
fix: oversized logo in footer

### DIFF
--- a/core/vibes/soul/sections/footer/index.tsx
+++ b/core/vibes/soul/sections/footer/index.tsx
@@ -93,13 +93,16 @@ export const Footer = ({
         <div className="flex flex-col justify-between gap-x-16 gap-y-12 @3xl:flex-row">
           <div className="flex flex-col gap-4 @3xl:w-1/3 @3xl:gap-6">
             {/* Logo Information */}
-            <Logo
-              height={logoHeight}
-              href={logoHref}
-              label={logoLabel}
-              logo={logo}
-              width={logoWidth}
-            />
+            <div className="flex items-center justify-start self-stretch">
+              <Logo
+                className="flex"
+                height={logoHeight}
+                href={logoHref}
+                label={logoLabel}
+                logo={logo}
+                width={logoWidth}
+              />
+            </div>
 
             {/* Contact Information */}
             <Stream fallback={<FooterContactSkeleton />} value={streamableContactInformation}>


### PR DESCRIPTION
## What/Why?
- adds same CSS classes to footer logo as header logo to ensure support for different logo widths
- fixes oversized logo in footer

## Testing
https://github.com/user-attachments/assets/46f028fa-52f9-40d0-a337-ae0134678d4a


