### PR TITLE
feat: slots for user-provided content on category pages

### DIFF
--- a/.changeset/thick-readers-deny.md
+++ b/.changeset/thick-readers-deny.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-makeswift": patch
+---
+
+feat: add slots for user-provided content on category pages

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -14,6 +14,7 @@ import { facetsTransformer } from '~/data-transformers/facets-transformer';
 import { pageInfoTransformer } from '~/data-transformers/page-info-transformer';
 import { pricesTransformer } from '~/data-transformers/prices-transformer';
 import { getPreferredCurrencyCode } from '~/lib/currency';
+import { Slot } from '~/lib/makeswift/slot';
 
 import { MAX_COMPARE_LIMIT } from '../../../compare/page-data';
 import { getCompareProducts } from '../../fetch-compare-products';
@@ -240,6 +241,10 @@ export default async function Category(props: Props) {
 
   return (
     <>
+      <Slot
+        label={`${category.name} top content`}
+        snapshotId={`category-${categoryId}-top-content`}
+      />
       <ProductsListSection
         breadcrumbs={breadcrumbs}
         compareLabel={t('Compare.compare')}
@@ -273,6 +278,10 @@ export default async function Category(props: Props) {
         sortParamName="sort"
         title={category.name}
         totalCount={streamableTotalCount}
+      />
+      <Slot
+        label={`${category.name} bottom content`}
+        snapshotId={`category-${categoryId}-bottom-content`}
       />
       <Stream value={streamableFacetedSearch}>
         {(search) => <CategoryViewed category={category} products={search.products.items} />}


### PR DESCRIPTION
## What/Why?

Add slots for user-provided content (e.g., banners, footers) to category pages, in the same way they are supported on the cart page.

## Testing

https://github.com/user-attachments/assets/04f05948-2f15-468b-ba26-8eb4c763c779

