### PR TITLE
feat: debounce quantity form per cart line item

### DIFF
--- a/core/app/[locale]/(default)/cart/_actions/update-line-item.ts
+++ b/core/app/[locale]/(default)/cart/_actions/update-line-item.ts
@@ -53,7 +53,7 @@ export const updateLineItem = async (
   }
 
   switch (submission.value.intent) {
-    case 'increment': {
+    case 'update': {
       const parsedSelectedOptions = cartLineItem.selectedOptions.reduce<CartSelectedOptionsInput>(
         (accum, option) => {
           let multipleChoicesOptionInput;
@@ -175,7 +175,7 @@ export const updateLineItem = async (
           productEntityId: cartLineItem.productEntityId,
           variantEntityId: cartLineItem.variantEntityId,
           selectedOptions: parsedSelectedOptions,
-          quantity: cartLineItem.quantity + 1,
+          quantity: submission.value.quantity,
         });
       } catch (error) {
         // eslint-disable-next-line no-console
@@ -197,165 +197,11 @@ export const updateLineItem = async (
         return { ...prevState, lastResult: submission.reply({ formErrors: [String(error)] }) };
       }
 
-      const item = submission.value;
+      const { id, quantity } = submission.value;
 
       return {
         lineItems: prevState.lineItems.map((lineItem) =>
-          lineItem.id === item.id ? { ...lineItem, quantity: lineItem.quantity + 1 } : lineItem,
-        ),
-        lastResult: submission.reply({ resetForm: true }),
-      };
-    }
-
-    case 'decrement': {
-      const parsedSelectedOptions = cartLineItem.selectedOptions.reduce<CartSelectedOptionsInput>(
-        (accum, option) => {
-          let multipleChoicesOptionInput;
-          let checkboxOptionInput;
-          let numberFieldOptionInput;
-          let textFieldOptionInput;
-          let multiLineTextFieldOptionInput;
-          let dateFieldOptionInput;
-
-          switch (option.__typename) {
-            case 'CartSelectedMultipleChoiceOption':
-              multipleChoicesOptionInput = {
-                optionEntityId: option.entityId,
-                optionValueEntityId: option.valueEntityId,
-              };
-
-              if (accum.multipleChoices) {
-                return {
-                  ...accum,
-                  multipleChoices: [...accum.multipleChoices, multipleChoicesOptionInput],
-                };
-              }
-
-              return {
-                ...accum,
-                multipleChoices: [multipleChoicesOptionInput],
-              };
-
-            case 'CartSelectedCheckboxOption':
-              checkboxOptionInput = {
-                optionEntityId: option.entityId,
-                optionValueEntityId: option.valueEntityId,
-              };
-
-              if (accum.checkboxes) {
-                return {
-                  ...accum,
-                  checkboxes: [...accum.checkboxes, checkboxOptionInput],
-                };
-              }
-
-              return { ...accum, checkboxes: [checkboxOptionInput] };
-
-            case 'CartSelectedNumberFieldOption':
-              numberFieldOptionInput = {
-                optionEntityId: option.entityId,
-                number: option.number,
-              };
-
-              if (accum.numberFields) {
-                return {
-                  ...accum,
-                  numberFields: [...accum.numberFields, numberFieldOptionInput],
-                };
-              }
-
-              return { ...accum, numberFields: [numberFieldOptionInput] };
-
-            case 'CartSelectedTextFieldOption':
-              textFieldOptionInput = {
-                optionEntityId: option.entityId,
-                text: option.text,
-              };
-
-              if (accum.textFields) {
-                return {
-                  ...accum,
-                  textFields: [...accum.textFields, textFieldOptionInput],
-                };
-              }
-
-              return { ...accum, textFields: [textFieldOptionInput] };
-
-            case 'CartSelectedMultiLineTextFieldOption':
-              multiLineTextFieldOptionInput = {
-                optionEntityId: option.entityId,
-                text: option.text,
-              };
-
-              if (accum.multiLineTextFields) {
-                return {
-                  ...accum,
-                  multiLineTextFields: [
-                    ...accum.multiLineTextFields,
-                    multiLineTextFieldOptionInput,
-                  ],
-                };
-              }
-
-              return {
-                ...accum,
-                multiLineTextFields: [multiLineTextFieldOptionInput],
-              };
-
-            case 'CartSelectedDateFieldOption':
-              dateFieldOptionInput = {
-                optionEntityId: option.entityId,
-                date: new Date(String(option.date.utc)).toISOString(),
-              };
-
-              if (accum.dateFields) {
-                return {
-                  ...accum,
-                  dateFields: [...accum.dateFields, dateFieldOptionInput],
-                };
-              }
-
-              return { ...accum, dateFields: [dateFieldOptionInput] };
-          }
-
-          return accum;
-        },
-        {},
-      );
-
-      try {
-        await updateQuantity({
-          lineItemEntityId: cartLineItem.id,
-          productEntityId: cartLineItem.productEntityId,
-          variantEntityId: cartLineItem.variantEntityId,
-          selectedOptions: parsedSelectedOptions,
-          quantity: cartLineItem.quantity - 1,
-        });
-      } catch (error) {
-        // eslint-disable-next-line no-console
-        console.error(error);
-
-        if (error instanceof BigCommerceGQLError) {
-          return {
-            ...prevState,
-            lastResult: submission.reply({
-              formErrors: error.errors.map(({ message }) => message),
-            }),
-          };
-        }
-
-        if (error instanceof Error) {
-          return { ...prevState, lastResult: submission.reply({ formErrors: [error.message] }) };
-        }
-
-        return { ...prevState, lastResult: submission.reply({ formErrors: [String(error)] }) };
-      }
-
-      const item = submission.value;
-
-      return {
-        lineItems: prevState.lineItems.map((lineItem) =>
-          lineItem.id === item.id ? { ...lineItem, quantity: lineItem.quantity - 1 } : lineItem,
+          lineItem.id === id ? { ...lineItem, quantity } : lineItem,
         ),
         lastResult: submission.reply({ resetForm: true }),
       };

--- a/core/vibes/soul/sections/cart/schema.ts
+++ b/core/vibes/soul/sections/cart/schema.ts
@@ -2,12 +2,9 @@ import { z } from 'zod';
 
 export const cartLineItemActionFormDataSchema = z.discriminatedUnion('intent', [
   z.object({
-    intent: z.literal('increment'),
+    intent: z.literal('update'),
     id: z.string(),
-  }),
-  z.object({
-    intent: z.literal('decrement'),
-    id: z.string(),
+    quantity: z.coerce.number().min(1),
   }),
   z.object({
     intent: z.literal('delete'),


### PR DESCRIPTION
## What/Why?
<!--- 
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
--->
The `updateLineItem` server action can be spammed pretty easily due to the fact that we are optimistically updating the cart line items in response to increment, decrement, and delete actions. Quantity updates were a good candidate for debouncing, which is exactly what this PR adds. With that said, this PR does not fix the fact that users can still spam delete actions on line items. That will need to be a fix for another PR. 

> [!IMPORTANT]
> This PR changes the CounterForm component pretty drastically. For one, it removes the HTML `<form>` entirely. When reviewing this PR, we should weigh the impact of decisions like that, I'd be interested in hearing everyone's thoughts. 

Fixes #2476 

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->
1. Navigate to Preview URL
2. Add a product to cart
3. Navigate to Cart
4. Open network panel
5. Rapidly increase the quantity of a cart line item by 10
6. Notice only one POST request to /cart is logged in the network panel.

## Migration
<!---
  If you have moved any files around, or made any breaking changes,
  please provide a migration guide for the developers to make rebases easier.
--->
🚧 TODO