### PR TITLE
refactor: add command name to bin field

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,7 +2,9 @@
   "name": "@bigcommerce/catalyst",
   "version": "0.1.0",
   "type": "module",
-  "bin": "dist/index.js",
+  "bin": {
+    "catalyst": "dist/index.js"
+  },
   "files": [
     "dist",
     "templates"


### PR DESCRIPTION
## What/Why?
<!--- 
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
--->
Allows you to run the `@bigcommerce/catalyst` CLI by calling:
```
pnpm exec catalyst <command>
```
instead of:
```
pnpm exec @bigcommerce/catalyst <command>
```

Docs: https://docs.npmjs.com/cli/v11/configuring-npm/package-json#bin

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->
Pull down branch, build CLI and run the CLI after adding it as a dependency in `core`

## Migration
<!---
  If you have moved any files around, or made any breaking changes,
  please provide a migration guide for the developers to make rebases easier.
--->
N/A