### PR TITLE
refactor(cli): use consola for version logs and update tests

### DIFF
--- a/packages/cli/src/commands/version.ts
+++ b/packages/cli/src/commands/version.ts
@@ -1,13 +1,14 @@
 import chalk from 'chalk';
 import { Command } from 'commander';
+import consola from 'consola';
 
 import PACKAGE_INFO from '../../package.json';
 
 export const version = new Command('version')
-  .description('Display detailed version information')
+  .description('Display detailed version information.')
   .action(() => {
-    console.log(chalk.cyanBright('\nVersion Information:'));
-    console.log(`${chalk.bold('CLI Version:')} ${PACKAGE_INFO.version}`);
-    console.log(`${chalk.bold('Node Version:')} ${process.version}`);
-    console.log(`${chalk.bold('Platform:')} ${process.platform} (${process.arch})\n`);
+    consola.log(chalk.cyanBright('\nVersion Information:'));
+    consola.log(`${chalk.bold('CLI Version:')} ${PACKAGE_INFO.version}`);
+    consola.log(`${chalk.bold('Node Version:')} ${process.version}`);
+    consola.log(`${chalk.bold('Platform:')} ${process.platform} (${process.arch})\n`);
   });

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import { Command } from 'commander';
+import consola from 'consola';
 
 import PACKAGE_INFO from '../package.json';
 
@@ -9,7 +10,7 @@ import { version } from './commands/version';
 
 export const program = new Command();
 
-console.log(chalk.cyanBright(`\n◢ ${PACKAGE_INFO.name} v${PACKAGE_INFO.version}\n`));
+consola.log(chalk.cyanBright(`\n◢ ${PACKAGE_INFO.name} v${PACKAGE_INFO.version}\n`));
 
 program
   .name(PACKAGE_INFO.name)

--- a/packages/cli/tests/commands/version.spec.ts
+++ b/packages/cli/tests/commands/version.spec.ts
@@ -1,7 +1,9 @@
 import { Command } from '@commander-js/extra-typings';
-import { afterEach, beforeEach, expect, MockInstance, test, vi } from 'vitest';
+import consola from 'consola';
+import { beforeAll, expect, test, vi } from 'vitest';
 
 import { version } from '../../src/commands/version';
+import { program } from '../../src/program';
 
 vi.mock('chalk', () => ({
   default: new Proxy(
@@ -12,36 +14,30 @@ vi.mock('chalk', () => ({
   ),
 }));
 
-let consoleMock: MockInstance;
-
-beforeEach(() => {
-  consoleMock = vi.spyOn(console, 'log').mockImplementation(() => null);
-});
-
-afterEach(() => {
-  consoleMock.mockReset();
+beforeAll(() => {
+  consola.mockTypes(() => vi.fn());
 });
 
 test('properly configured Command instance', () => {
   expect(version).toBeInstanceOf(Command);
   expect(version.name()).toBe('version');
-  expect(version.description()).toBe('Display detailed version information');
+  expect(version.description()).toBe('Display detailed version information.');
 });
 
 test('displays version information when executed', async () => {
-  await version.parseAsync([]);
+  await program.parseAsync(['node', 'catalyst', 'version']);
 
-  expect(consoleMock).toHaveBeenCalledWith(expect.stringContaining('Version Information:'));
+  expect(consola.log).toHaveBeenCalledWith(expect.stringContaining('Version Information:'));
 
-  expect(consoleMock).toHaveBeenCalledWith(
+  expect(consola.log).toHaveBeenCalledWith(
     expect.stringContaining(`CLI Version: ${process.env.npm_package_version}`),
   );
 
-  expect(consoleMock).toHaveBeenCalledWith(
+  expect(consola.log).toHaveBeenCalledWith(
     expect.stringContaining(`Node Version: ${process.version}`),
   );
 
-  expect(consoleMock).toHaveBeenCalledWith(
+  expect(consola.log).toHaveBeenCalledWith(
     expect.stringContaining(`Platform: ${process.platform} (${process.arch})`),
   );
 });

--- a/packages/cli/tests/index.spec.ts
+++ b/packages/cli/tests/index.spec.ts
@@ -15,5 +15,7 @@ describe('CLI program', () => {
     const commands = program.commands.map((cmd) => cmd.name());
 
     expect(commands).toContain('version');
+    expect(commands).toContain('build');
+    expect(commands).toContain('deploy');
   });
 });


### PR DESCRIPTION
## What/Why?
+ Updates `version` to use `consola`
+ Updates tests for `version` and `program`

## Testing
Tests pass

## Migration
N/A
