### PR TITLE
feat(core): Add gift certificates to orders list and order details

### DIFF
--- a/core/app/[locale]/(default)/account/orders/[id]/page-data.tsx
+++ b/core/app/[locale]/(default)/account/orders/[id]/page-data.tsx
@@ -6,7 +6,7 @@ import { client } from '~/client';
 import { graphql } from '~/client/graphql';
 import { TAGS } from '~/client/tags';
 
-import { OrderItemFragment } from '../fragment';
+import { OrderGiftCertificateItemFragment, OrderItemFragment } from '../fragment';
 
 const CustomerOrderDetails = graphql(
   `
@@ -109,12 +109,28 @@ const CustomerOrderDetails = graphql(
                 }
               }
             }
+            email {
+              giftCertificates {
+                edges {
+                  node {
+                    recipientEmail
+                    lineItems {
+                      edges {
+                        node {
+                          ...OrderGiftCertificateItemFragment
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
     }
   `,
-  [OrderItemFragment],
+  [OrderItemFragment, OrderGiftCertificateItemFragment],
 );
 
 export const getCustomerOrderDetails = cache(async (id: number) => {
@@ -150,6 +166,20 @@ export const getCustomerOrderDetails = cache(async (id: number) => {
             shipments: removeEdgesAndNodes(consignment.shipments),
           };
         }),
+      email:
+        order.consignments?.email &&
+        removeEdgesAndNodes(order.consignments.email.giftCertificates).map(
+          ({ recipientEmail, lineItems }) => {
+            return {
+              email: recipientEmail,
+              lineItems: removeEdgesAndNodes(lineItems).map(({ entityId, name, salePrice }) => ({
+                entityId,
+                name,
+                salePrice,
+              })),
+            };
+          },
+        ),
     },
   };
 });

--- a/core/app/[locale]/(default)/account/orders/fragment.ts
+++ b/core/app/[locale]/(default)/account/orders/fragment.ts
@@ -33,3 +33,15 @@ export const OrderItemFragment = graphql(`
     }
   }
 `);
+
+export const OrderGiftCertificateItemFragment = graphql(`
+  fragment OrderGiftCertificateItemFragment on OrderGiftCertificateLineItem {
+    entityId
+    name
+    salePrice {
+      value
+      formattedV2
+      currencyCode
+    }
+  }
+`);

--- a/core/app/[locale]/(default)/account/orders/page-data.ts
+++ b/core/app/[locale]/(default)/account/orders/page-data.ts
@@ -7,7 +7,7 @@ import { PaginationFragment } from '~/client/fragments/pagination';
 import { graphql, VariablesOf } from '~/client/graphql';
 import { TAGS } from '~/client/tags';
 
-import { OrderItemFragment } from './fragment';
+import { OrderGiftCertificateItemFragment, OrderItemFragment } from './fragment';
 
 const CustomerAllOrders = graphql(
   `
@@ -51,6 +51,21 @@ const CustomerAllOrders = graphql(
                     }
                   }
                 }
+                email {
+                  giftCertificates {
+                    edges {
+                      node {
+                        lineItems {
+                          edges {
+                            node {
+                              ...OrderGiftCertificateItemFragment
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
               }
             }
           }
@@ -58,7 +73,7 @@ const CustomerAllOrders = graphql(
       }
     }
   `,
-  [OrderItemFragment, PaginationFragment],
+  [OrderItemFragment, OrderGiftCertificateItemFragment, PaginationFragment],
 );
 
 type OrdersFiltersInput = VariablesOf<typeof CustomerAllOrders>['filters'];
@@ -116,6 +131,21 @@ export const getCustomerOrders = cache(
                   lineItems: removeEdgesAndNodes(consignment.lineItems),
                 };
               }),
+            email:
+              order.consignments?.email &&
+              removeEdgesAndNodes(order.consignments.email.giftCertificates).map(
+                ({ lineItems }) => {
+                  return {
+                    lineItems: removeEdgesAndNodes(lineItems).map(
+                      ({ entityId, name, salePrice }) => ({
+                        entityId,
+                        name,
+                        salePrice,
+                      }),
+                    ),
+                  };
+                },
+              ),
           },
         };
       }),

--- a/core/data-transformers/order-details-transformer.ts
+++ b/core/data-transformers/order-details-transformer.ts
@@ -104,6 +104,24 @@ export const orderDetailsTransformer = (
           }),
         };
       }) ?? [],
+    emailDestinations:
+      order.consignments.email?.map(({ email, lineItems }) => ({
+        title: t('digitalDelivery', { email }),
+        email,
+        lineItems: lineItems.map((item) => ({
+          id: String(item.entityId),
+          title: item.name,
+          price: format.number(item.salePrice.value, {
+            style: 'currency',
+            currency: item.salePrice.currencyCode,
+          }),
+          totalPrice: format.number(item.salePrice.value, {
+            style: 'currency',
+            currency: item.salePrice.currencyCode,
+          }),
+          quantity: 1,
+        })),
+      })) ?? [],
     summary: {
       total: format.number(order.totalIncTax.value, {
         style: 'currency',

--- a/core/data-transformers/orders-transformer.ts
+++ b/core/data-transformers/orders-transformer.ts
@@ -9,6 +9,53 @@ export const ordersTransformer = (
   format: ExistingResultType<typeof getFormatter>,
 ): Order[] => {
   return orders.map((order) => {
+    const lineItems =
+      order.consignments.shipping?.flatMap((consignment) => {
+        return consignment.lineItems.map((lineItem) => {
+          const price = lineItem.catalogProductWithOptionSelections?.prices?.price
+            ? format.number(lineItem.catalogProductWithOptionSelections.prices.price.value, {
+                style: 'currency',
+                currency: lineItem.catalogProductWithOptionSelections.prices.price.currencyCode,
+              })
+            : format.number(lineItem.subTotalListPrice.value / lineItem.quantity, {
+                style: 'currency',
+                currency: lineItem.subTotalListPrice.currencyCode,
+              });
+
+          return {
+            id: lineItem.entityId.toString(),
+            href: lineItem.baseCatalogProduct?.path ?? '#',
+            title: lineItem.name,
+            subtitle: lineItem.brand ?? undefined,
+            price,
+            totalPrice: format.number(lineItem.subTotalListPrice.value, {
+              style: 'currency',
+              currency: lineItem.subTotalListPrice.currencyCode,
+            }),
+            image: lineItem.image
+              ? {
+                  src: lineItem.image.url,
+                  alt: lineItem.image.altText,
+                }
+              : undefined,
+          };
+        });
+      }) ?? [];
+
+    const giftCertificates =
+      order.consignments.email?.flatMap((consignment) => {
+        return consignment.lineItems.map((lineItem) => {
+          return {
+            id: lineItem.entityId.toString(),
+            href: '#',
+            title: lineItem.name,
+            price: '',
+            totalPrice: '',
+            image: undefined,
+          };
+        });
+      }) ?? [];
+
     return {
       id: order.entityId.toString(),
       href: `/account/orders/${order.entityId}`,
@@ -17,38 +64,7 @@ export const ordersTransformer = (
         style: 'currency',
         currency: order.totalIncTax.currencyCode,
       }),
-      lineItems:
-        order.consignments.shipping?.flatMap((consignment) => {
-          return consignment.lineItems.map((lineItem) => {
-            const price = lineItem.catalogProductWithOptionSelections?.prices?.price
-              ? format.number(lineItem.catalogProductWithOptionSelections.prices.price.value, {
-                  style: 'currency',
-                  currency: lineItem.catalogProductWithOptionSelections.prices.price.currencyCode,
-                })
-              : format.number(lineItem.subTotalListPrice.value / lineItem.quantity, {
-                  style: 'currency',
-                  currency: lineItem.subTotalListPrice.currencyCode,
-                });
-
-            return {
-              id: lineItem.entityId.toString(),
-              href: lineItem.baseCatalogProduct?.path ?? '#',
-              title: lineItem.name,
-              subtitle: lineItem.brand ?? undefined,
-              price,
-              totalPrice: format.number(lineItem.subTotalListPrice.value, {
-                style: 'currency',
-                currency: lineItem.subTotalListPrice.currencyCode,
-              }),
-              image: lineItem.image
-                ? {
-                    src: lineItem.image.url,
-                    alt: lineItem.image.altText,
-                  }
-                : undefined,
-            };
-          });
-        }) ?? [],
+      lineItems: [...lineItems, ...giftCertificates].flat(),
     } satisfies Order;
   });
 };

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -159,6 +159,7 @@
         "summaryTotal": "Total",
         "destination": "Destination",
         "destinationWithCount": "Destination {number, number}/{total, number}",
+        "digitalDelivery": "Digital delivery to {email}",
         "subtotal": "Subtotal",
         "shipping": "Shipping",
         "tax": "Tax",

--- a/core/vibes/soul/sections/order-details-section/index.tsx
+++ b/core/vibes/soul/sections/order-details-section/index.tsx
@@ -65,12 +65,19 @@ interface Destination {
   lineItems: ShipmentLineItem[];
 }
 
+interface EmailDestination {
+  title: string;
+  email: string;
+  lineItems: ShipmentLineItem[];
+}
+
 export interface Order {
   id: string;
   status: string;
   statusColor?: 'success' | 'warning' | 'error' | 'info';
   date: string;
   destinations: Destination[];
+  emailDestinations: EmailDestination[];
   summary: Summary;
 }
 
@@ -152,6 +159,9 @@ export function OrderDetailsSection({
                     methodLabel={shipmentMethodLabel}
                   />
                 ))}
+                {order.emailDestinations.map((destination, index) => (
+                  <EmailDestination destination={destination} key={`email-destination-${index}`} />
+                ))}
               </div>
               <div className="order-1 basis-72 pt-8 @3xl:order-2">
                 <div className="font-[family-name:var(--order-details-section-title-font-family,var(--font-family-heading))] text-2xl font-medium">
@@ -205,6 +215,21 @@ function Shipment({
               </div>
             </div>
           ))}
+        </div>
+        {destination.lineItems.map((lineItem) => (
+          <ShipmentLineItem key={lineItem.id} lineItem={lineItem} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function EmailDestination({ destination }: { destination: EmailDestination }) {
+  return (
+    <div className="border-b border-[var(--order-details-section-border,hsl(var(--contrast-100)))] py-8 @container">
+      <div className="space-y-6">
+        <div className="font-[family-name:var(--order-details-section-title-font-family,var(--font-family-heading))] text-2xl font-medium">
+          {destination.title}
         </div>
         {destination.lineItems.map((lineItem) => (
           <ShipmentLineItem key={lineItem.id} lineItem={lineItem} />


### PR DESCRIPTION
## What/Why?
Add ability to see Gift Certificates in the order details of previous orders, and ensure that they are displayed in the orders list as well.

## Testing

<img width="1141" height="466" alt="image" src="https://github.com/user-attachments/assets/6f12fcf0-b2b9-4cf2-a9fc-b4fbb2664b64" />

<img width="1121" height="824" alt="image" src="https://github.com/user-attachments/assets/75f0bd54-9a27-4012-b1dd-f2215bd9d418" />


## Migration
<!---
  If you have moved any files around, or made any breaking changes,
  please provide a migration guide for the developers to make rebases easier.
--->
