### PR TITLE
refactor: proxy next build if framework is nextjs

### DIFF
--- a/packages/cli/tests/commands/build.spec.ts
+++ b/packages/cli/tests/commands/build.spec.ts
@@ -1,7 +1,21 @@
 import { Command } from 'commander';
-import { expect, test } from 'vitest';
+import { execa } from 'execa';
+import { expect, test, vi } from 'vitest';
 
 import { build } from '../../src/commands/build';
+import { program } from '../../src/program';
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+vi.spyOn(process, 'exit').mockImplementation(() => null as never);
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(() => true),
+}));
+
+vi.mock('execa', () => ({
+  execa: vi.fn(() => Promise.resolve({ stdout: '' })),
+  __esModule: true,
+}));
 
 test('properly configured Command instance', () => {
   expect(build).toBeInstanceOf(Command);
@@ -11,5 +25,18 @@ test('properly configured Command instance', () => {
       expect.objectContaining({ long: '--framework' }),
       expect.objectContaining({ long: '--project-uuid' }),
     ]),
+  );
+});
+
+test('calls execa with Next.js build if framework is nextjs', async () => {
+  await program.parseAsync(['node', 'catalyst', 'build', '--framework', 'nextjs', '--debug']);
+
+  expect(execa).toHaveBeenCalledWith(
+    'node_modules/.bin/next',
+    ['build', '--debug'],
+    expect.objectContaining({
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    }),
   );
 });


### PR DESCRIPTION
## What/Why?
<!--- 
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
--->
Responds to the `--framework` option (or `framework` property in project config) to decide whether the `build` command should use `next` or `opennextjs-cloudflare` to build the project. Follows the same implementation in `dev` and `start` commands.

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->
Added basic unit test (need to revisit, I don't think this test is very valuable, I'm just copying it over from similar files)

## Migration
<!---
  If you have moved any files around, or made any breaking changes,
  please provide a migration guide for the developers to make rebases easier.
--->
N/A