### PR TITLE
fix(core): handle inline scripts with src attribute

### DIFF
--- a/.changeset/poor-baths-hear.md
+++ b/.changeset/poor-baths-hear.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Updates the scripts transformer to account for inline scripts having a `src` attribute with empty content.


### PR DESCRIPTION
## What/Why?

This PR fixes a bug in the scripts transformer where inline scripts containing a `src` attribute with empty content were not being handled properly.

**Problem:**
The BigCommerce API can return scripts marked as `InlineScript` types that contain a `src` attribute instead of (or in addition to) inline text content. The previous implementation of `extractInlineScriptContent` only extracted text content from within `<script>` tags, which meant scripts with only a `src` attribute would be silently dropped.

**Solution:**

- Renamed `extractInlineScriptContent` to `extractScriptInfo` to better reflect its expanded purpose
- Modified the function to return a discriminated union type (`ScriptInfo`) that can represent either:
  - Inline scripts with `textContent`
  - External scripts with `src` attributes
- Updated the transformer logic to handle both cases, preferring `textContent` when available but falling back to `src` when present
- Added proper type discrimination to ensure the correct properties are used based on what was extracted

This ensures that all script types from the BigCommerce API are properly transformed and rendered, preventing scripts from being inadvertently dropped.

## Testing

**Manual Testing:**

1. Test with a store that has scripts configured in BigCommerce with various configurations:
   - Inline scripts with text content only
   - Scripts with `src` attributes (external scripts)
   - Scripts with both `src` and empty/minimal content
2. Verify that all scripts are properly rendered in the application
3. Check that scripts with consent categories are properly categorized

**Automated Testing:**

- Existing tests in `core/tests/` should continue to pass
- Run `pnpm test` to verify e2e tests
- Run `pnpm typecheck` to verify TypeScript types are correct

## Migration

No migration required - this is a backward-compatible bug fix that improves handling of edge cases in script transformation.

---

**This pull request description was generated with the assistance of AI. Portions of the code and/or implementation ideas in this PR may also have been created or influenced by AI tools.**

### Initial Prompt

The code changes in this PR were generated from the following initial prompt:

> Update the scripts transformer to account for inline scripts having a `src` attribute with empty content.
