### PR TITLE
feat: catalyst toast to window object

### DIFF
--- a/core/b2b/script-production.tsx
+++ b/core/b2b/script-production.tsx
@@ -35,7 +35,7 @@ export function ScriptProduction({ cartId, storeHash, channelId, token, environm
         data-channelid={channelId}
         data-environment={environment}
         data-storehash={storeHash}
-        src={`https://cdn.bundleb2b.net/b2b/${environment}/storefront/headless.js`}
+        src={'https://microapps.bigcommerce.com/b2b-buyer-portal/headless.js'}
         type="module"
       />
     </>

--- a/core/b2b/types.ts
+++ b/core/b2b/types.ts
@@ -1,3 +1,6 @@
+import { ReactNode } from 'react';
+import { ToasterProps } from 'sonner';
+
 export interface B2BProductOption {
   optionEntityId: number;
   optionValueEntityId: number;
@@ -46,8 +49,27 @@ interface LineItem {
   selectedOptions?: B2BProductOption[];
 }
 
+interface ToastOptions {
+  action?: {
+    label: string;
+    onClick: () => void;
+  };
+  description?: string;
+  position?: ToasterProps['position'];
+  dismissLabel?: string;
+}
+
+
 declare global {
   interface Window {
+    catalyst?: {
+      toast?: {
+        success: (message: ReactNode, options?: ToastOptions) => void;
+        error: (message: ReactNode, options?: ToastOptions) => void;
+        warning: (message: ReactNode, options?: ToastOptions) => void;
+        info: (message: ReactNode, options?: ToastOptions) => void;
+      };
+    };
     b2b?: {
       utils?: {
         openPage: (page: string) => void;

--- a/core/b2b/use-b2b-sdk.ts
+++ b/core/b2b/use-b2b-sdk.ts
@@ -1,11 +1,15 @@
 'use client';
 
+import { toast } from '@/vibes/soul/primitives/toaster';
 import { useEffect, useState } from 'react';
 
 export const useSDK = () => {
   const [sdk, setSdk] = useState<NonNullable<typeof window.b2b> | null>(null);
 
   useEffect(() => {
+    window.catalyst = { 
+      toast,
+    };
     const interval = setInterval(() => {
       const getQuoteConfigs = window.b2b?.utils?.quote?.getQuoteConfigs;
 


### PR DESCRIPTION
## What/Why?
Adding the toast object to the window instance.
Also updating buyer portal url to microapps instance.

## Testing

https://github.com/user-attachments/assets/162d2b46-e875-442b-8b5b-201953f15c79



## Migration
not a breaking change
