### PR TITLE
chore: add 1.3.4 changeset

### DIFF
--- a/.changeset/khaki-badgers-mate.md
+++ b/.changeset/khaki-badgers-mate.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Noop release to account for typecheck issue.


### PR DESCRIPTION
## What/Why?
Adds a noop 1.3.4 changeset to fix an issue with the typecheck command failing due to code that should've been removed in the 1.3.3 version. People utilizing the latest tag will get this 1.3.4 version so the typecheck command doesn't fail.

## Testing
N/A

## Migration
N/A