### PR TITLE
fix(cli): prevent existing bundle.zip from being included in the bundle

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -63,6 +63,7 @@ const DeploymentStatusSchema = z.object({
 export const generateBundleZip = async () => {
   consola.info('Generating bundle...');
 
+  const bigcommerceDir = join(process.cwd(), '.bigcommerce');
   const distDir = join(process.cwd(), '.bigcommerce', 'dist');
 
   // Check if .bigcommerce/dist exists
@@ -79,7 +80,7 @@ export const generateBundleZip = async () => {
     throw new Error(`Dist directory is empty: ${distDir}`);
   }
 
-  const outputZip = join(distDir, 'bundle.zip');
+  const outputZip = join(bigcommerceDir, 'bundle.zip');
 
   // Use AdmZip to create the zip
   const zip = new AdmZip();
@@ -125,7 +126,7 @@ export const generateUploadSignature = async (
 export const uploadBundleZip = async (uploadUrl: string) => {
   consola.info('Uploading bundle...');
 
-  const zipPath = join(process.cwd(), '.bigcommerce', 'dist', 'bundle.zip');
+  const zipPath = join(process.cwd(), '.bigcommerce', 'bundle.zip');
 
   // Read the zip file as a buffer
   const fileBuffer = await readFile(zipPath);

--- a/packages/cli/tests/commands/deploy.spec.ts
+++ b/packages/cli/tests/commands/deploy.spec.ts
@@ -56,10 +56,10 @@ beforeAll(async () => {
   // Normalize to /private/var to avoid /var vs /private/var mismatches
   tmpDir = await realpath(tmpDir);
 
-  const workerPath = join(tmpDir, '.bigcommerce/dist/worker.js');
-  const assetsDir = join(tmpDir, '.bigcommerce/dist/assets');
+  const workerPath = join(tmpDir, '.bigcommerce', 'dist', 'worker.js');
+  const assetsDir = join(tmpDir, '.bigcommerce', 'dist', 'assets');
 
-  outputZip = join(tmpDir, '.bigcommerce/dist/bundle.zip');
+  outputZip = join(tmpDir, '.bigcommerce', 'bundle.zip');
 
   await mkdir(dirname(workerPath), { recursive: true });
   await writeFile(workerPath, 'console.log("worker");');


### PR DESCRIPTION
## What/Why?
Because we put `bundle.zip` inside the zip folder, this was being re-bundled when a new deploy was created. By moving to `.bigcommerce` folder, it fixers this issue but also we feel it makes more sense that we store the `bundle.zip` in that folder.

## Testing
Locally bundle does not have bundle.zip and unit tests

## Migration
N/A
