### PR TITLE
chore: create the alpha version of the CLI

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -12,6 +12,5 @@
     "tag": true
   },
   "baseBranch": "canary",
-  "updateInternalDependencies": "patch",
-  "ignore": ["@bigcommerce/catalyst"]
+  "updateInternalDependencies": "patch"
 }

--- a/.changeset/itchy-lions-work.md
+++ b/.changeset/itchy-lions-work.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst": major
+---
+
+Alpha version of the CLI

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,10 @@
+{
+  "mode": "pre",
+  "tag": "alpha",
+  "initialVersions": {
+    "@bigcommerce/catalyst": "1.0.0"
+  },
+  "changesets": [
+    "itchy-lions-work"
+  ]
+}

--- a/packages/catalyst/CHANGELOG.md
+++ b/packages/catalyst/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @bigcommerce/catalyst
+
+## 1.0.0-alpha.0
+
+### Major Changes
+
+- [`acee114`](https://github.com/bigcommerce/catalyst/commit/acee114ca0ee7428e33b1db28a5b3b18914cde4b) Thanks [@chanceaclark](https://github.com/chanceaclark)! - Alpha version of the CLI

--- a/packages/catalyst/package.json
+++ b/packages/catalyst/package.json
@@ -9,7 +9,6 @@
     "dist",
     "templates"
   ],
-  "private": true,
   "scripts": {
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",

--- a/packages/catalyst/package.json
+++ b/packages/catalyst/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/catalyst",
-  "version": "0.1.0",
+  "version": "1.0.0-alpha.0",
   "type": "module",
   "bin": {
     "catalyst": "dist/cli.js"


### PR DESCRIPTION
## What/Why?
> [!WARNING]
> Merging this into a separate `alpha` branch instead of `canary`. changesets recommends tracking it in a separate branch to keep `canary` releasable.

Using an `alpha` branch to publish `alpha` versions of the new `@bigcommerce/catalyst` package. This package will be used for experimenting with new features we want to bring to Catalyst. For now, we want to publish the CLI as an alpha so we can make sure it works as expected.

In order to publish, this need to be published manually, via `pnpm changeset publish`.

## Testing
N/A

## Migration
N/A
