### PR TITLE
chore: use @commander-js/extra-typings as devDep

### DIFF
--- a/packages/cli/commander.d.ts
+++ b/packages/cli/commander.d.ts
@@ -1,0 +1,3 @@
+declare module 'commander' {
+  export * from '@commander-js/extra-typings';
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,13 +21,13 @@
     "node": "^20.0.0 || ^22.0.0"
   },
   "dependencies": {
-    "@commander-js/extra-typings": "^14.0.0",
     "chalk": "^5.3.0",
     "commander": "^14.0.0"
   },
   "devDependencies": {
     "@bigcommerce/eslint-config": "^2.11.0",
     "@bigcommerce/eslint-config-catalyst": "workspace:^",
+    "@commander-js/extra-typings": "^14.0.0",
     "@types/node": "^22.15.30",
     "@vitest/coverage-v8": "^3.2.4",
     "@vitest/ui": "^3.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,9 +288,6 @@ importers:
 
   packages/cli:
     dependencies:
-      '@commander-js/extra-typings':
-        specifier: ^14.0.0
-        version: 14.0.0(commander@14.0.0)
       chalk:
         specifier: ^5.3.0
         version: 5.4.1
@@ -304,6 +301,9 @@ importers:
       '@bigcommerce/eslint-config-catalyst':
         specifier: workspace:^
         version: link:../eslint-config-catalyst
+      '@commander-js/extra-typings':
+        specifier: ^14.0.0
+        version: 14.0.0(commander@14.0.0)
       '@types/node':
         specifier: ^22.15.30
         version: 22.15.30


### PR DESCRIPTION
> [!WARNING]
> Merge after #2461

## What/Why?
<!--- 
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
--->
Maintainers of `@commander-js/extra-typings` recently provided updated documentation on how to configure the package as a `devDependency` to get the extra typings from the ambient module without needing extra typings at runtime: https://github.com/commander-js/extra-typings/pull/92

In my opinion, this is worth doing because by default, IDE’s like VSCode automatically import from "commander" instead of "@commander-js/extra-typings" which easily slips through PR reviews (hence why all of the imports in `@bigcommerce/catalyst` are importing from `"commander"` instead of `"@commander-js/extra-typings"`

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->
Add an option to a command, see that it is typed.

## Migration
<!---
  If you have moved any files around, or made any breaking changes,
  please provide a migration guide for the developers to make rebases easier.
--->
N/A