### PR TITLE
feat(cli): add --dry-run option to deploy

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -60,10 +60,10 @@ const DeploymentStatusSchema = z.object({
     .optional(),
 });
 
-export const generateBundleZip = async (rootDir: string) => {
+export const generateBundleZip = async () => {
   consola.info('Generating bundle...');
 
-  const distDir = join(rootDir, '.bigcommerce/dist');
+  const distDir = join(process.cwd(), '.bigcommerce', 'dist');
 
   // Check if .bigcommerce/dist exists
   try {
@@ -122,10 +122,10 @@ export const generateUploadSignature = async (
   return data;
 };
 
-export const uploadBundleZip = async (uploadUrl: string, rootDir: string) => {
+export const uploadBundleZip = async (uploadUrl: string) => {
   consola.info('Uploading bundle...');
 
-  const zipPath = join(rootDir, '.bigcommerce/dist/bundle.zip');
+  const zipPath = join(process.cwd(), '.bigcommerce/dist/bundle.zip');
 
   // Read the zip file as a buffer
   const fileBuffer = await readFile(zipPath);
@@ -287,18 +287,15 @@ export const deploy = new Command('deploy')
       'BigCommerce headless project UUID. Can be found via the BigCommerce API (GET /v3/infrastructure/projects).',
     ).env('BIGCOMMERCE_PROJECT_UUID'),
   )
-  .option(
-    '--root-dir <path>',
-    'Path to the root directory of your Catalyst project (default: current working directory).',
-    process.cwd(),
-  )
-  .action(async (opts) => {
+  .option('--dry-run', 'Run the command to generate the bundle without uploading or deploying.')
+
+  .action(async (options) => {
     try {
-      const config = getProjectConfig(opts.rootDir);
+      const config = getProjectConfig();
 
-      await telemetry.identify(opts.storeHash);
+      await telemetry.identify(options.storeHash);
 
-      const projectUuid = opts.projectUuid ?? config.get('projectUuid');
+      const projectUuid = options.projectUuid ?? config.get('projectUuid');
 
       if (!projectUuid) {
         throw new Error(
@@ -306,25 +303,40 @@ export const deploy = new Command('deploy')
         );
       }
 
-      await generateBundleZip(opts.rootDir);
+      await generateBundleZip();
+
+      if (options.dryRun) {
+        consola.info('Dry run enabled — skipping upload and deployment steps.');
+        consola.info('Next steps (skipped):');
+        consola.info('- Generate upload signature');
+        consola.info('- Upload bundle.zip');
+        consola.info('- Create deployment');
+
+        process.exit(0);
+      }
 
       const uploadSignature = await generateUploadSignature(
-        opts.storeHash,
-        opts.accessToken,
-        opts.apiHost,
+        options.storeHash,
+        options.accessToken,
+        options.apiHost,
       );
 
-      await uploadBundleZip(uploadSignature.upload_url, opts.rootDir);
+      await uploadBundleZip(uploadSignature.upload_url);
 
       const { deployment_uuid: deploymentUuid } = await createDeployment(
         projectUuid,
         uploadSignature.upload_uuid,
-        opts.storeHash,
-        opts.accessToken,
-        opts.apiHost,
+        options.storeHash,
+        options.accessToken,
+        options.apiHost,
       );
 
-      await getDeploymentStatus(deploymentUuid, opts.storeHash, opts.accessToken, opts.apiHost);
+      await getDeploymentStatus(
+        deploymentUuid,
+        options.storeHash,
+        options.accessToken,
+        options.apiHost,
+      );
     } catch (error) {
       consola.error(error);
       process.exit(1);

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -125,7 +125,7 @@ export const generateUploadSignature = async (
 export const uploadBundleZip = async (uploadUrl: string) => {
   consola.info('Uploading bundle...');
 
-  const zipPath = join(process.cwd(), '.bigcommerce/dist/bundle.zip');
+  const zipPath = join(process.cwd(), '.bigcommerce', 'dist', 'bundle.zip');
 
   // Read the zip file as a buffer
   const fileBuffer = await readFile(zipPath);


### PR DESCRIPTION
## What/Why?
Add `--dry-run` option for the cases where we only.
Remove `--root-dir` since we're moving away from that option.

## Testing
Unit tests and locally

```
◢ @bigcommerce/catalyst v0.1.0                                                                                                                                    2:49:37 PM

ℹ Generating bundle...                                                                                                                                           2:49:37 PM
✔ Bundle created at: /Users/jorge.moya/dev/catalyst/core/.bigcommerce/dist/bundle.zip                                                                            2:49:39 PM
ℹ Dry run enabled — skipping upload and deployment steps.                                                                                                        2:49:39 PM
ℹ Next steps (skipped):                                                                                                                                          2:49:39 PM
ℹ - Generate upload signature                                                                                                                                    2:49:39 PM
ℹ - Upload bundle.zip                                                                                                                                            2:49:39 PM
ℹ - Create deployment  
```

## Migration
N/A
