### PR TITLE
Feature/b2b build hash vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,3 +54,13 @@ B2B_API_TOKEN=
 # Base URL for a production build of Buyer Portal. Uncomment if connecting to a deployed custom Buyer Portal.
 #   Example URL format: ${PROD_BUYER_PORTAL_URL}/index.js
 # PROD_BUYER_PORTAL_URL=https://my-b2b-catalyst.com/b2b/20260101
+
+# Hashes for Buyer Portal top-level assets, if hash was included in custom production build
+# Leave these commented out if hash was not included in build files
+#   Example URL formats: 
+#       ${PROD_BUYER_PORTAL_URL}/index.${PROD_BUYER_PORTAL_HASH_INDEX}.js
+#       ${PROD_BUYER_PORTAL_URL}/index-legacy.${PROD_BUYER_PORTAL_HASH_INDEX_LEGACY}.js
+#       ${PROD_BUYER_PORTAL_URL}/polyfills-legacy.${PROD_BUYER_PORTAL_HASH_POLYFILLS}.js
+# PROD_BUYER_PORTAL_HASH_INDEX=
+# PROD_BUYER_PORTAL_HASH_INDEX_LEGACY=
+# PROD_BUYER_PORTAL_HASH_POLYFILLS=

--- a/core/b2b/loader.tsx
+++ b/core/b2b/loader.tsx
@@ -12,6 +12,9 @@ const EnvironmentSchema = z.object({
   LOCAL_BUYER_PORTAL_HOST: z.string().url().optional(),
   PROD_BUYER_PORTAL_URL: z.string().url().optional(),
   STAGING_B2B_CDN_ORIGIN: z.string().optional(),
+  PROD_BUYER_PORTAL_HASH_INDEX: z.string().optional(),
+  PROD_BUYER_PORTAL_HASH_INDEX_LEGACY: z.string().optional(),
+  PROD_BUYER_PORTAL_HASH_POLYFILLS: z.string().optional(),
 });
 
 export async function B2BLoader() {
@@ -21,6 +24,9 @@ export async function B2BLoader() {
     LOCAL_BUYER_PORTAL_HOST,
     PROD_BUYER_PORTAL_URL,
     STAGING_B2B_CDN_ORIGIN,
+    PROD_BUYER_PORTAL_HASH_INDEX,
+    PROD_BUYER_PORTAL_HASH_INDEX_LEGACY,
+    PROD_BUYER_PORTAL_HASH_POLYFILLS,
   } = EnvironmentSchema.parse(process.env);
 
   const session = await auth();
@@ -45,6 +51,9 @@ export async function B2BLoader() {
         storeHash={BIGCOMMERCE_STORE_HASH}
         token={session?.b2bToken}
         prodUrl={PROD_BUYER_PORTAL_URL}
+        hashIndex={PROD_BUYER_PORTAL_HASH_INDEX}
+        hashIndexLegacy={PROD_BUYER_PORTAL_HASH_INDEX_LEGACY}
+        hashPolyfills={PROD_BUYER_PORTAL_HASH_POLYFILLS}
       />
     );
   }

--- a/core/b2b/script-production-custom.tsx
+++ b/core/b2b/script-production-custom.tsx
@@ -5,19 +5,15 @@ import Script from 'next/script';
 import { useB2BAuth } from './use-b2b-auth';
 import { useB2BCart } from './use-b2b-cart';
 
-/**
- * Use these vars if using build hashes in B2B Buyer Portal files.
- */
-const hashIndex = undefined;
-const hashIndexLegacy = undefined;
-const hashPolyfills = undefined;
-
 interface Props {
   storeHash: string;
   channelId: string;
   token?: string;
   cartId?: string | null;
   prodUrl: string;
+  hashIndex?: string;
+  hashIndexLegacy?: string;
+  hashPolyfills?: string;
 }
 
 export function ScriptProductionCustom({ 
@@ -26,6 +22,9 @@ export function ScriptProductionCustom({
   channelId, 
   token,
   prodUrl,
+  hashIndex,
+  hashIndexLegacy,
+  hashPolyfills,
 }: Props) {
   useB2BAuth(token);
   useB2BCart(cartId);


### PR DESCRIPTION
## What/Why?

Builds on PR #2626 

B2B Buyer Portal build filenames may include unique build hashes depending on the build configuration.

For the custom Buyer Portal loader script, this PR swaps out managing these build hashes in code for managing them with env vars.