### PR TITLE
fix(core): CATALYST-1579 Ensure "Proceed to checkout" has loading state, respect trailing slash on checkout action path

### DIFF
--- a/.changeset/tiny-jobs-know.md
+++ b/.changeset/tiny-jobs-know.md
@@ -1,0 +1,18 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Minor refactor to improve the performance when navigating from the cart to the checkout.
+- [#2680](https://github.com/bigcommerce/catalyst/pull/2680)
+- [#2681](https://github.com/bigcommerce/catalyst/pull/2681)
+
+### Migration
+
+Use the above PR diffs as a reference.
+
+1. Remove `core/app/[locale]/(default)/cart/_actions/redirect-to-checkout.ts`
+2. Update `checkoutAction` in `core/app/[locale]/(default)/cart/page.tsx` to `"/checkout"`
+3. Copy changes to `core/app/[locale]/(default)/checkout/route.ts`
+4. Update `core/lib/server-toast.ts` and set the cookie `maxAge` to `1` - this ensures any toast errors live through the redirect back to the `/cart` page
+5. Copy changes in `core/vibes/soul/sections/cart/client.tsx`
+6. Update `en.json` with the updated translation values (optional)

--- a/core/app/[locale]/(default)/cart/page.tsx
+++ b/core/app/[locale]/(default)/cart/page.tsx
@@ -20,6 +20,8 @@ interface Props {
   params: Promise<{ locale: string }>;
 }
 
+const CHECKOUT_URL = process.env.TRAILING_SLASH !== 'false' ? '/checkout/' : '/checkout';
+
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale } = await params;
 
@@ -250,7 +252,7 @@ export default async function Cart({ params }: Props) {
               },
             ].filter(exists),
           }}
-          checkoutAction="/checkout"
+          checkoutAction={CHECKOUT_URL}
           checkoutLabel={t('proceedToCheckout')}
           couponCode={{
             action: updateCouponCode,

--- a/core/vibes/soul/sections/cart/client.tsx
+++ b/core/vibes/soul/sections/cart/client.tsx
@@ -633,7 +633,11 @@ function CheckoutButton({
 } & ComponentPropsWithoutRef<typeof Button>) {
   const [lastResult, formAction] = useActionState(
     async (state: SubmissionResult | null, formData: FormData) => {
-      if (typeof action !== 'function') {
+      if (typeof action === 'string') {
+        await new Promise<void>(() => {
+          window.location.assign(action);
+        });
+
         return null;
       }
 
@@ -653,7 +657,7 @@ function CheckoutButton({
   }, [form.errors]);
 
   return (
-    <form action={typeof action === 'string' ? action : formAction}>
+    <form action={formAction}>
       <SubmitButton {...props} isCartUpdatePending={isCartUpdatePending} />
     </form>
   );


### PR DESCRIPTION
## What/Why?
Follow-up PR for https://github.com/bigcommerce/catalyst/pull/2680 to ensure that the "Proceed to checkout" button displays a loading spinner while navigating away from the page.

## Testing

https://github.com/user-attachments/assets/0050a01b-cd4a-47d2-9760-84766da231d4


## Migration
Copy all changes from this PR