### PR TITLE
chore: merge 1.3.2 changelog into canary

### DIFF
--- a/.changeset/poor-baths-hear.md
+++ b/.changeset/poor-baths-hear.md
@@ -1,5 +1,0 @@
----
-"@bigcommerce/catalyst-core": patch
----
-
-Updates the scripts transformer to account for inline scripts having a `src` attribute with empty content.

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.3.2
+
+### Patch Changes
+
+- [`ce1731f`](https://github.com/bigcommerce/catalyst/commit/ce1731f0cb0f0e411c3ffa4734b0256dbdacafbb) Thanks [@chanceaclark](https://github.com/chanceaclark)! - Updates the scripts transformer to account for inline scripts having a `src` attribute with empty content.
+
 ## 1.3.1
 
 ### Patch Changes

--- a/core/package.json
+++ b/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigcommerce/catalyst-core",
   "description": "BigCommerce Catalyst is a Next.js starter kit for building headless BigCommerce storefronts.",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": true,
   "scripts": {
     "dev": "npm run generate && next dev",


### PR DESCRIPTION
## What/Why?
I already made a `1.3.2` patch to fix the issue with scripts https://github.com/bigcommerce/catalyst/releases/tag/%40bigcommerce%2Fcatalyst-core%401.3.2

This PR merges the changelog into canary in order to make sure we carry over the changeset.

## Testing
https://github.com/bigcommerce/catalyst/releases/tag/%40bigcommerce%2Fcatalyst-core%401.3.2

## Migration
N/A