### PR TITLE
feat(scripts): filter script manager gql response based on cookie consent

### DIFF
--- a/.changeset/large-ties-tap.md
+++ b/.changeset/large-ties-tap.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Filters BigCommerce header and footer scripts by consent. Ensures only consented scripts load and updates on preference changes.

--- a/core/components/scripts/fragment.ts
+++ b/core/components/scripts/fragment.ts
@@ -4,13 +4,21 @@ export const ScriptsFragment = graphql(`
   fragment ScriptsFragment on Content {
     headerScripts: scripts(
       first: 50
-      filters: { visibilities: [ALL_PAGES, STOREFRONT], location: HEAD }
+      filters: {
+        visibilities: [ALL_PAGES, STOREFRONT]
+        location: HEAD
+        consentCategories: $consentCategories
+      }
     ) {
       ...ScriptTypeConnectionFragment
     }
     footerScripts: scripts(
       first: 50
-      filters: { visibilities: [ALL_PAGES, STOREFRONT], location: FOOTER }
+      filters: {
+        visibilities: [ALL_PAGES, STOREFRONT]
+        location: FOOTER
+        consentCategories: $consentCategories
+      }
     ) {
       ...ScriptTypeConnectionFragment
     }

--- a/core/lib/consent-manager/action.ts
+++ b/core/lib/consent-manager/action.ts
@@ -1,0 +1,19 @@
+'use server';
+
+import { revalidateTag } from 'next/cache';
+
+import { setConsentCookie } from './cookies/server';
+import { ConsentStateSchema } from './schema';
+
+export const setConsentAction = async (preferences: Record<string, boolean>) => {
+  const validatedPreferences = ConsentStateSchema.parse(preferences);
+
+  await setConsentCookie({
+    preferences: validatedPreferences,
+    timestamp: new Date().toISOString(),
+  });
+
+  revalidateTag('scripts');
+
+  return { success: true };
+};

--- a/core/lib/consent-manager/cookies/utils.ts
+++ b/core/lib/consent-manager/cookies/utils.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+
+import { ConsentCookieSchema, ConsentStateSchema } from '../schema';
+
+type ConsentState = z.infer<typeof ConsentStateSchema>;
+type ConsentCookie = z.infer<typeof ConsentCookieSchema>;
+type BigCommerceScriptConsentCategory =
+  | 'ANALYTICS'
+  | 'ESSENTIAL'
+  | 'FUNCTIONAL'
+  | 'TARGETING'
+  | 'UNKNOWN';
+
+export const getConsentCategoriesFromCookie = (
+  consent: ConsentCookie | null,
+): BigCommerceScriptConsentCategory[] => {
+  if (!consent) {
+    return ['ESSENTIAL'];
+  }
+
+  const categories: BigCommerceScriptConsentCategory[] = [];
+  const mapping: Record<keyof ConsentState, BigCommerceScriptConsentCategory> = {
+    measurement: 'ANALYTICS',
+    necessary: 'ESSENTIAL',
+    functionality: 'FUNCTIONAL',
+    experience: 'FUNCTIONAL',
+    marketing: 'TARGETING',
+  };
+
+  const preferences = consent.preferences;
+  const entries = Object.entries(preferences);
+
+  const enabledCategories = entries
+    .filter(([, value]) => value)
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    .map(([key]) => mapping[key as keyof ConsentState]);
+
+  categories.push(...enabledCategories);
+
+  const allTruthy = entries.every(([, value]) => value);
+
+  if (allTruthy) {
+    categories.push('UNKNOWN');
+  }
+
+  return categories;
+};

--- a/core/lib/consent-manager/handlers.ts
+++ b/core/lib/consent-manager/handlers.ts
@@ -1,4 +1,6 @@
-import { getConsentCookie, setConsentCookie } from './cookies/client';
+import { setConsentAction } from './action';
+import { getConsentCookie } from './cookies/client';
+import { ConsentStateSchema } from './schema';
 
 const ok = <T>(data: T | null = null) => ({
   data,
@@ -32,13 +34,12 @@ export function showConsentBanner() {
   });
 }
 
-export function setConsent(options?: { body?: { preferences?: Record<string, boolean> } }) {
+export async function setConsent(options?: { body?: { preferences?: Record<string, boolean> } }) {
   const { preferences } = options?.body ?? {};
 
-  setConsentCookie({
-    preferences: preferences ?? {},
-    timestamp: new Date().toISOString(),
-  });
+  const validatedPreferences = ConsentStateSchema.parse(preferences);
+
+  await setConsentAction(validatedPreferences);
 
   return ok();
 }

--- a/core/lib/consent-manager/schema.ts
+++ b/core/lib/consent-manager/schema.ts
@@ -1,7 +1,14 @@
 import { z } from 'zod';
 
-const ConsentNamesSchema = z.enum(['necessary', 'functionality', 'marketing', 'measurement']);
-const ConsentStateSchema = z.record(ConsentNamesSchema, z.boolean());
+const ConsentNamesSchema = z.enum([
+  'necessary',
+  'functionality',
+  'marketing',
+  'measurement',
+  'experience',
+]);
+
+export const ConsentStateSchema = z.record(ConsentNamesSchema, z.boolean());
 
 export const ConsentCookieSchema = z.object({
   preferences: ConsentStateSchema,


### PR DESCRIPTION
> [!WARNING]
> Depends on #2650

## What/Why?
Filters BigCommerce scripts based on cookie consent. Reads consent from `c15t-consent` on the server, maps C15T consent categories (which cannot be changed, unfortunately) to BigCommerce Script Consent Categories as follows:
* C15T `measurement` → BigCommerce `ANALYTICS`
* C15T `necessary` → BigCommerce `ESSENTIAL`
* C15T `functionality` → BigCommerce `FUNCTIONAL`
* C15T `experience` → BigCommerce `FUNCTIONAL` (BigCommerce does not have a fifth category, C15T does)
* C15T `marketing` → BigCommerce `TARGETING`

These categories are passed to the GraphQL query filter, which does not fetch scripts from BC until the user consents.

## Testing
1. Created a script for each category of consent BigCommerce offers (even "unknown", which is the default for scripts created via API that do not specify "consent_category". For these scripts, our API states Scripts with an unknown consent category do not display on stores with customer cookie consent banners enabled, so I followed that and only display "unknown" scripts when full consent is provided)
2. Shows storefront loading only ESSENTIAL scripts when consent has not been provided
3. Shows storefront loading only ESSENTIAL scripts when "Reject All" (only ESSENTIAL) consent has been provided
4. Shows storefront loading ALL scripts when "Accept All" consent has been provided (including UNKNOWN)
5. Shows storefront loading selective scripts based on customized consent settings (and notably, not loading UNKNOWN in the case where some consent categories have been rejected)

Demo of the testing above:
https://github.com/user-attachments/assets/be44cb40-9077-40a0-9775-0b5170de68f8

## Migration
1. New files:
   - `core/lib/consent-manager/action.ts` - Server action for consent updates
2. Modified files:
   - `core/lib/consent-manager/cookies.ts` - Adds `experience`, exports `ConsentStateSchema`, adds `getConsentCategoriesFromCookie` mapping
   - `core/lib/consent-manager/handlers.ts` - `setConsent` is async; uses server action with revalidation
   - `core/app/[locale]/layout.tsx` - Reads cookie, maps categories, passes to GraphQL
   - `core/components/scripts/fragment.ts` - Adds `consentCategories` filter to header/footer queries
3. Breaking changes:
   - `setConsent` is async; update callers to await it
   - Adds `experience` consent type; UI components already support it
4. Category mapping:
   - `measurement` → `ANALYTICS`
   - `necessary` → `ESSENTIAL`
   - `functionality`, `experience` → `FUNCTIONAL`
   - `marketing` → `TARGETING`
   - If all categories accepted, includes `UNKNOWN`
   - No consent defaults to `ESSENTIAL` only
5. Cache revalidation:
   - Uses `revalidateTag('layout')` so layout data updates after consent changes
7. GraphQL variables:
   - `RootLayoutMetadataQuery` now requires `$consentCategories`
   - Layout reads `c15t-consent` and derives categories before the query