### PR TITLE
refactor: default framework to nextjs on conf init

### DIFF
--- a/packages/cli/src/lib/project-config.ts
+++ b/packages/cli/src/lib/project-config.ts
@@ -20,7 +20,7 @@ export function getProjectConfig(rootDir = process.cwd()) {
       framework: {
         type: 'string',
         enum: ['catalyst', 'nextjs'],
-        default: 'catalyst',
+        default: 'nextjs',
       },
       telemetry: {
         type: 'object',

--- a/packages/cli/tests/lib/project-config.spec.ts
+++ b/packages/cli/tests/lib/project-config.spec.ts
@@ -46,11 +46,11 @@ test('writes and reads field from .bigcommerce/project.json', async () => {
   expect(modifiedProjectUuid).toBe(projectUuid);
 });
 
-test('sets default framework to catalyst', async () => {
+test('sets default framework to nextjs', async () => {
   const projectJsonPath = join(tmpDir, '.bigcommerce/project.json');
 
   await mkdir(dirname(projectJsonPath), { recursive: true });
   await writeFile(projectJsonPath, JSON.stringify({}));
 
-  expect(config.get('framework')).toBe('catalyst');
+  expect(config.get('framework')).toBe('nextjs');
 });


### PR DESCRIPTION
## What/Why?
<!--- 
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
--->
We use a library called [Conf](https://github.com/sindresorhus/conf) in the Catalyst CLI to persist per-project config data for the CLI. Currently, when you initialize a new `.bigcommerce/project.json` file (which is done whenever you call a command that interacts with Conf), it sets the `"framework"` field in `.bigcommerce/.project.json` to `"catalyst"` by default. `"framework"` should only ever be set to `"catalyst"` after a user has successfully linked their local Catalyst repository to an Ignition project via `link`, or by providing a `--framework` override argument.

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->
Run any command that depends on `.bigcommerce/project.json` while the file does not yet exist on your machine; the `framework` field will be set to `nextjs` (with the exception of the `link` command)

## Migration
<!---
  If you have moved any files around, or made any breaking changes,
  please provide a migration guide for the developers to make rebases easier.
--->
N/A