### PR TITLE
fix(core): Update with-routes to account for trailing slash or capitalizations when redirecting

### DIFF
--- a/.changeset/old-days-tan.md
+++ b/.changeset/old-days-tan.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Fixed issue with 301 redirect loops when `TRAILING_SLASH` is set to `false`, or when 301 redirects exist targeting the same path but with different capitalization.

--- a/core/tests/environment.ts
+++ b/core/tests/environment.ts
@@ -29,6 +29,7 @@ export const testEnv = createEnv({
     TEST_CUSTOMER_PASSWORD: z.string().optional(),
     DEFAULT_PRODUCT_ID: z.coerce.number().optional(),
     DEFAULT_COMPLEX_PRODUCT_ID: z.coerce.number().optional(),
+    TRAILING_SLASH: z.stringbool().optional().default(true),
   },
   runtimeEnv: process.env,
   emptyStringAsUndefined: true,

--- a/core/tests/fixtures/index.ts
+++ b/core/tests/fixtures/index.ts
@@ -14,6 +14,7 @@ import { CustomerFixture } from './customer';
 import { OrderFixture } from './order';
 import { extendedPage, toHaveURL } from './page';
 import { PromotionFixture } from './promotion';
+import { RedirectsFixture } from './redirects';
 import { SettingsFixture } from './settings';
 import { WebPageFixture } from './webpage';
 
@@ -24,6 +25,7 @@ interface Fixtures {
   customer: CustomerFixture;
   currency: CurrencyFixture;
   promotion: PromotionFixture;
+  redirects: RedirectsFixture;
   settings: SettingsFixture;
   webPage: WebPageFixture;
   /**
@@ -106,6 +108,16 @@ export const test = baseTest.extend<Fixtures>({
       await use(promotionFixture);
 
       await promotionFixture.cleanup();
+    },
+    { scope: 'test' },
+  ],
+  redirects: [
+    async ({ page }, use, currentTest) => {
+      const redirectsFixture = new RedirectsFixture(page, currentTest);
+
+      await use(redirectsFixture);
+
+      await redirectsFixture.cleanup();
     },
     { scope: 'test' },
   ],

--- a/core/tests/fixtures/redirects/index.ts
+++ b/core/tests/fixtures/redirects/index.ts
@@ -1,0 +1,22 @@
+import { Fixture } from '~/tests/fixtures/fixture';
+import { Redirect, UpsertRedirectData } from '~/tests/fixtures/utils/api/redirects';
+
+export class RedirectsFixture extends Fixture {
+  redirects: Redirect[] = [];
+
+  async upsertRedirect(data: UpsertRedirectData): Promise<Redirect | undefined> {
+    this.skipIfReadonly();
+
+    const redirect = await this.api.redirects.upsert(data);
+
+    if (redirect) {
+      this.redirects.push(redirect);
+    }
+
+    return redirect;
+  }
+
+  async cleanup() {
+    await this.api.redirects.delete(this.redirects.map(({ id }) => id));
+  }
+}

--- a/core/tests/fixtures/utils/api/catalog/http.ts
+++ b/core/tests/fixtures/utils/api/catalog/http.ts
@@ -95,6 +95,7 @@ const ProductSchema = z
       price: data.price,
       retailPrice: data.retail_price,
       salePrice: data.sale_price,
+      customUrl: data.custom_url,
       path: data.custom_url.url,
       variants: data.variants,
       categories: data.categories,
@@ -104,12 +105,19 @@ const ProductSchema = z
     }),
   );
 
+const ProductCreateCustomUrlSchema = z.object({
+  url: z.string(),
+  is_customized: z.boolean().optional(),
+  create_redirect: z.boolean().optional(),
+});
+
 const ProductCreateSchema = z.object({
   name: z.string(),
   weight: z.number(),
   price: z.number(),
   sale_price: z.number().optional(),
   retail_price: z.number().optional(),
+  custom_url: ProductCreateCustomUrlSchema.optional(),
   sku: z.string().optional(),
   type: z.enum(['physical', 'digital']).optional(),
   description: z.string().optional(),
@@ -171,6 +179,18 @@ const transformCreateVariantData = (data: CreateVariantData) =>
     inventory_warning_level: data.inventoryWarningLevel,
   });
 
+const transformCreateProductCustomUrl = (data: CreateProductData['customUrl']) => {
+  if (!data) {
+    return undefined;
+  }
+
+  return ProductCreateCustomUrlSchema.parse({
+    url: data.url,
+    is_customized: data.isCustomized,
+    create_redirect: data.createRedirect,
+  });
+};
+
 const transformCreateProductData = (data: CreateProductData) =>
   ProductCreateSchema.parse({
     name: data.name,
@@ -179,6 +199,7 @@ const transformCreateProductData = (data: CreateProductData) =>
     sku: data.sku,
     type: data.type,
     description: data.description,
+    custom_url: transformCreateProductCustomUrl(data.customUrl),
     is_visible: data.isVisible ?? true,
     variants: data.variants?.map(transformCreateVariantData),
     categories: data.categories,

--- a/core/tests/fixtures/utils/api/catalog/index.ts
+++ b/core/tests/fixtures/utils/api/catalog/index.ts
@@ -28,6 +28,9 @@ export interface Product {
   readonly inventoryLevel?: number;
   readonly inventoryWarningLevel?: number;
   readonly inventoryTracking?: 'none' | 'product' | 'variant';
+  readonly customUrl: {
+    url: string;
+  };
 }
 
 export interface CreateVariantData {
@@ -58,6 +61,11 @@ export interface CreateProductData {
   inventoryLevel?: number;
   inventoryWarningLevel?: number;
   inventoryTracking?: 'none' | 'product' | 'variant';
+  customUrl?: {
+    url: string;
+    isCustomized?: boolean;
+    createRedirect?: boolean;
+  };
 }
 
 export interface Category {

--- a/core/tests/fixtures/utils/api/index.ts
+++ b/core/tests/fixtures/utils/api/index.ts
@@ -4,6 +4,7 @@ import { CurrenciesApi, currenciesHttpClient } from '~/tests/fixtures/utils/api/
 import { CustomersApi, customersHttpClient } from '~/tests/fixtures/utils/api/customers';
 import { OrdersApi, ordersHttpClient } from '~/tests/fixtures/utils/api/orders';
 import { PromotionsApi, promotionsHttpClient } from '~/tests/fixtures/utils/api/promotions';
+import { RedirectsApi, redirectsHttpClient } from '~/tests/fixtures/utils/api/redirects';
 import { SettingsApi, settingsHttpClient } from '~/tests/fixtures/utils/api/settings';
 import { WebPagesApi, webPagesHttpClient } from '~/tests/fixtures/utils/api/webpages';
 
@@ -16,6 +17,7 @@ export interface ApiClient {
   promotions: PromotionsApi;
   settings: SettingsApi;
   webPages: WebPagesApi;
+  redirects: RedirectsApi;
 }
 
 export const httpApiClient: ApiClient = {
@@ -27,4 +29,5 @@ export const httpApiClient: ApiClient = {
   promotions: promotionsHttpClient,
   settings: settingsHttpClient,
   webPages: webPagesHttpClient,
+  redirects: redirectsHttpClient,
 };

--- a/core/tests/fixtures/utils/api/redirects/http.ts
+++ b/core/tests/fixtures/utils/api/redirects/http.ts
@@ -1,0 +1,101 @@
+import { z } from 'zod';
+
+import { testEnv } from '~/tests/environment';
+
+import { httpClient } from '../client';
+import { apiResponseSchema } from '../schema';
+
+import { Redirect, RedirectsApi, UpsertRedirectData } from '.';
+
+const RedirectToTypeSchema = z.enum(['product', 'brand', 'category', 'page', 'post', 'url']);
+
+const RedirectToEntitySchema = z.object({
+  type: RedirectToTypeSchema.exclude(['url']),
+  entity_id: z.number(),
+});
+
+const RedirectToUrlSchema = z.object({
+  type: z.literal('url'),
+  url: z.string(),
+});
+
+const RedirectToSchema = z.union([RedirectToEntitySchema, RedirectToUrlSchema]);
+
+const RedirectSchema = z
+  .object({
+    id: z.number(),
+    site_id: z.number(),
+    from_path: z.string(),
+    to: RedirectToSchema,
+  })
+  .transform(
+    (data): Redirect => ({
+      id: data.id,
+      siteId: data.site_id,
+      fromPath: data.from_path,
+      to:
+        data.to.type === 'url'
+          ? { type: 'url', url: data.to.url }
+          : {
+              type: data.to.type,
+              entityId: data.to.entity_id,
+            },
+    }),
+  );
+
+const RedirectUpsertDataSchema = z.object({
+  site_id: z.number(),
+  from_path: z.string(),
+  to: RedirectToSchema,
+});
+
+const transformRedirectTo = (data: UpsertRedirectData['to']) => {
+  if (data.type === 'url') {
+    return RedirectToSchema.parse({
+      type: 'url',
+      url: data.url,
+    });
+  }
+
+  return RedirectToSchema.parse({
+    type: data.type,
+    entity_id: data.entityId,
+  });
+};
+
+const transformRedirectUpsertData = (data: UpsertRedirectData & { siteId: number }) =>
+  RedirectUpsertDataSchema.parse({
+    site_id: data.siteId,
+    from_path: data.fromPath,
+    to: transformRedirectTo(data.to),
+  });
+
+export const redirectsHttpClient: RedirectsApi = {
+  upsert: async (data) => {
+    // Redirects require a siteID, so it must be fetched via the channel ID
+    const channelId = Number(testEnv.BIGCOMMERCE_CHANNEL_ID);
+    const {
+      data: { id: siteId },
+    } = await httpClient
+      .get(`/v3/channels/${channelId}/site`)
+      .parse(apiResponseSchema(z.object({ id: z.number() })));
+
+    await httpClient
+      .put('/v3/storefront/redirects', [transformRedirectUpsertData({ ...data, siteId })])
+      .parse(apiResponseSchema(z.array(RedirectSchema)));
+
+    // Upsert redirects API will not return created redirects, just a 200 success with an empty array.
+    // Because of this, a GET needs to be done for the newly created redirect in order to get the ID.
+
+    const created = await httpClient
+      .get(`/v3/storefront/redirects?site_id=${siteId}&keyword=${data.fromPath}`)
+      .parse(apiResponseSchema(z.array(RedirectSchema)));
+
+    return created.data[0];
+  },
+  delete: async (ids: number[]) => {
+    if (ids.length > 0) {
+      await httpClient.delete(`/v3/storefront/redirects?id:in=${ids.join(',')}`);
+    }
+  },
+};

--- a/core/tests/fixtures/utils/api/redirects/index.ts
+++ b/core/tests/fixtures/utils/api/redirects/index.ts
@@ -1,0 +1,30 @@
+type RedirectToType = 'product' | 'brand' | 'category' | 'page' | 'post' | 'url';
+
+interface RedirectToEntity {
+  type: Exclude<RedirectToType, 'url'>;
+  entityId: number;
+}
+
+interface RedirectToUrl {
+  type: 'url';
+  url: string;
+}
+
+export interface Redirect {
+  readonly id: number;
+  readonly siteId: number;
+  readonly fromPath: string;
+  readonly to: RedirectToEntity | RedirectToUrl;
+}
+
+export interface UpsertRedirectData {
+  fromPath: string;
+  to: RedirectToEntity | RedirectToUrl;
+}
+
+export interface RedirectsApi {
+  upsert: (data: UpsertRedirectData) => Promise<Redirect | undefined>;
+  delete: (ids: number[]) => Promise<void>;
+}
+
+export { redirectsHttpClient } from './http';

--- a/core/tests/ui/e2e/middleware/redirects.spec.ts
+++ b/core/tests/ui/e2e/middleware/redirects.spec.ts
@@ -1,0 +1,103 @@
+import { faker } from '@faker-js/faker';
+
+import { testEnv } from '~/tests/environment';
+import { expect, test } from '~/tests/fixtures';
+
+test('Middleware follows a dynamic 301 redirect correctly', async ({
+  page,
+  catalog,
+  redirects,
+}) => {
+  const redirectFrom = `/test-dynamic-redirect-${faker.string.alpha(6)}`;
+  const product = await catalog.getDefaultOrCreateSimpleProduct();
+
+  await redirects.upsertRedirect({
+    fromPath: redirectFrom,
+    to: {
+      type: 'product',
+      entityId: product.id,
+    },
+  });
+
+  await page.goto(redirectFrom);
+  await expect(page).toHaveURL(product.customUrl.url);
+});
+
+test('Middleware follows a manual redirect correctly', async ({ page, redirects }) => {
+  const fromPath = `/test-manual-redirect-${faker.string.alpha(6)}`;
+  const toPath = `/test-manual-destination-${faker.string.alpha(6)}`;
+
+  await redirects.upsertRedirect({
+    fromPath,
+    to: {
+      type: 'url',
+      url: toPath,
+    },
+  });
+
+  // First, navigate to the original fromPath and expect to be redirected to toPath
+  await page.goto(fromPath);
+  await expect(page).toHaveURL(toPath);
+});
+
+test('Middleware follows redirects in respect to capitalization', async ({ page, redirects }) => {
+  const fromPath = '/path-test';
+  const toPath = '/path-TEST';
+
+  await redirects.upsertRedirect({
+    fromPath,
+    to: {
+      type: 'url',
+      url: toPath,
+    },
+  });
+
+  await page.goto(fromPath);
+  await expect(page).toHaveURL(toPath);
+});
+
+test.describe('Trailing slash redirect loop regression tests', () => {
+  test.skip(() => testEnv.TRAILING_SLASH);
+
+  test('Dynamic redirect to a product with a trailing slash in the url does not cause a redirect loop when TRAILING_SLASH=false', async ({
+    page,
+    catalog,
+    redirects,
+  }) => {
+    const productUrlWithoutTrailingSlash = `/dynamic-redirect-product-${faker.string.alpha(6)}`;
+    const product = await catalog.createSimpleProduct({
+      customUrl: {
+        url: `${productUrlWithoutTrailingSlash}/`,
+      },
+    });
+
+    await redirects.upsertRedirect({
+      fromPath: productUrlWithoutTrailingSlash,
+      to: {
+        type: 'product',
+        entityId: product.id,
+      },
+    });
+
+    await page.goto(productUrlWithoutTrailingSlash);
+    await expect(page).toHaveURL(productUrlWithoutTrailingSlash);
+  });
+
+  test('Manual redirect from a non-trailing-slash path to a trailing-slash path does not cause a redirect loop when TRAILING_SLASH=false', async ({
+    page,
+    redirects,
+  }) => {
+    const pathNoSlash = `/test-manual-redirect-${faker.string.alpha(6)}`;
+
+    await redirects.upsertRedirect({
+      fromPath: pathNoSlash,
+      to: {
+        type: 'url',
+        url: `${pathNoSlash}/`,
+      },
+    });
+
+    await page.goto(pathNoSlash);
+    await expect(page).toHaveURL(pathNoSlash);
+  });
+});


### PR DESCRIPTION
## What/Why?
Update the with-routes middleware to account for the `TRAILING_SLASH` env var, as well as capitalized letters in 301 Redirects.

There was a reported issue where when using `TRAILING_SLASH=false` in the Catalyst environment variables, redirect loops could occur if you had a redirect going from `/example-path -> /example-path/`, or capitalizations like `/some-url -> /some-URL`

## Testing
Tested locally, confirmed fix works.

### Regression test results before changes:
<img width="1108" height="542" alt="image" src="https://github.com/user-attachments/assets/82457fd8-7baf-4590-93cc-12d13125f84f" />

### Regression test results after changes:
<img width="1049" height="530" alt="image" src="https://github.com/user-attachments/assets/e0dedd4b-6c78-4444-9a31-2540b515520c" />


### Before fix
**Dynamic 301 Redirect from `/infinite-redirect-test` to a product with the URL `/infinite-redirect-test/` while `TRAILING_SLASH=false`**

https://github.com/user-attachments/assets/de33a638-88dd-470b-8dc5-7278f4395c7d

**Manual 301 Redirect from `/redirect-test` to `/redirect-TEST`**

https://github.com/user-attachments/assets/d5ae1973-c2e9-49f6-90ab-a42747388889

### After fix

**Dynamic 301 Redirect from `/infinite-redirect-test` to a product with the URL `/infinite-redirect-test/` while `TRAILING_SLASH=false`**

https://github.com/user-attachments/assets/1398df93-92a9-4a7f-8370-2fdff2c871d0

**Manual 301 Redirect from `/redirect-test` to `/redirect-TEST`**

https://github.com/user-attachments/assets/963d71b6-f0f7-43a7-94cc-d6ce72c47edb

## Migration
Copy changes from `with-routes.ts` using this PR as a reference
