### PR TITLE
chore: add 1.3.3 changeset

### DIFF
--- a/.changeset/social-ghosts-tan.md
+++ b/.changeset/social-ghosts-tan.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-makeswift": patch
+---
+
+Pulls in changes from the @bigcommerce/catalyst-core@1.3.3 patch.


### PR DESCRIPTION
## What/Why?
Adds a changeset to release `integrations/makeswift`.

## Testing
N/A

## Migration
N/A