### PR TITLE
chore(core): remove runtime edge declarations

### DIFF
--- a/.changeset/silent-ideas-flash.md
+++ b/.changeset/silent-ideas-flash.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Remove edge runtime declarations to be able to run Catalyst with OpenNext.

--- a/core/app/[locale]/(default)/(auth)/login/token/[token]/route.ts
+++ b/core/app/[locale]/(default)/(auth)/login/token/[token]/route.ts
@@ -33,5 +33,4 @@ export async function GET(_: Request, { params }: { params: Promise<{ token: str
   }
 }
 
-export const runtime = 'edge';
 export const dynamic = 'force-dynamic';

--- a/core/app/admin/route.ts
+++ b/core/app/admin/route.ts
@@ -18,5 +18,3 @@ export const GET = () => {
     locale: defaultLocale,
   });
 };
-
-export const runtime = 'edge';

--- a/core/app/api/auth/[...nextauth]/route.ts
+++ b/core/app/api/auth/[...nextauth]/route.ts
@@ -1,4 +1,3 @@
 import { handlers } from '~/auth';
 
 export const { GET, POST } = handlers;
-export const runtime = 'edge';

--- a/core/app/sitemap.xml/route.ts
+++ b/core/app/sitemap.xml/route.ts
@@ -16,5 +16,3 @@ export const GET = async () => {
     },
   });
 };
-
-export const runtime = 'edge';

--- a/core/app/xmlsitemap.php/route.ts
+++ b/core/app/xmlsitemap.php/route.ts
@@ -12,5 +12,3 @@ import { permanentRedirect } from '~/i18n/routing';
 export const GET = () => {
   permanentRedirect({ href: '/sitemap.xml', locale: defaultLocale });
 };
-
-export const runtime = 'edge';


### PR DESCRIPTION
## What/Why?
Remove edge runtime declarations to be able to run Catalyst with OpenNext.

We had previously removed these declarations, unsure if there's a specific reason these routes had these declared.

## Testing
Sitemap redirect works
<img width="1473" alt="Screenshot 2025-07-03 at 11 37 00 AM" src="https://github.com/user-attachments/assets/c8a06e55-f9fe-4f22-821e-b2b0367b6a3d" />

Auth flow works
<img width="1152" alt="Screenshot 2025-07-03 at 11 37 37 AM" src="https://github.com/user-attachments/assets/8d1172cb-096e-44fb-932b-c1cc0c7ed48f" />

Admin route redirects to bigcommerce
<img width="944" alt="Screenshot 2025-07-03 at 11 45 43 AM" src="https://github.com/user-attachments/assets/f186d9ea-ef11-4e67-b902-42f2ca2167f7" />


## Migration
Remove `export const runtime = 'edge';` from all files.
