### PR TITLE
Pre-fill forgot password form with email URL param

### DIFF
--- a/core/app/[locale]/(default)/(auth)/login/forgot-password/page.tsx
+++ b/core/app/[locale]/(default)/(auth)/login/forgot-password/page.tsx
@@ -26,6 +26,7 @@ import { resetPassword } from './_actions/reset-password';
 
 interface Props {
   params: Promise<{ locale: string }>;
+  searchParams: Promise<{ email?: string }>;
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
@@ -40,6 +41,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function Reset(props: Props) {
   const { locale } = await props.params;
+  const { email } = await props.searchParams;
 
   setRequestLocale(locale);
 
@@ -53,6 +55,11 @@ export default async function Reset(props: Props) {
   // const recaptchaSettings = await bypassReCaptcha(data.site.settings?.reCaptcha);
 
   return (
-    <ForgotPasswordSection action={resetPassword} subtitle={t('subtitle')} title={t('title')} />
+    <ForgotPasswordSection 
+      action={resetPassword} 
+      subtitle={t('subtitle')} 
+      title={t('title')} 
+      defaultEmail={email}
+    />
   );
 }

--- a/core/vibes/soul/sections/forgot-password-section/forgot-password-form.tsx
+++ b/core/vibes/soul/sections/forgot-password-section/forgot-password-form.tsx
@@ -22,16 +22,19 @@ interface Props {
   action: ForgotPasswordAction;
   emailLabel?: string;
   submitLabel?: string;
+  defaultEmail?: string;
 }
 
 export function ForgotPasswordForm({
   action,
   emailLabel = 'Email',
   submitLabel = 'Reset password',
+  defaultEmail,
 }: Props) {
   const [{ lastResult, successMessage }, formAction] = useActionState(action, { lastResult: null });
   const [form, fields] = useForm({
     lastResult,
+    defaultValue: { email: defaultEmail || '' },
     constraint: getZodConstraint(schema),
     shouldValidate: 'onBlur',
     shouldRevalidate: 'onInput',

--- a/core/vibes/soul/sections/forgot-password-section/index.tsx
+++ b/core/vibes/soul/sections/forgot-password-section/index.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 export function ForgotPasswordSection({
   title = 'Forgot your password?',
-  subtitle = 'Enter the email associated with your account below. We'll send you instructions to reset your password.',
+  subtitle = 'Enter the email associated with your account below. We\'ll send you instructions to reset your password.',
   emailLabel,
   submitLabel,
   action,

--- a/core/vibes/soul/sections/forgot-password-section/index.tsx
+++ b/core/vibes/soul/sections/forgot-password-section/index.tsx
@@ -6,14 +6,16 @@ interface Props {
   action: ForgotPasswordAction;
   emailLabel?: string;
   submitLabel?: string;
+  defaultEmail?: string;
 }
 
 export function ForgotPasswordSection({
   title = 'Forgot your password?',
-  subtitle = 'Enter the email associated with your account below. We’ll send you instructions to reset your password.',
+  subtitle = 'Enter the email associated with your account below. We'll send you instructions to reset your password.',
   emailLabel,
   submitLabel,
   action,
+  defaultEmail,
 }: Props) {
   return (
     <div className="@container">
@@ -21,7 +23,7 @@ export function ForgotPasswordSection({
         <div className="flex w-full flex-col @xl:max-w-md @xl:pr-10 @4xl:pr-20">
           <h1 className="mb-5 text-4xl font-medium leading-none @xl:text-5xl">{title}</h1>
           <p className="mb-10 text-base font-light leading-none @xl:text-lg">{subtitle}</p>
-          <ForgotPasswordForm action={action} emailLabel={emailLabel} submitLabel={submitLabel} />
+          <ForgotPasswordForm action={action} emailLabel={emailLabel} submitLabel={submitLabel} defaultEmail={defaultEmail} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What/Why?
This PR introduces a new feature that allows the forgot password form to be pre-filled with an email address provided via a URL parameter.

Specifically, if a user navigates to `/login/forgot-password?email=user@example.com`, the email input field will automatically be populated with `user@example.com`. This improves the user experience by enabling direct links to the forgot password page with the email already entered.

The implementation involves:
- Updating the `forgot-password/page.tsx` to accept and extract the `email` from `searchParams`.
- Passing this `email` as a `defaultEmail` prop through `ForgotPasswordSection` to `ForgotPasswordForm`.
- Utilizing the `defaultValue` option in the `useForm` hook within `ForgotPasswordForm` to pre-fill the email input.

## Testing
To test this feature:
1. Navigate to `/login/forgot-password?email=test@example.com`.
2. Verify that the email input field is pre-filled with "test@example.com".
3. Ensure the form still functions correctly when an email is provided via the URL parameter.
4. Navigate to `/login/forgot-password` (without the `?email=` parameter) and confirm the form loads normally without any pre-filled email.

## Migration
No migration steps are required as this change introduces a new feature without breaking existing functionality or moving files.

---
[Slack Thread](https://bigcommerce.slack.com/archives/C06U627FQKW/p1756148774776619?thread_ts=1756148774.776619&cid=C06U627FQKW)

<a href="https://cursor.com/background-agent?bcId=bc-658d7fa5-46b8-407b-b026-ec8e9c49feb4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-658d7fa5-46b8-407b-b026-ec8e9c49feb4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

