### PR TITLE
refactor: add options for framework and project uuid to build command

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,4 +1,4 @@
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import consola from 'consola';
 import { execa } from 'execa';
 import { cp } from 'node:fs/promises';
@@ -34,6 +34,13 @@ export function createFilter(root: string, skipDirs: Set<string>) {
 
 export const build = new Command('build')
   .option('--keep-temp-dir', 'Keep the temporary directory after the build')
+  .option('--project-uuid <uuid>', 'Project UUID to be included in the deployment configuration.')
+  .addOption(
+    new Option('--framework <framework>', 'The framework to use for the build.').choices([
+      'nextjs',
+      'catalyst',
+    ]),
+  )
   .action(async (options) => {
     const [tmpDir, rmTempDir] = await mkTempDir('catalyst-build-');
 

--- a/packages/cli/tests/commands/build.spec.ts
+++ b/packages/cli/tests/commands/build.spec.ts
@@ -48,7 +48,11 @@ test('properly configured Command instance', () => {
   expect(build).toBeInstanceOf(Command);
   expect(build.name()).toBe('build');
   expect(build.options).toEqual(
-    expect.arrayContaining([expect.objectContaining({ flags: '--keep-temp-dir' })]),
+    expect.arrayContaining([
+      expect.objectContaining({ long: '--keep-temp-dir' }),
+      expect.objectContaining({ long: '--framework' }),
+      expect.objectContaining({ long: '--project-uuid' }),
+    ]),
   );
 });
 


### PR DESCRIPTION
## What/Why?
<!--- 
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
--->
Adds options for `--project-uuid` and `--framework` to `build` command. In the future, the `build` command will:
* Read `--framework` to decide whether to build the project with `next` or `catalyst`
* Read `--project-uuid` to dynamically inject the `name` field in `wrangler.jsonc`

Both of these options will serve as overrides to `config.get('framework')` and `config.get('projectUuid')`

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->
Updated tests

## Migration
<!---
  If you have moved any files around, or made any breaking changes,
  please provide a migration guide for the developers to make rebases easier.
--->
N/A