### PR TITLE
Use min and max purchase quantity to set bounds of quantity number input

### DIFF
--- a/.changeset/moody-coats-see.md
+++ b/.changeset/moody-coats-see.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Respect min/max purchase quantity from API in quantity selector

--- a/core/app/[locale]/(default)/product/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/product/[slug]/page-data.ts
@@ -242,6 +242,8 @@ const StreamableProductQuery = graphql(
               }
             }
           }
+          minPurchaseQuantity
+          maxPurchaseQuantity
           warranty
           inventory {
             isInStock

--- a/core/app/[locale]/(default)/product/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/page.tsx
@@ -267,6 +267,18 @@ export default async function Product({ params, searchParams }: Props) {
     return productCardTransformer(relatedProducts, format);
   });
 
+  const streamableMinQuantity = Streamable.from(async () => {
+    const product = await streamableProduct;
+
+    return product.minPurchaseQuantity;
+  });
+
+  const streamableMaxQuantity = Streamable.from(async () => {
+    const product = await streamableProduct;
+
+    return product.maxPurchaseQuantity;
+  });
+
   const streamableAnalyticsData = Streamable.from(async () => {
     const [extendedProduct, pricingProduct] = await Streamable.all([
       streamableProduct,
@@ -313,6 +325,8 @@ export default async function Product({ params, searchParams }: Props) {
             subtitle: baseProduct.brand?.name,
             rating: baseProduct.reviewSummary.averageRating,
             accordions: streameableAccordions,
+            minQuantity: streamableMinQuantity,
+            maxQuantity: streamableMaxQuantity,
           }}
           quantityLabel={t('ProductDetails.quantity')}
           thumbnailLabel={t('ProductDetails.thumbnail')}

--- a/core/vibes/soul/sections/product-detail/index.tsx
+++ b/core/vibes/soul/sections/product-detail/index.tsx
@@ -28,6 +28,8 @@ interface ProductDetailProduct {
       content: ReactNode;
     }>
   >;
+  minQuantity?: Streamable<number | null>;
+  maxQuantity?: Streamable<number | null>;
 }
 
 export interface ProductDetailProps<F extends Field> {
@@ -142,9 +144,11 @@ export function ProductDetail<F extends Field>({
                         streamableFields,
                         streamableCtaLabel,
                         streamableCtaDisabled,
+                        product.minQuantity,
+                        product.maxQuantity,
                       ])}
                     >
-                      {([fields, ctaLabel, ctaDisabled]) => (
+                      {([fields, ctaLabel, ctaDisabled, minQuantity, maxQuantity]) => (
                         <ProductDetailForm
                           action={action}
                           additionalActions={additionalActions}
@@ -154,6 +158,8 @@ export function ProductDetail<F extends Field>({
                           emptySelectPlaceholder={emptySelectPlaceholder}
                           fields={fields}
                           incrementLabel={incrementLabel}
+                          maxQuantity={maxQuantity ?? undefined}
+                          minQuantity={minQuantity ?? undefined}
                           prefetch={prefetch}
                           productId={product.id}
                           quantityLabel={quantityLabel}

--- a/core/vibes/soul/sections/product-detail/product-detail-form.tsx
+++ b/core/vibes/soul/sections/product-detail/product-detail-form.tsx
@@ -56,6 +56,8 @@ export interface ProductDetailFormProps<F extends Field> {
   ctaDisabled?: boolean;
   prefetch?: boolean;
   additionalActions?: ReactNode;
+  minQuantity?: number;
+  maxQuantity?: number;
 }
 
 export function ProductDetailForm<F extends Field>({
@@ -70,6 +72,8 @@ export function ProductDetailForm<F extends Field>({
   ctaDisabled = false,
   prefetch = false,
   additionalActions,
+  minQuantity,
+  maxQuantity,
 }: ProductDetailFormProps<F>) {
   const router = useRouter();
   const pathname = usePathname();
@@ -98,7 +102,7 @@ export function ProductDetailForm<F extends Field>({
       ...acc,
       [field.name]: params[field.name] ?? field.defaultValue,
     }),
-    { quantity: 1 },
+    { quantity: minQuantity ?? 1 },
   );
 
   const [{ lastResult, successMessage }, formAction] = useActionState(action, {
@@ -120,9 +124,9 @@ export function ProductDetailForm<F extends Field>({
 
   const [form, formFields] = useForm({
     lastResult,
-    constraint: getZodConstraint(schema(fields)),
+    constraint: getZodConstraint(schema(fields, minQuantity, maxQuantity)),
     onValidate({ formData }) {
-      return parseWithZod(formData, { schema: schema(fields) });
+      return parseWithZod(formData, { schema: schema(fields, minQuantity, maxQuantity) });
     },
     onSubmit(event, { formData }) {
       event.preventDefault();
@@ -170,7 +174,8 @@ export function ProductDetailForm<F extends Field>({
               aria-label={quantityLabel}
               decrementLabel={decrementLabel}
               incrementLabel={incrementLabel}
-              min={1}
+              max={maxQuantity}
+              min={minQuantity ?? 1}
               name={formFields.quantity.name}
               onBlur={quantityControl.blur}
               onChange={(e) => quantityControl.change(e.currentTarget.value)}

--- a/core/vibes/soul/sections/product-detail/schema.ts
+++ b/core/vibes/soul/sections/product-detail/schema.ts
@@ -120,10 +120,20 @@ export interface SchemaRawShape {
   quantity: z.ZodNumber;
 }
 
-export function schema(fields: Field[]): z.ZodObject<SchemaRawShape> {
+export function schema(
+  fields: Field[],
+  minQuantity?: number,
+  maxQuantity?: number,
+): z.ZodObject<SchemaRawShape> {
+  let quantitySchema = z.number().min(minQuantity ?? 1);
+
+  if (maxQuantity != null) {
+    quantitySchema = quantitySchema.max(maxQuantity);
+  }
+
   const shape: SchemaRawShape = {
     id: z.string(),
-    quantity: z.number().min(1),
+    quantity: quantitySchema,
   };
 
   fields.forEach((field) => {


### PR DESCRIPTION
## What/Why?
Respect the min and max purchase quantity of the product, as returned by GraphQL.

## Testing
Before:
<img width="924" alt="image" src="https://github.com/user-attachments/assets/87445d10-12aa-4fc3-a201-c401cbf46a03" />

After:
<img width="521" alt="image" src="https://github.com/user-attachments/assets/9340d4e3-0922-4622-892d-ca86093de684" />


## Migration
N/A
