### PR TITLE
feat(core): Add link to Gift Certificates page in header/footer

### DIFF
--- a/.changeset/big-moons-beg.md
+++ b/.changeset/big-moons-beg.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Add Gift Certificates link to the header/footer.

--- a/core/app/[locale]/(default)/page-data.ts
+++ b/core/app/[locale]/(default)/page-data.ts
@@ -20,16 +20,27 @@ export const LayoutQuery = graphql(
   [HeaderFragment, FooterFragment],
 );
 
+const GiftCertificatesEnabledFragment = graphql(`
+  fragment GiftCertificatesEnabledFragment on Settings {
+    giftCertificates(currencyCode: $currencyCode) {
+      isEnabled
+    }
+  }
+`);
+
 export const GetLinksAndSectionsQuery = graphql(
   `
-    query GetLinksAndSectionsQuery {
+    query GetLinksAndSectionsQuery($currencyCode: currencyCode) {
       site {
+        settings {
+          ...GiftCertificatesEnabledFragment
+        }
         ...HeaderLinksFragment
         ...FooterSectionsFragment
       }
     }
   `,
-  [HeaderLinksFragment, FooterSectionsFragment],
+  [HeaderLinksFragment, FooterSectionsFragment, GiftCertificatesEnabledFragment],
 );
 
 const HomePageQuery = graphql(

--- a/core/components/footer/fragment.ts
+++ b/core/components/footer/fragment.ts
@@ -30,6 +30,12 @@ export const FooterFragment = graphql(`
 
 export const FooterSectionsFragment = graphql(`
   fragment FooterSectionsFragment on Site {
+    settings {
+      giftCertificates(currencyCode: $currencyCode) {
+        currencyCode
+        isEnabled
+      }
+    }
     content {
       pages(filters: { parentEntityIds: [0] }) {
         edges {

--- a/core/components/footer/index.tsx
+++ b/core/components/footer/index.tsx
@@ -16,7 +16,9 @@ import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
 import { readFragment } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
+import { CurrencyCode } from '~/components/header/fragment';
 import { logoTransformer } from '~/data-transformers/logo-transformer';
+import { getPreferredCurrencyCode } from '~/lib/currency';
 
 import { FooterFragment, FooterSectionsFragment } from './fragment';
 import { AmazonIcon } from './payment-icons/amazon';
@@ -44,18 +46,21 @@ const socialIcons: Record<string, { icon: JSX.Element }> = {
   YouTube: { icon: <SiYoutube title="YouTube" /> },
 };
 
-const getFooterSections = cache(async (customerAccessToken?: string) => {
-  const { data: response } = await client.fetch({
-    document: GetLinksAndSectionsQuery,
-    customerAccessToken,
-    // Since this query is needed on every page, it's a good idea not to validate the customer access token.
-    // The 'cache' function also caches errors, so we might get caught in a redirect loop if the cache saves an invalid token error response.
-    validateCustomerAccessToken: false,
-    fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
-  });
+const getFooterSections = cache(
+  async (customerAccessToken?: string, currencyCode?: CurrencyCode) => {
+    const { data: response } = await client.fetch({
+      document: GetLinksAndSectionsQuery,
+      customerAccessToken,
+      variables: { currencyCode },
+      // Since this query is needed on every page, it's a good idea not to validate the customer access token.
+      // The 'cache' function also caches errors, so we might get caught in a redirect loop if the cache saves an invalid token error response.
+      validateCustomerAccessToken: false,
+      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
+    });
 
-  return readFragment(FooterSectionsFragment, response).site;
-});
+    return readFragment(FooterSectionsFragment, response).site;
+  },
+);
 
 const getFooterData = cache(async () => {
   const { data: response } = await client.fetch({
@@ -68,7 +73,6 @@ const getFooterData = cache(async () => {
 
 export const Footer = async () => {
   const t = await getTranslations('Components.Footer');
-
   const data = await getFooterData();
 
   const logo = data.settings ? logoTransformer(data.settings) : '';
@@ -91,8 +95,8 @@ export const Footer = async () => {
 
   const streamableSections = Streamable.from(async () => {
     const customerAccessToken = await getSessionCustomerAccessToken();
-
-    const sectionsData = await getFooterSections(customerAccessToken);
+    const currencyCode = await getPreferredCurrencyCode();
+    const sectionsData = await getFooterSections(customerAccessToken, currencyCode);
 
     return [
       {
@@ -111,10 +115,20 @@ export const Footer = async () => {
       },
       {
         title: t('navigate'),
-        links: removeEdgesAndNodes(sectionsData.content.pages).map((page) => ({
-          label: page.name,
-          href: page.__typename === 'ExternalLinkPage' ? page.link : page.path,
-        })),
+        links: [
+          ...(sectionsData.settings?.giftCertificates?.isEnabled
+            ? [
+                {
+                  label: t('giftCertificates'),
+                  href: '/gift-certificates',
+                },
+              ]
+            : []),
+          ...removeEdgesAndNodes(sectionsData.content.pages).map((page) => ({
+            label: page.name,
+            href: page.__typename === 'ExternalLinkPage' ? page.link : page.path,
+          })),
+        ],
       },
     ];
   });

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -458,7 +458,8 @@
       "Icons": {
         "account": "Profile",
         "cart": "Cart",
-        "search": "Open search popup"
+        "search": "Open search popup",
+        "giftCertificates": "Gift certificates"
       },
       "SwitchCurrency": {
         "label": "Switch currency",
@@ -482,7 +483,8 @@
       "socialMediaLinks": "Social media links",
       "categories": "Categories",
       "brands": "Brands",
-      "navigate": "Navigate"
+      "navigate": "Navigate",
+      "giftCertificates": "Gift certificates"
     },
     "Subscribe": {
       "title": "Sign up for our newsletter",

--- a/core/vibes/soul/primitives/navigation/index.tsx
+++ b/core/vibes/soul/primitives/navigation/index.tsx
@@ -6,7 +6,15 @@ import * as NavigationMenu from '@radix-ui/react-navigation-menu';
 import * as Popover from '@radix-ui/react-popover';
 import { clsx } from 'clsx';
 import debounce from 'lodash.debounce';
-import { ArrowRight, ChevronDown, Search, SearchIcon, ShoppingBag, User } from 'lucide-react';
+import {
+  ArrowRight,
+  ChevronDown,
+  GiftIcon,
+  Search,
+  SearchIcon,
+  ShoppingBag,
+  User,
+} from 'lucide-react';
 import { useParams, useSearchParams } from 'next/navigation';
 import React, {
   forwardRef,
@@ -119,6 +127,9 @@ interface Props<S extends SearchResult> {
   searchLabel?: string;
   mobileMenuTriggerLabel?: string;
   switchCurrencyLabel?: string;
+  giftCertificatesLabel?: string;
+  giftCertificatesHref: string;
+  giftCertificatesEnabled?: Streamable<boolean>;
 }
 
 const MobileMenuButton = forwardRef<
@@ -286,6 +297,9 @@ export const Navigation = forwardRef(function Navigation<S extends SearchResult>
     searchLabel = 'Search',
     mobileMenuTriggerLabel = 'Toggle navigation',
     switchCurrencyLabel,
+    giftCertificatesLabel = 'Gift Certificates',
+    giftCertificatesHref,
+    giftCertificatesEnabled: streamableGiftCertificatesEnabled,
   }: Props<S>,
   ref: Ref<HTMLDivElement>,
 ) {
@@ -594,6 +608,20 @@ export const Navigation = forwardRef(function Navigation<S extends SearchResult>
               }
             </Stream>
           </Link>
+
+          <Stream fallback={null} value={streamableGiftCertificatesEnabled}>
+            {(giftCertificatesEnabled) =>
+              giftCertificatesEnabled && (
+                <Link
+                  aria-label={giftCertificatesLabel}
+                  className={navButtonClassName}
+                  href={giftCertificatesHref}
+                >
+                  <GiftIcon size={20} strokeWidth={1} />
+                </Link>
+              )
+            }
+          </Stream>
 
           {/* Locale / Language Dropdown */}
           {locales && locales.length > 1 ? (


### PR DESCRIPTION
## What/Why?
We noticed that the Gift Certificate header/footer links commit got left out of the original PR adding the functionality to the `canary` branch. This pulls them back in.

## Testing
<img width="500" height="190" alt="image" src="https://github.com/user-attachments/assets/42793625-8041-48aa-8316-1401a0b2187f" />
<img width="284" height="160" alt="image" src="https://github.com/user-attachments/assets/ec1b24d1-d2c2-4472-82aa-d693ea146dfb" />

## Migration

### Update GraphQL Query

In `/app/[locale]/(default)/page-data.ts`, update the `LayoutQuery` to accept a `$currencyCode` variable and include the new giftCertificates field.

### Update Header Fragment

In `/components/header/fragment.ts`, add the `giftCertificates(currencyCode: $currencyCode)` field to the header fragment, including its properties.

### Update Header Data Fetching

In `/components/header/index.tsx`, pass the preferred currency code when fetching header data and add new props for gift certificates (label, link, enabled flag) to header links.

### Add Localization

In /messages/en.json, add a new entry for "giftCertificates": "Gift Certificates" under the "Icons" section.

### Update Navigation Component

In `/vibes/soul/primitives/navigation/index.tsx`:
Import `GiftIcon` from `lucide-react`.

Add new props for the gift certificates label, link, and enabled flag.

Render the new "Gift Certificates" navigation link and icon, conditionally shown when enabled.

