### PR TITLE
feat(core): simplify analytics provider

### DIFF
--- a/.changeset/tiny-horses-accept.md
+++ b/.changeset/tiny-horses-accept.md
@@ -1,0 +1,14 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Replace `StreamableAnalyticsProvider`with simplified `AnalyticsProvider` component.
+
+- Removed `StreamableAnalyticsProvider` that used `Streamable.from()` for async data loading.
+- Added new `AnalyticsProvider` component that accepts `channelId` and `settings` as direct props.
+- Simplifies analytics initialization by removing unnecessary streaming complexity.
+- Maintains same functionality with cleaner, more straightforward implementation.
+- Fixes issue of events not triggering by properly wrapping `children` inside the provider.
+
+## Migration
+- Use new `AnalyticsProvider` component in `core/app/[locale]/layout.tsx`, instead of `StreamableAnalyticsProvider`.

--- a/core/app/[locale]/layout.tsx
+++ b/core/app/[locale]/layout.tsx
@@ -10,7 +10,6 @@ import { cache, PropsWithChildren } from 'react';
 
 import '../../globals.css';
 
-import { Streamable } from '@/vibes/soul/lib/streamable';
 import { fonts } from '~/app/fonts';
 import { CookieNotifications } from '~/app/notifications';
 import { Providers } from '~/app/providers';
@@ -18,7 +17,7 @@ import { client } from '~/client';
 import { graphql } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
 import { WebAnalyticsFragment } from '~/components/analytics/fragment';
-import { StreamableAnalyticsProvider } from '~/components/analytics/streamable-provider';
+import { AnalyticsProvider } from '~/components/analytics/provider';
 import { ConsentManagerDialog } from '~/components/consent-manager/consent-manager-dialog';
 import { CookieBanner } from '~/components/consent-manager/cookie-banner';
 import { ContainerQueryPolyfill } from '~/components/polyfills/container-query';
@@ -115,15 +114,6 @@ export default async function RootLayout({ params, children }: Props) {
   // https://next-intl-docs.vercel.app/docs/getting-started/app-router#add-setRequestLocale-to-all-layouts-and-pages
   setRequestLocale(locale);
 
-  const streamableAnalyticsData = Streamable.from(async () => {
-    const { data } = await fetchRootLayoutMetadata();
-
-    return {
-      channelId: data.channel.entityId,
-      settings: data.site.settings,
-    };
-  });
-
   return (
     <html className={clsx(fonts.map((f) => f.variable))} lang={locale}>
       <head>
@@ -136,15 +126,19 @@ export default async function RootLayout({ params, children }: Props) {
         <NextIntlClientProvider>
           <ConsentManagerProvider>
             <NuqsAdapter>
-              <StreamableAnalyticsProvider data={streamableAnalyticsData} />
-              <Providers>
-                {toastNotificationCookieData && (
-                  <CookieNotifications {...toastNotificationCookieData} />
-                )}
-                <ConsentManagerDialog />
-                <CookieBanner />
-                {children}
-              </Providers>
+              <AnalyticsProvider
+                channelId={rootData.data.channel.entityId}
+                settings={rootData.data.site.settings}
+              >
+                <Providers>
+                  {toastNotificationCookieData && (
+                    <CookieNotifications {...toastNotificationCookieData} />
+                  )}
+                  <ConsentManagerDialog />
+                  <CookieBanner />
+                  {children}
+                </Providers>
+              </AnalyticsProvider>
             </NuqsAdapter>
           </ConsentManagerProvider>
         </NextIntlClientProvider>

--- a/core/components/analytics/provider.tsx
+++ b/core/components/analytics/provider.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { Suspense } from 'react';
+import { PropsWithChildren } from 'react';
 
-import { Streamable, useStreamable } from '@/vibes/soul/lib/streamable';
 import { FragmentOf } from '~/client/graphql';
 import { Analytics } from '~/lib/analytics';
 import { GoogleAnalyticsProvider } from '~/lib/analytics/providers/google-analytics';
@@ -37,17 +36,8 @@ const getAnalytics = (
   return null;
 };
 
-export function StreamableAnalyticsProvider({ data }: { data: Streamable<Props> }) {
-  return (
-    <Suspense fallback={null}>
-      <StreamableAnalyticsProviderResolved data={data} />
-    </Suspense>
-  );
-}
-
-function StreamableAnalyticsProviderResolved({ data }: { data: Streamable<Props> }) {
-  const { channelId, settings } = useStreamable(data);
+export function AnalyticsProvider({ channelId, settings, children }: PropsWithChildren<Props>) {
   const analytics = getAnalytics(channelId, settings);
 
-  return <AnalyticsProviderLib analytics={analytics ?? null} />;
+  return <AnalyticsProviderLib analytics={analytics ?? null}>{children}</AnalyticsProviderLib>;
 }


### PR DESCRIPTION
## What/Why?
Replace `StreamableAnalyticsProvider` with simplified `AnalyticsProvider` component.

- Removed `StreamableAnalyticsProvider` that used `Streamable.from()` for async data loading
- Added new `AnalyticsProvider` component that accepts `channelId` and `settings` as direct props
- Simplifies analytics initialization by removing unnecessary streaming complexity
- Maintains same functionality with cleaner, more straightforward implementation
- Fixes issue of events not triggering by properly wrapping `children` inside the provider.

## Testing
Tested by adding a product to cart.

Before:
<img width="557" height="218" alt="Screenshot 2025-10-31 at 12 53 19 PM" src="https://github.com/user-attachments/assets/4c823b41-8013-47b4-847c-71480a1604f7" />

After:
<img width="564" height="265" alt="Screenshot 2025-10-31 at 12 52 40 PM" src="https://github.com/user-attachments/assets/ee7336db-5c24-40e3-a40a-1f4d1a8721d7" />


## Migration
- Use new `AnalyticsProvider` component in `core/app/[locale]/layout.tsx`, instead of `StreamableAnalyticsProvider`.
