### PR TITLE
chore: cleanup changelog addition

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,13 +1,5 @@
 # Changelog
 
-## 1.3.3
-
-### Patch Changes
-
-- [#2695](https://github.com/bigcommerce/catalyst/pull/2695) [`6d565c2`](https://github.com/bigcommerce/catalyst/commit/6d565c2cbf98e3fa0c2b0142734fc68a5d48bd2c) Thanks [@jordanarldt](https://github.com/jordanarldt)! - Add Gift Certificates link to the header/footer.
-
-- [#2694](https://github.com/bigcommerce/catalyst/pull/2694) [`fdedcaa`](https://github.com/bigcommerce/catalyst/commit/fdedcaa99c83d5c32c54dec0974962b7d17447cf) Thanks [@BC-AdamWard](https://github.com/BC-AdamWard)! - Fix anonymous session cookie maxAge calculation to correctly set 7 days instead of 7 hours.
-
 ## 1.3.2
 
 ### Patch Changes


### PR DESCRIPTION
## What/Why?
Removes the changelog from the 1.3.3 release.

## Testing
N/A

## Migration
N/A