### PR TITLE
fix: build command --project-uuid should also read from env

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -18,7 +18,12 @@ export const build = new Command('build')
     '[next-build-options...]',
     'Next.js `build` options (see: https://nextjs.org/docs/app/api-reference/cli/next#next-build-options)',
   )
-  .option('--project-uuid <uuid>', 'Project UUID to be included in the deployment configuration.')
+  .addOption(
+    new Option(
+      '--project-uuid <uuid>',
+      'Project UUID to be included in the deployment configuration.',
+    ).env('BIGCOMMERCE_PROJECT_UUID'),
+  )
   .addOption(
     new Option('--framework <framework>', 'The framework to use for the build.').choices([
       'nextjs',


### PR DESCRIPTION
## What/Why?
<!--- 
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
--->
`--project-uuid` should also read from `BIGCOMMERCE_PROJECT_UUID` for CI environments

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->
N/A

## Migration
<!---
  If you have moved any files around, or made any breaking changes,
  please provide a migration guide for the developers to make rebases easier.
--->
N/A