### PR TITLE
feat(core): Add link to Gift Certificates page in header/footer

### DIFF
--- a/core/app/[locale]/(default)/page-data.ts
+++ b/core/app/[locale]/(default)/page-data.ts
@@ -20,16 +20,27 @@ export const LayoutQuery = graphql(
   [HeaderFragment, FooterFragment],
 );
 
+const GiftCertificatesEnabledFragment = graphql(`
+  fragment GiftCertificatesEnabledFragment on Settings {
+    giftCertificates(currencyCode: $currencyCode) {
+      isEnabled
+    }
+  }
+`);
+
 export const GetLinksAndSectionsQuery = graphql(
   `
-    query GetLinksAndSectionsQuery {
+    query GetLinksAndSectionsQuery($currencyCode: currencyCode) {
       site {
+        settings {
+          ...GiftCertificatesEnabledFragment
+        }
         ...HeaderLinksFragment
         ...FooterSectionsFragment
       }
     }
   `,
-  [HeaderLinksFragment, FooterSectionsFragment],
+  [HeaderLinksFragment, FooterSectionsFragment, GiftCertificatesEnabledFragment],
 );
 
 const HomePageQuery = graphql(

--- a/core/components/footer/fragment.ts
+++ b/core/components/footer/fragment.ts
@@ -30,6 +30,12 @@ export const FooterFragment = graphql(`
 
 export const FooterSectionsFragment = graphql(`
   fragment FooterSectionsFragment on Site {
+    settings {
+      giftCertificates(currencyCode: $currencyCode) {
+        currencyCode
+        isEnabled
+      }
+    }
     content {
       pages(filters: { parentEntityIds: [0] }) {
         edges {

--- a/core/components/footer/index.tsx
+++ b/core/components/footer/index.tsx
@@ -16,7 +16,9 @@ import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
 import { readFragment } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
+import { CurrencyCode } from '~/components/header/fragment';
 import { logoTransformer } from '~/data-transformers/logo-transformer';
+import { getPreferredCurrencyCode } from '~/lib/currency';
 
 import { FooterFragment, FooterSectionsFragment } from './fragment';
 import { AmazonIcon } from './payment-icons/amazon';
@@ -44,18 +46,21 @@ const socialIcons: Record<string, { icon: JSX.Element }> = {
   YouTube: { icon: <SiYoutube title="YouTube" /> },
 };
 
-const getFooterSections = cache(async (customerAccessToken?: string) => {
-  const { data: response } = await client.fetch({
-    document: GetLinksAndSectionsQuery,
-    customerAccessToken,
-    // Since this query is needed on every page, it's a good idea not to validate the customer access token.
-    // The 'cache' function also caches errors, so we might get caught in a redirect loop if the cache saves an invalid token error response.
-    validateCustomerAccessToken: false,
-    fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
-  });
+const getFooterSections = cache(
+  async (customerAccessToken?: string, currencyCode?: CurrencyCode) => {
+    const { data: response } = await client.fetch({
+      document: GetLinksAndSectionsQuery,
+      customerAccessToken,
+      variables: { currencyCode },
+      // Since this query is needed on every page, it's a good idea not to validate the customer access token.
+      // The 'cache' function also caches errors, so we might get caught in a redirect loop if the cache saves an invalid token error response.
+      validateCustomerAccessToken: false,
+      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
+    });
 
-  return readFragment(FooterSectionsFragment, response).site;
-});
+    return readFragment(FooterSectionsFragment, response).site;
+  },
+);
 
 const getFooterData = cache(async () => {
   const { data: response } = await client.fetch({
@@ -68,7 +73,6 @@ const getFooterData = cache(async () => {
 
 export const Footer = async () => {
   const t = await getTranslations('Components.Footer');
-
   const data = await getFooterData();
 
   const logo = data.settings ? logoTransformer(data.settings) : '';
@@ -91,8 +95,8 @@ export const Footer = async () => {
 
   const streamableSections = Streamable.from(async () => {
     const customerAccessToken = await getSessionCustomerAccessToken();
-
-    const sectionsData = await getFooterSections(customerAccessToken);
+    const currencyCode = await getPreferredCurrencyCode();
+    const sectionsData = await getFooterSections(customerAccessToken, currencyCode);
 
     return [
       {
@@ -111,10 +115,20 @@ export const Footer = async () => {
       },
       {
         title: t('navigate'),
-        links: removeEdgesAndNodes(sectionsData.content.pages).map((page) => ({
-          label: page.name,
-          href: page.__typename === 'ExternalLinkPage' ? page.link : page.path,
-        })),
+        links: [
+          ...(sectionsData.settings?.giftCertificates?.isEnabled
+            ? [
+                {
+                  label: t('giftCertificates'),
+                  href: '/gift-certificates',
+                },
+              ]
+            : []),
+          ...removeEdgesAndNodes(sectionsData.content.pages).map((page) => ({
+            label: page.name,
+            href: page.__typename === 'ExternalLinkPage' ? page.link : page.path,
+          })),
+        ],
       },
     ];
   });

--- a/core/components/header/index.tsx
+++ b/core/components/header/index.tsx
@@ -16,7 +16,7 @@ import { getPreferredCurrencyCode } from '~/lib/currency';
 
 import { search } from './_actions/search';
 import { switchCurrency } from './_actions/switch-currency';
-import { HeaderFragment, HeaderLinksFragment } from './fragment';
+import { CurrencyCode, HeaderFragment, HeaderLinksFragment } from './fragment';
 
 const GetCartCountQuery = graphql(`
   query GetCartCountQuery($cartId: String) {
@@ -47,17 +47,18 @@ const getCartCount = cache(async (cartId: string, customerAccessToken?: string) 
   return response.data.site.cart?.lineItems.totalQuantity ?? null;
 });
 
-const getHeaderLinks = cache(async (customerAccessToken?: string) => {
+const getHeaderLinks = cache(async (customerAccessToken?: string, currencyCode?: CurrencyCode) => {
   const { data: response } = await client.fetch({
     document: GetLinksAndSectionsQuery,
     customerAccessToken,
+    variables: { currencyCode },
     // Since this query is needed on every page, it's a good idea not to validate the customer access token.
     // The 'cache' function also caches errors, so we might get caught in a redirect loop if the cache saves an invalid token error response.
     validateCustomerAccessToken: false,
     fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
   });
 
-  return readFragment(HeaderLinksFragment, response).site.categoryTree;
+  return readFragment(HeaderLinksFragment, response).site;
 });
 
 const getHeaderData = cache(async () => {
@@ -95,8 +96,8 @@ export const Header = async () => {
 
   const streamableLinks = Streamable.from(async () => {
     const customerAccessToken = await getSessionCustomerAccessToken();
-
-    const categoryTree = await getHeaderLinks(customerAccessToken);
+    const currencyCode = await getPreferredCurrencyCode();
+    const categoryTree = (await getHeaderLinks(customerAccessToken, currencyCode)).categoryTree;
 
     /**  To prevent the navigation menu from overflowing, we limit the number of categories to 6.
    To show a full list of categories, modify the `slice` method to remove the limit.
@@ -116,6 +117,15 @@ export const Header = async () => {
         })),
       })),
     }));
+  });
+
+  const streamableGiftCertificatesEnabled = Streamable.from(async () => {
+    const currencyCode = await getPreferredCurrencyCode();
+    const customerAccessToken = await getSessionCustomerAccessToken();
+    const giftCertificateSettings = (await getHeaderLinks(customerAccessToken, currencyCode))
+      .settings?.giftCertificates;
+
+    return giftCertificateSettings?.isEnabled ?? false;
   });
 
   const streamableCartCount = Streamable.from(async () => {
@@ -144,6 +154,9 @@ export const Header = async () => {
         accountLabel: t('Icons.account'),
         cartHref: '/cart',
         cartLabel: t('Icons.cart'),
+        giftCertificatesLabel: t('Icons.giftCertificates'),
+        giftCertificatesHref: '/gift-certificates',
+        giftCertificatesEnabled: streamableGiftCertificatesEnabled,
         searchHref: '/search',
         searchParamName: 'term',
         searchAction: search,

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -438,7 +438,8 @@
       "Icons": {
         "account": "Profile",
         "cart": "Cart",
-        "search": "Open search popup"
+        "search": "Open search popup",
+        "giftCertificates": "Gift certificates"
       },
       "SwitchCurrency": {
         "label": "Switch currency",
@@ -462,7 +463,8 @@
       "socialMediaLinks": "Social media links",
       "categories": "Categories",
       "brands": "Brands",
-      "navigate": "Navigate"
+      "navigate": "Navigate",
+      "giftCertificates": "Gift certificates"
     },
     "Subscribe": {
       "title": "Sign up for our newsletter",

--- a/core/vibes/soul/primitives/navigation/index.tsx
+++ b/core/vibes/soul/primitives/navigation/index.tsx
@@ -6,7 +6,15 @@ import * as NavigationMenu from '@radix-ui/react-navigation-menu';
 import * as Popover from '@radix-ui/react-popover';
 import { clsx } from 'clsx';
 import debounce from 'lodash.debounce';
-import { ArrowRight, ChevronDown, Search, SearchIcon, ShoppingBag, User } from 'lucide-react';
+import {
+  ArrowRight,
+  ChevronDown,
+  GiftIcon,
+  Search,
+  SearchIcon,
+  ShoppingBag,
+  User,
+} from 'lucide-react';
 import { useParams, useSearchParams } from 'next/navigation';
 import React, {
   forwardRef,
@@ -119,6 +127,9 @@ interface Props<S extends SearchResult> {
   searchLabel?: string;
   mobileMenuTriggerLabel?: string;
   switchCurrencyLabel?: string;
+  giftCertificatesLabel?: string;
+  giftCertificatesHref: string;
+  giftCertificatesEnabled?: Streamable<boolean>;
 }
 
 const MobileMenuButton = forwardRef<
@@ -286,6 +297,9 @@ export const Navigation = forwardRef(function Navigation<S extends SearchResult>
     searchLabel = 'Search',
     mobileMenuTriggerLabel = 'Toggle navigation',
     switchCurrencyLabel,
+    giftCertificatesLabel = 'Gift Certificates',
+    giftCertificatesHref,
+    giftCertificatesEnabled: streamableGiftCertificatesEnabled,
   }: Props<S>,
   ref: Ref<HTMLDivElement>,
 ) {
@@ -594,6 +608,20 @@ export const Navigation = forwardRef(function Navigation<S extends SearchResult>
               }
             </Stream>
           </Link>
+
+          <Stream fallback={null} value={streamableGiftCertificatesEnabled}>
+            {(giftCertificatesEnabled) =>
+              giftCertificatesEnabled && (
+                <Link
+                  aria-label={giftCertificatesLabel}
+                  className={navButtonClassName}
+                  href={giftCertificatesHref}
+                >
+                  <GiftIcon size={20} strokeWidth={1} />
+                </Link>
+              )
+            }
+          </Stream>
 
           {/* Locale / Language Dropdown */}
           {locales && locales.length > 1 ? (


### PR DESCRIPTION
## What/Why?
Add a link in the header and footer to route to `/gift-certificates`. This link is only visible when the active currency has Gift Certificates enabled.

Adding them to both will make it easier if consumers want to customize it and remove it from just the header or the footer.

## Testing

<img width="487" height="90" alt="image" src="https://github.com/user-attachments/assets/7fa8096a-bf79-40d6-a852-4e1f8a841860" />

<img width="450" height="328" alt="image" src="https://github.com/user-attachments/assets/afa18307-9dbf-4dcf-af2e-f31be57752c0" />

## Migration

### Update GraphQL Query

In `/app/[locale]/(default)/page-data.ts`, update the `LayoutQuery` to accept a `$currencyCode` variable and include the new giftCertificates field.

### Update Header Fragment

In `/components/header/fragment.ts`, add the `giftCertificates(currencyCode: $currencyCode)` field to the header fragment, including its properties.

### Update Header Data Fetching

In `/components/header/index.tsx`, pass the preferred currency code when fetching header data and add new props for gift certificates (label, link, enabled flag) to header links.

### Add Localization

In /messages/en.json, add a new entry for "giftCertificates": "Gift Certificates" under the "Icons" section.

### Update Navigation Component

In `/vibes/soul/primitives/navigation/index.tsx`:
Import `GiftIcon` from `lucide-react`.

Add new props for the gift certificates label, link, and enabled flag.

Render the new "Gift Certificates" navigation link and icon, conditionally shown when enabled.

