### PR TITLE
fix: optimize catalyst deployments

### DIFF
--- a/packages/catalyst/src/cli/commands/build.ts
+++ b/packages/catalyst/src/cli/commands/build.ts
@@ -64,7 +64,7 @@ export const build = new Command('build')
           );
         }
 
-        const wranglerConfig = getWranglerConfig(projectUuid, 'PLACEHOLDER_KV_ID');
+        const wranglerConfig = getWranglerConfig(projectUuid);
 
         consola.start('Copying templates...');
 
@@ -122,6 +122,11 @@ export const build = new Command('build')
           recursive: true,
           force: true,
         });
+
+        await copyFile(
+          join(getModuleCliPath(), 'templates', 'public_headers'),
+          join(coreDir, '.bigcommerce', 'dist', 'assets', '_headers'),
+        );
       }
     } catch (error) {
       consola.error(error);

--- a/packages/catalyst/src/cli/commands/deploy.spec.ts
+++ b/packages/catalyst/src/cli/commands/deploy.spec.ts
@@ -71,6 +71,7 @@ beforeAll(async () => {
 
 beforeEach(() => {
   process.chdir(tmpDir);
+  vi.spyOn(consola, 'prompt').mockResolvedValue(true);
 });
 
 afterEach(() => {
@@ -176,7 +177,7 @@ describe('deployment and event streaming', () => {
       'Fetching...',
       'Processing...',
       'Finalizing...',
-      'Deployment completed successfully.',
+      'Deployment completed successfully.\n',
     ]);
   });
 
@@ -191,7 +192,7 @@ describe('deployment and event streaming', () => {
             start(controller) {
               controller.enqueue(
                 encoder.encode(
-                  `data: {"deployment_status":"in_progress","deployment_uuid":"${deploymentUuid}","event":{"step":"processing","progress":75}}`,
+                  `data: {"deployment_status":"in_progress","deployment_uuid":"${deploymentUuid}","deployment_url":null,"event":{"step":"processing","progress":75}}`,
                 ),
               );
               setTimeout(() => {
@@ -201,7 +202,7 @@ describe('deployment and event streaming', () => {
               setTimeout(() => {
                 controller.enqueue(
                   encoder.encode(
-                    `data: {"deployment_status":"in_progress","deployment_uuid":"${deploymentUuid}","event":{"step":"finalizing","progress":99}}`,
+                    `data: {"deployment_status":"in_progress","deployment_uuid":"${deploymentUuid}","deployment_url":null,"event":{"step":"finalizing","progress":99}}`,
                   ),
                 );
                 controller.close();
@@ -225,7 +226,7 @@ describe('deployment and event streaming', () => {
       'Fetching...',
       'Processing...',
       'Finalizing...',
-      'Deployment completed successfully.',
+      'Deployment completed successfully.\n',
     ]);
 
     expect(consola.warn).toHaveBeenCalledWith(
@@ -245,13 +246,13 @@ describe('deployment and event streaming', () => {
             start(controller) {
               controller.enqueue(
                 encoder.encode(
-                  `data: {"deployment_status":"in_progress","deployment_uuid":"${deploymentUuid}","event":{"step":"processing","progress":75}}`,
+                  `data: {"deployment_status":"in_progress","deployment_uuid":"${deploymentUuid}","deployment_url":null,"event":{"step":"processing","progress":75}}`,
                 ),
               );
               setTimeout(() => {
                 controller.enqueue(
                   encoder.encode(
-                    `data: {"deployment_status":"in_progress","deployment_uuid":"${deploymentUuid}","event":{"step":"unzipping","progress":99},"error":{"code":30}}`,
+                    `data: {"deployment_status":"in_progress","deployment_uuid":"${deploymentUuid}","deployment_url":null,"event":{"step":"unzipping","progress":99},"error":{"code":30}}`,
                   ),
                 );
               }, 10);

--- a/packages/catalyst/src/cli/lib/wrangler-config.spec.ts
+++ b/packages/catalyst/src/cli/lib/wrangler-config.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from 'vitest';
 import { getWranglerConfig } from './wrangler-config';
 
 test('returns a config with name identical to worker self reference service', () => {
-  const config = getWranglerConfig('uuid', 'kv-namespace-id');
+  const config = getWranglerConfig('uuid');
 
   expect(config.name).toBe(`project-uuid`);
   expect(

--- a/packages/catalyst/src/cli/lib/wrangler-config.ts
+++ b/packages/catalyst/src/cli/lib/wrangler-config.ts
@@ -1,9 +1,9 @@
-export function getWranglerConfig(projectUuid: string, kvNamespaceId: string) {
+export function getWranglerConfig(projectUuid: string) {
   return {
     $schema: 'node_modules/wrangler/config-schema.json',
     main: '../.open-next/worker.js',
     name: `project-${projectUuid}`,
-    compatibility_date: '2025-07-15',
+    compatibility_date: '2025-09-15',
     compatibility_flags: ['nodejs_compat', 'global_fetch_strictly_public'],
     observability: {
       enabled: true,
@@ -24,10 +24,10 @@ export function getWranglerConfig(projectUuid: string, kvNamespaceId: string) {
         service: `project-${projectUuid}`,
       },
     ],
-    kv_namespaces: [
+    r2_buckets: [
       {
-        binding: 'NEXT_INC_CACHE_KV',
-        id: kvNamespaceId,
+        binding: 'NEXT_INC_CACHE_R2_BUCKET',
+        bucket_name: `project-${projectUuid}`,
       },
     ],
     durable_objects: {

--- a/packages/catalyst/templates/open-next.config.ts
+++ b/packages/catalyst/templates/open-next.config.ts
@@ -1,20 +1,26 @@
 import { defineCloudflareConfig, type OpenNextConfig } from '@opennextjs/cloudflare';
 import { purgeCache } from '@opennextjs/cloudflare/overrides/cache-purge/index';
-import kvIncrementalCache from '@opennextjs/cloudflare/overrides/incremental-cache/kv-incremental-cache';
+import r2IncrementalCache from '@opennextjs/cloudflare/overrides/incremental-cache/r2-incremental-cache';
+import { withRegionalCache } from '@opennextjs/cloudflare/overrides/incremental-cache/regional-cache';
 import doQueue from '@opennextjs/cloudflare/overrides/queue/do-queue';
 import queueCache from '@opennextjs/cloudflare/overrides/queue/queue-cache';
 import doShardedTagCache from '@opennextjs/cloudflare/overrides/tag-cache/do-sharded-tag-cache';
 
 const cloudflareConfig = defineCloudflareConfig({
-  incrementalCache: kvIncrementalCache,
+  incrementalCache: withRegionalCache(r2IncrementalCache, {
+    mode: 'long-lived',
+    bypassTagCacheOnCacheHit: true,
+  }),
   queue: queueCache(doQueue, {
     regionalCacheTtlSec: 5,
+    waitForQueueAck: true,
   }),
   routePreloadingBehavior: 'withWaitUntil',
   tagCache: doShardedTagCache({
     baseShardSize: 12,
     regionalCache: true,
     regionalCacheTtlSec: 5,
+    regionalCacheDangerouslyPersistMissingTags: true,
     shardReplication: {
       numberOfSoftReplicas: 4,
       numberOfHardReplicas: 2,

--- a/packages/catalyst/templates/public_headers
+++ b/packages/catalyst/templates/public_headers
@@ -1,0 +1,2 @@
+/_next/static/*
+  Cache-Control: public,max-age=31536000,immutable

--- a/packages/catalyst/tests/mocks/handlers.ts
+++ b/packages/catalyst/tests/mocks/handlers.ts
@@ -44,14 +44,14 @@ export const handlers = [
           controller.enqueue(
             encoder.encode(
               // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-              `data: {"deployment_status":"in_progress","deployment_uuid":"${params.deploymentUuid}","event":{"step":"processing","progress":75}}`,
+              `data: {"deployment_status":"in_progress","deployment_uuid":"${params.deploymentUuid}","event":{"step":"processing","progress":75},"deployment_url":null}`,
             ),
           );
           setTimeout(() => {
             controller.enqueue(
               encoder.encode(
                 // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-                `data: {"deployment_status":"in_progress","deployment_uuid":"${params.deploymentUuid}","event":{"step":"finalizing","progress":99}}`,
+                `data: {"deployment_status":"in_progress","deployment_uuid":"${params.deploymentUuid}","event":{"step":"finalizing","progress":99},"deployment_url":null}`,
               ),
             );
           }, 10);
@@ -59,7 +59,7 @@ export const handlers = [
             controller.enqueue(
               encoder.encode(
                 // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-                `data: {"deployment_status":"completed","deployment_uuid":"${params.deploymentUuid}","event":null}`,
+                `data: {"deployment_status":"completed","deployment_uuid":"${params.deploymentUuid}","event":null,"deployment_url":"https://example.com"}`,
               ),
             );
             controller.close();


### PR DESCRIPTION
## What/Why?

This PR updates the Catalyst deployment infrastructure to use R2 instead of KV for incremental caching, adds deployment confirmation prompts, and improves deployment feedback.

**Key changes:**

1. **R2 Incremental Cache Migration**: Migrated from KV-based incremental cache to R2-based storage with regional caching enabled. This provides better performance and storage capabilities for Next.js incremental static regeneration (ISR) cache.

2. **Deployment Improvements**:
   - Added project name confirmation prompt before deployment (skipped in CI environments)
   - Display deployment URL upon successful deployment
   - Improved deployment success message formatting

3. **Public Asset Caching**: Added `_headers` file to configure long-term caching for Next.js static assets (`/_next/static/*`) with `Cache-Control: public,max-age=31536000,immutable`.

4. **Wrangler Configuration Updates**:
   - Removed `kvNamespaceId` parameter from `getWranglerConfig()` as it's no longer needed
   - Updated compatibility date from `2025-07-15` to `2025-09-15`
   - Replaced `kv_namespaces` with `r2_buckets` configuration

5. **OpenNext Configuration Enhancements**:
   - Enabled regional cache with `long-lived` mode
   - Added `bypassTagCacheOnCacheHit` optimization
   - Enabled `waitForQueueAck` for queue operations
   - Enabled `regionalCacheDangerouslyPersistMissingTags` for improved cache behavior

## Testing

<img width="1458" height="375" alt="Screenshot 2025-10-20 at 17 20 59" src="https://github.com/user-attachments/assets/b7bbc802-73c3-4369-aa27-3981755b3ab1" />



1. Run `pnpm build` in the root directory to verify the build process completes successfully
2. Verify the `_headers` file is copied to `.bigcommerce/dist/assets/_headers` after build
3. Test deployment flow:
   - Run `pnpm catalyst deploy` (or equivalent deploy command)
   - Verify project name confirmation prompt appears (when not in CI)
   - Confirm deployment URL is displayed after successful deployment
4. Check Wrangler configuration is generated correctly with R2 bucket binding instead of KV namespace
5. Verify incremental cache functionality works with R2 backend

## Migration

- The `getWranglerConfig()` function signature has changed - the second parameter `kvNamespaceId` has been removed. Any direct callers of this function should update their calls to remove this parameter.
- Deployments will now use R2 buckets for caching instead of KV namespaces. Existing KV cache data will not be migrated automatically.
- The OpenNext configuration now includes regional cache settings. If you have custom OpenNext configurations, you may want to review and adopt these new settings.

---

This pull request description was generated with the assistance of AI. Portions of the code and/or implementation ideas in this PR may also have been created or influenced by AI tools.
