### PR TITLE
chore: explicitly hoist eslint for pnpm 10

### DIFF
--- a/core/.eslintrc.cjs
+++ b/core/.eslintrc.cjs
@@ -2,7 +2,7 @@
 
 require('@bigcommerce/eslint-config/patch');
 
-/** @type {import('eslint').Linter.Config} */
+/** @type {import('eslint').Linter.LegacyConfig} */
 const config = {
   root: true,
   extends: [

--- a/packages/cli/.eslintrc.cjs
+++ b/packages/cli/.eslintrc.cjs
@@ -1,6 +1,6 @@
 // @ts-check
 
-/** @type {import('eslint').Linter.Config} */
+/** @type {import('eslint').Linter.LegacyConfig} */
 const config = {
   root: true,
   extends: ['@bigcommerce/catalyst/base', '@bigcommerce/catalyst/prettier'],

--- a/packages/client/.eslintrc.cjs
+++ b/packages/client/.eslintrc.cjs
@@ -1,6 +1,6 @@
 // @ts-check
 
-/** @type {import('eslint').Linter.Config} */
+/** @type {import('eslint').Linter.LegacyConfig} */
 const config = {
   root: true,
   extends: ['@bigcommerce/catalyst/base', '@bigcommerce/catalyst/prettier'],

--- a/packages/create-catalyst/.eslintrc.cjs
+++ b/packages/create-catalyst/.eslintrc.cjs
@@ -1,6 +1,6 @@
 // @ts-check
 
-/** @type {import('eslint').Linter.Config} */
+/** @type {import('eslint').Linter.LegacyConfig} */
 const config = {
   root: true,
   extends: ['@bigcommerce/catalyst/base', '@bigcommerce/catalyst/prettier'],

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,14 @@
 packages:
   - core
   - packages/*
+publicHoistPattern:
+  - '@bigcommerce/eslint-*'
+  - '@bigcommerce/eslint-*'
+  - '@next/eslint-*'
+  - '@stylistic/eslint-*'
+  - '@typescript-eslint/*'
+  - 'eslint-config-*'
+  - 'eslint-plugin-*'
 onlyBuiltDependencies:
   - '@parcel/watcher'
   - '@swc/core'


### PR DESCRIPTION
## What/Why?
[`pnpm@10` introduced a breaking change where modules are no longer hoisted to the root modules directory by default](https://github.com/pnpm/pnpm/releases/tag/v10.0.0). While this does not break `eslint` when it's run as a script, it does cause errors for the ESLint LSP. See screenshots below

## Testing
Before:
<img width="1624" alt="Screenshot 2025-07-01 at 6 30 05 PM" src="https://github.com/user-attachments/assets/181a398a-32bd-420c-a1fe-917e0fd91077" />

After:
<img width="1624" alt="Screenshot 2025-07-01 at 6 31 49 PM" src="https://github.com/user-attachments/assets/3e917468-ae0c-4853-8164-bd21da2ea3ff" />

## Migration
<!---
  If you have moved any files around, or made any breaking changes,
  please provide a migration guide for the developers to make rebases easier.
--->
Delete `node_modules` and run `pnpm install` again