### PR TITLE
fix: pass cart id on B2B authentication

### DIFF
--- a/core/b2b/server-login.ts
+++ b/core/b2b/server-login.ts
@@ -5,14 +5,17 @@ import { AuthError } from 'next-auth';
 import { getTranslations } from 'next-intl/server';
 
 import { signIn } from '~/auth';
+import { getCartId } from '~/lib/cart';
 
 export const login = async (email: string, password: string) => {
   const t = await getTranslations('Auth.Login');
+  const cartId = await getCartId();
 
   try {
     await signIn('password', {
       email,
       password,
+      cartId,
       redirect: false,
     });
   } catch (error) {


### PR DESCRIPTION
## What/Why?
Retrieving cartId via `getCartId` function inside the B2B server login. This will help keep anonymous carts when a user logs in/register.

## Testing
TODO
Before:
https://github.com/user-attachments/assets/33221579-0339-4222-ad37-7b252c54b11d

After:

https://github.com/user-attachments/assets/2d8816e0-ace0-4e00-90f0-c4c0e055e147


## Migration
No breaking changes.