### PR TITLE
chore(core): removes unused export types from UI components

### DIFF
--- a/.changeset/five-moose-wish.md
+++ b/.changeset/five-moose-wish.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Remove unused export types from UI components.

--- a/core/vibes/soul/form/checkbox/index.tsx
+++ b/core/vibes/soul/form/checkbox/index.tsx
@@ -8,7 +8,7 @@ import { ComponentPropsWithoutRef, ReactNode, useId } from 'react';
 
 import { FieldError } from '@/vibes/soul/form/field-error';
 
-export interface CheckboxProps extends ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root> {
+interface CheckboxProps extends ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root> {
   label?: ReactNode;
   errors?: string[];
   colorScheme?: 'light' | 'dark';

--- a/core/vibes/soul/form/dynamic-form/index.tsx
+++ b/core/vibes/soul/form/dynamic-form/index.tsx
@@ -40,7 +40,7 @@ interface State<F extends Field> {
 
 export type DynamicFormAction<F extends Field> = Action<State<F>, FormData>;
 
-export interface DynamicFormProps<F extends Field> {
+interface DynamicFormProps<F extends Field> {
   fields: Array<F | FieldGroup<F>>;
   action: DynamicFormAction<F>;
   buttonSize?: ButtonProps['size'];

--- a/core/vibes/soul/form/dynamic-form/schema.ts
+++ b/core/vibes/soul/form/dynamic-form/schema.ts
@@ -139,7 +139,7 @@ export type Field =
 
 export type FieldGroup<F> = F[];
 
-export type SchemaRawShape = Record<
+type SchemaRawShape = Record<
   string,
   | z.ZodString
   | z.ZodOptional<z.ZodString>

--- a/core/vibes/soul/form/select-field/index.tsx
+++ b/core/vibes/soul/form/select-field/index.tsx
@@ -7,7 +7,7 @@ import { FieldError } from '@/vibes/soul/form/field-error';
 import { Label } from '@/vibes/soul/form/label';
 import { Select, type SelectProps } from '@/vibes/soul/primitives/select';
 
-export interface SelectFieldProps extends SelectProps {
+interface SelectFieldProps extends SelectProps {
   label: string;
   name: string;
   value: string;

--- a/core/vibes/soul/primitives/accordion/index.tsx
+++ b/core/vibes/soul/primitives/accordion/index.tsx
@@ -4,7 +4,7 @@ import * as AccordionPrimitive from '@radix-ui/react-accordion';
 import { clsx } from 'clsx';
 import { ComponentPropsWithoutRef, useEffect, useState } from 'react';
 
-export interface AccordionProps extends ComponentPropsWithoutRef<typeof AccordionPrimitive.Item> {
+interface AccordionProps extends ComponentPropsWithoutRef<typeof AccordionPrimitive.Item> {
   colorScheme?: 'light' | 'dark';
 }
 

--- a/core/vibes/soul/primitives/animated-underline/index.tsx
+++ b/core/vibes/soul/primitives/animated-underline/index.tsx
@@ -1,6 +1,6 @@
 import { clsx } from 'clsx';
 
-export interface AnimatedUnderlineProps {
+interface AnimatedUnderlineProps {
   children: string;
   className?: string;
 }

--- a/core/vibes/soul/primitives/badge/index.tsx
+++ b/core/vibes/soul/primitives/badge/index.tsx
@@ -1,6 +1,6 @@
 import { clsx } from 'clsx';
 
-export interface BadgeProps {
+interface BadgeProps {
   children: string;
   shape?: 'pill' | 'rounded';
   variant?: 'primary' | 'warning' | 'error' | 'success' | 'info';

--- a/core/vibes/soul/primitives/button-link/index.tsx
+++ b/core/vibes/soul/primitives/button-link/index.tsx
@@ -3,7 +3,7 @@ import { ComponentPropsWithoutRef } from 'react';
 
 import { Link } from '~/components/link';
 
-export interface ButtonLinkProps extends ComponentPropsWithoutRef<typeof Link> {
+interface ButtonLinkProps extends ComponentPropsWithoutRef<typeof Link> {
   variant?: 'primary' | 'secondary' | 'tertiary' | 'ghost';
   size?: 'large' | 'medium' | 'small' | 'x-small';
   shape?: 'pill' | 'rounded' | 'square' | 'circle';

--- a/core/vibes/soul/primitives/calendar/index.tsx
+++ b/core/vibes/soul/primitives/calendar/index.tsx
@@ -7,7 +7,7 @@ const components = {
   Chevron: () => <ChevronLeftIcon className="h-5 w-5" strokeWidth={1} />,
 };
 
-export type CalendarProps = ComponentPropsWithoutRef<typeof DayPicker> & {
+type CalendarProps = ComponentPropsWithoutRef<typeof DayPicker> & {
   colorScheme?: 'light' | 'dark';
 };
 

--- a/core/vibes/soul/primitives/carousel/index.tsx
+++ b/core/vibes/soul/primitives/carousel/index.tsx
@@ -321,11 +321,4 @@ function CarouselScrollbar({
   );
 }
 
-export {
-  type CarouselApi,
-  Carousel,
-  CarouselContent,
-  CarouselItem,
-  CarouselButtons,
-  CarouselScrollbar,
-};
+export { Carousel, CarouselContent, CarouselItem, CarouselButtons, CarouselScrollbar };

--- a/core/vibes/soul/primitives/compare-card/index.tsx
+++ b/core/vibes/soul/primitives/compare-card/index.tsx
@@ -21,7 +21,7 @@ export interface CompareProduct extends Product {
   isPreorder?: boolean;
 }
 
-export interface CompareCardProps {
+interface CompareCardProps {
   className?: string;
   product: CompareProduct;
   addToCartLabel?: string;

--- a/core/vibes/soul/primitives/compare-drawer/index.tsx
+++ b/core/vibes/soul/primitives/compare-drawer/index.tsx
@@ -109,7 +109,7 @@ interface CompareDrawerItem {
   title: string;
 }
 
-export interface CompareDrawerProps {
+interface CompareDrawerProps {
   href?: string;
   paramName?: string;
   submitLabel?: string;

--- a/core/vibes/soul/primitives/favorite/index.tsx
+++ b/core/vibes/soul/primitives/favorite/index.tsx
@@ -2,7 +2,7 @@ import * as Toggle from '@radix-ui/react-toggle';
 
 import { Heart } from '@/vibes/soul/primitives/favorite/heart';
 
-export interface FavoriteProps {
+interface FavoriteProps {
   label?: string;
   checked?: boolean;
   setChecked?: (liked: boolean) => void;

--- a/core/vibes/soul/primitives/price-label/index.tsx
+++ b/core/vibes/soul/primitives/price-label/index.tsx
@@ -1,12 +1,12 @@
 import { clsx } from 'clsx';
 
-export interface PriceRange {
+interface PriceRange {
   type: 'range';
   minValue: string;
   maxValue: string;
 }
 
-export interface PriceSale {
+interface PriceSale {
   type: 'sale';
   previousValue: string;
   currentValue: string;

--- a/core/vibes/soul/primitives/rating/index.tsx
+++ b/core/vibes/soul/primitives/rating/index.tsx
@@ -1,6 +1,6 @@
 import { clsx } from 'clsx';
 
-export interface Props {
+interface Props {
   showRating?: boolean;
   rating: number;
   className?: string;

--- a/core/vibes/soul/primitives/reveal/index.tsx
+++ b/core/vibes/soul/primitives/reveal/index.tsx
@@ -6,7 +6,7 @@ import { ReactNode, useEffect, useRef, useState } from 'react';
 import { AnimatedUnderline } from '@/vibes/soul/primitives/animated-underline';
 import { Button } from '@/vibes/soul/primitives/button';
 
-export interface RevealProps {
+interface RevealProps {
   variant?: 'underline' | 'button';
   showLabel?: string;
   hideLabel?: string;

--- a/core/vibes/soul/sections/account-settings/change-password-form.tsx
+++ b/core/vibes/soul/sections/account-settings/change-password-form.tsx
@@ -20,7 +20,7 @@ interface State {
 
 export type ChangePasswordAction = Action<State, FormData>;
 
-export interface ChangePasswordFormProps {
+interface ChangePasswordFormProps {
   action: ChangePasswordAction;
   currentPasswordLabel?: string;
   newPasswordLabel?: string;

--- a/core/vibes/soul/sections/account-settings/index.tsx
+++ b/core/vibes/soul/sections/account-settings/index.tsx
@@ -1,7 +1,7 @@
 import { ChangePasswordAction, ChangePasswordForm } from './change-password-form';
 import { Account, UpdateAccountAction, UpdateAccountForm } from './update-account-form';
 
-export interface AccountSettingsSectionProps {
+interface AccountSettingsSectionProps {
   title?: string;
   account: Account;
   updateAccountAction: UpdateAccountAction;

--- a/core/vibes/soul/sections/account-settings/update-account-form.tsx
+++ b/core/vibes/soul/sections/account-settings/update-account-form.tsx
@@ -23,7 +23,7 @@ interface State {
   lastResult: SubmissionResult | null;
 }
 
-export interface UpdateAccountFormProps {
+interface UpdateAccountFormProps {
   action: UpdateAccountAction;
   account: Account;
   firstNameLabel?: string;

--- a/core/vibes/soul/sections/address-list-section/index.tsx
+++ b/core/vibes/soul/sections/address-list-section/index.tsx
@@ -38,7 +38,7 @@ interface State<A extends Address, F extends Field> {
   fields: Array<F | FieldGroup<F>>;
 }
 
-export interface AddressListSectionProps<A extends Address, F extends Field> {
+interface AddressListSectionProps<A extends Address, F extends Field> {
   title?: string;
   addresses: A[];
   fields: Array<F | FieldGroup<F>>;

--- a/core/vibes/soul/sections/breadcrumbs/index.tsx
+++ b/core/vibes/soul/sections/breadcrumbs/index.tsx
@@ -11,7 +11,7 @@ export interface Breadcrumb {
   href: string;
 }
 
-export interface BreadcrumbsProps {
+interface BreadcrumbsProps {
   breadcrumbs: Streamable<Breadcrumb[]>;
   className?: string;
 }

--- a/core/vibes/soul/sections/cart/client.tsx
+++ b/core/vibes/soul/sections/cart/client.tsx
@@ -38,12 +38,12 @@ export interface CartLineItem {
   price: string;
 }
 
-export interface CartSummaryItem {
+interface CartSummaryItem {
   label: string;
   value: string;
 }
 
-export interface CartState<LineItem extends CartLineItem> {
+interface CartState<LineItem extends CartLineItem> {
   lineItems: LineItem[];
   lastResult: SubmissionResult | null;
 }

--- a/core/vibes/soul/sections/cart/coupon-code-form/coupon-chip.tsx
+++ b/core/vibes/soul/sections/cart/coupon-code-form/coupon-chip.tsx
@@ -5,7 +5,7 @@ import { Chip } from '@/vibes/soul/primitives/chip';
 
 import { couponCodeActionFormDataSchema } from '../schema';
 
-export interface CouponChipProps {
+interface CouponChipProps {
   action: (payload: FormData) => void;
   onSubmit: (formData: FormData) => void;
   couponCode: string;

--- a/core/vibes/soul/sections/cart/coupon-code-form/index.tsx
+++ b/core/vibes/soul/sections/cart/coupon-code-form/index.tsx
@@ -20,7 +20,7 @@ export interface CouponCodeFormState {
   lastResult: SubmissionResult | null;
 }
 
-export interface CouponCodeFormProps {
+interface CouponCodeFormProps {
   action: Action<CouponCodeFormState, FormData>;
   couponCodes?: string[];
   ctaLabel?: string;

--- a/core/vibes/soul/sections/cart/index.tsx
+++ b/core/vibes/soul/sections/cart/index.tsx
@@ -27,7 +27,7 @@ export function Cart<LineItem extends CartLineItem>({
   );
 }
 
-export interface CartSkeletonProps {
+interface CartSkeletonProps {
   className?: string;
   placeholderCount?: number;
   summaryPlaceholderCount?: number;

--- a/core/vibes/soul/sections/featured-product-carousel/index.tsx
+++ b/core/vibes/soul/sections/featured-product-carousel/index.tsx
@@ -9,7 +9,7 @@ interface Link {
   href: string;
 }
 
-export interface FeaturedProductCarouselProps {
+interface FeaturedProductCarouselProps {
   title: string;
   description?: string;
   cta?: Link;

--- a/core/vibes/soul/sections/featured-product-list/index.tsx
+++ b/core/vibes/soul/sections/featured-product-list/index.tsx
@@ -9,7 +9,7 @@ interface Link {
   href: string;
 }
 
-export interface FeaturedProductsListProps {
+interface FeaturedProductsListProps {
   title: string;
   description?: string;
   cta?: Link;

--- a/core/vibes/soul/sections/footer/index.tsx
+++ b/core/vibes/soul/sections/footer/index.tsx
@@ -16,7 +16,7 @@ interface Link {
   label: string;
 }
 
-export interface Section {
+interface Section {
   title?: string;
   links: Link[];
 }
@@ -31,7 +31,7 @@ interface ContactInformation {
   phone?: string;
 }
 
-export interface FooterProps {
+interface FooterProps {
   logo: Streamable<string | Image>;
   sections: Streamable<Section[]>;
   copyright?: Streamable<string>;

--- a/core/vibes/soul/sections/not-found/index.tsx
+++ b/core/vibes/soul/sections/not-found/index.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/vibes/soul/primitives/button';
 import { SectionLayout } from '@/vibes/soul/sections/section-layout';
 import { useSearch } from '~/lib/search';
 
-export interface NotFoundProps {
+interface NotFoundProps {
   title?: string;
   subtitle?: string;
   ctaLabel?: string;

--- a/core/vibes/soul/sections/order-details-section/index.tsx
+++ b/core/vibes/soul/sections/order-details-section/index.tsx
@@ -74,7 +74,7 @@ export interface Order {
   summary: Summary;
 }
 
-export interface OrderDetailsSectionProps {
+interface OrderDetailsSectionProps {
   order: Streamable<Order>;
   title?: string;
   orderSummaryLabel?: string;

--- a/core/vibes/soul/sections/order-list/index.tsx
+++ b/core/vibes/soul/sections/order-list/index.tsx
@@ -19,12 +19,12 @@ export interface Order {
   lineItems: OrderLineItem[];
 }
 
-export interface OrderLineItem extends Product {
+interface OrderLineItem extends Product {
   price: string;
   totalPrice: string;
 }
 
-export interface OrderListProps {
+interface OrderListProps {
   className?: string;
   title?: string;
   orders: Streamable<Order[]>;

--- a/core/vibes/soul/sections/product-carousel/index.tsx
+++ b/core/vibes/soul/sections/product-carousel/index.tsx
@@ -18,7 +18,7 @@ import * as Skeleton from '@/vibes/soul/primitives/skeleton';
 
 export type CarouselProduct = Product;
 
-export interface ProductCarouselProps {
+interface ProductCarouselProps {
   products: Streamable<CarouselProduct[]>;
   className?: string;
   colorScheme?: 'light' | 'dark';

--- a/core/vibes/soul/sections/product-detail/index.tsx
+++ b/core/vibes/soul/sections/product-detail/index.tsx
@@ -32,7 +32,7 @@ interface ProductDetailProduct {
   maxQuantity?: Streamable<number | null>;
 }
 
-export interface ProductDetailProps<F extends Field> {
+interface ProductDetailProps<F extends Field> {
   breadcrumbs?: Streamable<Breadcrumb[]>;
   product: Streamable<ProductDetailProduct | null>;
   action: ProductDetailFormAction<F>;

--- a/core/vibes/soul/sections/product-detail/product-detail-form.tsx
+++ b/core/vibes/soul/sections/product-detail/product-detail-form.tsx
@@ -44,7 +44,7 @@ interface State<F extends Field> {
 
 export type ProductDetailFormAction<F extends Field> = Action<State<F>, FormData>;
 
-export interface ProductDetailFormProps<F extends Field> {
+interface ProductDetailFormProps<F extends Field> {
   fields: F[];
   action: ProductDetailFormAction<F>;
   productId: string;

--- a/core/vibes/soul/sections/product-detail/product-gallery.tsx
+++ b/core/vibes/soul/sections/product-detail/product-gallery.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from 'react';
 
 import { Image } from '~/components/image';
 
-export interface ProductGalleryProps {
+interface ProductGalleryProps {
   images: Array<{ alt: string; src: string }>;
   className?: string;
   thumbnailLabel?: string;

--- a/core/vibes/soul/sections/products-list-section/filters-panel.tsx
+++ b/core/vibes/soul/sections/products-list-section/filters-panel.tsx
@@ -20,27 +20,27 @@ import { Link } from '~/components/link';
 
 import { getFilterParsers } from './filter-parsers';
 
-export interface LinkGroupFilter {
+interface LinkGroupFilter {
   type: 'link-group';
   label: string;
   links: Array<{ label: string; href: string }>;
 }
 
-export interface ToggleGroupFilter {
+interface ToggleGroupFilter {
   type: 'toggle-group';
   paramName: string;
   label: string;
   options: Array<{ label: string; value: string; disabled?: boolean }>;
 }
 
-export interface RatingFilter {
+interface RatingFilter {
   type: 'rating';
   paramName: string;
   label: string;
   disabled?: boolean;
 }
 
-export interface RangeFilter {
+interface RangeFilter {
   type: 'range';
   label: string;
   minParamName: string;

--- a/core/vibes/soul/sections/section-layout/index.tsx
+++ b/core/vibes/soul/sections/section-layout/index.tsx
@@ -1,7 +1,7 @@
 import { clsx } from 'clsx';
 import { ReactNode } from 'react';
 
-export interface SectionLayoutProps {
+interface SectionLayoutProps {
   className?: string;
   children: ReactNode;
   containerSize?: 'md' | 'lg' | 'xl' | '2xl' | 'full';


### PR DESCRIPTION
## What/Why?
Remove unused export types from UI components.

## Testing
N/A

## Migration
Remove `export` declaration from types in UI components.