### PR TITLE
chore: release 1.3.2

### DIFF
--- a/.changeset/poor-baths-hear.md
+++ b/.changeset/poor-baths-hear.md
@@ -1,5 +1,0 @@
----
-"@bigcommerce/catalyst-makeswift": patch
----
-
-Pulls in changes from the `@bigcommerce/catalyst-core@1.3.2` patch.

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.3.2
+
+### Patch Changes
+
+- [`6c94dec`](https://github.com/bigcommerce/catalyst/commit/6c94dece0f72f2bc74ef67b456f2522475e2f129) Thanks [@chanceaclark](https://github.com/chanceaclark)! - Pulls in changes from the `@bigcommerce/catalyst-core@1.3.2` patch.
+
 ## 1.3.1
 
 ### Patch Changes

--- a/core/package.json
+++ b/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigcommerce/catalyst-makeswift",
   "description": "BigCommerce Catalyst is a Next.js starter kit for building headless BigCommerce storefronts.",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": true,
   "scripts": {
     "dev": "npm run generate && next dev",


### PR DESCRIPTION
## What/Why?
Manually release the `1.3.2` version for this branch. This just merges in the changelog.

## Testing
https://github.com/bigcommerce/catalyst/releases/tag/%40bigcommerce%2Fcatalyst-makeswift%401.3.2

## Migration
N/A
