### PR TITLE
feat(core): load ga4 from c15t, configure via provider

### DIFF
--- a/.changeset/nice-cougars-tease.md
+++ b/.changeset/nice-cougars-tease.md
@@ -1,0 +1,12 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Load GA4 (gtag) using C15T's prebuilt script. Consent will be shared by Consent Manager. Configuration available via `GtagConfig` prop in `ConsentManager` component.
+
+## Migration
+- Install `@c15t/scripts` library
+- Update `ConsentManager` component to include `GtagConfig` and pass `gtag` script to `ConsentManagerProvider`.
+- Update `core/lib/analytics/providers/google-analytics/index.ts` to use `gtag` loaded from C15T instead of initializing directly.
+
+

--- a/core/app/[locale]/layout.tsx
+++ b/core/app/[locale]/layout.tsx
@@ -119,7 +119,12 @@ export default async function RootLayout({ params, children }: Props) {
     <html className={clsx(fonts.map((f) => f.variable))} lang={locale}>
       <body className="flex min-h-screen flex-col">
         <NextIntlClientProvider>
-          <ConsentManager scripts={scripts}>
+          <ConsentManager
+            gtagConfig={{
+              gaId: rootData.data.site.settings?.webAnalytics?.ga4?.tagId,
+            }}
+            scripts={scripts}
+          >
             <NuqsAdapter>
               <AnalyticsProvider
                 channelId={rootData.data.channel.entityId}

--- a/core/components/analytics/provider.tsx
+++ b/core/components/analytics/provider.tsx
@@ -21,9 +21,6 @@ const getAnalytics = (
   if (settings?.webAnalytics?.ga4?.tagId && channelId) {
     const googleAnalytics = new GoogleAnalyticsProvider({
       gaId: settings.webAnalytics.ga4.tagId,
-      // TODO: Need to implement consent mode
-      // https://github.com/bigcommerce/catalyst/issues/2066
-      consentModeEnabled: false,
       developerId: 'dMjk3Nj',
     });
 

--- a/core/components/consent-manager/index.tsx
+++ b/core/components/consent-manager/index.tsx
@@ -1,18 +1,43 @@
 'use client';
 
+import { gtag } from '@c15t/scripts/google-tag';
 import type { PropsWithChildren } from 'react';
 
 import { ConsentManagerDialog } from './consent-manager-dialog';
 import { type C15tScripts, ConsentManagerProvider } from './consent-providers';
 import { CookieBanner } from './cookie-banner';
 
-interface ConsentManagerProps extends PropsWithChildren {
-  scripts: C15tScripts;
+interface GtagConfig {
+  gaId?: string;
+  category?: 'measurement' | 'marketing';
+  dataLayerName?: string;
+  nonce?: string;
 }
 
-export function ConsentManager({ children, scripts }: ConsentManagerProps) {
+interface ConsentManagerProps extends PropsWithChildren {
+  scripts: C15tScripts;
+  gtagConfig?: GtagConfig;
+}
+
+export function ConsentManager({ children, scripts, gtagConfig }: ConsentManagerProps) {
+  const scriptsWithPrebuiltScripts = gtagConfig?.gaId
+    ? [
+        gtag({
+          id: gtagConfig.gaId,
+          category: gtagConfig.category ?? 'measurement',
+          script: {
+            src: gtagConfig.dataLayerName
+              ? `https://www.googletagmanager.com/gtag/js?id=${gtagConfig.gaId}&l=${gtagConfig.dataLayerName}`
+              : `https://www.googletagmanager.com/gtag/js?id=${gtagConfig.gaId}`,
+            nonce: gtagConfig.nonce,
+          },
+        }),
+        ...scripts,
+      ]
+    : scripts;
+
   return (
-    <ConsentManagerProvider scripts={scripts}>
+    <ConsentManagerProvider scripts={scriptsWithPrebuiltScripts}>
       <ConsentManagerDialog />
       <CookieBanner />
       {children}

--- a/core/package.json
+++ b/core/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@bigcommerce/catalyst-client": "workspace:^",
     "@c15t/nextjs": "^1.7.0",
+    "@c15t/scripts": "^1.0.0",
     "@conform-to/react": "^1.6.1",
     "@conform-to/zod": "^1.6.1",
     "@icons-pack/react-simple-icons": "^11.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@c15t/nextjs':
         specifier: ^1.7.0
         version: 1.7.0(@opentelemetry/api@1.9.0)(@opentelemetry/instrumentation@0.203.0(@opentelemetry/api@1.9.0))(@types/react-dom@19.1.6(@types/react@19.1.6))(@types/react@19.1.6)(crossws@0.3.5)(next@15.5.1-canary.4(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typeorm@0.3.27(reflect-metadata@0.2.2)(ts-node@10.9.2(@swc/core@1.11.31)(@types/node@22.15.30)(typescript@5.8.3)))(ws@8.18.2)
+      '@c15t/scripts':
+        specifier: ^1.0.0
+        version: 1.0.0
       '@conform-to/react':
         specifier: ^1.6.1
         version: 1.6.1(react@19.1.0)
@@ -1114,6 +1117,9 @@ packages:
     peerDependencies:
       react: ^19.0.0 || ^19.0.0-rc || ^18.0.0 || ^17.0.0 || ^16.8.0
       react-dom: ^19.0.0 || ^19.0.0-rc || ^18.0.0 || ^17.0.0 || ^16.8.0
+
+  '@c15t/scripts@1.0.0':
+    resolution: {integrity: sha512-mMV9BC5HqRvMm1sLzMk3B7XOfaihTfPg1eZr6XJNml5XsKtyrQgbTPHNK5bFH0HBK4jAZYKLGI87qaCJtuQURQ==}
 
   '@c15t/translations@1.7.0':
     resolution: {integrity: sha512-irrJAni2Cei56wHLmGoIoPHoXk/ygXllWs4dBF9LL0D/Ns7bvcBi/CAPCnCD1hw4FnoJ9amPqYtVKQ3sT++JaQ==}
@@ -11439,6 +11445,8 @@ snapshots:
       - typeorm
       - use-sync-external-store
       - ws
+
+  '@c15t/scripts@1.0.0': {}
 
   '@c15t/translations@1.7.0': {}
 


### PR DESCRIPTION
## What/Why?
Load GA4 (gtag) using C15T's prebuilt script. Consent will be shared by Consent Manager. Configuration available via `GtagConfig` prop in `ConsentManager` component.

## Testing
<img width="521" height="294" alt="Screenshot 2025-10-31 at 5 08 59 PM" src="https://github.com/user-attachments/assets/ac7e895b-45bd-4f30-81d2-0b44d9ac430e" />


## Migration
- Install `@c15t/scripts` library
- Update `ConsentManager` component to include `GtagConfig` and pass `gtag` script to `ConsentManagerProvider`.
- Update `core/lib/analytics/providers/google-analytics/index.ts` to use `gtag` loaded from C15T instead of initializing directly.
