### PR TITLE
chore: fix performance.now to 2 decimal places

### DIFF
--- a/.changeset/tender-women-smash.md
+++ b/.changeset/tender-women-smash.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-client": patch
+---
+
+Truncate performance.now to 2 decimal places

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -247,7 +247,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
 
     return (response: Response) => {
       const timeEnd = performance.now();
-      const duration = timeEnd - timeStart;
+      const duration = (timeEnd - timeStart).toFixed(2);
 
       const complexity = response.headers.get('x-bc-graphql-complexity');
 


### PR DESCRIPTION
## What/Why?
<!--- 
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
--->
Fixes `duration` in the client logger to 2 decimal places

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->
Before:
<img width="1512" height="982" alt="Screenshot 2025-08-29 at 2 57 42 PM" src="https://github.com/user-attachments/assets/5c55b4f8-9e7a-47d7-ab0d-23bcc633915b" />

After:
<img width="1512" height="982" alt="Screenshot 2025-08-29 at 2 58 13 PM" src="https://github.com/user-attachments/assets/e9aaddc1-e897-4135-b67b-208b8c4629aa" />


## Migration
<!---
  If you have moved any files around, or made any breaking changes,
  please provide a migration guide for the developers to make rebases easier.
--->
Add `.toFixed(2)` to the duration calculation in the client logger