### PR TITLE
Bump TTL for URL lookups in with-routes middleware to 24 hours

### DIFF
--- a/.changeset/chilly-melons-go.md
+++ b/.changeset/chilly-melons-go.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Bump TTL for URL lookups in with-routes middleware to 24 hours

--- a/core/middlewares/with-routes.ts
+++ b/core/middlewares/with-routes.ts
@@ -183,7 +183,7 @@ const updateRouteCache = async (
 ): Promise<RouteCache> => {
   const routeCache: RouteCache = {
     route: await getRoute(pathname, channelId),
-    expiryTime: Date.now() + 1000 * 60 * 30, // 30 minutes
+    expiryTime: Date.now() + 1000 * 60 * 60 * 24, // 24 hours
   };
 
   event.waitUntil(kv.set(kvKey(pathname, channelId), routeCache));


### PR DESCRIPTION
## What/Why?
Update the TTL for URL lookups from 30 minutes to 24 hours; this will drastically reduce writes to Runtime Cache especially for stores with lots of URLs, whilst this TTL is appropriate for most production stores.

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->

## Migration
<!---
  If you have moved any files around, or made any breaking changes,
  please provide a migration guide for the developers to make rebases easier.
--->
