### PR TITLE
chore: improve the way we supply b2b cdn url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,3 +42,8 @@ BIGCOMMERCE_ACCESS_TOKEN=
 
 # URL for the local buyer portal instance. Uncomment if developing locally.
 # LOCAL_BUYER_PORTAL_HOST=http://localhost:3001
+
+# If you don't need local buyer portal but you need to work in a different environment
+# this variable will supply the correct microapps cdn url.
+# It will default to "production". 
+# BUYER_PORTAL_ENVIRONMENT=production

--- a/core/b2b/loader.tsx
+++ b/core/b2b/loader.tsx
@@ -9,7 +9,7 @@ const EnvironmentSchema = z.object({
   BIGCOMMERCE_STORE_HASH: z.string({ message: 'BIGCOMMERCE_STORE_HASH is required' }),
   BIGCOMMERCE_CHANNEL_ID: z.string({ message: 'BIGCOMMERCE_CHANNEL_ID is required' }),
   LOCAL_BUYER_PORTAL_HOST: z.string().url().optional(),
-  STAGING_B2B_CDN_ORIGIN: z.string().optional(),
+  BUYER_PORTAL_ENVIRONMENT: z.enum(['production', 'staging', 'integration']).optional().default('production'),
 });
 
 export async function B2BLoader() {
@@ -17,7 +17,7 @@ export async function B2BLoader() {
     BIGCOMMERCE_STORE_HASH,
     BIGCOMMERCE_CHANNEL_ID,
     LOCAL_BUYER_PORTAL_HOST,
-    STAGING_B2B_CDN_ORIGIN,
+    BUYER_PORTAL_ENVIRONMENT,
   } = EnvironmentSchema.parse(process.env);
 
   const session = await auth();
@@ -34,13 +34,11 @@ export async function B2BLoader() {
     );
   }
 
-  const environment = STAGING_B2B_CDN_ORIGIN === 'true' ? 'staging' : 'production';
-
   return (
     <ScriptProduction
       cartId={session?.user?.cartId}
       channelId={BIGCOMMERCE_CHANNEL_ID}
-      environment={environment}
+      environment={BUYER_PORTAL_ENVIRONMENT}
       storeHash={BIGCOMMERCE_STORE_HASH}
       token={session?.b2bToken}
     />

--- a/core/b2b/script-production.tsx
+++ b/core/b2b/script-production.tsx
@@ -9,13 +9,21 @@ interface Props {
   storeHash: string;
   channelId: string;
   token?: string;
-  environment: 'staging' | 'production';
+  environment: 'staging' | 'production' | 'integration';
   cartId?: string | null;
 }
+
+const CDN_BY_ENV: Record<Props['environment'], string> = {
+  production: 'https://microapps.bigcommerce.com',
+  staging: 'https://microapps.staging.zone',
+  integration: 'https://microapps.integration.zone',
+};
 
 export function ScriptProduction({ cartId, storeHash, channelId, token, environment }: Props) {
   useB2BAuth(token);
   useB2BCart(cartId);
+
+  const src = `${CDN_BY_ENV[environment]}/b2b-buyer-portal/headless.js`;
 
   return (
     <>
@@ -35,7 +43,7 @@ export function ScriptProduction({ cartId, storeHash, channelId, token, environm
         data-channelid={channelId}
         data-environment={environment}
         data-storehash={storeHash}
-        src={'https://microapps.bigcommerce.com/b2b-buyer-portal/headless.js'}
+        src={src}
         type="module"
       />
     </>


### PR DESCRIPTION
## What/Why?
- Add `BUYER_PORTAL_ENVIRONMENT` to select the Buyer Portal CDN: `production` (default), `staging`, or `integration`.
- In `ScriptProduction` resolve CDN via a simple env→URL map 
- Update `loader.ts` to pass the optional `BUYER_PORTAL_ENVIRONMENT` (defaults to `production`).

## Testing
- With `LOCAL_BUYER_PORTAL_HOST` set, dev mode should still load the local app (no changes needed).
- With `LOCAL_BUYER_PORTAL_HOST` unset:
  - `BUYER_PORTAL_ENVIRONMENT=production` → `https://microapps.bigcommerce.com/b2b-buyer-portal/headless.js`
  - `BUYER_PORTAL_ENVIRONMENT=staging` → `https://microapps.staging.zone/b2b-buyer-portal/headless.js`
  - `BUYER_PORTAL_ENVIRONMENT=integration` → `https://microapps.integration.zone/b2b-buyer-portal/headless.js`
- Verify in the Network tab and ensure the script tag includes `data-environment` with the expected value.
- Sign in and confirm the Buyer Portal loads and session behaviors (cart sync, events) are unchanged.

https://github.com/user-attachments/assets/fc484aaf-12ee-485d-a675-4caddd1a1c35

## Migration
- Optional: replace previous staging/custom origin envs with the new single `BUYER_PORTAL_ENVIRONMENT`.
  - Remove any use of `STAGING_B2B_CDN_ORIGIN` if present.
  - Add `BUYER_PORTAL_ENVIRONMENT=staging|integration` as needed; omit for production (default).
- No code changes required for consumers; `B2BLoader` now passes `environment` to `ScriptProduction`.
-