### PR TITLE
chore: sync `integrations/makeswift` and add changeset.

### DIFF
--- a/.changeset/dull-ears-search.md
+++ b/.changeset/dull-ears-search.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-makeswift": minor
+---
+
+Synced the changes made on `canary`. See the 1.3.0 changelog for more details: https://github.com/bigcommerce/catalyst/releases/tag/%40bigcommerce%2Fcatalyst-core%401.3.0


### PR DESCRIPTION
## What/Why?
Syncs the `integrations/makeswift` branch one more time and adds the `1.3.0` changeset.

## Testing
N/A

## Migration
N/A
