### PR TITLE
feat: add alias for foreground and text variables

### DIFF
--- a/.changeset/fuzzy-rabbits-walk.md
+++ b/.changeset/fuzzy-rabbits-walk.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-makeswift": minor
+---
+
+Create alias for variables for button and button-link components

--- a/core/lib/makeswift/components/site-theme/client.tsx
+++ b/core/lib/makeswift/components/site-theme/client.tsx
@@ -16,7 +16,13 @@ export const SiteTheme = ({ fontTokens, ...theme }: TokensProps & ThemeProps) =>
   <style data-makeswift="theme">{`:root {
       ${fontTokensToCssVars(fontTokens).join('\n')}
       ${themeToCssVars(theme).join('\n')}
+      /* Variable aliases for backward compatibility */
       --font-family-mono: var(--font-family-accent);
+      --button-primary-text: var(--button-primary-foreground);
+      --button-secondary-text: var(--button-secondary-foreground);
+      --button-tertiary-text: var(--button-tertiary-foreground);
+      --button-ghost-text: var(--button-ghost-foreground);
+      --button-danger-text: var(--button-danger-foreground);
     }
   `}</style>
 );

--- a/core/lib/makeswift/components/site-theme/components/button.ts
+++ b/core/lib/makeswift/components/site-theme/components/button.ts
@@ -20,7 +20,7 @@ const colorGroup = (
     props: {
       background: Color({ label: 'Background', defaultValue: defaults.background }),
       backgroundHover: Color({ label: 'Background hover', defaultValue: defaults.backgroundHover }),
-      foreground: Color({ label: 'Foreground', defaultValue: defaults.foreground }),
+      foreground: Color({ label: 'Text', defaultValue: defaults.foreground }),
       border: Color({ label: 'Border', defaultValue: defaults.border }),
     },
   });

--- a/core/vibes/soul/primitives/button-link/index.tsx
+++ b/core/vibes/soul/primitives/button-link/index.tsx
@@ -20,19 +20,19 @@ export interface ButtonLinkProps extends ComponentPropsWithoutRef<typeof Link> {
  *   --button-font-family: var(--font-family-body);
  *   --button-primary-background: hsl(var(--primary));
  *   --button-primary-background-hover: color-mix(in oklab, hsl(var(--primary)), white 75%);
- *   --button-primary-foreground: hsl(var(--foreground));
+ *   --button-primary-text: hsl(var(--foreground));
  *   --button-primary-border: hsl(var(--primary));
  *   --button-secondary-background: hsl(var(--foreground));
  *   --button-secondary-background-hover: hsl(var(--background));
- *   --button-secondary-foreground: hsl(var(--background));
+ *   --button-secondary-text: hsl(var(--background));
  *   --button-secondary-border: hsl(var(--foreground));
  *   --button-tertiary-background: hsl(var(--background));
  *   --button-tertiary-background-hover: hsl(var(--contrast-100));
- *   --button-tertiary-foreground: hsl(var(--foreground));
+ *   --button-tertiary-text: hsl(var(--foreground));
  *   --button-tertiary-border: hsl(var(--contrast-200));
  *   --button-ghost-background: transparent;
  *   --button-ghost-background-hover: hsl(var(--foreground) / 5%);
- *   --button-ghost-foreground: hsl(var(--foreground));
+ *   --button-ghost-text: hsl(var(--foreground));
  *   --button-ghost-border: transparent;
  * }
  * ```
@@ -52,13 +52,13 @@ export function ButtonLink({
         'relative z-0 inline-flex h-fit select-none items-center justify-center overflow-hidden border text-center font-[family-name:var(--button-font-family)] font-semibold leading-normal after:absolute after:inset-0 after:-z-10 after:-translate-x-[105%] after:transition-[opacity,transform] after:duration-300 after:[animation-timing-function:cubic-bezier(0,0.25,0,1)] hover:after:translate-x-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--button-focus,hsl(var(--primary)))] focus-visible:ring-offset-2',
         {
           primary:
-            'border-[var(--button-primary-border,hsl(var(--primary)))] bg-[var(--button-primary-background,hsl(var(--primary)))] text-[var(--button-primary-foreground,hsl(var(--foreground)))] after:bg-[var(--button-primary-background-hover,color-mix(in_oklab,hsl(var(--primary)),white_75%))]',
+            'border-[var(--button-primary-border,hsl(var(--primary)))] bg-[var(--button-primary-background,hsl(var(--primary)))] text-[var(--button-primary-text,hsl(var(--foreground)))] after:bg-[var(--button-primary-background-hover,color-mix(in_oklab,hsl(var(--primary)),white_75%))]',
           secondary:
-            'border-[var(--button-secondary-border,hsl(var(--foreground)))] bg-[var(--button-secondary-background,hsl(var(--foreground)))] text-[var(--button-secondary-foreground,hsl(var(--background)))] after:bg-[var(--button-secondary-background-hover,hsl(var(--background)))]',
+            'border-[var(--button-secondary-border,hsl(var(--foreground)))] bg-[var(--button-secondary-background,hsl(var(--foreground)))] text-[var(--button-secondary-text,hsl(var(--background)))] after:bg-[var(--button-secondary-background-hover,hsl(var(--background)))]',
           tertiary:
-            'border-[var(--button-tertiary-border,hsl(var(--contrast-200)))] bg-[var(--button-tertiary-background,hsl(var(--background)))] text-[var(--button-tertiary-foreground,hsl(var(--foreground)))] after:bg-[var(--button-tertiary-background-hover,hsl(var(--contrast-100)))]',
+            'border-[var(--button-tertiary-border,hsl(var(--contrast-200)))] bg-[var(--button-tertiary-background,hsl(var(--background)))] text-[var(--button-tertiary-text,hsl(var(--foreground)))] after:bg-[var(--button-tertiary-background-hover,hsl(var(--contrast-100)))]',
           ghost:
-            'border-[var(--button-ghost-border,transparent)] bg-[var(--button-ghost-background,transparent)] text-[var(--button-ghost-foreground,hsl(var(--foreground)))] after:bg-[var(--button-ghost-background-hover,hsl(var(--foreground)/5%))]',
+            'border-[var(--button-ghost-border,transparent)] bg-[var(--button-ghost-background,transparent)] text-[var(--button-ghost-text,hsl(var(--foreground)))] after:bg-[var(--button-ghost-background-hover,hsl(var(--foreground)/5%))]',
         }[variant],
         {
           'x-small': 'min-h-8 text-xs',

--- a/core/vibes/soul/primitives/button/index.tsx
+++ b/core/vibes/soul/primitives/button/index.tsx
@@ -20,24 +20,24 @@ export interface ButtonProps extends ComponentPropsWithoutRef<'button'> {
  *   --button-font-family: var(--font-family-body);
  *   --button-primary-background: hsl(var(--primary));
  *   --button-primary-background-hover: color-mix(in oklab, hsl(var(--primary)), white 75%);
- *   --button-primary-foreground: hsl(var(--foreground));
+ *   --button-primary-text: hsl(var(--foreground));
  *   --button-primary-border: hsl(var(--primary));
  *   --button-secondary-background: hsl(var(--foreground));
  *   --button-secondary-background-hover: hsl(var(--background));
- *   --button-secondary-foreground: hsl(var(--background));
+ *   --button-secondary-text: hsl(var(--background));
  *   --button-secondary-border: hsl(var(--foreground));
  *   --button-tertiary-background: hsl(var(--background));
  *   --button-tertiary-background-hover: hsl(var(--contrast-100));
- *   --button-tertiary-foreground: hsl(var(--foreground));
+ *   --button-tertiary-text: hsl(var(--foreground));
  *   --button-tertiary-border: hsl(var(--contrast-200));
  *   --button-ghost-background: transparent;
  *   --button-ghost-background-hover: hsl(var(--foreground) / 5%);
- *   --button-ghost-foreground: hsl(var(--foreground));
+ *   --button-ghost-text: hsl(var(--foreground));
  *   --button-ghost-border: transparent;
  *   --button-loader-icon: hsl(var(--foreground));
  *   --button-danger-background: color-mix(in oklab, hsl(var(--error)), white 30%);
  *   --button-danger-background-hover: color-mix(in oklab, hsl(var(--error)), white 75%);
- *   --button-danger-foreground: hsl(var(--foreground));
+ *   --button-danger-text: hsl(var(--foreground));
  *   --button-danger-border: color-mix(in oklab, hsl(var(--error)), white 30%);
  * }
  * ```
@@ -61,15 +61,15 @@ export function Button({
         'relative z-0 inline-flex h-fit cursor-pointer select-none items-center justify-center overflow-hidden border text-center font-[family-name:var(--button-font-family,var(--font-family-body))] font-semibold leading-normal after:absolute after:inset-0 after:-z-10 after:-translate-x-[105%] after:duration-300 after:[animation-timing-function:cubic-bezier(0,0.25,0,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--button-focus,hsl(var(--primary)))] focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-30',
         {
           primary:
-            'border-[var(--button-primary-border,hsl(var(--primary)))] bg-[var(--button-primary-background,hsl(var(--primary)))] text-[var(--button-primary-foreground,hsl(var(--foreground)))] after:bg-[var(--button-primary-background-hover,color-mix(in_oklab,hsl(var(--primary)),white_75%))]',
+            'border-[var(--button-primary-border,hsl(var(--primary)))] bg-[var(--button-primary-background,hsl(var(--primary)))] text-[var(--button-primary-text,hsl(var(--foreground)))] after:bg-[var(--button-primary-background-hover,color-mix(in_oklab,hsl(var(--primary)),white_75%))]',
           secondary:
-            'border-[var(--button-secondary-border,hsl(var(--foreground)))] bg-[var(--button-secondary-background,hsl(var(--foreground)))] text-[var(--button-secondary-foreground,hsl(var(--background)))] after:bg-[var(--button-secondary-background-hover,hsl(var(--background)))]',
+            'border-[var(--button-secondary-border,hsl(var(--foreground)))] bg-[var(--button-secondary-background,hsl(var(--foreground)))] text-[var(--button-secondary-text,hsl(var(--background)))] after:bg-[var(--button-secondary-background-hover,hsl(var(--background)))]',
           tertiary:
-            'border-[var(--button-tertiary-border,hsl(var(--contrast-200)))] bg-[var(--button-tertiary-background,hsl(var(--background)))] text-[var(--button-tertiary-foreground,hsl(var(--foreground)))] after:bg-[var(--button-tertiary-background-hover,hsl(var(--contrast-100)))]',
+            'border-[var(--button-tertiary-border,hsl(var(--contrast-200)))] bg-[var(--button-tertiary-background,hsl(var(--background)))] text-[var(--button-tertiary-text,hsl(var(--foreground)))] after:bg-[var(--button-tertiary-background-hover,hsl(var(--contrast-100)))]',
           ghost:
-            'border-[var(--button-ghost-border,transparent)] bg-[var(--button-ghost-background,transparent)] text-[var(--button-ghost-foreground,hsl(var(--foreground)))] after:bg-[var(--button-ghost-background-hover,hsl(var(--foreground)/5%))]',
+            'border-[var(--button-ghost-border,transparent)] bg-[var(--button-ghost-background,transparent)] text-[var(--button-ghost-text,hsl(var(--foreground)))] after:bg-[var(--button-ghost-background-hover,hsl(var(--foreground)/5%))]',
           danger:
-            'border-[var(--button-danger-border,color-mix(in_oklab,hsl(var(--error)),white_30%))] bg-[var(--button-danger-background,color-mix(in_oklab,hsl(var(--error)),white_30%))] text-[var(--button-danger-foreground)] after:bg-[var(--button-danger-background-hover,color-mix(in_oklab,hsl(var(--error)),white_75%))]',
+            'border-[var(--button-danger-border,color-mix(in_oklab,hsl(var(--error)),white_30%))] bg-[var(--button-danger-background,color-mix(in_oklab,hsl(var(--error)),white_30%))] text-[var(--button-danger-text)] after:bg-[var(--button-danger-background-hover,color-mix(in_oklab,hsl(var(--error)),white_75%))]',
         }[variant],
         {
           pill: 'rounded-full after:rounded-full',


### PR DESCRIPTION
## What/Why?
- adds alias for renamed variables on `button` and `button-link` components
- renamed `Foreground` to `Text` in site theme editor for `Button` component

## Testing

https://github.com/user-attachments/assets/d33bca1f-a1c4-41bb-9301-ab2a1bdd5992

