### PR TITLE
Preconnect to checkout origin on cart page

### DIFF
--- a/.changeset/smooth-rats-rule.md
+++ b/.changeset/smooth-rats-rule.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Preconnect to checkout domain on cart page to improve checkout load time

--- a/core/app/[locale]/(default)/cart/_components/checkout-preconnect.tsx
+++ b/core/app/[locale]/(default)/cart/_components/checkout-preconnect.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import { preconnect } from 'react-dom';
+
+export function CheckoutPreconnect({ url }: { url: string }) {
+  preconnect(url);
+
+  return null;
+}

--- a/core/app/[locale]/(default)/cart/page-data.ts
+++ b/core/app/[locale]/(default)/cart/page-data.ts
@@ -190,6 +190,11 @@ const CartPageQuery = graphql(
   `
     query CartPageQuery($cartId: String) {
       site {
+        settings {
+          url {
+            checkoutUrl
+          }
+        }
         cart(entityId: $cartId) {
           entityId
           version

--- a/core/app/[locale]/(default)/cart/page.tsx
+++ b/core/app/[locale]/(default)/cart/page.tsx
@@ -12,6 +12,7 @@ import { updateCouponCode } from './_actions/update-coupon-code';
 import { updateLineItem } from './_actions/update-line-item';
 import { updateShippingInfo } from './_actions/update-shipping-info';
 import { CartViewed } from './_components/cart-viewed';
+import { CheckoutPreconnect } from './_components/checkout-preconnect';
 import { getCart, getShippingCountries } from './page-data';
 
 interface Props {
@@ -152,9 +153,12 @@ export default async function Cart({ params }: Props) {
   const showShippingForm =
     shippingConsignment?.address && !shippingConsignment.selectedShippingOption;
 
+  const checkoutUrl = data.site.settings?.url.checkoutUrl;
+
   return (
     <>
       <CartAnalyticsProvider data={Streamable.from(() => getAnalyticsData(cartId))}>
+        {checkoutUrl ? <CheckoutPreconnect url={checkoutUrl} /> : null}
         <CartComponent
           cart={{
             lineItems: formattedLineItems,


### PR DESCRIPTION
## What/Why?
On the cart page, add a preconnect tag for the checkout URL, to make sure DNS and TLS connection is already done by the time the user needs to redirect to checkout, thus improving checkout load performance for the redirected checkout.

https://nextjs.org/docs/app/api-reference/functions/generate-metadata#resource-hints

## Testing
<img width="1745" height="996" alt="image" src="https://github.com/user-attachments/assets/291792d9-0574-4ff1-a597-e86aa85c3600" />


## Migration
<!---
  If you have moved any files around, or made any breaking changes,
  please provide a migration guide for the developers to make rebases easier.
--->
