### PR TITLE
feat: pass shopper consent to checkout

### DIFF
--- a/.changeset/huge-dryers-dig.md
+++ b/.changeset/huge-dryers-dig.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Passes the shoppers consent to the checkout redirect mutation


### PR DESCRIPTION
## What/Why?

This pull request enhances the checkout redirect flow by passing shopper consent preferences to the checkout redirect mutation. Previously, the checkout redirect only included basic cart and visitor information (`cartId`, `visitId`, `visitorId`). This update extends the mutation to include comprehensive analytics data, including:

- **Consent preferences**: Analytics, functional, and targeting consent flags based on the shopper's consent manager preferences
- **Request context**: Referer URL and user agent information for better tracking and analytics
- **Visitor identification**: Visit ID and visitor ID (now passed as part of the analytics initiator structure)

### Technical Details

The `CheckoutRedirectMutation` GraphQL mutation has been expanded to accept additional parameters:
- `referer` (URL): The referring page URL from the request headers
- `userAgent` (String): The user agent string from the request headers
- `analyticsConsent`, `functionalConsent`, `targetingConsent` (Boolean): Consent preferences derived from the consent manager cookie

These parameters are passed through a new `analytics` object structure in the mutation input, which includes:
- `initiator`: Contains `visitId` and `visitorId` for visitor tracking
- `request`: Contains `url` (referer) and `userAgent` for request context
- `consent`: Contains the three consent preference flags

The implementation retrieves consent preferences from the consent manager cookie using `getConsentCookie()` and maps them to the appropriate checkout analytics fields:
- `measurement` → `analyticsConsent`
- `functionality` → `functionalConsent`
- `marketing` → `targetingConsent`

All new required fields use sensible fallback values (empty strings for missing headers, `false` for undefined consent preferences) to ensure the mutation always has valid data.

## Testing
Even though there are no new fields on the `session_payload`, the `visit_id` and `visitor_id` fields are being pass from the new analytics object.
<img width="670" height="538" alt="Screenshot 2025-10-31 at 16 56 47" src="https://github.com/user-attachments/assets/a4103269-51b7-4105-b319-709049d3cce8" />

## Migration

No migration required. This is a backward-compatible enhancement to the checkout flow. The changes are contained within the checkout route handler and do not affect existing functionality or require updates to other parts of the codebase.

---

**This pull request description was generated with the assistance of AI. Portions of the code and/or implementation ideas in this PR may also have been created or influenced by AI tools.**
