### PR TITLE
refactor: unwrap get and set instance methods of conf

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -6,7 +6,7 @@ import { join } from 'node:path';
 import yoctoSpinner from 'yocto-spinner';
 import { z } from 'zod';
 
-import { ProjectConfig } from '../lib/project-config';
+import { getProjectConfig } from '../lib/project-config';
 import { Telemetry } from '../lib/telemetry';
 
 const telemetry = new Telemetry();
@@ -291,11 +291,17 @@ export const deploy = new Command('deploy')
   )
   .action(async (opts) => {
     try {
-      const config = new ProjectConfig(opts.rootDir);
+      const config = getProjectConfig(opts.rootDir);
 
       await telemetry.identify(opts.storeHash);
 
       const projectUuid = opts.projectUuid ?? config.get('projectUuid');
+
+      if (!projectUuid) {
+        throw new Error(
+          'Project UUID is required. Please run either `bigcommerce link` or this command again with --project-uuid <uuid>.',
+        );
+      }
 
       await generateBundleZip(opts.rootDir);
 

--- a/packages/cli/src/commands/link.ts
+++ b/packages/cli/src/commands/link.ts
@@ -2,7 +2,7 @@ import { Command, Option } from 'commander';
 import consola from 'consola';
 import z from 'zod';
 
-import { ProjectConfig } from '../lib/project-config';
+import { getProjectConfig } from '../lib/project-config';
 import { Telemetry } from '../lib/telemetry';
 
 const telemetry = new Telemetry();
@@ -73,7 +73,7 @@ export const link = new Command('link')
   )
   .action(async (options) => {
     try {
-      const config = new ProjectConfig(options.rootDir);
+      const config = getProjectConfig(options.rootDir);
 
       const writeProjectConfig = (uuid: string) => {
         consola.start('Writing project UUID to .bigcommerce/project.json...');

--- a/packages/cli/src/lib/project-config.ts
+++ b/packages/cli/src/lib/project-config.ts
@@ -10,43 +10,25 @@ export interface ProjectConfigSchema {
   };
 }
 
-export class ProjectConfig {
-  private config: Conf<ProjectConfigSchema>;
-
-  constructor(rootDir = process.cwd()) {
-    this.config = new Conf<ProjectConfigSchema>({
-      cwd: join(rootDir, '.bigcommerce'),
-      projectSuffix: '',
-      configName: 'project',
-      schema: {
-        projectUuid: { type: 'string', format: 'uuid' },
-        framework: {
-          type: 'string',
-          enum: ['catalyst', 'nextjs'],
-          default: 'catalyst',
-        },
-        telemetry: {
-          type: 'object',
-          properties: {
-            enabled: { type: 'boolean' },
-            anonymousId: { type: 'string' },
-          },
+export function getProjectConfig(rootDir = process.cwd()) {
+  return new Conf<ProjectConfigSchema>({
+    cwd: join(rootDir, '.bigcommerce'),
+    projectSuffix: '',
+    configName: 'project',
+    schema: {
+      projectUuid: { type: 'string', format: 'uuid' },
+      framework: {
+        type: 'string',
+        enum: ['catalyst', 'nextjs'],
+        default: 'catalyst',
+      },
+      telemetry: {
+        type: 'object',
+        properties: {
+          enabled: { type: 'boolean' },
+          anonymousId: { type: 'string' },
         },
       },
-    });
-  }
-
-  get<T extends keyof ProjectConfigSchema>(field: T): ProjectConfigSchema[T] {
-    const value = this.config.get(field);
-
-    if (!value) {
-      throw new Error(`No \`${field}\` found in .bigcommerce/project.json.`);
-    }
-
-    return value;
-  }
-
-  set(field: string, value: string | boolean): void {
-    this.config.set(field, value);
-  }
+    },
+  });
 }

--- a/packages/cli/tests/commands/link.spec.ts
+++ b/packages/cli/tests/commands/link.spec.ts
@@ -1,11 +1,12 @@
 import { Command } from 'commander';
+import Conf from 'conf';
 import consola from 'consola';
 import { http, HttpResponse } from 'msw';
 import { afterAll, afterEach, beforeAll, expect, MockInstance, test, vi } from 'vitest';
 
 import { link } from '../../src/commands/link';
 import { mkTempDir } from '../../src/lib/mk-temp-dir';
-import { ProjectConfig } from '../../src/lib/project-config';
+import { getProjectConfig, ProjectConfigSchema } from '../../src/lib/project-config';
 import { program } from '../../src/program';
 import { server } from '../mocks/node';
 
@@ -13,7 +14,7 @@ let exitMock: MockInstance;
 
 let tmpDir: string;
 let cleanup: () => Promise<void>;
-let config: ProjectConfig;
+let config: Conf<ProjectConfigSchema>;
 
 const { mockIdentify } = vi.hoisted(() => ({
   mockIdentify: vi.fn(),
@@ -47,7 +48,7 @@ beforeAll(async () => {
 
   [tmpDir, cleanup] = await mkTempDir();
 
-  config = new ProjectConfig(tmpDir);
+  config = getProjectConfig(tmpDir);
 });
 
 afterEach(() => {

--- a/packages/cli/tests/lib/project-config.spec.ts
+++ b/packages/cli/tests/lib/project-config.spec.ts
@@ -1,35 +1,25 @@
+import Conf from 'conf';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { afterAll, beforeAll, expect, test } from 'vitest';
 
 import { mkTempDir } from '../../src/lib/mk-temp-dir';
-import { ProjectConfig } from '../../src/lib/project-config';
+import { getProjectConfig, ProjectConfigSchema } from '../../src/lib/project-config';
 
 let tmpDir: string;
 let cleanup: () => Promise<void>;
-let config: ProjectConfig;
+let config: Conf<ProjectConfigSchema>;
 
 const projectUuid = 'a23f5785-fd99-4a94-9fb3-945551623923';
 
 beforeAll(async () => {
   [tmpDir, cleanup] = await mkTempDir();
 
-  config = new ProjectConfig(tmpDir);
+  config = getProjectConfig(tmpDir);
 });
 
 afterAll(async () => {
   await cleanup();
-});
-
-test('throws error if field is missing', async () => {
-  const projectJsonPath = join(tmpDir, '.bigcommerce/project.json');
-
-  await mkdir(dirname(projectJsonPath), { recursive: true });
-  await writeFile(projectJsonPath, JSON.stringify({}));
-
-  expect(() => config.get('projectUuid')).toThrowError(
-    'No `projectUuid` found in .bigcommerce/project.json.',
-  );
 });
 
 test('throws error if field does not match schema', async () => {


### PR DESCRIPTION
## What/Why?
<!--- 
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
--->
As discussed in https://github.com/bigcommerce/catalyst/pull/2514#discussion_r2257806601, this PR refactors the `ProjectConfig` class so that it does not wrap `get` and `set` methods. For example, the [`get`](https://github.com/sindresorhus/conf?tab=readme-ov-file#getkey-defaultvalue) method from Conf accepts a second parameter for a `defaultValue`, but we don't allow that. 

The original idea behind creating the `ProjectConfig` class was to reduce the boilerplate required to instantiate `Conf` with `cwd`,  `projectSuffix`, `configName`, etc. options; this refactor still accomplishes that goal, while making the `get` and `set` calls more flexible.

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->
Test suite passes

## Migration
<!---
  If you have moved any files around, or made any breaking changes,
  please provide a migration guide for the developers to make rebases easier.
--->
N/A