### PR TITLE
refactor: remove chalk in favor of consola.colorize

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "adm-zip": "^0.5.16",
-    "chalk": "^5.3.0",
     "commander": "^14.0.0",
     "conf": "^13.1.0",
     "consola": "^3.4.2",

--- a/packages/cli/src/commands/version.ts
+++ b/packages/cli/src/commands/version.ts
@@ -1,4 +1,3 @@
-import chalk from 'chalk';
 import { Command } from 'commander';
 import consola from 'consola';
 
@@ -7,8 +6,8 @@ import PACKAGE_INFO from '../../package.json';
 export const version = new Command('version')
   .description('Display detailed version information.')
   .action(() => {
-    consola.log(chalk.cyanBright('\nVersion Information:'));
-    consola.log(`${chalk.bold('CLI Version:')} ${PACKAGE_INFO.version}`);
-    consola.log(`${chalk.bold('Node Version:')} ${process.version}`);
-    consola.log(`${chalk.bold('Platform:')} ${process.platform} (${process.arch})\n`);
+    consola.log('Version Information:');
+    consola.log(`CLI Version: ${PACKAGE_INFO.version}`);
+    consola.log(`Node Version: ${process.version}`);
+    consola.log(`Platform: ${process.platform} (${process.arch})`);
   });

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -1,6 +1,6 @@
-import chalk from 'chalk';
 import { Command } from 'commander';
 import consola from 'consola';
+import { colorize } from 'consola/utils';
 
 import PACKAGE_INFO from '../package.json';
 
@@ -13,7 +13,7 @@ import { version } from './commands/version';
 
 export const program = new Command();
 
-consola.log(chalk.cyanBright(`\n◢ ${PACKAGE_INFO.name} v${PACKAGE_INFO.version}\n`));
+consola.log(colorize('cyanBright', `◢ ${PACKAGE_INFO.name} v${PACKAGE_INFO.version}\n`));
 
 program
   .name(PACKAGE_INFO.name)

--- a/packages/cli/tests/commands/version.spec.ts
+++ b/packages/cli/tests/commands/version.spec.ts
@@ -5,15 +5,6 @@ import { beforeAll, expect, test, vi } from 'vitest';
 import { version } from '../../src/commands/version';
 import { program } from '../../src/program';
 
-vi.mock('chalk', () => ({
-  default: new Proxy(
-    {},
-    {
-      get: () => (str: string) => str,
-    },
-  ),
-}));
-
 beforeAll(() => {
   consola.mockTypes(() => vi.fn());
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,9 +291,6 @@ importers:
       adm-zip:
         specifier: ^0.5.16
         version: 0.5.16
-      chalk:
-        specifier: ^5.3.0
-        version: 5.4.1
       commander:
         specifier: ^14.0.0
         version: 14.0.0


### PR DESCRIPTION
## What/Why?
<!--- 
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
--->
In the spirit of #2505, I don't think we need `chalk` anymore. Since we are using `consola` we can instead use `consola.colorize('cyan', '<str>')` ([docs](https://github.com/unjs/consola?tab=readme-ov-file#console-utils)) whenever we want to colorize logs. 

Additionally, since we have the `version` command, we don't need to log the CLI version each time the CLI runs. I am open to reverting this change if it's too drastic, I'm not sure if there are good reasons to keep the log (IMO, the log prints every time tests run which adds to the test log output which is slightly annoying). 

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->
Run `pnpm test` and see that all tests still pass

## Migration
<!---
  If you have moved any files around, or made any breaking changes,
  please provide a migration guide for the developers to make rebases easier.
--->
N/A