### PR TITLE
feat: add checkout as a valid landing location after registration

### DIFF
--- a/core/b2b/use-b2b-auth.ts
+++ b/core/b2b/use-b2b-auth.ts
@@ -9,6 +9,12 @@ import { toast } from '@/vibes/soul/primitives/toaster';
 import { login } from './server-login';
 import { useSDK } from './use-b2b-sdk';
 
+enum LandingLocations {
+  Home = '0',
+  Orders = '1',
+  Checkout = '2',
+}
+
 const handleRegistered = ({ data: { email, password, landingLoginLocation } }: Data) => {
   void login(email, password).then((error) => {
     if (error) {
@@ -20,8 +26,10 @@ const handleRegistered = ({ data: { email, password, landingLoginLocation } }: D
       return;
     }
 
-    if (landingLoginLocation === '0') {
+    if (landingLoginLocation === LandingLocations.Home) {
       window.location.href = '/';
+    } else if (landingLoginLocation === LandingLocations.Checkout) {
+      window.location.href = '/checkout';
     } else {
       window.location.href = '/?section=orders';
     }


### PR DESCRIPTION
## What/Why?
We recently added a feature to redirect to storefront for registration in checkout, we need to be able to take users back to checkout.

Sibling: 
- https://github.com/bigcommerce/b2b-buyer-portal/pull/542
- https://github.com/b3bc-external/b2b-checkout-app/pull/387

## Testing
 

https://github.com/user-attachments/assets/e3831f86-48ef-4a22-9a28-c9d05cf7662b



## Migration
You'll need to add the option to redirect to your checkout page in the useB2BAuth hook.