### PR TITLE
feat: support target prop in Footer links

### DIFF
--- a/.changeset/loud-actors-build.md
+++ b/.changeset/loud-actors-build.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-makeswift": minor
+---
+
+Now have the ability to make footer links open in new tabs

--- a/core/lib/makeswift/components/site-footer/client.tsx
+++ b/core/lib/makeswift/components/site-footer/client.tsx
@@ -43,7 +43,7 @@ interface Props {
     title: string;
     links: Array<{
       label: string;
-      link: { href: string };
+      link: { href: string; target?: string };
     }>;
   }>;
   copyright?: string;
@@ -57,7 +57,7 @@ function combineSections(
     passedSections,
     makeswiftSections.map(({ title, links }) => ({
       title,
-      links: links.map(({ label, link }) => ({ label, href: link.href })),
+      links: links.map(({ label, link }) => ({ label, href: link.href, target: link.target })),
     })),
     (left, right) => ({ ...left, links: [...left.links, ...right.links] }),
   );

--- a/core/vibes/soul/sections/footer/index.tsx
+++ b/core/vibes/soul/sections/footer/index.tsx
@@ -14,6 +14,7 @@ interface Image {
 interface Link {
   href: string;
   label: string;
+  target?: string;
 }
 
 export interface Section {
@@ -175,6 +176,8 @@ export const Footer = ({
                                 <Link
                                   className="block rounded-lg py-2 text-sm font-medium text-[var(--footer-link,hsl(var(--contrast-500)))] ring-[var(--footer-focus,hsl(var(--primary)))] transition-colors duration-300 hover:text-[var(--footer-link-hover,hsl(var(--foreground)))] focus-visible:outline-0 focus-visible:ring-2"
                                   href={link.href}
+                                  rel={link.target === '_blank' ? 'noopener noreferrer' : undefined}
+                                  target={link.target}
                                 >
                                   {link.label}
                                 </Link>


### PR DESCRIPTION
## What/Why?
- adds support for `target` in `Footer` links

## Testing

https://github.com/user-attachments/assets/896692bf-60e4-4dbf-ad08-3f099bdcc367

