### PR TITLE
chore: remove makeswift team from codeowners file for integrations/makeswift

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @bigcommerce/team-catalyst @bigcommerce/makeswift
+* @bigcommerce/team-catalyst


### PR DESCRIPTION
## What/Why?

Members of the Makeswift team that don't own this code are getting pinged for PRs that update this branch.

https://makeswifthq.slack.com/archives/C014SCS4G75/p1757962467576659