### PR TITLE
Proxy sitemaps within sitemap index for prettier sitemap URLs

### DIFF
--- a/core/app/sitemap.xml/route.ts
+++ b/core/app/sitemap.xml/route.ts
@@ -7,10 +7,77 @@ import { getChannelIdFromLocale } from '~/channels.config';
 import { client } from '~/client';
 import { defaultLocale } from '~/i18n/locales';
 
-export const GET = async () => {
+export const GET = async (request: Request) => {
+  const url = new URL(request.url);
+  const incomingHost = request.headers.get('host') ?? url.host;
+  const incomingProto = request.headers.get('x-forwarded-proto') ?? url.protocol.replace(':', '');
+
+  const type = url.searchParams.get('type');
+  const page = url.searchParams.get('page');
+
+  // If a specific sitemap within the index is requested, require both params
+  if (type !== null || page !== null) {
+    if (!type || !page) {
+      return new Response('Both "type" and "page" query params are required', {
+        status: 400,
+        headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+      });
+    }
+
+    const upstream = await client.fetchSitemapResponse(
+      { type, page },
+      getChannelIdFromLocale(defaultLocale),
+    );
+
+    // Pass-through upstream status/body but enforce XML content-type
+    const body = await upstream.text();
+
+    return new Response(body, {
+      status: upstream.status,
+      statusText: upstream.statusText,
+      headers: { 'Content-Type': 'application/xml' },
+    });
+  }
+
+  // Otherwise, return the sitemap index with normalized internal links
   const sitemapIndex = await client.fetchSitemapIndex(getChannelIdFromLocale(defaultLocale));
 
-  return new Response(sitemapIndex, {
+  const rewritten = sitemapIndex.replace(
+    /<loc>([^<]+)<\/loc>/g,
+    (match: string, locUrlStr: string) => {
+      try {
+        // Decode XML entities for '&' so URL parsing works
+        const decoded: string = locUrlStr.replace(/&amp;/g, '&');
+        const original = new URL(decoded);
+
+        if (!original.pathname.endsWith('/xmlsitemap.php')) {
+          return match;
+        }
+
+        const normalized = new URL(`${incomingProto}://${incomingHost}/sitemap.xml`);
+
+        const t = original.searchParams.get('type');
+        const p = original.searchParams.get('page');
+
+        // Only rewrite entries that include both type and page; otherwise leave untouched
+        if (!t || !p) {
+          return match;
+        }
+
+        normalized.searchParams.set('type', t);
+        normalized.searchParams.set('page', p);
+
+        // Re-encode '&' for XML output
+        const normalizedXml: string = normalized.toString().replace(/&/g, '&amp;');
+
+        return `<loc>${normalizedXml}</loc>`;
+      } catch {
+        return match;
+      }
+    },
+  );
+
+  return new Response(rewritten, {
     headers: {
       'Content-Type': 'application/xml',
     },

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -210,6 +210,43 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     return response.text();
   }
 
+  async fetchSitemap(
+    params: { type?: string | null; page?: string | number | null },
+    channelId?: string,
+  ): Promise<string> {
+    const response = await this.fetchSitemapResponse(params, channelId);
+
+    if (!response.ok) {
+      throw new Error(`Unable to get Sitemap: ${response.statusText}`);
+    }
+
+    return response.text();
+  }
+
+  async fetchSitemapResponse(
+    params: { type?: string | null; page?: string | number | null },
+    channelId?: string,
+  ): Promise<Response> {
+    const baseUrl = new URL(`${await this.getCanonicalUrl(channelId)}/xmlsitemap.php`);
+
+    // Only forward well-known params
+    if (params.type) baseUrl.searchParams.set('type', String(params.type));
+    if (params.page !== undefined && params.page !== null)
+      baseUrl.searchParams.set('page', String(params.page));
+
+    const response = await fetch(baseUrl.toString(), {
+      method: 'GET',
+      headers: {
+        Accept: 'application/xml',
+        'Content-Type': 'application/xml',
+        'User-Agent': this.backendUserAgent,
+        ...(this.trustedProxySecret && { 'X-BC-Trusted-Proxy-Secret': this.trustedProxySecret }),
+      },
+    });
+
+    return response;
+  }
+
   private async getCanonicalUrl(channelId?: string) {
     const resolvedChannelId = channelId ?? (await this.getChannelId(this.defaultChannelId));
 


### PR DESCRIPTION
## What/Why?
Catalyst's sitemap was using the channel canonical URL for the internal sitemap URLs, in order to avoid the complexity of proxying these internally via Catalyst itself and provide a reliable way to fetch them. Research shows this is OK for SEO, but we've received a steady stream of customer feedback indicating that having internal sitemap URLs that match the domain of the website is preferable.

This PR does that, by proxying the sitemap index, rewriting the internal URLs for the sitemap to live on `https://store.com/sitemap.xml?...`, and then proxies those requests for the actual sitemaps as well.

Since Next.js does not provide a variable to easily understand the "production" hostname for the app, I am relying on on the `Host` header for this.

Based on feedback from @apledger I have extracted it into its own package to abstract the complexity and make it easier to update later via a version bump.

## Testing
Before, from https://catalyst-canary.store/sitemap.xml

```
<sitemapindex xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
--
<sitemap>
<loc>https://store-vcijajnodd-1543376.mybigcommerce.com/xmlsitemap.php?type=pages&amp;page=1</loc>
</sitemap><sitemap>
<loc>https://store-vcijajnodd-1543376.mybigcommerce.com/xmlsitemap.php?type=products&amp;page=1</loc>
</sitemap><sitemap>
<loc>https://store-vcijajnodd-1543376.mybigcommerce.com/xmlsitemap.php?type=categories&amp;page=1</loc>
</sitemap><sitemap>
<loc>https://store-vcijajnodd-1543376.mybigcommerce.com/xmlsitemap.php?type=brands&amp;page=1</loc>
</sitemap><sitemap>
<loc>https://store-vcijajnodd-1543376.mybigcommerce.com/xmlsitemap.php?type=news&amp;page=1</loc>
</sitemap>
</sitemapindex>
```

After, on https://catalyst-canary-3e4nxxptx-bigcommerce-platform.vercel.app/sitemap.xml

```
<sitemapindex xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
--
<sitemap>
<loc>https://catalyst-canary-3e4nxxptx-bigcommerce-platform.vercel.app/sitemap.xml?type=pages&amp;page=1</loc>
</sitemap><sitemap>
<loc>https://catalyst-canary-3e4nxxptx-bigcommerce-platform.vercel.app/sitemap.xml?type=products&amp;page=1</loc>
</sitemap><sitemap>
<loc>https://catalyst-canary-3e4nxxptx-bigcommerce-platform.vercel.app/sitemap.xml?type=categories&amp;page=1</loc>
</sitemap><sitemap>
<loc>https://catalyst-canary-3e4nxxptx-bigcommerce-platform.vercel.app/sitemap.xml?type=brands&amp;page=1</loc>
</sitemap><sitemap>
<loc>https://catalyst-canary-3e4nxxptx-bigcommerce-platform.vercel.app/sitemap.xml?type=news&amp;page=1</loc>
</sitemap>
</sitemapindex>

```

Internal URLs also work.


## Migration
N/A
