### PR TITLE
feat: override buildcommand when building with opennextjs-cloudflare

### DIFF
--- a/packages/cli/templates/open-next.config.ts
+++ b/packages/cli/templates/open-next.config.ts
@@ -1,12 +1,12 @@
-// @ts-nocheck
 import { defineCloudflareConfig } from '@opennextjs/cloudflare';
 import { purgeCache } from '@opennextjs/cloudflare/overrides/cache-purge/index';
 import kvIncrementalCache from '@opennextjs/cloudflare/overrides/incremental-cache/kv-incremental-cache';
 import doQueue from '@opennextjs/cloudflare/overrides/queue/do-queue';
 import queueCache from '@opennextjs/cloudflare/overrides/queue/queue-cache';
 import doShardedTagCache from '@opennextjs/cloudflare/overrides/tag-cache/do-sharded-tag-cache';
+import { type OpenNextConfig } from '@opennextjs/cloudflare';
 
-export default defineCloudflareConfig({
+const cloudflareConfig = defineCloudflareConfig({
   incrementalCache: kvIncrementalCache,
   queue: queueCache(doQueue, {
     regionalCacheTtlSec: 5,
@@ -27,3 +27,10 @@ export default defineCloudflareConfig({
   enableCacheInterception: false,
   cachePurge: purgeCache({ type: 'durableObject' }),
 });
+
+const config: OpenNextConfig = {
+  buildCommand: 'node_modules/.bin/next build',
+  ...cloudflareConfig,
+};
+
+export default config;


### PR DESCRIPTION
## What/Why?
<!--- 
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
--->
When we place `scripts.build` in `core/package.json` with `catalyst build` instead of `next build`, `opennextjs-cloudflare build` [will just recursively call](https://github.com/opennextjs/opennextjs-aws/blob/551dc85ec6f6e7ccb209ecc957c2c19b4ce1e6f6/packages/open-next/src/build/buildNextApp.ts#L13-L24) `pnpm run build` — this PR overrides the build command allowing us to break out of the recursion.

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->
N/A

## Migration
<!---
  If you have moved any files around, or made any breaking changes,
  please provide a migration guide for the developers to make rebases easier.
--->
N/A