### PR TITLE
feat: copy templates from cli to catalyst build tmpdir

### DIFF
--- a/packages/cli/.eslintrc.cjs
+++ b/packages/cli/.eslintrc.cjs
@@ -9,7 +9,7 @@ const config = {
     'import/no-named-as-default': 'off',
     '@typescript-eslint/naming-convention': 'off',
   },
-  ignorePatterns: ['/dist/**'],
+  ignorePatterns: ['/dist/**', '/templates/**'],
 };
 
 module.exports = config;

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "bin": "dist/index.js",
   "files": [
-    "dist"
+    "dist",
+    "templates"
   ],
   "private": true,
   "scripts": {

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -4,6 +4,7 @@ import { cp } from 'node:fs/promises';
 import { join, relative, sep } from 'node:path';
 import { addDevDependency, installDependencies, runScript } from 'nypm';
 
+import { getModuleCliPath } from '../lib/get-module-cli-path';
 import { mkTempDir } from '../lib/mk-temp-dir';
 
 const OPENNEXTJS_CLOUDFLARE_VERSION = '1.5.2';
@@ -71,6 +72,15 @@ export const build = new Command('build')
       });
 
       consola.success('Dependencies built');
+
+      consola.start('Copying templates...');
+
+      await cp(join(getModuleCliPath(), 'templates'), join(tmpDir, 'core'), {
+        recursive: true,
+        force: true,
+      });
+
+      consola.success('Templates copied');
     } catch (error) {
       consola.error(error);
       process.exitCode = 1;

--- a/packages/cli/src/lib/get-module-cli-path.ts
+++ b/packages/cli/src/lib/get-module-cli-path.ts
@@ -1,0 +1,11 @@
+/* eslint-disable no-underscore-dangle */
+
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export function getModuleCliPath() {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = dirname(__filename);
+
+  return join(__dirname, '..');
+}

--- a/packages/cli/templates/open-next.config.ts
+++ b/packages/cli/templates/open-next.config.ts
@@ -1,0 +1,29 @@
+// @ts-nocheck
+import { defineCloudflareConfig } from '@opennextjs/cloudflare';
+import { purgeCache } from '@opennextjs/cloudflare/overrides/cache-purge/index';
+import kvIncrementalCache from '@opennextjs/cloudflare/overrides/incremental-cache/kv-incremental-cache';
+import doQueue from '@opennextjs/cloudflare/overrides/queue/do-queue';
+import queueCache from '@opennextjs/cloudflare/overrides/queue/queue-cache';
+import doShardedTagCache from '@opennextjs/cloudflare/overrides/tag-cache/do-sharded-tag-cache';
+
+export default defineCloudflareConfig({
+  incrementalCache: kvIncrementalCache,
+  queue: queueCache(doQueue, {
+    regionalCacheTtlSec: 5,
+  }),
+  routePreloadingBehavior: 'withWaitUntil',
+  tagCache: doShardedTagCache({
+    baseShardSize: 12,
+    regionalCache: true,
+    regionalCacheTtlSec: 5,
+    shardReplication: {
+      numberOfSoftReplicas: 4,
+      numberOfHardReplicas: 2,
+      regionalReplication: {
+        defaultRegion: 'enam',
+      },
+    },
+  }),
+  enableCacheInterception: false,
+  cachePurge: purgeCache({ type: 'durableObject' }),
+});

--- a/packages/cli/templates/wrangler.jsonc
+++ b/packages/cli/templates/wrangler.jsonc
@@ -1,0 +1,48 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "main": ".open-next/worker.js",
+  "name": "store-hash-project-uuid",
+  "compatibility_date": "2025-07-15",
+  "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
+  "observability": {
+    "enabled": true,
+  },
+  "assets": {
+    "directory": ".open-next/assets",
+    "binding": "ASSETS",
+  },
+  "services": [
+    {
+      "binding": "WORKER_SELF_REFERENCE",
+      "service": "store-hash-project-uuid",
+    },
+  ],
+  "kv_namespaces": [
+    {
+      "binding": "NEXT_INC_CACHE_KV",
+      "id": "placeholder-kv-id",
+    },
+  ],
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "NEXT_CACHE_DO_QUEUE",
+        "class_name": "DOQueueHandler",
+      },
+      {
+        "name": "NEXT_TAG_CACHE_DO_SHARDED",
+        "class_name": "DOShardedTagCache",
+      },
+      {
+        "name": "NEXT_CACHE_DO_PURGE",
+        "class_name": "BucketCachePurge",
+      },
+    ],
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["DOQueueHandler", "DOShardedTagCache", "BucketCachePurge"],
+    },
+  ],
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -3,7 +3,7 @@
   "display": "Node",
   "compilerOptions": {
     "strict": true,
-    "target": "es6",
+    "target": "es2020",
     "module": "esnext",
     "moduleResolution": "bundler",
     "esModuleInterop": true,


### PR DESCRIPTION
## What/Why?
<!--- 
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
--->
There are at least two templates that do not exist in the `core/` folder that need to exist in order for `opennextjs-cloudflare build` to succeed. 

The `opennextjs-cloudflare` CLI does create these files for you [if they do not exist](https://github.com/opennextjs/opennextjs-cloudflare/blob/54e65c5092d21aee3731c105f915ff17bef8fae0/packages/cloudflare/src/cli/index.ts#L32), however you must answer an interactive prompt. Rather than trying to answer the prompt in our CLI, we can just manually copy the templates from the CLI module in NPM. This also gives us more control over the contents of the templates in case we want to tweak any settings. 

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->
Pull down this branch, install deps (`pnpm i`), build the CLI (`pnpm -F "./packages/cli" build`), and run the build command in Catalyst root (`node packages/cli/dist/index.js build --keep-temp-dir`). You should see the files copied:
<img width="496" height="758" alt="Screenshot 2025-07-21 at 1 14 05 PM" src="https://github.com/user-attachments/assets/e28f247b-2466-4f14-a848-dab8765c09db" />

## Migration
<!---
  If you have moved any files around, or made any breaking changes,
  please provide a migration guide for the developers to make rebases easier.
--->
N/A