### PR TITLE
feat(cli): add env option to deploy command

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -155,27 +155,21 @@ export const parseEnvironmentVariables = (envOption?: string) => {
     | undefined;
 
   if (envOption) {
-    try {
-      environmentVariables = envOption.split(',').map((envVar) => {
-        const [key, value] = envVar.split('=');
+    environmentVariables = envOption.split(',').map((envVar) => {
+      const [key, value] = envVar.split('=');
 
-        if (!key || !value) {
-          throw new Error(
-            `Invalid environment variable format: ${envVar}. Expected format: KEY=VALUE`,
-          );
-        }
+      if (!key || !value) {
+        throw new Error(
+          `Invalid environment variable format: ${envVar}. Expected format: KEY=VALUE`,
+        );
+      }
 
-        return {
-          type: 'secret' as const,
-          key: key.trim(),
-          value: value.trim(),
-        };
-      });
-    } catch (error) {
-      throw new Error(
-        `Failed to parse environment variables: ${error instanceof Error ? error.message : 'Unknown error'}`,
-      );
-    }
+      return {
+        type: 'secret' as const,
+        key: key.trim(),
+        value: value.trim(),
+      };
+    });
   }
 
   return environmentVariables;

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -148,7 +148,7 @@ export const uploadBundleZip = async (uploadUrl: string) => {
   return true;
 };
 
-export const getEnvironmentVariables = (envOption?: string) => {
+export const parseEnvironmentVariables = (envOption?: string) => {
   // Parse environment variables if provided
   let environmentVariables:
     | Array<{ type: 'secret' | 'plain_text'; key: string; value: string }>
@@ -177,27 +177,6 @@ export const getEnvironmentVariables = (envOption?: string) => {
       );
     }
   }
-
-  // Add required environment variables if not already provided
-  const requiredEnvVars = [
-    { key: 'BIGCOMMERCE_STORE_HASH', value: process.env.BIGCOMMERCE_STORE_HASH },
-    { key: 'BIGCOMMERCE_STOREFRONT_TOKEN', value: process.env.BIGCOMMERCE_STOREFRONT_TOKEN },
-    { key: 'BIGCOMMERCE_CHANNEL_ID', value: process.env.BIGCOMMERCE_CHANNEL_ID },
-  ];
-
-  environmentVariables ??= [];
-
-  const existingKeys = new Set(environmentVariables.map((env) => env.key));
-
-  requiredEnvVars.forEach(({ key, value }) => {
-    if (!existingKeys.has(key) && value) {
-      environmentVariables.push({
-        type: 'secret' as const,
-        key,
-        value,
-      });
-    }
-  });
 
   return environmentVariables;
 };
@@ -386,7 +365,7 @@ export const deploy = new Command('deploy')
 
       await uploadBundleZip(uploadSignature.upload_url);
 
-      const environmentVariables = getEnvironmentVariables(options.env);
+      const environmentVariables = parseEnvironmentVariables(options.env);
 
       const { deployment_uuid: deploymentUuid } = await createDeployment(
         projectUuid,

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -148,8 +148,8 @@ export const uploadBundleZip = async (uploadUrl: string) => {
   return true;
 };
 
-export const parseEnvironmentVariables = (secretOption?: string) => {
-  return secretOption?.split(',').map((envVar) => {
+export const parseEnvironmentVariables = (secretOption?: string[]) => {
+  return secretOption?.map((envVar) => {
     const [key, value] = envVar.split('=');
 
     if (!key || !value) {
@@ -308,7 +308,7 @@ export const deploy = new Command('deploy')
   )
   .addOption(
     new Option(
-      '--secret <secrets>',
+      '--secret <secrets...>',
       'Secrets to set for the deployment. Format: SECRET_1=FOO,SECRET_2=BAR',
     ),
   )

--- a/packages/cli/tests/commands/deploy.spec.ts
+++ b/packages/cli/tests/commands/deploy.spec.ts
@@ -93,7 +93,7 @@ test('properly configured Command instance', () => {
       expect.objectContaining({ flags: '--access-token <token>' }),
       expect.objectContaining({ flags: '--api-host <host>', defaultValue: 'api.bigcommerce.com' }),
       expect.objectContaining({ flags: '--project-uuid <uuid>' }),
-      expect.objectContaining({ flags: '--secret <secrets>' }),
+      expect.objectContaining({ flags: '--secret <secrets...>' }),
       expect.objectContaining({ flags: '--dry-run' }),
     ]),
   );
@@ -304,9 +304,10 @@ test('--dry-run skips upload and deployment', async () => {
 });
 
 test('reads from env options', () => {
-  const envVariables = parseEnvironmentVariables(
-    'BIGCOMMERCE_STORE_HASH=123,BIGCOMMERCE_STOREFRONT_TOKEN=456',
-  );
+  const envVariables = parseEnvironmentVariables([
+    'BIGCOMMERCE_STORE_HASH=123',
+    'BIGCOMMERCE_STOREFRONT_TOKEN=456',
+  ]);
 
   expect(envVariables).toEqual([
     {
@@ -321,7 +322,7 @@ test('reads from env options', () => {
     },
   ]);
 
-  expect(() => parseEnvironmentVariables('foo_bar')).toThrow(
+  expect(() => parseEnvironmentVariables(['foo_bar'])).toThrow(
     'Invalid secret format: foo_bar. Expected format: KEY=VALUE',
   );
 });

--- a/packages/cli/tests/commands/deploy.spec.ts
+++ b/packages/cli/tests/commands/deploy.spec.ts
@@ -93,7 +93,7 @@ test('properly configured Command instance', () => {
       expect.objectContaining({ flags: '--access-token <token>' }),
       expect.objectContaining({ flags: '--api-host <host>', defaultValue: 'api.bigcommerce.com' }),
       expect.objectContaining({ flags: '--project-uuid <uuid>' }),
-      expect.objectContaining({ flags: '--env <variables>' }),
+      expect.objectContaining({ flags: '--secret <secrets>' }),
       expect.objectContaining({ flags: '--dry-run' }),
     ]),
   );
@@ -322,6 +322,6 @@ test('reads from env options', () => {
   ]);
 
   expect(() => parseEnvironmentVariables('foo_bar')).toThrow(
-    'Invalid environment variable format: foo_bar. Expected format: KEY=VALUE',
+    'Invalid secret format: foo_bar. Expected format: KEY=VALUE',
   );
 });

--- a/packages/cli/tests/commands/deploy.spec.ts
+++ b/packages/cli/tests/commands/deploy.spec.ts
@@ -322,6 +322,6 @@ test('reads from env options', () => {
   ]);
 
   expect(() => parseEnvironmentVariables('foo_bar')).toThrow(
-    'Failed to parse environment variables: Invalid environment variable format: foo_bar. Expected format: KEY=VALUE',
+    'Invalid environment variable format: foo_bar. Expected format: KEY=VALUE',
   );
 });

--- a/packages/cli/tests/commands/deploy.spec.ts
+++ b/packages/cli/tests/commands/deploy.spec.ts
@@ -22,7 +22,7 @@ import {
   generateBundleZip,
   generateUploadSignature,
   getDeploymentStatus,
-  getEnvironmentVariables,
+  parseEnvironmentVariables,
   uploadBundleZip,
 } from '../../src/commands/deploy';
 import { mkTempDir } from '../../src/lib/mk-temp-dir';
@@ -304,17 +304,14 @@ test('--dry-run skips upload and deployment', async () => {
 });
 
 test('reads from env options', () => {
-  process.env.BIGCOMMERCE_STORE_HASH = storeHash;
-  process.env.BIGCOMMERCE_STOREFRONT_TOKEN = accessToken;
-
-  const envVariables = getEnvironmentVariables(
-    'BIGCOMMERCE_THEME_ID=123,BIGCOMMERCE_STOREFRONT_TOKEN=456',
+  const envVariables = parseEnvironmentVariables(
+    'BIGCOMMERCE_STORE_HASH=123,BIGCOMMERCE_STOREFRONT_TOKEN=456',
   );
 
   expect(envVariables).toEqual([
     {
       type: 'secret',
-      key: 'BIGCOMMERCE_THEME_ID',
+      key: 'BIGCOMMERCE_STORE_HASH',
       value: '123',
     },
     {
@@ -322,14 +319,9 @@ test('reads from env options', () => {
       key: 'BIGCOMMERCE_STOREFRONT_TOKEN',
       value: '456',
     },
-    {
-      type: 'secret',
-      key: 'BIGCOMMERCE_STORE_HASH',
-      value: storeHash,
-    },
   ]);
 
-  expect(() => getEnvironmentVariables('foo_bar')).toThrow(
+  expect(() => parseEnvironmentVariables('foo_bar')).toThrow(
     'Failed to parse environment variables: Invalid environment variable format: foo_bar. Expected format: KEY=VALUE',
   );
 });

--- a/packages/cli/tests/commands/deploy.spec.ts
+++ b/packages/cli/tests/commands/deploy.spec.ts
@@ -22,6 +22,7 @@ import {
   generateBundleZip,
   generateUploadSignature,
   getDeploymentStatus,
+  getEnvironmentVariables,
   uploadBundleZip,
 } from '../../src/commands/deploy';
 import { mkTempDir } from '../../src/lib/mk-temp-dir';
@@ -92,6 +93,7 @@ test('properly configured Command instance', () => {
       expect.objectContaining({ flags: '--access-token <token>' }),
       expect.objectContaining({ flags: '--api-host <host>', defaultValue: 'api.bigcommerce.com' }),
       expect.objectContaining({ flags: '--project-uuid <uuid>' }),
+      expect.objectContaining({ flags: '--env <variables>' }),
       expect.objectContaining({ flags: '--dry-run' }),
     ]),
   );
@@ -299,4 +301,35 @@ test('--dry-run skips upload and deployment', async () => {
   expect(consola.info).toHaveBeenCalledWith('- Upload bundle.zip');
   expect(consola.info).toHaveBeenCalledWith('- Create deployment');
   expect(exitMock).toHaveBeenCalledWith(0);
+});
+
+test('reads from env options', () => {
+  process.env.BIGCOMMERCE_STORE_HASH = storeHash;
+  process.env.BIGCOMMERCE_STOREFRONT_TOKEN = accessToken;
+
+  const envVariables = getEnvironmentVariables(
+    'BIGCOMMERCE_THEME_ID=123,BIGCOMMERCE_STOREFRONT_TOKEN=456',
+  );
+
+  expect(envVariables).toEqual([
+    {
+      type: 'secret',
+      key: 'BIGCOMMERCE_THEME_ID',
+      value: '123',
+    },
+    {
+      type: 'secret',
+      key: 'BIGCOMMERCE_STOREFRONT_TOKEN',
+      value: '456',
+    },
+    {
+      type: 'secret',
+      key: 'BIGCOMMERCE_STORE_HASH',
+      value: storeHash,
+    },
+  ]);
+
+  expect(() => getEnvironmentVariables('foo_bar')).toThrow(
+    'Failed to parse environment variables: Invalid environment variable format: foo_bar. Expected format: KEY=VALUE',
+  );
 });


### PR DESCRIPTION
## What/Why?
Parses `env.options` to send to create deployment.

Will also read from env variables if the corresponding key was not passed in `env.options`.

Variables we're looking for:
`BIGCOMMERCE_STORE_HASH`
`BIGCOMMERCE_STOREFRONT_TOKEN`
`BIGCOMMERCE_CHANNEL_ID`

## Testing
Locally and unit tests.

## Migration
N/A
