### PR TITLE
feat(core): Add /gift-certificates page on enabled currencies, add gift certificate ui components

### DIFF
--- a/core/app/[locale]/(default)/gift-certificates/page-data.ts
+++ b/core/app/[locale]/(default)/gift-certificates/page-data.ts
@@ -1,0 +1,37 @@
+import { cache } from 'react';
+
+import { client } from '~/client';
+import { graphql } from '~/client/graphql';
+import { revalidate } from '~/client/revalidate-target';
+import { CurrencyCode } from '~/components/header/fragment';
+import { StoreLogoFragment } from '~/components/store-logo/fragment';
+import { logoTransformer } from '~/data-transformers/logo-transformer';
+
+const GiftCertificatesRootQuery = graphql(
+  `
+    query GiftCertificatesRootQuery($currencyCode: currencyCode) {
+      site {
+        settings {
+          giftCertificates(currencyCode: $currencyCode) {
+            isEnabled
+          }
+          ...StoreLogoFragment
+        }
+      }
+    }
+  `,
+  [StoreLogoFragment],
+);
+
+export const getGiftCertificatesData = cache(async (currencyCode?: CurrencyCode) => {
+  const response = await client.fetch({
+    document: GiftCertificatesRootQuery,
+    variables: { currencyCode },
+    fetchOptions: { next: { revalidate } },
+  });
+
+  return {
+    giftCertificatesEnabled: response.data.site.settings?.giftCertificates?.isEnabled ?? false,
+    logo: response.data.site.settings ? logoTransformer(response.data.site.settings) : '',
+  };
+});

--- a/core/app/[locale]/(default)/gift-certificates/page.tsx
+++ b/core/app/[locale]/(default)/gift-certificates/page.tsx
@@ -1,0 +1,55 @@
+import type { Metadata } from 'next';
+import { getFormatter, getTranslations, setRequestLocale } from 'next-intl/server';
+
+import { GiftCertificatesSection } from '@/vibes/soul/sections/gift-certificates-section';
+import { redirect } from '~/i18n/routing';
+import { getPreferredCurrencyCode } from '~/lib/currency';
+
+import { getGiftCertificatesData } from './page-data';
+
+interface Props {
+  params: Promise<{ locale: string }>;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+
+  const t = await getTranslations({ locale, namespace: 'GiftCertificates' });
+
+  return {
+    title: t('title') || 'Gift certificates',
+  };
+}
+
+export default async function GiftCertificates(props: Props) {
+  const { locale } = await props.params;
+
+  setRequestLocale(locale);
+
+  const t = await getTranslations('GiftCertificates');
+  const format = await getFormatter();
+  const currencyCode = await getPreferredCurrencyCode();
+  const data = await getGiftCertificatesData(currencyCode);
+
+  if (!data.giftCertificatesEnabled) {
+    return redirect({ href: '/', locale });
+  }
+
+  const exampleBalance = format.number(25.0, {
+    style: 'currency',
+    currency: currencyCode,
+  });
+
+  return (
+    <GiftCertificatesSection
+      checkBalanceHref="/gift-certificates/balance"
+      checkBalanceLabel={t('checkBalanceLabel')}
+      description={t('description')}
+      exampleBalance={exampleBalance}
+      logo={data.logo}
+      purchaseHref="/gift-certificates/purchase"
+      purchaseLabel={t('purchaseLabel')}
+      title={t('title')}
+    />
+  );
+}

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -472,5 +472,11 @@
       "description": "Stay up to date with the latest news and offers from our store.",
       "success": "Thank you for your interest! Newsletter feature is coming soon!"
     }
+  },
+  "GiftCertificates": {
+    "title": "Gift certificates",
+    "description": "Give the perfect gift that never goes out of style. Let friends and loved ones choose exactly what they want from our entire collection.",
+    "purchaseLabel": "Shop now",
+    "checkBalanceLabel": "Check balance"
   }
 }

--- a/core/vibes/soul/primitives/gift-certificate-card/gift-certificate-card-logo.tsx
+++ b/core/vibes/soul/primitives/gift-certificate-card/gift-certificate-card-logo.tsx
@@ -1,0 +1,41 @@
+import { clsx } from 'clsx';
+
+import { Stream, Streamable } from '@/vibes/soul/lib/streamable';
+import { Image } from '~/components/image';
+
+interface Props {
+  className?: string;
+  logo?: Streamable<string | { src: string; alt: string } | null>;
+  label?: string;
+}
+
+export function GiftCertificateCardLogo({ className, logo: streamableLogo, label }: Props) {
+  return (
+    <Stream
+      fallback={<div className="h-6 w-16 animate-pulse rounded-md bg-contrast-100" />}
+      value={streamableLogo}
+    >
+      {(logo) => (
+        <div
+          aria-label={label}
+          className={clsx(
+            'relative font-[family-name:var(--logo-font-family,var(--font-family-heading))] font-semibold leading-none',
+            className,
+          )}
+        >
+          {typeof logo === 'object' && logo !== null && logo.src !== '' ? (
+            <Image
+              alt={logo.alt}
+              className="h-auto w-full object-left"
+              fill
+              src={logo.src}
+              style={{ objectFit: 'contain' }}
+            />
+          ) : (
+            typeof logo === 'string' && <span>{logo}</span>
+          )}
+        </div>
+      )}
+    </Stream>
+  );
+}

--- a/core/vibes/soul/primitives/gift-certificate-card/index.tsx
+++ b/core/vibes/soul/primitives/gift-certificate-card/index.tsx
@@ -1,0 +1,88 @@
+import { clsx } from 'clsx';
+
+import { Stream, Streamable } from '@/vibes/soul/lib/streamable';
+import { Badge } from '@/vibes/soul/primitives/badge';
+import { GiftCertificateCardLogo } from '@/vibes/soul/primitives/gift-certificate-card/gift-certificate-card-logo';
+
+interface Props {
+  balance?: Streamable<string>;
+  expiresAt?: Streamable<string | null>;
+  expiresAtLabel?: string;
+  status?: Streamable<'ACTIVE' | 'EXPIRED' | 'PENDING' | 'DISABLED'>;
+  logo?: Streamable<string | { src: string; alt: string } | null>;
+  logoLabel?: string;
+  className?: string;
+  loading?: boolean;
+}
+
+// eslint-disable-next-line valid-jsdoc
+/**
+ * This component supports various CSS variables for theming. Here's a comprehensive list, along
+ * with their default values:
+ *
+ * ```css
+ * :root {
+ *   --gift-certificate-background-gradient-top: #212B1B;
+ *   --gift-certificate-background-gradient-bottom: #3C4E31;
+ * }
+ * ```
+ */
+export function GiftCertificateCard({
+  balance: streamableBalance,
+  expiresAtLabel = 'Valid thru',
+  expiresAt: streamableExpiresAt,
+  status: streamableStatus,
+  loading,
+  logo,
+  logoLabel,
+  className,
+}: Props) {
+  return (
+    <div
+      className={clsx(
+        'flex aspect-[16/9] w-full flex-col justify-between overflow-hidden rounded-2xl bg-gradient-to-b from-[var(--gift-certificate-background-gradient-top,#212B1B)] to-[var(--gift-certificate-background-gradient-bottom,#3C4E31)] px-6 py-4 text-primary-highlight @container',
+        className,
+      )}
+    >
+      <div className="flex min-h-8 items-center justify-start self-stretch">
+        <GiftCertificateCardLogo
+          className="h-[clamp(1.25rem,8cqw,2.25rem)] flex-1 text-[clamp(1.25rem,8cqw,2.25rem)]"
+          label={logoLabel}
+          logo={logo}
+        />
+        <Stream fallback={null} value={streamableStatus}>
+          {(status) =>
+            !loading &&
+            status != null &&
+            status !== 'ACTIVE' && (
+              <Badge variant={status === 'PENDING' ? 'info' : 'error'}>{status}</Badge>
+            )
+          }
+        </Stream>
+      </div>
+
+      <div className="flex justify-between font-heading text-[clamp(1.5rem,14cqw,4rem)] leading-none text-white">
+        <div className="flex flex-col justify-end font-body text-[clamp(0.7rem,4cqw,2rem)]">
+          <Stream fallback={null} value={streamableExpiresAt}>
+            {(expiresAt) =>
+              !loading &&
+              expiresAt != null && (
+                <div className="flex flex-col space-y-1 @xs:space-y-2">
+                  <span className="text-primary">{expiresAtLabel}</span>
+                  <time dateTime={expiresAt}>{expiresAt}</time>
+                </div>
+              )
+            }
+          </Stream>
+        </div>
+        <Stream fallback={<span className="animate-pulse">....</span>} value={streamableBalance}>
+          {(balance) => (
+            <span className={loading ? 'animate-pulse' : ''}>
+              {loading ? '....' : (balance ?? '....')}
+            </span>
+          )}
+        </Stream>
+      </div>
+    </div>
+  );
+}

--- a/core/vibes/soul/sections/gift-certificates-section/index.tsx
+++ b/core/vibes/soul/sections/gift-certificates-section/index.tsx
@@ -1,0 +1,106 @@
+import { clsx } from 'clsx';
+import { ArrowRightIcon } from 'lucide-react';
+
+import { ButtonLink } from '@/vibes/soul/primitives/button-link';
+import { GiftCertificateCard } from '@/vibes/soul/primitives/gift-certificate-card';
+import { SectionLayout } from '@/vibes/soul/sections/section-layout';
+
+interface Props {
+  title?: string;
+  description?: string;
+  logo: string | { src: string; alt: string };
+  checkBalanceLabel?: string;
+  checkBalanceHref: string;
+  exampleBalance?: string;
+  purchaseLabel?: string;
+  purchaseHref: string;
+  variant?: 'left' | 'right';
+}
+
+// eslint-disable-next-line valid-jsdoc
+/**
+ * This component supports various CSS variables for theming. Here's a comprehensive list, along
+ * with their default values:
+ *
+ * ```css
+ * :root {
+ *   --gift-certificate-title-font-family: var(--font-family-heading);
+ *   --gift-certificate-title: hsl(var(--foreground));
+ * }
+ * ```
+ */
+export function GiftCertificatesSection({
+  title = 'Gift certificates',
+  description = 'Give the perfect gift that never goes out of style. Let friends and loved ones choose exactly what they want from our entire collection.',
+  logo,
+  purchaseLabel = 'Shop now',
+  purchaseHref,
+  checkBalanceLabel = 'Check Balance',
+  checkBalanceHref,
+  exampleBalance,
+  variant = 'left',
+}: Props) {
+  return (
+    <SectionLayout containerSize="xl">
+      <div className="flex flex-col justify-center gap-x-4 gap-y-6 py-10 @md:gap-x-6 @lg:gap-x-8 @xl:flex-row @xl:gap-y-24 @2xl:gap-x-12 @4xl:gap-x-24">
+        <div
+          className={clsx(
+            'flex w-full flex-1 flex-col',
+            {
+              left: 'order-1 @xl:order-1',
+              right: 'order-2 @xl:order-2',
+            }[variant],
+          )}
+        >
+          <h1 className="mb-10 font-[family-name:var(--gift-certificate-title-font-family,var(--font-family-heading))] text-4xl font-medium leading-none text-[var(--gift-certificate-title,hsl(var(--foreground)))] @xl:text-5xl">
+            {title}
+          </h1>
+          <div className="text-contrast-500">
+            <p>{description}</p>
+          </div>
+          <div className="hidden @xl:flex">
+            <ButtonLink className="mt-10" href={purchaseHref}>
+              <div className="flex items-center">
+                {purchaseLabel}
+                <ArrowRightIcon className="ml-2" size={20} />
+              </div>
+            </ButtonLink>
+            <ButtonLink className="ml-4 mt-10" href={checkBalanceHref} variant="ghost">
+              {checkBalanceLabel}
+            </ButtonLink>
+          </div>
+        </div>
+
+        <div
+          className={clsx(
+            'flex flex-1 rounded-xl bg-contrast-100 @container',
+            {
+              left: 'order-2 @xl:order-2',
+              right: 'order-1 @xl:order-1',
+            }[variant],
+          )}
+        >
+          <div
+            className={clsx(
+              'flex flex-1 items-center justify-center p-2 @[250px]:p-4 @[300px]:p-8 @[350px]:p-12 @[450px]:p-16',
+            )}
+          >
+            <GiftCertificateCard balance={exampleBalance ?? '....'} logo={logo} />
+          </div>
+        </div>
+
+        <div className="order-3 flex flex-col space-y-2 @xl:hidden">
+          <ButtonLink href={purchaseHref}>
+            <div className="flex items-center">
+              {purchaseLabel}
+              <ArrowRightIcon className="ml-2" size={20} />
+            </div>
+          </ButtonLink>
+          <ButtonLink href={checkBalanceHref} variant="ghost">
+            {checkBalanceLabel}
+          </ButtonLink>
+        </div>
+      </div>
+    </SectionLayout>
+  );
+}


### PR DESCRIPTION
## What/Why?
- Add the `/gift-certificates` root page
- Add `GiftCertificateCard` and `GiftCertificateSection` components

## Testing

<img width="1650" height="617" alt="image" src="https://github.com/user-attachments/assets/89c79bcc-d751-4ceb-b446-39c4b445c9f9" />

<img width="541" height="807" alt="image" src="https://github.com/user-attachments/assets/95b081a8-56e7-4ec2-a00f-68a883ec3e61" />

## Migration

### UI Components

Copy the `GiftCertificateCard` and `GiftCertificateSection` components from this PR.

### Add translations

Copy the translations from this PR into your translations file (e.g. `en.json`)
```
  "GiftCertificates": {
    "title": "Gift certificates",
    "description": "Give the perfect gift that never goes out of style. Let friends and loved ones choose exactly what they want from our entire collection.",
    "purchaseLabel": "Shop now",
    "checkBalanceLabel": "Check balance"
  }
```

### Add the page route

Copy all the files in the `core/app/[locale]/(default)/gift-certificates` from this branch/PR