### PR TITLE
feat: enable consent update for analytics provider

### DIFF
--- a/.changeset/petite-snails-teach.md
+++ b/.changeset/petite-snails-teach.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Provides a way to track analytics consent updates within the analytics provider. This also enables a the Google Analytics provider to be able to get the initial consent values so it can initialize the default consent values.

--- a/core/app/[locale]/layout.tsx
+++ b/core/app/[locale]/layout.tsx
@@ -128,6 +128,7 @@ export default async function RootLayout({ params, children }: Props) {
             <NuqsAdapter>
               <AnalyticsProvider
                 channelId={rootData.data.channel.entityId}
+                isCookieConsentEnabled={isCookieConsentEnabled}
                 settings={rootData.data.site.settings}
               >
                 <Providers>

--- a/core/components/analytics/provider.tsx
+++ b/core/components/analytics/provider.tsx
@@ -1,30 +1,44 @@
 'use client';
 
-import { PropsWithChildren } from 'react';
+import { useConsentManager } from '@c15t/nextjs';
+import { PropsWithChildren, useEffect, useRef } from 'react';
 
 import { FragmentOf } from '~/client/graphql';
 import { Analytics } from '~/lib/analytics';
 import { GoogleAnalyticsProvider } from '~/lib/analytics/providers/google-analytics';
 import { AnalyticsProvider as AnalyticsProviderLib } from '~/lib/analytics/react';
+import { getConsentCookie } from '~/lib/consent-manager/cookies/client';
 
 import { WebAnalyticsFragment } from './fragment';
 
 interface Props {
   channelId: number;
+  isCookieConsentEnabled: boolean;
   settings?: FragmentOf<typeof WebAnalyticsFragment> | null;
 }
 
-const getAnalytics = (
-  channelId: number,
-  settings?: FragmentOf<typeof WebAnalyticsFragment> | null,
-) => {
+const getConsent = () => {
+  const consentCookie = getConsentCookie();
+
+  if (!consentCookie) {
+    return null;
+  }
+
+  return {
+    functionality: consentCookie.preferences.functionality ?? false,
+    marketing: consentCookie.preferences.marketing ?? false,
+    measurement: consentCookie.preferences.measurement ?? false,
+    necessary: consentCookie.preferences.necessary ?? false,
+  };
+};
+
+const getAnalytics = ({ channelId, isCookieConsentEnabled, settings }: Props): Analytics | null => {
   if (settings?.webAnalytics?.ga4?.tagId && channelId) {
     const googleAnalytics = new GoogleAnalyticsProvider({
       gaId: settings.webAnalytics.ga4.tagId,
-      // TODO: Need to implement consent mode
-      // https://github.com/bigcommerce/catalyst/issues/2066
-      consentModeEnabled: false,
+      consentModeEnabled: isCookieConsentEnabled,
       developerId: 'dMjk3Nj',
+      getConsent,
     });
 
     return new Analytics({
@@ -36,8 +50,41 @@ const getAnalytics = (
   return null;
 };
 
-export function AnalyticsProvider({ channelId, settings, children }: PropsWithChildren<Props>) {
-  const analytics = getAnalytics(channelId, settings);
+export function AnalyticsProvider({
+  channelId,
+  isCookieConsentEnabled,
+  settings,
+  children,
+}: PropsWithChildren<Props>) {
+  const { consents } = useConsentManager();
+  const prevConsentsRef = useRef<Record<string, boolean> | null>(null);
+
+  const analytics = getAnalytics({
+    channelId,
+    isCookieConsentEnabled,
+    settings,
+  });
+
+  // Update consent when user changes preferences
+  useEffect(() => {
+    if (!isCookieConsentEnabled || !analytics) {
+      return;
+    }
+
+    const currentConsents = consents;
+    const prevConsents = prevConsentsRef.current;
+
+    // Check if consents have changed
+    if (prevConsents && JSON.stringify(currentConsents) !== JSON.stringify(prevConsents)) {
+      const consentState = getConsent();
+
+      if (consentState) {
+        analytics.consent.consentUpdated(consentState);
+      }
+    }
+
+    prevConsentsRef.current = currentConsents;
+  }, [isCookieConsentEnabled, analytics, consents]);
 
   return <AnalyticsProviderLib analytics={analytics ?? null}>{children}</AnalyticsProviderLib>;
 }

--- a/core/lib/analytics/analytics.d.ts
+++ b/core/lib/analytics/analytics.d.ts
@@ -86,4 +86,17 @@ declare namespace Analytics {
       productRemoved: (payload: ProductRemovedPayload) => void;
     }
   }
+
+  export namespace Consent {
+    type ConsentNames = 'necessary' | 'functionality' | 'marketing' | 'measurement';
+    type ConsentValues = Record<ConsentNames, boolean>;
+
+    interface ProviderEvents {
+      consentUpdated: (consent: ConsentValues, metadata: Metadata) => void;
+    }
+
+    export interface Events {
+      consentUpdated: (consent: ConsentValues) => void;
+    }
+  }
 }

--- a/core/lib/analytics/index.ts
+++ b/core/lib/analytics/index.ts
@@ -7,6 +7,7 @@ export class Analytics implements IAnalytics {
 
   readonly cart = this.bindCartEvents();
   readonly navigation = this.bindNavigationEvents();
+  readonly consent = this.bindConsentEvents();
 
   constructor(private readonly config: AnalyticsConfig) {
     if (!Analytics.#instance) {
@@ -70,5 +71,18 @@ export class Analytics implements IAnalytics {
         });
       },
     } satisfies Analytics.Navigation.Events;
+  }
+
+  private bindConsentEvents() {
+    return {
+      consentUpdated: (payload) => {
+        this.config.providers.forEach((provider) => {
+          provider.consent.consentUpdated(payload, {
+            channelId: this.config.channelId,
+            eventUuid: uuidV4(),
+          });
+        });
+      },
+    } satisfies Analytics.Consent.Events;
   }
 }

--- a/core/lib/analytics/types.ts
+++ b/core/lib/analytics/types.ts
@@ -1,6 +1,7 @@
 export interface AnalyticsProvider {
   cart: Analytics.Cart.ProviderEvents;
   navigation: Analytics.Navigation.ProviderEvents;
+  consent: Analytics.Consent.ProviderEvents;
 
   initialize: () => void;
 }
@@ -13,6 +14,7 @@ export interface AnalyticsConfig {
 export interface Analytics {
   readonly cart: Analytics.Cart.Events;
   readonly navigation: Analytics.Navigation.Events;
+  readonly consent: Analytics.Consent.Events;
 
   initialize(): void;
 }


### PR DESCRIPTION
## What/Why?

This PR implements analytics consent tracking and Google Analytics consent mode integration. It enables the analytics system to:

1. **Track consent updates**: The analytics provider now listens to consent preference changes and propagates them to analytics providers
2. **Initialize Google Analytics with consent mode**: GA4 is now initialized with default consent values based on the user's current consent preferences or defaults to denied if no consent exists
3. **Update consent dynamically**: When users update their consent preferences through the consent manager, the changes are immediately reflected in Google Analytics

### Technical Details

- Added `Analytics.Consent` namespace with `ConsentNames`, `ConsentValues`, and event types for consent management
- Extended `AnalyticsProvider` interface to include `consent` event handlers
- Implemented consent tracking in the main `Analytics` class that broadcasts consent updates to all registered providers
- Updated `GoogleAnalyticsProvider` to:
  - Accept `getConsent` callback in configuration to retrieve initial consent values
  - Initialize Google Analytics with appropriate consent mode defaults (`ad_storage`, `ad_user_data`, `ad_personalization`, `analytics_storage`)
  - Handle consent updates via `gtag('consent', 'update', ...)` calls
- Modified `AnalyticsProvider` React component to:
  - Accept `isCookieConsentEnabled` prop to conditionally enable consent mode
  - Monitor consent changes using `useConsentManager` hook
  - Trigger consent updates when user preferences change
- Added `getConsentCookie` utility to read consent values from client-side cookies

The consent values map the following preferences:

- `marketing` → `ad_storage`, `ad_user_data`, `ad_personalization`
- `measurement` → `analytics_storage`

## Testing

### Consent is not enabled
<img width="1160" height="567" alt="Screenshot 2025-10-31 at 15 51 28" src="https://github.com/user-attachments/assets/eb757a68-47e9-488e-b557-097468ede8cd" />

### All consent is enabled
<img width="1139" height="485" alt="Screenshot 2025-10-31 at 15 51 40" src="https://github.com/user-attachments/assets/9b34bb3d-f59b-4450-80aa-a8c40ae06486" />

### Partial consent enabled
<img width="1173" height="485" alt="Screenshot 2025-10-31 at 15 52 09" src="https://github.com/user-attachments/assets/ccfaefa9-9280-49b4-8b61-040d205fc0b5" />

## Migration

No breaking changes. This is a backward-compatible enhancement.

Existing implementations will continue to work as before. To enable consent mode:

1. Ensure cookie consent is enabled in your channel settings
2. The `isCookieConsentEnabled` prop is automatically passed from the root layout based on channel configuration
3. Google Analytics consent mode will automatically activate when both conditions are met:
   - `isCookieConsentEnabled` is `true`
   - `consentModeEnabled` is set in the GoogleAnalyticsProvider config (now defaults to the value of `isCookieConsentEnabled`)

---

This pull request description was generated with the assistance of AI. Portions of the code and/or implementation ideas in this PR may also have been created or influenced by AI tools.
