### PR TITLE
feat(cli): run opennext-cloudflare preview for catalyst framework

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -75,10 +75,14 @@ export const build = new Command('build')
 
         consola.start('Building project...');
 
-        await execa('pnpm', ['exec', 'opennextjs-cloudflare', 'build'], {
-          stdout: ['pipe', 'inherit'],
-          cwd: coreDir,
-        });
+        await execa(
+          'pnpm',
+          ['exec', 'opennextjs-cloudflare', 'build', '--skipWranglerConfigCheck'],
+          {
+            stdout: ['pipe', 'inherit'],
+            cwd: coreDir,
+          },
+        );
 
         await execa(
           'pnpm',
@@ -86,6 +90,8 @@ export const build = new Command('build')
             'dlx',
             `wrangler@${WRANGLER_VERSION}`,
             'deploy',
+            '--config',
+            join(coreDir, '.bigcommerce', 'wrangler.jsonc'),
             '--keep-vars',
             '--outdir',
             bigcommerceDistDir,

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -13,6 +13,7 @@ const WRANGLER_VERSION = '4.24.3';
 
 export const build = new Command('build')
   .allowUnknownOption()
+  // The unknown options end up in program.args, not in program.opts(). Commander does not take a guess at how to interpret the unknown options.
   .argument(
     '[next-build-options...]',
     'Next.js `build` options (see: https://nextjs.org/docs/app/api-reference/cli/next#next-build-options)',

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -9,6 +9,7 @@ export const dev = new Command('dev')
   // Proxy `--help` to the underlying `next dev` command
   .helpOption(false)
   .allowUnknownOption(true)
+  // The unknown options end up in program.args, not in program.opts(). Commander does not take a guess at how to interpret the unknown options.
   .argument(
     '[options...]',
     'Next.js `dev` options (see: https://nextjs.org/docs/app/api-reference/cli/next#next-dev-options)',

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1,8 +1,10 @@
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import consola from 'consola';
 import { execa } from 'execa';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
+
+import { getProjectConfig } from '../lib/project-config';
 
 export const start = new Command('start')
   .description('Start your Catalyst storefront in optimized production mode.')
@@ -10,26 +12,51 @@ export const start = new Command('start')
   .helpOption(false)
   .allowUnknownOption(true)
   .argument(
-    '[options...]',
+    '[buildOptions...]',
     'Next.js `start` options (see: https://nextjs.org/docs/app/api-reference/cli/next#next-start-options)',
   )
-  .action(async (options) => {
+  .addOption(
+    new Option('--framework <framework>', 'The framework to use for the preview').choices([
+      'catalyst',
+      'nextjs',
+    ]),
+  )
+  .action(async (buildOptions, options) => {
     try {
-      const nextBin = join('node_modules', '.bin', 'next');
+      const config = getProjectConfig();
+      const framework = options.framework ?? config.get('framework');
 
-      if (!existsSync(nextBin)) {
-        throw new Error(
-          `Next.js is not installed in ${process.cwd()}. Are you in a valid Next.js project?`,
-        );
+      if (framework === 'nextjs') {
+        const nextBin = join('node_modules', '.bin', 'next');
+
+        if (!existsSync(nextBin)) {
+          throw new Error(
+            `Next.js is not installed in ${process.cwd()}. Are you in a valid Next.js project?`,
+          );
+        }
+
+        await execa(nextBin, ['start', ...buildOptions], {
+          stdio: 'inherit',
+          cwd: process.cwd(),
+        });
       }
 
-      // @todo conditionally run `next start` or `opennextjs-cloudflare preview` based on the framework type
-      await execa(nextBin, ['start', ...options], {
-        stdio: 'inherit',
-        cwd: process.cwd(),
-      });
+      await execa(
+        'pnpm',
+        [
+          'exec',
+          'opennextjs-cloudflare',
+          'preview',
+          '--config',
+          join('.bigcommerce', 'wrangler.jsonc'),
+          ...buildOptions,
+        ],
+        {
+          stdio: 'inherit',
+          cwd: process.cwd(),
+        },
+      );
     } catch (error) {
       consola.error(error instanceof Error ? error.message : error);
-      process.exit(1);
     }
   });

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -8,12 +8,11 @@ import { getProjectConfig } from '../lib/project-config';
 
 export const start = new Command('start')
   .description('Start your Catalyst storefront in optimized production mode.')
-  // Proxy `--help` to the underlying `next start` command
-  .helpOption(false)
   .allowUnknownOption(true)
+  // The unknown options end up in program.args, not in program.opts(). Commander does not take a guess at how to interpret the unknown options.
   .argument(
-    '[buildOptions...]',
-    'Next.js `start` options (see: https://nextjs.org/docs/app/api-reference/cli/next#next-start-options)',
+    '[start-options...]',
+    'Pass additional options to the start command. If framework is Next.js, see https://nextjs.org/docs/api-reference/cli#start for available options.',
   )
   .addOption(
     new Option('--framework <framework>', 'The framework to use for the preview').choices([
@@ -21,7 +20,7 @@ export const start = new Command('start')
       'nextjs',
     ]),
   )
-  .action(async (buildOptions, options) => {
+  .action(async (startOptions, options) => {
     try {
       const config = getProjectConfig();
       const framework = options.framework ?? config.get('framework');
@@ -35,7 +34,7 @@ export const start = new Command('start')
           );
         }
 
-        await execa(nextBin, ['start', ...buildOptions], {
+        await execa(nextBin, ['start', ...startOptions], {
           stdio: 'inherit',
           cwd: process.cwd(),
         });
@@ -49,7 +48,7 @@ export const start = new Command('start')
           'preview',
           '--config',
           join('.bigcommerce', 'wrangler.jsonc'),
-          ...buildOptions,
+          ...startOptions,
         ],
         {
           stdio: 'inherit',

--- a/packages/cli/src/lib/wrangler-config.ts
+++ b/packages/cli/src/lib/wrangler-config.ts
@@ -1,7 +1,7 @@
 export function getWranglerConfig(projectUuid: string, kvNamespaceId: string) {
   return {
     $schema: 'node_modules/wrangler/config-schema.json',
-    main: '.open-next/worker.js',
+    main: '../.open-next/worker.js',
     name: `project-${projectUuid}`,
     compatibility_date: '2025-07-15',
     compatibility_flags: ['nodejs_compat', 'global_fetch_strictly_public'],
@@ -15,7 +15,7 @@ export function getWranglerConfig(projectUuid: string, kvNamespaceId: string) {
       },
     },
     assets: {
-      directory: '.open-next/assets',
+      directory: '../.open-next/assets',
       binding: 'ASSETS',
     },
     services: [

--- a/packages/cli/tests/commands/start.spec.ts
+++ b/packages/cli/tests/commands/start.spec.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
+import consola from 'consola';
 import { execa } from 'execa';
-import { expect, test, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import { start } from '../../src/commands/start';
 import { program } from '../../src/program';
@@ -14,18 +15,87 @@ vi.mock('execa', () => ({
   __esModule: true,
 }));
 
+vi.mock('../../src/lib/project-config', () => ({
+  getProjectConfig: vi.fn(() => ({
+    get: vi.fn((key) => {
+      if (key === 'framework') {
+        return 'catalyst';
+      }
+
+      return undefined;
+    }),
+  })),
+}));
+
+beforeAll(() => {
+  consola.wrapAll();
+});
+
+beforeEach(() => {
+  consola.mockTypes(() => vi.fn());
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
 test('properly configured Command instance', () => {
   expect(start).toBeInstanceOf(Command);
   expect(start.name()).toBe('start');
   expect(start.description()).toBe('Start your Catalyst storefront in optimized production mode.');
+  expect(start.options).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        flags: '--framework <framework>',
+        argChoices: ['catalyst', 'nextjs'],
+      }),
+    ]),
+  );
 });
 
 test('calls execa with Next.js production optimized server', async () => {
-  await program.parseAsync(['node', 'catalyst', 'start', '-p', '3001']);
+  await program.parseAsync([
+    'node',
+    'catalyst',
+    'start',
+    '--port',
+    '3001',
+    '--framework',
+    'nextjs',
+  ]);
 
   expect(execa).toHaveBeenCalledWith(
     'node_modules/.bin/next',
-    ['start', '-p', '3001'],
+    ['start', '--port', '3001'],
+    expect.objectContaining({
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    }),
+  );
+});
+
+test('calls execa with OpenNext production optimized server', async () => {
+  await program.parseAsync([
+    'node',
+    'catalyst',
+    'start',
+    '--port',
+    '3001',
+    '--framework',
+    'catalyst',
+  ]);
+
+  expect(execa).toHaveBeenCalledWith(
+    'pnpm',
+    [
+      'exec',
+      'opennextjs-cloudflare',
+      'preview',
+      '--config',
+      '.bigcommerce/wrangler.jsonc',
+      '--port',
+      '3001',
+    ],
     expect.objectContaining({
       stdio: 'inherit',
       cwd: process.cwd(),


### PR DESCRIPTION
Builds on top of #2517 

## What/Why?
Runs either `nextjs start` or `opennextjs-cloudflare preview` when running `catalyst start`, depending on the selected framework.

## Testing
Locally it runs both versions + unit tests.

```
❯ pnpm run start

> @bigcommerce/catalyst-core@1.1.0 start /Users/jorge.moya/dev/catalyst/core
> catalyst start

◢ @bigcommerce/catalyst v0.1.0                                                                    3:24:47 PM


┌───────────────────────────────┐
│ OpenNext — Cloudflare preview │
└───────────────────────────────┘

Monorepo detected at /Users/jorge.moya/dev/catalyst

Populating KV incremental cache...
▲ [WARNING]                             You have defined bindings to the following internal Durable Objects:

                                - {"name":"NEXT_CACHE_DO_QUEUE","class_name":"DOQueueHandler"}
  - {"name":"NEXT_TAG_CACHE_DO_SHARDED","class_name":"DOShardedTagCache"}
  - {"name":"NEXT_CACHE_DO_PURGE","class_name":"BucketCachePurge"}
                                These will not work in local development, but they should work in production.

                                If you want to develop these locally, you can define your DO in a separate Worker, with a
  separate configuration file.
                                For detailed instructions, refer to the Durable Objects section here:
  https://developers.cloudflare.com/workers/wrangler/api#supported-bindings


workerd/server/server.c++:1874: warning: A DurableObjectNamespace in the config referenced the class "DOQueueHandler", but no such Durable Object class is exported from the worker. Please make sure the class name matches, it is exported, and the class extends 'DurableObject'. Attempts to call to this Durable Object class will fail at runtime, but historically this was not a startup-time error. Future versions of workerd may make this a startup-time error.
workerd/server/server.c++:1874: warning: A DurableObjectNamespace in the config referenced the class "DOShardedTagCache", but no such Durable Object class is exported from the worker. Please make sure the class name matches, it is exported, and the class extends 'DurableObject'. Attempts to call to this Durable Object class will fail at runtime, but historically this was not a startup-time error. Future versions of workerd may make this a startup-time error.
workerd/server/server.c++:1874: warning: A DurableObjectNamespace in the config referenced the class "BucketCachePurge", but no such Durable Object class is exported from the worker. Please make sure the class name matches, it is exported, and the class extends 'DurableObject'. Attempts to call to this Durable Object class will fail at runtime, but historically this was not a startup-time error. Future versions of workerd may make this a startup-time error.
Inserting 54 assets to KV in chunks of 25
100%|█████████████████████████████████████████████| 3/3 [00:01:<00:00:, 1.79it/s]
Successfully populated cache with 54 assets
Tag cache does not need populating

 ⛅️ wrangler 4.29.0
───────────────────
Your Worker has access to the following bindings:
Binding                                                      Resource            Mode
env.NEXT_CACHE_DO_QUEUE (DOQueueHandler)                     Durable Object      local
env.NEXT_TAG_CACHE_DO_SHARDED (DOShardedTagCache)            Durable Object      local
env.NEXT_CACHE_DO_PURGE (BucketCachePurge)                   Durable Object      local
env.NEXT_INC_CACHE_KV (placeholder-kv-id)                    KV Namespace        local
env.WORKER_SELF_REFERENCE (store-hash-project-uuid)          Worker              local [not connected]
env.ASSETS                                                   Assets              local


Service bindings, Durable Object bindings, and Tail consumers connect to other `wrangler dev` processes running locally, with their connection status indicated by [connected] or [not connected]. For more details, refer to https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/#local-development

╭──────────────────────────────────────────────────────────────────────╮
│  [b] open a browser [d] open devtools [c] clear console [x] to exit  │
╰──────────────────────────────────────────────────────────────────────╯
⎔ Starting local server...
[wrangler:info] Ready on http://localhost:3000
```

## Migration
N/A