### PR TITLE
fix(core): set secure value whenever we prefix cookie

### DIFF
--- a/.changeset/afraid-parts-prove.md
+++ b/.changeset/afraid-parts-prove.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+The anonymous session cookie had `secure` always set to true regardless if we were prefixing it or not. This change updates the cookie to set `secure` to the same "value" if we prefix the cookie with `__Secure-`.

--- a/core/auth/anonymous-session.ts
+++ b/core/auth/anonymous-session.ts
@@ -29,7 +29,7 @@ export const anonymousSignIn = async (user: Partial<AnonymousUser> = { cartId: n
   });
 
   cookieJar.set(`${cookiePrefix}${anonymousCookieName}`, jwt, {
-    secure: true,
+    secure: useSecureCookies,
     sameSite: 'lax',
     // We set the maxAge to 7 days as a good default for anonymous sessions.
     // This can be adjusted based on your application's needs.
@@ -70,7 +70,7 @@ export const clearAnonymousSession = async () => {
 
   cookieJar.delete({
     name: `${cookiePrefix}${anonymousCookieName}`,
-    secure: true,
+    secure: useSecureCookies,
     sameSite: 'lax',
     httpOnly: true,
   });


### PR DESCRIPTION
## What/Why?
The anonymous session cookie had `secure` always set to true regardless if we were prefixing it or not. This change updates the cookie to set `secure` to the same "value" if we prefix the cookie with `__Secure-`.

## Testing
### `secure: false`:
<img width="967" height="182" alt="Screenshot 2025-08-18 at 15 20 34" src="https://github.com/user-attachments/assets/23cd8df3-ee37-4061-a3e3-ac3a1da05f35" />

### `secure: true`:
<img width="1824" height="209" alt="Screenshot 2025-08-18 at 15 55 33" src="https://github.com/user-attachments/assets/dfccdd6c-fa0d-4432-86ee-932a816ecff2" />


## Migration
Just rebase like normal or manually update the code.
