### PR TITLE
feat(core): Add payment methods to order details

### DIFF
--- a/core/app/[locale]/(default)/account/orders/[id]/page-data.tsx
+++ b/core/app/[locale]/(default)/account/orders/[id]/page-data.tsx
@@ -59,6 +59,28 @@ const CustomerOrderDetails = graphql(
             postalCode
             country
           }
+          payments {
+            edges {
+              node {
+                paymentMethodId
+                paymentMethodName
+                detail {
+                  __typename
+                  ... on CreditCardPaymentInstrument {
+                    brand
+                    last4
+                  }
+                  ... on GiftCertificatePaymentInstrument {
+                    code
+                  }
+                }
+                amount {
+                  value
+                  currencyCode
+                }
+              }
+            }
+          }
           consignments {
             shipping {
               edges {

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -163,7 +163,15 @@
         "subtotal": "Subtotal",
         "shipping": "Shipping",
         "tax": "Tax",
-        "orderSummary": "Order summary"
+        "orderSummary": "Order summary",
+        "paymentMethodsLabel": "{count, plural, =1 {Payment method} other {Payment methods}}",
+        "paymentEndingInLabel": "ending in",
+        "PaymentMethods": {
+          "creditCard": "Credit card",
+          "giftCertificate": "Gift certificate",
+          "storeCredit": "Store credit",
+          "other": "Other"
+        }
       }
     },
     "Addresses": {

--- a/core/vibes/soul/sections/order-details-section/index.tsx
+++ b/core/vibes/soul/sections/order-details-section/index.tsx
@@ -7,6 +7,17 @@ import * as Skeleton from '@/vibes/soul/primitives/skeleton';
 import { Image } from '~/components/image';
 import { Link } from '~/components/link';
 
+interface OrderPayment {
+  title: string;
+  subtitle?: string;
+  amount: string;
+}
+
+interface PaymentsSummary {
+  title: string;
+  payments: OrderPayment[];
+}
+
 interface Summary {
   lineItems: Array<{
     label: string;
@@ -79,6 +90,7 @@ export interface Order {
   destinations: Destination[];
   emailDestinations: EmailDestination[];
   summary: Summary;
+  paymentsSummary: PaymentsSummary;
 }
 
 export interface OrderDetailsSectionProps {
@@ -164,10 +176,20 @@ export function OrderDetailsSection({
                 ))}
               </div>
               <div className="order-1 basis-72 pt-8 @3xl:order-2">
-                <div className="font-[family-name:var(--order-details-section-title-font-family,var(--font-family-heading))] text-2xl font-medium">
-                  {orderSummaryLabel}
+                <div className="flex flex-col gap-8">
+                  <div className="flex-1">
+                    <div className="font-[family-name:var(--order-details-section-title-font-family,var(--font-family-heading))] text-2xl font-medium">
+                      {orderSummaryLabel}
+                    </div>
+                    <Summary summary={order.summary} totalLabel={summaryTotalLabel} />
+                  </div>
+                  <div className="flex-1">
+                    <div className="font-[family-name:var(--order-details-section-title-font-family,var(--font-family-heading))] text-2xl font-medium">
+                      {order.paymentsSummary.title || 'Payment methods'}
+                    </div>
+                    <PaymentsSummary payments={order.paymentsSummary.payments} />
+                  </div>
                 </div>
-                <Summary summary={order.summary} totalLabel={summaryTotalLabel} />
               </div>
             </div>
           </>
@@ -462,6 +484,48 @@ function SummarySkeleton({ placeholderCount = 2 }: { placeholderCount?: number }
   );
 }
 
+function PaymentsSummary({ payments }: { payments: OrderPayment[] }) {
+  return (
+    <div>
+      <div className="space-y-2 pb-3 pt-5">
+        {payments.map((payment, index) => (
+          <div className="flex justify-between" key={index}>
+            <div>
+              <div className="text-sm">{payment.title}</div>
+              {payment.subtitle != null && (
+                <div className="text-xs text-[var(--order-details-section-line-item-subtext,hsl(var(--contrast-400)))]">
+                  {payment.subtitle}
+                </div>
+              )}
+            </div>
+
+            <span className="text-sm">{payment.amount}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function PaymentsSummarySkeleton({ placeholderCount = 2 }: { placeholderCount?: number }) {
+  return (
+    <div>
+      <div className="space-y-2 pb-3 pt-5">
+        {Array.from({ length: placeholderCount }).map((_, index) => (
+          <div className="flex justify-between" key={index}>
+            <div>
+              <Skeleton.Text characterCount={6} className="rounded text-sm" />
+              <Skeleton.Text characterCount={12} className="rounded text-xs" />
+            </div>
+
+            <Skeleton.Text characterCount={6} className="rounded text-sm" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 function OrderDetailsSectionSkeleton({
   prevHref,
   placeholderCount = 1,
@@ -494,8 +558,16 @@ function OrderDetailsSectionSkeleton({
           ))}
         </div>
         <div className="order-1 basis-72 pt-8 @3xl:order-2">
-          <Skeleton.Text characterCount={10} className="rounded text-2xl" />
-          <SummarySkeleton placeholderCount={3} />
+          <div className="flex flex-col gap-8">
+            <div className="flex-1">
+              <Skeleton.Text characterCount={10} className="rounded text-2xl" />
+              <SummarySkeleton placeholderCount={3} />
+            </div>
+            <div className="flex-1">
+              <Skeleton.Text characterCount={10} className="rounded text-2xl" />
+              <PaymentsSummarySkeleton placeholderCount={3} />
+            </div>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What/Why?
Add payment methods (including store credit and gift certificates) to the order details page.

## Testing
<img width="1374" height="630" alt="image" src="https://github.com/user-attachments/assets/a2e675b3-e5ca-4cf7-a9b7-c1a76c60799e" />

## Migration
1. Update the GraphQL query in `core/app/[locale]/(default)/account/orders/[id]/page-data.tsx` to include the payments
2. Add all of the translation values into `Order.Details`
3. Update `core/data-transformers/order-details-transformer.ts` to return the values from the updated query
4. Update `core/vibes/soul/sections/order-details-section/index.tsx` and add the payments summary section.

For migration, it is best to use this PR as a reference.
