### PR TITLE
Revert "chore(core): removes unused exports from UI components"

### DIFF
--- a/.changeset/polite-badgers-film.md
+++ b/.changeset/polite-badgers-film.md
@@ -1,5 +1,0 @@
----
-"@bigcommerce/catalyst-core": patch
----
-
-Remove unused exports from UI components.

--- a/core/vibes/soul/primitives/compare-drawer/index.tsx
+++ b/core/vibes/soul/primitives/compare-drawer/index.tsx
@@ -30,7 +30,7 @@ interface CompareDrawerContext {
   maxItems?: number;
 }
 
-const CompareDrawerContext = createContext<CompareDrawerContext>({
+export const CompareDrawerContext = createContext<CompareDrawerContext>({
   optimisticItems: [],
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   setOptimisticItems: () => {},

--- a/core/vibes/soul/primitives/cursor-pagination/index.tsx
+++ b/core/vibes/soul/primitives/cursor-pagination/index.tsx
@@ -131,7 +131,7 @@ function SkeletonLink({ children }: { children: React.ReactNode }) {
   );
 }
 
-function CursorPaginationSkeleton() {
+export function CursorPaginationSkeleton() {
   return (
     <div className="flex w-full justify-center bg-background py-10 text-xs">
       <div className="flex gap-2">

--- a/core/vibes/soul/sections/blog-post-content/index.tsx
+++ b/core/vibes/soul/sections/blog-post-content/index.tsx
@@ -149,7 +149,7 @@ function BlogPostBodySkeleton() {
   );
 }
 
-function BlogPostContentSkeleton() {
+export function BlogPostContentSkeleton() {
   return (
     <div>
       <div className="mx-auto w-full max-w-4xl pb-8 @2xl:pb-12 @4xl:pb-16">

--- a/core/vibes/soul/sections/blog-post-list/index.tsx
+++ b/core/vibes/soul/sections/blog-post-list/index.tsx
@@ -53,7 +53,7 @@ export function BlogPostList({
   );
 }
 
-function BlogPostListSkeleton({
+export function BlogPostListSkeleton({
   className,
   placeholderCount = 6,
 }: Pick<Props, 'className' | 'placeholderCount'>) {
@@ -68,7 +68,7 @@ function BlogPostListSkeleton({
   );
 }
 
-function BlogPostListEmptyState({
+export function BlogPostListEmptyState({
   className,
   placeholderCount = 6,
   emptyStateTitle,

--- a/core/vibes/soul/sections/breadcrumbs/index.tsx
+++ b/core/vibes/soul/sections/breadcrumbs/index.tsx
@@ -97,7 +97,7 @@ export function BreadcrumbsSkeleton({ className }: Pick<BreadcrumbsProps, 'class
   );
 }
 
-function BreadCrumbEmptyState({ className }: Pick<BreadcrumbsProps, 'className'>) {
+export function BreadCrumbEmptyState({ className }: Pick<BreadcrumbsProps, 'className'>) {
   return (
     <Skeleton.Root className={className}>
       <div className={clsx('min-h-[1lh]', className)} />

--- a/core/vibes/soul/sections/compare-section/index.tsx
+++ b/core/vibes/soul/sections/compare-section/index.tsx
@@ -143,7 +143,7 @@ export function CompareSection({
   );
 }
 
-function CompareSectionSkeleton({
+export function CompareSectionSkeleton({
   className,
   title = 'Compare products',
   placeholderCount = 4,
@@ -189,7 +189,7 @@ function CompareSectionSkeleton({
   );
 }
 
-function CompareSectionEmptyState({
+export function CompareSectionEmptyState({
   className,
   emptyStateTitle,
   emptyStateSubtitle,

--- a/core/vibes/soul/sections/product-carousel/index.tsx
+++ b/core/vibes/soul/sections/product-carousel/index.tsx
@@ -129,7 +129,7 @@ export function ProductCarousel({
   );
 }
 
-function ProductsCarouselSkeleton({
+export function ProductsCarouselSkeleton({
   className,
   placeholderCount = 8,
   hideOverflow,
@@ -163,7 +163,7 @@ function ProductsCarouselSkeleton({
   );
 }
 
-function ProductsCarouselEmptyState({
+export function ProductsCarouselEmptyState({
   className,
   placeholderCount = 8,
   emptyStateTitle,

--- a/core/vibes/soul/sections/product-detail/index.tsx
+++ b/core/vibes/soul/sections/product-detail/index.tsx
@@ -332,7 +332,7 @@ function ProductAccordionsSkeleton() {
   );
 }
 
-function ProductDetailSkeleton() {
+export function ProductDetailSkeleton() {
   return (
     <Skeleton.Root
       className="grid grid-cols-1 items-stretch gap-x-6 gap-y-8 group-has-[[data-pending]]/product-detail:animate-pulse @2xl:grid-cols-2 @5xl:gap-x-12"

--- a/core/vibes/soul/sections/product-list/index.tsx
+++ b/core/vibes/soul/sections/product-list/index.tsx
@@ -127,7 +127,7 @@ export function ProductList({
   );
 }
 
-function ProductListSkeleton({
+export function ProductListSkeleton({
   className,
   placeholderCount = 8,
 }: Pick<ProductListProps, 'className' | 'placeholderCount'>) {
@@ -145,7 +145,7 @@ function ProductListSkeleton({
   );
 }
 
-function ProductListEmptyState({
+export function ProductListEmptyState({
   className,
   placeholderCount = 8,
   emptyStateTitle,

--- a/core/vibes/soul/sections/products-list-section/filters-panel.tsx
+++ b/core/vibes/soul/sections/products-list-section/filters-panel.tsx
@@ -92,7 +92,7 @@ export function FiltersPanel({
   );
 }
 
-function FiltersPanelInner({
+export function FiltersPanelInner({
   className,
   filters: streamableFilters,
   resetFiltersLabel: streamableResetFiltersLabel,
@@ -301,7 +301,7 @@ function FiltersPanelInner({
   );
 }
 
-function FiltersSkeleton() {
+export function FiltersSkeleton() {
   return (
     <div className="space-y-5">
       <AccordionSkeleton>

--- a/core/vibes/soul/sections/reviews/index.tsx
+++ b/core/vibes/soul/sections/reviews/index.tsx
@@ -112,7 +112,7 @@ export function Reviews({
   );
 }
 
-function ReviewsEmptyState({
+export function ReviewsEmptyState({
   message = 'No reviews have been added for this product',
   reviewsLabel = 'Reviews',
 }: {
@@ -141,7 +141,7 @@ function ReviewsEmptyState({
   );
 }
 
-function ReviewsSkeleton({ reviewsLabel = 'Reviews' }: { reviewsLabel?: string }) {
+export function ReviewsSkeleton({ reviewsLabel = 'Reviews' }: { reviewsLabel?: string }) {
   return (
     <StickySidebarLayout
       sidebar={


### PR DESCRIPTION
Reverts bigcommerce/catalyst#2576.

These exports are required for the `integrations/makeswift` branch.