### PR TITLE
chore: prefer performance.now over Date.now in server component

### DIFF
--- a/.changeset/cruel-pens-dance.md
+++ b/.changeset/cruel-pens-dance.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-client": patch
+---
+
+Replace usage of Date.now with performance.now for compatibility with upcoming Next.js Composable Cache feature

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -243,10 +243,10 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
 
     const { name, type } = getOperationInfo(document);
 
-    const timeStart = Date.now();
+    const timeStart = performance.now();
 
     return (response: Response) => {
-      const timeEnd = Date.now();
+      const timeEnd = performance.now();
       const duration = timeEnd - timeStart;
 
       const complexity = response.headers.get('x-bc-graphql-complexity');


### PR DESCRIPTION
## What/Why?
<!--- 
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
--->
Fixes the following error when `cacheComponents` is set to `true`
> Cannot access `Date.now()`, `Date()`, or `new Date()` before other uncached data or Request data in a Server Component

Docs: https://nextjs.org/docs/messages/next-prerender-current-time 

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->
Before:
<img width="1512" height="982" alt="Screenshot 2025-08-29 at 2 25 33 PM" src="https://github.com/user-attachments/assets/64852426-6157-45af-929f-efd5e0661cba" />


After:
<img width="1512" height="982" alt="Screenshot 2025-08-29 at 2 16 44 PM" src="https://github.com/user-attachments/assets/2dd4cbfb-a57e-47a4-8e57-5cfd3dae045b" />


## Migration
<!---
  If you have moved any files around, or made any breaking changes,
  please provide a migration guide for the developers to make rebases easier.
--->
Replace usage of Date.now with performance.now in @bigcommerce/catalyst-client