### PR TITLE
feat(cli): allow creation of project in link command

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -284,7 +284,7 @@ export const deploy = new Command('deploy')
   .addOption(
     new Option(
       '--project-uuid <uuid>',
-      'BigCommerce headless project UUID. Can be found via the BigCommerce API (GET /v3/infrastructure/projects).',
+      'BigCommerce intrastructure project UUID. Can be found via the BigCommerce API (GET /v3/infrastructure/projects).',
     ).env('BIGCOMMERCE_PROJECT_UUID'),
   )
   .option(

--- a/packages/cli/tests/mocks/handlers.ts
+++ b/packages/cli/tests/mocks/handlers.ts
@@ -73,4 +73,16 @@ export const handlers = [
       });
     },
   ),
+
+  // Handle for createProjects
+  http.post('https://:apiHost/stores/:storeHash/v3/infrastructure/projects', () =>
+    HttpResponse.json({
+      data: {
+        uuid: 'c23f5785-fd99-4a94-9fb3-945551623925',
+        name: 'New Project',
+        date_created: new Date().toISOString(),
+        date_modified: new Date().toISOString(),
+      },
+    }),
+  ),
 ];


### PR DESCRIPTION
## What/Why?
Adds a new option in the prompt to create a new project.

## Testing
Locally and unit tests.

```
◢ @bigcommerce/catalyst v0.1.0                                                         1:15:22 PM

◐ Fetching projects...                                                                 1:15:22 PM
✔ Projects fetched.                                                                   1:15:23 PM

✔ Select a project (Press <enter> to select).
Create a new project

✔ Enter a name for the new project:
Team Gucci 3
✔ Project "Team Gucci 3" created successfully.                                        1:15:37 PM
◐ Writing project UUID to .bigcommerce/project.json...                                 1:15:37 PM
✔ Project UUID written to .bigcommerce/project.json.   
```

## Migration
N/A
