### PR TITLE
refactor: proxy all valid next start and dev options

### DIFF
--- a/packages/cli/tests/commands/dev.spec.ts
+++ b/packages/cli/tests/commands/dev.spec.ts
@@ -5,6 +5,10 @@ import { expect, test, vi } from 'vitest';
 import { dev } from '../../src/commands/dev';
 import { program } from '../../src/program';
 
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(() => true),
+}));
+
 vi.mock('execa', () => ({
   execa: vi.fn(() => Promise.resolve({ stdout: '' })),
   __esModule: true,
@@ -14,31 +18,17 @@ test('properly configured Command instance', () => {
   expect(dev).toBeInstanceOf(Command);
   expect(dev.name()).toBe('dev');
   expect(dev.description()).toBe('Start the Catalyst development server.');
-  expect(dev.options).toEqual(
-    expect.arrayContaining([
-      expect.objectContaining({ flags: '-p, --port <number>', defaultValue: '3000' }),
-      expect.objectContaining({ flags: '--root-dir <path>', defaultValue: process.cwd() }),
-    ]),
-  );
 });
 
 test('calls execa with Next.js development server', async () => {
-  await program.parseAsync([
-    'node',
-    'catalyst',
-    'dev',
-    '-p',
-    '3001',
-    '--root-dir',
-    '/path/to/root',
-  ]);
+  await program.parseAsync(['node', 'catalyst', 'dev', '-p', '3001']);
 
   expect(execa).toHaveBeenCalledWith(
-    '/path/to/root/node_modules/.bin/next',
+    'node_modules/.bin/next',
     ['dev', '-p', '3001'],
     expect.objectContaining({
       stdio: 'inherit',
-      cwd: '/path/to/root',
+      cwd: process.cwd(),
     }),
   );
 });

--- a/packages/cli/tests/commands/start.spec.ts
+++ b/packages/cli/tests/commands/start.spec.ts
@@ -5,6 +5,10 @@ import { expect, test, vi } from 'vitest';
 import { start } from '../../src/commands/start';
 import { program } from '../../src/program';
 
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(() => true),
+}));
+
 vi.mock('execa', () => ({
   execa: vi.fn(() => Promise.resolve({})),
   __esModule: true,
@@ -14,31 +18,17 @@ test('properly configured Command instance', () => {
   expect(start).toBeInstanceOf(Command);
   expect(start.name()).toBe('start');
   expect(start.description()).toBe('Start your Catalyst storefront in optimized production mode.');
-  expect(start.options).toEqual(
-    expect.arrayContaining([
-      expect.objectContaining({ flags: '-p, --port <number>', defaultValue: '3000' }),
-      expect.objectContaining({ flags: '--root-dir <path>', defaultValue: process.cwd() }),
-    ]),
-  );
 });
 
 test('calls execa with Next.js production optimized server', async () => {
-  await program.parseAsync([
-    'node',
-    'catalyst',
-    'start',
-    '-p',
-    '3001',
-    '--root-dir',
-    '/path/to/root',
-  ]);
+  await program.parseAsync(['node', 'catalyst', 'start', '-p', '3001']);
 
   expect(execa).toHaveBeenCalledWith(
-    '/path/to/root/node_modules/.bin/next',
+    'node_modules/.bin/next',
     ['start', '-p', '3001'],
     expect.objectContaining({
       stdio: 'inherit',
-      cwd: '/path/to/root',
+      cwd: process.cwd(),
     }),
   );
 });


### PR DESCRIPTION
## What/Why?
<!--- 
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
--->
Currently, the Catalyst CLI start and dev commands only accept options for -p/--portand --root-dir. The actual Next.js [start](https://nextjs.org/docs/app/api-reference/cli/next#next-start-options) and [dev](https://nextjs.org/docs/app/api-reference/cli/next#next-dev-options) commands accept more options than those; this PR ensures that:
1. All valid options are passed to the underlying `next` command equivalent
2. Suppress the Catalyst CLI `helpOption` so that running `pnpm catalyst dev --help` prints the help message from the underlying `next` command
3. Removes support for setting the `cwd` of the subprocess spawned by execa; I tried to parse out `[directory]` from `options[0]`, but this led to issues with how `next dev` and `next start` handle `[directory]` argument. May revisit down the line, but right now I don't think it's unreasonable to require that users run these commands from within a valid Next.js project directory. 

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->
Updated tests, and did a bit of manual testing:
<img width="823" height="728" alt="Screenshot 2025-08-14 at 2 30 14 PM" src="https://github.com/user-attachments/assets/cbc53dab-fb54-42af-9233-9ed989087a61" />

## Migration
<!---
  If you have moved any files around, or made any breaking changes,
  please provide a migration guide for the developers to make rebases easier.
--->
N/A