### PR TITLE
chore: change version bump from major to a minor

### DIFF
--- a/.changeset/orange-games-obey.md
+++ b/.changeset/orange-games-obey.md
@@ -1,5 +1,5 @@
 ---
-"@bigcommerce/catalyst-core": major
+"@bigcommerce/catalyst-core": minor
 ---
 
 Add current stock message to product details page based on the store/product inventory settings.


### PR DESCRIPTION
## What/Why?
Noticed in the https://github.com/bigcommerce/catalyst/pull/2575 it was cutting a 2.0 release because of this changeset. Instead we want to release version 1.3 so we need to change this changeset to a minor.

## Testing
N/A

## Migration
N/A