### PR TITLE
feat: prevent invalid changesets from being merged into integrations/makeswift

### DIFF
--- a/.github/scripts/prevent-invalid-changesets.js
+++ b/.github/scripts/prevent-invalid-changesets.js
@@ -2,6 +2,12 @@ const fs = require("fs");
 
 module.exports = async ({ core, exec }) => {
   try {
+    await exec.exec("git", [
+      "fetch",
+      "https://github.com/bigcommerce/catalyst.git",
+      "integrations/makeswift",
+    ]);
+
     const { stdout } = await exec.getExecOutput("git", [
       "diff",
       "--name-only",

--- a/.github/scripts/prevent-invalid-changesets.js
+++ b/.github/scripts/prevent-invalid-changesets.js
@@ -1,0 +1,105 @@
+const fs = require("fs");
+
+module.exports = async ({ core, exec }) => {
+  try {
+    const { stdout } = await exec.getExecOutput("git", [
+      "diff",
+      "--name-only",
+      `origin/integrations/makeswift...HEAD`,
+    ]);
+
+    const allFilenames = stdout.split("\n").filter((line) => line.trim());
+    const changesetFilenames = allFilenames.filter(
+      (file) => file.startsWith(".changeset/") && file.endsWith(".md")
+    );
+
+    if (changesetFilenames.length === 0) {
+      core.info("No changeset files found to validate");
+      return;
+    }
+
+    core.info(`Found ${changesetFilenames.length} changeset files to validate`);
+
+    for (const filename of changesetFilenames) {
+      core.info(`Checking ${filename}...`);
+
+      // .changeset/*.md filenames should only contain alphanumeric characters, hyphens, and underscores
+      if (!/^\.changeset\/[a-zA-Z0-9_-]+\.md$/.test(filename)) {
+        core.setFailed(`Invalid filename pattern: ${filename}`);
+        return;
+      }
+
+      // extra defense against path traversal attacks
+      if (
+        filename.includes("..") ||
+        (filename.includes("/") && !filename.startsWith(".changeset/"))
+      ) {
+        core.setFailed(`Suspicious file path: ${filename}`);
+        return;
+      }
+
+      // check if file exists
+      if (!fs.existsSync(filename)) {
+        core.setFailed(`File not found: ${filename}`);
+        return;
+      }
+
+      // check file size (limit to 100KB)
+      const stats = fs.statSync(filename);
+      if (stats.size > 102400) {
+        core.error(`File too large`, { file: filename });
+        core.setFailed(`File ${filename} is too large`);
+        return;
+      }
+
+      // check if it's a symlink
+      if (stats.isSymbolicLink()) {
+        core.error(`Symlinks are not allowed`, { file: filename });
+        core.setFailed(`File ${filename} is a symlink`);
+        return;
+      }
+
+      const content = fs.readFileSync(filename, "utf8");
+
+      // starts with "---", captures everything until the next "---"
+      const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+
+      if (!frontmatterMatch) {
+        core.error(`Failed to extract frontmatter or file has no frontmatter`, {
+          file: filename,
+        });
+        core.setFailed(`File ${filename} has invalid or missing frontmatter`);
+        return;
+      }
+
+      const frontmatter = frontmatterMatch[1];
+
+      // extract package references from frontmatter
+      const packageMatches = frontmatter.match(/"@bigcommerce\/[^"]+"/g);
+
+      if (packageMatches) {
+        const invalidPackages = packageMatches.filter(
+          (pkg) => pkg !== '"@bigcommerce/catalyst-makeswift"'
+        );
+
+        if (invalidPackages.length > 0) {
+          const sanitizedFile = filename.replace(/[^a-zA-Z0-9.\/_-]/g, "");
+          core.error(
+            `Invalid package found in changeset file. Only @bigcommerce/catalyst-makeswift is allowed.`,
+            { file: sanitizedFile }
+          );
+          core.setFailed(
+            `File ${filename} contains invalid packages: ${invalidPackages.join(
+              ", "
+            )}`
+          );
+          return;
+        }
+      }
+    }
+
+    core.info("All changeset files validated successfully");
+  } catch (error) {
+    core.setFailed(`Validation failed: ${error.message}`);
+  }
+};

--- a/.github/scripts/prevent-invalid-changesets.js
+++ b/.github/scripts/prevent-invalid-changesets.js
@@ -38,7 +38,6 @@ module.exports = async ({ core, exec }) => {
         return;
       }
 
-      // check if file exists
       if (!fs.existsSync(filename)) {
         core.setFailed(`File not found: ${filename}`);
         return;
@@ -52,7 +51,6 @@ module.exports = async ({ core, exec }) => {
         return;
       }
 
-      // check if it's a symlink
       if (stats.isSymbolicLink()) {
         core.error(`Symlinks are not allowed`, { file: filename });
         core.setFailed(`File ${filename} is a symlink`);
@@ -74,7 +72,7 @@ module.exports = async ({ core, exec }) => {
 
       const frontmatter = frontmatterMatch[1];
 
-      // extract package references from frontmatter
+      // extract all packages starting with "@bigcommerce/
       const packageMatches = frontmatter.match(/"@bigcommerce\/[^"]+"/g);
 
       if (packageMatches) {
@@ -83,10 +81,9 @@ module.exports = async ({ core, exec }) => {
         );
 
         if (invalidPackages.length > 0) {
-          const sanitizedFile = filename.replace(/[^a-zA-Z0-9.\/_-]/g, "");
           core.error(
             `Invalid package found in changeset file. Only @bigcommerce/catalyst-makeswift is allowed.`,
-            { file: sanitizedFile }
+            { file: filename }
           );
           core.setFailed(
             `File ${filename} contains invalid packages: ${invalidPackages.join(

--- a/.github/workflows/prevent-invalid-changesets.yml
+++ b/.github/workflows/prevent-invalid-changesets.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - integrations/makeswift
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   validate-changesets:
     runs-on: ubuntu-latest
@@ -16,22 +20,63 @@ jobs:
       - name: Get changed .changeset files
         id: changed
         run: |
-          files=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep '^\.changeset/.*\.md$' || true)
-          echo "files<<EOF" >> $GITHUB_OUTPUT
+          set -euo pipefail
+
+          files=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" | grep '^\.changeset/.*\.md$' || true)
+
+          # sanitize the file list to prevent injection
+          files=$(echo "$files" | grep -E '^\.changeset/[a-zA-Z0-9_-]+\.md$' || true)
+
+          delimiter="changeset_files_$(date +%s)_$$"
+          echo "files<<$delimiter" >> $GITHUB_OUTPUT
           echo "$files" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "$delimiter" >> $GITHUB_OUTPUT
 
       - name: Validate changesets only target @bigcommerce/catalyst-makeswift
         if: steps.changed.outputs.files != ''
         run: |
-          echo "${{ steps.changed.outputs.files }}" | while read file; do
-            echo "Checking $file..."
+          set -euo pipefail
+          echo "${{ steps.changed.outputs.files }}" | while IFS= read -r file; do
+            # .changeset/*.md filenames should only contain alphanumeric characters, hyphens, and underscores
+            if [[ ! "$file" =~ ^\.changeset/[a-zA-Z0-9_-]+\.md$ ]]; then
+              printf "::error::Invalid filename pattern: %s\n" "$file"
+              exit 1
+            fi
 
-            frontmatter=$(awk '/^---/{if (++count == 2) exit; next} count==1' "$file")
+            # extra defense against path traversal attacks
+            if [[ "$file" == *".."* ]] || [[ "$file" == *"/"* && "$file" != .changeset/* ]]; then
+              printf "::error::Suspicious file path: %s\n" "$file"
+              exit 1
+            fi
+
+            printf "Checking %s...\n" "$file"
+
+            # processing untrusted file contents through awk/grep without size limits could lead to resource exhaustion
+            # limit file size to 100KB
+            if [[ $(stat -f%z "$file" 2>/dev/null || stat -c%s "$file" 2>/dev/null) -gt 102400 ]]; then
+              printf "::error file=%s::File too large\n" "$file"
+              exit 1
+            fi
+
+            if [[ -L "$file" ]]; then
+              printf "::error file=%s::Symlinks are not allowed\n" "$file"
+              exit 1
+            fi
+
+            if [[ ! -f "$file" ]]; then
+              printf "::error::File not found: %s\n" "$file"
+              exit 1
+            fi
+
+            frontmatter=$(timeout 10s awk '/^---/{if (++count == 2) exit; next} count==1' "$file" 2>/dev/null || echo "")
+            if [[ -z "$frontmatter" ]]; then
+              printf "::error file=%s::Failed to extract frontmatter or file has no frontmatter\n" "$file"
+              exit 1
+            fi
 
             # fails the check if it finds a changeset file with frontmatter containing a package that is not "@bigcommerce/catalyst-makeswift"
             echo "$frontmatter" | grep -Eo '"@bigcommerce/[^"]+"' | grep -v '"@bigcommerce/catalyst-makeswift"' && {
-              echo "::error file=$file::Invalid package found in changeset file. Only @bigcommerce/catalyst-makeswift is allowed."
+              printf "::error file=%s::Invalid package found in changeset file. Only @bigcommerce/catalyst-makeswift is allowed.\n" "${file//[^a-zA-Z0-9.\/_-]/}"
               exit 1
             }
           done

--- a/.github/workflows/prevent-invalid-changesets.yml
+++ b/.github/workflows/prevent-invalid-changesets.yml
@@ -16,68 +16,12 @@ jobs:
     steps:
       - name: Checkout PR code
         uses: actions/checkout@v4
-
-      - name: Get changed .changeset files
-        id: changed
-        run: |
-          set -euo pipefail
-
-          files=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" | grep '^\.changeset/.*\.md$' || true)
-
-          # sanitize the file list to prevent injection
-          files=$(echo "$files" | grep -E '^\.changeset/[a-zA-Z0-9_-]+\.md$' || true)
-
-          delimiter="changeset_files_$(date +%s)_$$"
-          echo "files<<$delimiter" >> $GITHUB_OUTPUT
-          echo "$files" >> $GITHUB_OUTPUT
-          echo "$delimiter" >> $GITHUB_OUTPUT
+        with:
+          fetch-depth: 0
 
       - name: Validate changesets only target @bigcommerce/catalyst-makeswift
-        if: steps.changed.outputs.files != ''
-        run: |
-          set -euo pipefail
-
-          echo "${{ steps.changed.outputs.files }}" | while IFS= read -r file; do
-            # .changeset/*.md filenames should only contain alphanumeric characters, hyphens, and underscores
-            if [[ ! "$file" =~ ^\.changeset/[a-zA-Z0-9_-]+\.md$ ]]; then
-              printf "::error::Invalid filename pattern: %s\n" "$file"
-              exit 1
-            fi
-
-            # extra defense against path traversal attacks
-            if [[ "$file" == *".."* ]] || [[ "$file" == *"/"* && "$file" != .changeset/* ]]; then
-              printf "::error::Suspicious file path: %s\n" "$file"
-              exit 1
-            fi
-
-            printf "Checking %s...\n" "$file"
-
-            # processing untrusted file contents through awk/grep without size limits could lead to resource exhaustion
-            # limit file size to 100KB
-            if [[ $(stat -f%z "$file" 2>/dev/null || stat -c%s "$file" 2>/dev/null) -gt 102400 ]]; then
-              printf "::error file=%s::File too large\n" "$file"
-              exit 1
-            fi
-
-            if [[ -L "$file" ]]; then
-              printf "::error file=%s::Symlinks are not allowed\n" "$file"
-              exit 1
-            fi
-
-            if [[ ! -f "$file" ]]; then
-              printf "::error::File not found: %s\n" "$file"
-              exit 1
-            fi
-
-            frontmatter=$(timeout 10s awk '/^---/{if (++count == 2) exit; next} count==1' "$file" 2>/dev/null || echo "")
-            if [[ -z "$frontmatter" ]]; then
-              printf "::error file=%s::Failed to extract frontmatter or file has no frontmatter\n" "$file"
-              exit 1
-            fi
-
-            # fails the check if it finds a changeset file with frontmatter containing a package that is not "@bigcommerce/catalyst-makeswift"
-            echo "$frontmatter" | grep -Eo '"@bigcommerce/[^"]+"' | grep -v '"@bigcommerce/catalyst-makeswift"' && {
-              printf "::error file=%s::Invalid package found in changeset file. Only @bigcommerce/catalyst-makeswift is allowed.\n" "${file//[^a-zA-Z0-9.\/_-]/}"
-              exit 1
-            }
-          done
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const script = require('./.github/scripts/prevent-invalid-changesets.js')
+            await script({ core, exec })

--- a/.github/workflows/prevent-invalid-changesets.yml
+++ b/.github/workflows/prevent-invalid-changesets.yml
@@ -36,6 +36,7 @@ jobs:
         if: steps.changed.outputs.files != ''
         run: |
           set -euo pipefail
+
           echo "${{ steps.changed.outputs.files }}" | while IFS= read -r file; do
             # .changeset/*.md filenames should only contain alphanumeric characters, hyphens, and underscores
             if [[ ! "$file" =~ ^\.changeset/[a-zA-Z0-9_-]+\.md$ ]]; then

--- a/.github/workflows/prevent-invalid-changesets.yml
+++ b/.github/workflows/prevent-invalid-changesets.yml
@@ -1,0 +1,37 @@
+name: Prevent invalid packages for Changesets
+
+on:
+  pull_request:
+    branches:
+      - integrations/makeswift
+
+jobs:
+  validate-changesets:
+    runs-on: ubuntu-latest
+    name: Validate Changeset Packages
+    steps:
+      - name: Checkout PR code
+        uses: actions/checkout@v4
+
+      - name: Get changed .changeset files
+        id: changed
+        run: |
+          files=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep '^\.changeset/.*\.md$' || true)
+          echo "files<<EOF" >> $GITHUB_OUTPUT
+          echo "$files" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Validate changesets only target @bigcommerce/catalyst-makeswift
+        if: steps.changed.outputs.files != ''
+        run: |
+          echo "${{ steps.changed.outputs.files }}" | while read file; do
+            echo "Checking $file..."
+
+            frontmatter=$(awk '/^---/{if (++count == 2) exit; next} count==1' "$file")
+
+            # fails the check if it finds a changeset file with frontmatter containing a package that is not "@bigcommerce/catalyst-makeswift"
+            echo "$frontmatter" | grep -Eo '"@bigcommerce/[^"]+"' | grep -v '"@bigcommerce/catalyst-makeswift"' && {
+              echo "::error file=$file::Invalid package found in changeset file. Only @bigcommerce/catalyst-makeswift is allowed."
+              exit 1
+            }
+          done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,8 +71,8 @@ To pull the latest code from `canary` into `integrations/makeswift`, follow the 
 > - The `name` field in `core/package.json` should remain `@bigcommerce/catalyst-makeswift`
 > - The `version` field in `core/package.json` should remain whatever the latest published `@bigcommerce/catalyst-makeswift` version was
 > - The `.changesets/` directory should not include any files that reference the `"@bigcommerce/catalyst-core"` package. If these files are merged into `integrations/makeswift`, they will cause the `Changesets Release` GitHub Action in `.github/workflows/changesets-release.yml` to fail with the error: `Error: Found changeset for package @bigcommerce/catalyst-core which is not in the workspace`
-
-<!-- TODO: The chances of someone accidentally merging a PR that references the `@bigcommerce/catalyst-core` package are quite high. We should find a better way to prevent this from happening. -->
+>
+> _Note: A [GitHub Action is in place](.github/workflows/prevent-invalid-changesets.yml) to help prevent invalid changesets from being merged into `integrations/makeswift`. Do not merge your PR if this GitHub Action fails._
 
 5. After resolving any merge conflicts, open a new PR in GitHub to merge your `{new-branch-name}` into `integrations/makeswift`. This PR should be code reviewed and approved before the next steps.
 
@@ -115,6 +115,8 @@ Once your PR is merged, our [GitHub Action](.github/workflows/changesets-release
 
 > [!WARNING]
 > It is very important that `.changeset/*.md` files targeting packages in `packages/` are not merged into the `integrations/makeswift` branch. While it is technically feasible to release packages from `integrations/makeswift`, we never want to do this. If we did this, we would need to sync the branches in the opposite direction, which was never intended to happen.
+>
+> _Note: A [GitHub Action is in place](.github/workflows/prevent-invalid-changesets.yml) to help prevent invalid changesets from being merged into `integrations/makeswift`. Do not merge your PR if this GitHub Action fails._
 
 ## Other Ways to Contribute
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ To pull the latest code from `canary` into `integrations/makeswift`, follow the 
 >
 > - The `name` field in `core/package.json` should remain `@bigcommerce/catalyst-makeswift`
 > - The `version` field in `core/package.json` should remain whatever the latest published `@bigcommerce/catalyst-makeswift` version was
-> - The `.changesets/` directory should not include any files that reference the `"@bigcommerce/catalyst-core"` package. If these files are merged into `integrations/makeswift`, they will cause the `Changesets Release` GitHub Action in `.github/workflows/changesets-release.yml` to fail with the error: `Error: Found changeset for package @bigcommerce/catalyst-core which is not in the workspace`
+> - The `.changeset/` directory should not include any files that reference the `"@bigcommerce/catalyst-core"` package. If these files are merged into `integrations/makeswift`, they will cause the `Changesets Release` GitHub Action in `.github/workflows/changesets-release.yml` to fail with the error: `Error: Found changeset for package @bigcommerce/catalyst-core which is not in the workspace`
 >
 > _Note: A [GitHub Action is in place](.github/workflows/prevent-invalid-changesets.yml) to help prevent invalid changesets from being merged into `integrations/makeswift`. Do not merge your PR if this GitHub Action fails._
 
@@ -109,7 +109,7 @@ pnpm changeset
 
 An interactive prompt will take you through the process of [adding your changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
 
-Once you've completed the interactive prompt, you'll see a new file in the `.changesets/` directory. This file contains the version bump and changelog entry for your changes. You should commit this file to the branch associated with your PR.
+Once you've completed the interactive prompt, you'll see a new file in the `.changeset/` directory. This file contains the version bump and changelog entry for your changes. You should commit this file to the branch associated with your PR.
 
 Once your PR is merged, our [GitHub Action](.github/workflows/changesets-release.yml) will handle the process of versioning and updating the changelog, (and in the case of `packages/`, publishing your changes to NPM). No further action is needed from you.
 


### PR DESCRIPTION
## What/Why?
<!--- 
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
--->
#2336 introduced updated documentation on how to keep `integrations/makeswift` up to date with `canary`. That documentation left room for potential human error. This PR introduces a GitHub Action to help prevent those errors. 

This action causes PR's to `integrations/makeswift` that contain `.changeset/*.md` files targeting packages that do not exist in that branch  (e.g., `"@bigcommerce/catalyst-core"`), or packages that we do not want to publish from this branch (e.g., `"@bigcommerce/catalyst-client"`, `"@bigcommerce/create-catalyst"`, or `"@bigcommerce/eslint-config-catalyst"`) to fail and prevent the PR from being merged. 

> [!NOTE]
> This work needs to be synced over to the `integrations/makeswift` branch to take effect. Will open a PR to do that after this. 

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->
Locally via https://github.com/nektos/act

Output for **FAILURE** will look something like:
```sh
act --container-architecture linux/amd64 -W '.github/workflows/prevent-invalid-changesets.yml'

INFO[0000] Using docker host 'unix:///Users/matt.volk/.rd/docker.sock', and daemon socket 
[Prevent invalid packages for Changesets/Validate Changeset Packages]   ✅  Success - Set up job
[Prevent invalid packages for Changesets/Validate Changeset Packages]   ✅  Success - Main Checkout PR code [1.523787542s]
[Prevent invalid packages for Changesets/Validate Changeset Packages] ⭐ Run Main Validate changesets only target @bigcommerce/catalyst-makeswift
[Prevent invalid packages for Changesets/Validate Changeset Packages]   🐳  docker cp src=/Users/matt.volk/.cache/act/actions-github-script@v7/ dst=/var/run/act/actions/actions-github-script@v7/
[Prevent invalid packages for Changesets/Validate Changeset Packages]   🐳  docker exec cmd=[/opt/acttoolcache/node/18.20.8/x64/bin/node /var/run/act/actions/actions-github-script@v7/dist/index.js] user= workdir=
| [command]/usr/bin/git diff --name-only origin/integrations/makeswift...HEAD
| .changeset/oopsie-daisy.md
| Found 1 changeset files to validate
| Checking .changeset/oopsie-daisy.md...
[Prevent invalid packages for Changesets/Validate Changeset Packages]   ❗  ::error file=.changeset/oopsie-daisy.md::Invalid package found in changeset file. Only @bigcommerce/catalyst-makeswift is allowed.
[Prevent invalid packages for Changesets/Validate Changeset Packages]   ❗  ::error::File .changeset/oopsie-daisy.md contains invalid packages: "@bigcommerce/catalyst-client"
[Prevent invalid packages for Changesets/Validate Changeset Packages]   ❌  Failure - Main Validate changesets only target @bigcommerce/catalyst-makeswift [1.24455075s]
```

## Migration
<!---
  If you have moved any files around, or made any breaking changes,
  please provide a migration guide for the developers to make rebases easier.
--->
N/A
