### PR TITLE
fix(core): add addition cookie options to anonymous cookie deletion

### DIFF
--- a/.changeset/ninety-flowers-retire.md
+++ b/.changeset/ninety-flowers-retire.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Fixes an issue where the anonymous session wasn't getting cleared after an actual session was established.

--- a/core/auth/anonymous-session.ts
+++ b/core/auth/anonymous-session.ts
@@ -68,7 +68,12 @@ export const clearAnonymousSession = async () => {
   const useSecureCookies = await shouldUseSecureCookie();
   const cookiePrefix = useSecureCookies ? '__Secure-' : '';
 
-  cookieJar.delete(`${cookiePrefix}${anonymousCookieName}`);
+  cookieJar.delete({
+    name: `${cookiePrefix}${anonymousCookieName}`,
+    secure: true,
+    sameSite: 'lax',
+    httpOnly: true,
+  });
 };
 
 export const updateAnonymousSession = async (user: AnonymousUser) => {


### PR DESCRIPTION
## What/Why?
Fixes an issue where when we were deleting the anonymous session, additional cookie options were not being passed to the `Set-Cookie` header, thus not clearing the anonymous session. You can see the issue in the following screenshot.
![Screenshot 2025-06-26 at 09 16 06](https://github.com/user-attachments/assets/7daa348f-f034-431a-847d-6475e43d2d59)


## Testing
### Before:
![Screenshot 2025-06-26 at 09 15 45](https://github.com/user-attachments/assets/a34692e7-d4ac-4547-acd6-6ab2007c79a5)
### After 
![Screenshot 2025-06-26 at 09 14 44](https://github.com/user-attachments/assets/ed79d71a-6d85-492b-8501-54455e39b976)

## Migration
Pull in the change like normal.
