### PR TITLE
refactor: modify cf observability config to decrease logs generated

### DIFF
--- a/packages/cli/templates/wrangler.jsonc
+++ b/packages/cli/templates/wrangler.jsonc
@@ -6,6 +6,12 @@
   "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
   "observability": {
     "enabled": true,
+    "head_sampling_rate": 0.05,
+    "logs": {
+      "enabled": true,
+      "head_sampling_rate": 1,
+      "invocation_logs": false,
+    },
   },
   "assets": {
     "directory": ".open-next/assets",


### PR DESCRIPTION
## What/Why?
<!--- 
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
--->
Recent load testing generated over 6 million logs on a single Catalyst deployment; this is quite a large number considering that the base paid plan only gets 20M logs for free, then requires that you pay for each million logs after that. In this PR we are primarily disabling [invocation logs](https://developers.cloudflare.com/workers/observability/logs/workers-logs/#invocation-logs) and lowering the sampling rate from the default (1) to 0.05 to decrease the number of logs emitted by a Catalyst deployment. 

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->
Will be tested during the next load test

## Migration
<!---
  If you have moved any files around, or made any breaking changes,
  please provide a migration guide for the developers to make rebases easier.
--->
N/A