### PR TITLE
feat: introduce telemetry to catalyst cli

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,6 +22,7 @@
     "node": "^20.0.0 || ^22.0.0"
   },
   "dependencies": {
+    "@segment/analytics-node": "^2.2.1",
     "adm-zip": "^0.5.16",
     "commander": "^14.0.0",
     "conf": "^13.1.0",

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -7,6 +7,9 @@ import yoctoSpinner from 'yocto-spinner';
 import { z } from 'zod';
 
 import { ProjectConfig } from '../lib/project-config';
+import { Telemetry } from '../lib/telemetry';
+
+const telemetry = new Telemetry();
 
 const stepsEnum = z.enum([
   'initializing',
@@ -289,6 +292,8 @@ export const deploy = new Command('deploy')
   .action(async (opts) => {
     try {
       const config = new ProjectConfig(opts.rootDir);
+
+      await telemetry.identify(opts.storeHash);
 
       const projectUuid = opts.projectUuid ?? config.get('projectUuid');
 

--- a/packages/cli/src/commands/link.ts
+++ b/packages/cli/src/commands/link.ts
@@ -3,6 +3,9 @@ import consola from 'consola';
 import z from 'zod';
 
 import { ProjectConfig } from '../lib/project-config';
+import { Telemetry } from '../lib/telemetry';
+
+const telemetry = new Telemetry();
 
 const fetchProjectsSchema = z.object({
   data: z.array(
@@ -86,6 +89,8 @@ export const link = new Command('link')
       }
 
       if (options.storeHash && options.accessToken) {
+        await telemetry.identify(options.storeHash);
+
         consola.start('Fetching projects...');
 
         const projects = await fetchProjects(

--- a/packages/cli/src/commands/telemetry.ts
+++ b/packages/cli/src/commands/telemetry.ts
@@ -1,0 +1,43 @@
+import { Argument, Command, Option } from 'commander';
+import consola from 'consola';
+import { colorize } from 'consola/utils';
+
+import { Telemetry } from '../lib/telemetry';
+
+const telemetryService = new Telemetry();
+let isEnabled = telemetryService.isEnabled();
+
+export const telemetry = new Command('telemetry')
+  .addArgument(new Argument('[arg]').choices(['disable', 'enable', 'status']))
+  .addOption(new Option('--enable', `Enables CLI telemetry collection.`).conflicts('disable'))
+  .option('--disable', `Disables CLI telemetry collection.`)
+  .action((arg, options) => {
+    if (options.enable || arg === 'enable') {
+      telemetryService.setEnabled(true);
+      isEnabled = true;
+
+      consola.success('Success!\n');
+    } else if (options.disable || arg === 'disable') {
+      telemetryService.setEnabled(false);
+
+      if (isEnabled) {
+        consola.success('Your preference has been saved to .bigcommerce/project.json');
+      } else {
+        consola.info(`Catalyst CLI telemetry collection is already disabled.`);
+      }
+
+      isEnabled = false;
+    } else {
+      consola.info('Catalyst CLI Telemetry\n');
+    }
+
+    consola.info(
+      `Status: ${colorize('bold', isEnabled ? colorize('green', 'Enabled') : colorize('red', 'Disabled'))}`,
+    );
+
+    if (!isEnabled) {
+      consola.info(
+        `You have opted-out of Catalyst CLI telemetry. No data will be collected from your machine.`,
+      );
+    }
+  });

--- a/packages/cli/src/hooks/telemetry.ts
+++ b/packages/cli/src/hooks/telemetry.ts
@@ -1,0 +1,50 @@
+import { Command } from '@commander-js/extra-typings';
+
+import { Telemetry } from '../lib/telemetry';
+
+const telemetry = new Telemetry();
+
+const allowlistArguments = ['--keep-temp-dir', '--api-host', '--project-uuid'];
+
+function parseArguments(args: string[]) {
+  return args.reduce<Record<string, string>>((result, arg, index, array) => {
+    if (arg.includes('=')) {
+      const [key, value] = arg.split('=');
+
+      if (allowlistArguments.includes(key)) {
+        return {
+          ...result,
+          [key]: value,
+        };
+      }
+    }
+
+    if (allowlistArguments.includes(arg)) {
+      const nextValue =
+        array[index + 1] && !array[index + 1].startsWith('--') ? array[index + 1] : null;
+
+      if (nextValue && !nextValue.includes('--')) {
+        return {
+          ...result,
+          [arg]: nextValue,
+        };
+      }
+    }
+
+    return result;
+  }, {});
+}
+
+export const telemetryPreHook = async (command: Command) => {
+  const [commandName, ...args] = command.args;
+
+  // Return the await to get a proper stack trace.
+  // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+  return await telemetry.track(commandName, {
+    ...parseArguments(args),
+  });
+};
+
+export const telemetryPostHook = async () => {
+  await telemetry.analytics.closeAndFlush();
+};

--- a/packages/cli/src/lib/project-config.ts
+++ b/packages/cli/src/lib/project-config.ts
@@ -4,6 +4,10 @@ import { join } from 'path';
 export interface ProjectConfigSchema {
   projectUuid: string;
   framework: 'catalyst' | 'nextjs';
+  telemetry: {
+    enabled: boolean;
+    anonymousId: string;
+  };
 }
 
 export class ProjectConfig {
@@ -21,11 +25,18 @@ export class ProjectConfig {
           enum: ['catalyst', 'nextjs'],
           default: 'catalyst',
         },
+        telemetry: {
+          type: 'object',
+          properties: {
+            enabled: { type: 'boolean' },
+            anonymousId: { type: 'string' },
+          },
+        },
       },
     });
   }
 
-  get(field: keyof ProjectConfigSchema): string {
+  get<T extends keyof ProjectConfigSchema>(field: T): ProjectConfigSchema[T] {
     const value = this.config.get(field);
 
     if (!value) {
@@ -35,7 +46,7 @@ export class ProjectConfig {
     return value;
   }
 
-  set(field: string, value: string): void {
+  set(field: string, value: string | boolean): void {
     this.config.set(field, value);
   }
 }

--- a/packages/cli/src/lib/telemetry.ts
+++ b/packages/cli/src/lib/telemetry.ts
@@ -1,0 +1,106 @@
+import { Analytics } from '@segment/analytics-node';
+import { randomBytes } from 'node:crypto';
+
+import PACKAGE_INFO from '../../package.json';
+
+import { ProjectConfig } from './project-config';
+
+export class Telemetry {
+  readonly sessionId: string;
+  readonly analytics: Analytics;
+
+  private projectConfig: ProjectConfig;
+  private CATALYST_TELEMETRY_DISABLED: string | undefined;
+
+  private readonly projectName = 'catalyst-cli';
+  private readonly projectVersion = PACKAGE_INFO.version;
+
+  constructor() {
+    this.CATALYST_TELEMETRY_DISABLED = process.env.CATALYST_TELEMETRY_DISABLED;
+
+    this.projectConfig = new ProjectConfig();
+
+    this.sessionId = randomBytes(32).toString('hex');
+    this.analytics = new Analytics({
+      writeKey: process.env.CLI_SEGMENT_WRITE_KEY ?? 'not-a-valid-segment-write-key',
+    });
+  }
+
+  async track(eventName: string, payload: Record<string, unknown>) {
+    if (!this.isEnabled()) {
+      return Promise.resolve(undefined);
+    }
+
+    this.analytics.track({
+      event: eventName,
+      anonymousId: this.getAnonymousId(),
+      properties: {
+        ...payload,
+        sessionId: this.sessionId,
+      },
+      context: {
+        app: {
+          name: this.projectName,
+          version: this.projectVersion,
+        },
+      },
+    });
+  }
+
+  async identify(storeHash?: string) {
+    if (!this.isEnabled()) {
+      return Promise.resolve(undefined);
+    }
+
+    if (!storeHash) {
+      return Promise.resolve(undefined);
+    }
+
+    this.analytics.identify({
+      userId: storeHash,
+      anonymousId: this.getAnonymousId(),
+      context: {
+        app: {
+          name: this.projectName,
+          version: this.projectVersion,
+        },
+      },
+    });
+  }
+
+  setEnabled = (_enabled: boolean) => {
+    const enabled = Boolean(_enabled);
+
+    this.projectConfig.set('telemetry.enabled', enabled);
+  };
+
+  isEnabled() {
+    try {
+      return !this.CATALYST_TELEMETRY_DISABLED && this.projectConfig.get('telemetry').enabled;
+    } catch {
+      return false;
+    }
+  }
+
+  private getAnonymousId(): string {
+    let anonymousId;
+
+    try {
+      anonymousId = this.projectConfig.get('telemetry').anonymousId;
+
+      if (!anonymousId) {
+        anonymousId = randomBytes(32).toString('hex');
+
+        this.projectConfig.set('telemetry.anonymousId', anonymousId);
+      }
+
+      return anonymousId;
+    } catch {
+      const generated = randomBytes(32).toString('hex');
+
+      this.projectConfig.set('telemetry.anonymousId', generated);
+
+      return generated;
+    }
+  }
+}

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -9,7 +9,9 @@ import { deploy } from './commands/deploy';
 import { dev } from './commands/dev';
 import { link } from './commands/link';
 import { start } from './commands/start';
+import { telemetry } from './commands/telemetry';
 import { version } from './commands/version';
+import { telemetryPostHook, telemetryPreHook } from './hooks/telemetry';
 
 export const program = new Command();
 
@@ -24,4 +26,7 @@ program
   .addCommand(start)
   .addCommand(build)
   .addCommand(deploy)
-  .addCommand(link);
+  .addCommand(link)
+  .addCommand(telemetry)
+  .hook('preAction', telemetryPreHook)
+  .hook('postAction', telemetryPostHook);

--- a/packages/cli/tests/vitest.setup.ts
+++ b/packages/cli/tests/vitest.setup.ts
@@ -1,6 +1,21 @@
-import { afterAll, afterEach, beforeAll } from 'vitest';
+import { afterAll, afterEach, beforeAll, vi } from 'vitest';
 
 import { server } from './mocks/node';
+
+vi.mock('../src/lib/telemetry', () => ({
+  Telemetry: vi.fn().mockImplementation(() => ({
+    sessionId: 'test-session-id',
+    analytics: {
+      track: vi.fn(),
+      identify: vi.fn(),
+      closeAndFlush: vi.fn().mockResolvedValue(undefined),
+    },
+    track: vi.fn().mockResolvedValue(undefined),
+    identify: vi.fn().mockResolvedValue(undefined),
+    setEnabled: vi.fn(),
+    isEnabled: vi.fn().mockReturnValue(false),
+  })),
+}));
 
 beforeAll(() => server.listen());
 afterEach(() => server.resetHandlers());

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -5,5 +5,8 @@ export default defineConfig((options: Options) => ({
   format: ['esm'],
   clean: !options.watch,
   sourcemap: true,
+  env: {
+    CLI_SEGMENT_WRITE_KEY: process.env.CLI_SEGMENT_WRITE_KEY ?? 'not-a-valid-segment-write-key',
+  },
   ...options,
 }));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,6 +288,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@segment/analytics-node':
+        specifier: ^2.2.1
+        version: 2.2.1(encoding@0.1.13)
       adm-zip:
         specifier: ^0.5.16
         version: 0.5.16
@@ -7014,6 +7017,7 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
@@ -8131,9 +8135,9 @@ snapshots:
       '@typescript-eslint/parser': 8.28.0(eslint@8.57.1)(typescript@5.8.3)
       eslint: 8.57.1
       eslint-config-prettier: 9.1.0(eslint@8.57.1)
-      eslint-import-resolver-typescript: 3.9.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.9.1(eslint-plugin-import@2.31.0)(eslint@8.57.1)
       eslint-plugin-gettext: 1.2.0
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.9.1)(eslint@8.57.1)
       eslint-plugin-jest: 28.11.0(@typescript-eslint/eslint-plugin@8.28.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(jest@29.7.0(@types/node@22.15.30)(ts-node@10.9.2(@swc/core@1.11.31)(@types/node@22.15.30)(typescript@5.8.3)))(typescript@5.8.3)
       eslint-plugin-jest-dom: 5.5.0(eslint@8.57.1)
       eslint-plugin-jest-formatting: 3.1.0(eslint@8.57.1)
@@ -12039,8 +12043,8 @@ snapshots:
       '@typescript-eslint/parser': 8.28.0(eslint@8.57.1)(typescript@5.8.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.9.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.9.1(eslint-plugin-import@2.31.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.9.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.4(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -12067,7 +12071,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.1
@@ -12078,7 +12082,7 @@ snapshots:
       stable-hash: 0.0.5
       tinyglobby: 0.2.14
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.9.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -12089,7 +12093,7 @@ snapshots:
       '@typescript-eslint/parser': 8.28.0(eslint@8.57.1)(typescript@5.8.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.9.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.9.1(eslint-plugin-import@2.31.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -12103,7 +12107,7 @@ snapshots:
     dependencies:
       gettext-parser: 4.2.0
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.9.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8


### PR DESCRIPTION
## What/Why?
<!--- 
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
--->
Introduces telemetry logic to the new Catalyst CLI. This code is largely ported over from the `create-catalyst` CLI.
Changes include:
1. Installing the `@segment/analytics-node` package
2. A new `telemetry` command that allows developers to opt-in/out of data collection
3. Telemetry lifecycle hooks that track usage of each command run by a user and optionally the flags a command was run with (if they are whitelisted)
4. A telemetry service class that persists user data collection preferences and exposes methods to track and identify users and their activity
5. Adds a new compile-time environment variable to our `tsup.config.ts`

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->
Demo:

https://github.com/user-attachments/assets/1c390362-d5f8-42a1-984e-234b05923377

`identify` is also captured, though I'll omit the video to prevent exposing sensitive secrets. Here is a screenshot of running `link` with `--store-hash` and `--access-token`:

<img width="839" height="239" alt="Screenshot 2025-08-06 at 12 06 27 PM" src="https://github.com/user-attachments/assets/6e91e69a-1721-43fa-a30c-7813898a9006" />


## Migration
<!---
  If you have moved any files around, or made any breaking changes,
  please provide a migration guide for the developers to make rebases easier.
--->
N/A