### PR TITLE
feat(scripts): integrate consent manager with control panel privacy setting

### DIFF
--- a/.changeset/silent-carrots-wash.md
+++ b/.changeset/silent-carrots-wash.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Integrates Catalyst's consent manager with the BigCommerce Control Panel's Cookie Consent setting, allowing merchants to centrally control whether the consent banner displays on the storefront. When disabled in the Control Panel, the consent banner is suppressed and all script categories are consented implicitly, matching Stencil behavior.

--- a/core/app/[locale]/layout.tsx
+++ b/core/app/[locale]/layout.tsx
@@ -30,6 +30,9 @@ const RootLayoutMetadataQuery = graphql(
     query RootLayoutMetadataQuery {
       site {
         settings {
+          privacy {
+            cookieConsentEnabled
+          }
           storeName
           seo {
             pageTitle
@@ -114,12 +117,14 @@ export default async function RootLayout({ params, children }: Props) {
   setRequestLocale(locale);
 
   const scripts = scriptsTransformer(rootData.data.site.content.scripts);
+  const isCookieConsentEnabled =
+    rootData.data.site.settings?.privacy?.cookieConsentEnabled ?? false;
 
   return (
     <html className={clsx(fonts.map((f) => f.variable))} lang={locale}>
       <body className="flex min-h-screen flex-col">
         <NextIntlClientProvider>
-          <ConsentManager scripts={scripts}>
+          <ConsentManager isCookieConsentEnabled={isCookieConsentEnabled} scripts={scripts}>
             <NuqsAdapter>
               <AnalyticsProvider
                 channelId={rootData.data.channel.entityId}

--- a/core/components/consent-manager/consent-providers.tsx
+++ b/core/components/consent-manager/consent-providers.tsx
@@ -10,9 +10,14 @@ export type C15tScripts = NonNullable<ComponentProps<typeof ClientSideOptionsPro
 
 interface ConsentManagerProviderProps extends PropsWithChildren {
   scripts: C15tScripts;
+  isCookieConsentEnabled: boolean;
 }
 
-export function ConsentManagerProvider({ children, scripts }: ConsentManagerProviderProps) {
+export function ConsentManagerProvider({
+  children,
+  scripts,
+  isCookieConsentEnabled,
+}: ConsentManagerProviderProps) {
   return (
     <C15TConsentManagerProvider
       options={{
@@ -21,7 +26,7 @@ export function ConsentManagerProvider({ children, scripts }: ConsentManagerProv
 
         // @ts-expect-error endpointHandlers type is not yet exposed by the package
         endpointHandlers: {
-          showConsentBanner,
+          showConsentBanner: () => showConsentBanner(isCookieConsentEnabled),
           setConsent,
           verifyConsent,
         },

--- a/core/components/consent-manager/index.tsx
+++ b/core/components/consent-manager/index.tsx
@@ -8,11 +8,12 @@ import { CookieBanner } from './cookie-banner';
 
 interface ConsentManagerProps extends PropsWithChildren {
   scripts: C15tScripts;
+  isCookieConsentEnabled: boolean;
 }
 
-export function ConsentManager({ children, scripts }: ConsentManagerProps) {
+export function ConsentManager({ children, scripts, isCookieConsentEnabled }: ConsentManagerProps) {
   return (
-    <ConsentManagerProvider scripts={scripts}>
+    <ConsentManagerProvider isCookieConsentEnabled={isCookieConsentEnabled} scripts={scripts}>
       <ConsentManagerDialog />
       <CookieBanner />
       {children}

--- a/core/lib/consent-manager/handlers.ts
+++ b/core/lib/consent-manager/handlers.ts
@@ -7,7 +7,7 @@ const ok = <T>(data: T | null = null) => ({
   response: null,
 });
 
-export function showConsentBanner() {
+export function showConsentBanner(isCookieConsentEnabled: boolean) {
   let show = true;
   let language = 'en';
 
@@ -21,6 +21,17 @@ export function showConsentBanner() {
     show = !consent;
   } catch {
     show = false;
+  }
+
+  if (!isCookieConsentEnabled) {
+    return ok({
+      showConsentBanner: false,
+      jurisdiction: { code: 'NONE' },
+      translations: {
+        language,
+      },
+      branding: 'none',
+    });
   }
 
   return ok({


### PR DESCRIPTION
> [!NOTE]
> This PR replaces #2658

Closes #2658

## What/Why?

This PR integrates Catalyst's consent manager with the BigCommerce Control Panel's Cookie Consent setting (`Channels > Channel > Customers' privacy > Turn on cookie consent banner for my store`), allowing merchants to centrally control whether the consent banner is shown to storefront visitors. The implementation queries the `site.settings.privacy.cookieConsentEnabled` field from the Store Settings API and threads it through the consent manager component hierarchy. When a merchant disables cookie consent in the Control Panel, the consent banner is suppressed and the `showConsentBanner` endpoint handler returns a response with `showConsentBanner: false` and `jurisdiction: { code: 'NONE' }` [which has the effect of auto-granting consents inside the c15t library](https://github.com/c15t/c15t/blob/f4411d824c14b5a59984cc726ecc8d54ae42e44b/packages/core/src/libs/fetch-consent-banner.ts#L68-L69).

## Testing

Demo:

https://github.com/user-attachments/assets/850b9bdc-b4ea-454d-8e8e-48350ba8a654



## Migration

This PR modifies the following files that you may encounter merge conflicts with:

1. **`core/app/[locale]/layout.tsx`**:
   - Added `privacy.cookieConsentEnabled` field to `RootLayoutMetadataQuery` (lines 34-36)
   - Added `isCookieConsentEnabled` constant derived from query result (lines 130-131)
   - Updated `ConsentManager` component to accept `isCookieConsentEnabled` prop (line 137)
   - **Resolution tip**: Add the `privacy { cookieConsentEnabled }` field to your metadata query, extract it from the result, and pass it to `<ConsentManager isCookieConsentEnabled={isCookieConsentEnabled} ... />`

2. **`core/components/consent-manager/index.tsx`**:
   - Added `isCookieConsentEnabled: boolean` to `ConsentManagerProps` interface
   - Prop is forwarded to `ConsentManagerProvider`
   - Exported `C15tScripts` type is now imported from `consent-providers.tsx`
   - **Resolution tip**: Update your interface to include the new required prop and ensure it's passed down

3. **`core/components/consent-manager/consent-providers.tsx`**:
   - Exported `C15tScripts` type (line 9)
   - Added `isCookieConsentEnabled` prop to interface
   - Updated `showConsentBanner` endpoint handler to be a closure that passes the setting: `showConsentBanner: () => showConsentBanner(isCookieConsentEnabled)`
   - **Resolution tip**: The showConsentBanner function is now wrapped in an arrow function to pass the control panel setting

4. **`core/lib/consent-manager/handlers.ts`**:
   - `showConsentBanner` now accepts `isCookieConsentEnabled: boolean` parameter
   - Returns early with `showConsentBanner: false` when consent is disabled in CP
   - **Resolution tip**: Update any custom handler implementations to accept and handle this parameter

If you've customized your consent manager implementation, ensure that:
- The `cookieConsentEnabled` field is queried from BigCommerce API
- The boolean value flows from your layout → ConsentManager → ConsentManagerProvider → showConsentBanner handler
- Your handler respects the setting and returns appropriately when consent is disabled