### PR TITLE
Revert package.json version to 1.3.0

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigcommerce/catalyst-makeswift",
   "description": "BigCommerce Catalyst is a Next.js starter kit for building headless BigCommerce storefronts.",
-  "version": "1.3.1",
+  "version": "1.3.0",
   "private": true,
   "scripts": {
     "dev": "npm run generate && next dev",


### PR DESCRIPTION
## What/Why?
Change the `package.json` version to `1.3.0` - I made a mistake during the release process and forgot to set this to the correct version of the makeswift branch.

## Testing
n/a

## Migration
n/a
