### PR TITLE
feat: Add out-of-stock/backorder message to product lists

### DIFF
--- a/.changeset/tricky-plants-teach.md
+++ b/.changeset/tricky-plants-teach.md
@@ -1,0 +1,105 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Add out-of-stock / backorder message to product cards on PLPs based on store settings:
+- Add out of stock message if the product is out of stock and stock is set to display it.
+- Add the backorder message if the product has no on-hand stock and is available for backorder and the store/product is set to display the backorder message
+
+## Migration
+
+### Option 1: Automatic Migration (Recommended)
+For existing Catalyst stores, the simplest way to get the newly added feature is to rebase the existing code with the new release code. The files that will be updated are listed below.
+
+### Option 2: Manual Migration
+If you prefer not to rebase or have made customizations that prevent rebasing, follow these manual steps:
+
+#### Step 1: Update GraphQL Fragment
+Add the inventory fields to your product card fragment in `core/components/product-card/fragment.ts` under `Product`:
+```graphql
+inventory {
+  hasVariantInventory
+  isInStock
+  aggregated {
+    availableForBackorder
+    unlimitedBackorder
+    availableOnHand
+  }
+}
+variants(first: 1) {
+  edges {
+    node {
+      entityId
+      sku
+      inventory {
+        byLocation {
+          edges {
+            node {
+              locationEntityId
+              backorderMessage
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+#### Step 2: Update Product interface in Product Card component
+Update the `Product` interface in `core/vibes/soul/primitives/product-card/index.tsx` adding the following field to it:
+
+`inventoryMessage?: string;`
+
+#### Step 3: Update Data Transformer
+Modify `core/data-transformers/product-card-transformer.ts` to include inventory message in the transformed data. You can simply copy the whole file from this release as it does not have UI breaking changes.
+
+#### Step 4: Update Product Card Layout
+Update `core/vibes/soul/primitives/product-card/index.tsx` layout to display the new `inventoryMessage` product field.
+
+#### Step 5: Update Page Data GraphQL queries
+Add inventory settings queries to the pages data. Add the following query to the main GQL query under `site.settings`:
+```
+inventory {
+  defaultOutOfStockMessage
+  showOutOfStockMessage
+  showBackorderMessage
+}
+```
+to the following page data files:
+- `core/app/[locale]/(default)/(faceted)/brand/[slug]/page-data.ts`
+- `core/app/[locale]/(default)/(faceted)/category/[slug]/page-data.ts`
+- `core/app/[locale]/(default)/(faceted)/search/page-data.ts`
+- `core/app/[locale]/(default)/page-data.ts`
+
+#### Step 6: Update Page Components
+Update the corresponding page components to use the `productCardTransformer` method (if not already using it) to get the product card, and pass inventory data to those product cards based on the store inventory settings. Use the following code while retrieving the product lists:
+```
+    const { defaultOutOfStockMessage, showOutOfStockMessage, showBackorderMessage } =
+      data.site.settings?.inventory ?? {};
+
+    return productCardTransformer(
+      featuredProducts,
+      format,
+      showOutOfStockMessage ? defaultOutOfStockMessage : undefined,
+      showBackorderMessage,
+    );
+```
+in the following files:
+- `core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx`
+- `core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx`
+- `core/app/[locale]/(default)/(faceted)/search/page.tsx`
+- `core/app/[locale]/(default)/page.tsx`
+
+### Files Modified in This Change
+- `core/app/[locale]/(default)/(faceted)/brand/[slug]/page-data.ts`
+- `core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx`
+- `core/app/[locale]/(default)/(faceted)/category/[slug]/page-data.ts`
+- `core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx`
+- `core/app/[locale]/(default)/(faceted)/search/page-data.ts`
+- `core/app/[locale]/(default)/(faceted)/search/page.tsx`
+- `core/app/[locale]/(default)/page-data.ts`
+- `core/app/[locale]/(default)/page.tsx`
+- `core/components/product-card/fragment.ts`
+- `core/data-transformers/product-card-transformer.ts`
+- `core/vibes/soul/primitives/product-card/index.tsx`

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page-data.ts
@@ -16,6 +16,11 @@ const BrandPageQuery = graphql(`
         }
       }
       settings {
+        inventory {
+          defaultOutOfStockMessage
+          showOutOfStockMessage
+          showBackorderMessage
+        }
         storefront {
           catalog {
             productComparisonsEnabled

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
@@ -11,7 +11,7 @@ import { getFilterParsers } from '@/vibes/soul/sections/products-list-section/fi
 import { getSessionCustomerAccessToken } from '~/auth';
 import { facetsTransformer } from '~/data-transformers/facets-transformer';
 import { pageInfoTransformer } from '~/data-transformers/page-info-transformer';
-import { pricesTransformer } from '~/data-transformers/prices-transformer';
+import { productCardTransformer } from '~/data-transformers/product-card-transformer';
 import { getPreferredCurrencyCode } from '~/lib/currency';
 
 import { MAX_COMPARE_LIMIT } from '../../../compare/page-data';
@@ -132,16 +132,15 @@ export default async function Brand(props: Props) {
     const search = await streamableFacetedSearch;
     const products = search.products.items;
 
-    return products.map((product) => ({
-      id: product.entityId.toString(),
-      title: product.name,
-      href: product.path,
-      image: product.defaultImage
-        ? { src: product.defaultImage.url, alt: product.defaultImage.altText }
-        : undefined,
-      price: pricesTransformer(product.prices, format),
-      subtitle: product.brand?.name ?? undefined,
-    }));
+    const { defaultOutOfStockMessage, showOutOfStockMessage, showBackorderMessage } =
+      settings?.inventory ?? {};
+
+    return productCardTransformer(
+      products,
+      format,
+      showOutOfStockMessage ? defaultOutOfStockMessage : undefined,
+      showBackorderMessage,
+    );
   });
 
   const streamableTotalCount = Streamable.from(async () => {

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page-data.ts
@@ -35,6 +35,11 @@ const CategoryPageQuery = graphql(
           }
         }
         settings {
+          inventory {
+            defaultOutOfStockMessage
+            showOutOfStockMessage
+            showBackorderMessage
+          }
           storefront {
             catalog {
               productComparisonsEnabled

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -12,7 +12,7 @@ import { getFilterParsers } from '@/vibes/soul/sections/products-list-section/fi
 import { getSessionCustomerAccessToken } from '~/auth';
 import { facetsTransformer } from '~/data-transformers/facets-transformer';
 import { pageInfoTransformer } from '~/data-transformers/page-info-transformer';
-import { pricesTransformer } from '~/data-transformers/prices-transformer';
+import { productCardTransformer } from '~/data-transformers/product-card-transformer';
 import { getPreferredCurrencyCode } from '~/lib/currency';
 
 import { MAX_COMPARE_LIMIT } from '../../../compare/page-data';
@@ -145,16 +145,15 @@ export default async function Category(props: Props) {
     const search = await streamableFacetedSearch;
     const products = search.products.items;
 
-    return products.map((product) => ({
-      id: product.entityId.toString(),
-      title: product.name,
-      href: product.path,
-      image: product.defaultImage
-        ? { src: product.defaultImage.url, alt: product.defaultImage.altText }
-        : undefined,
-      price: pricesTransformer(product.prices, format),
-      subtitle: product.brand?.name ?? undefined,
-    }));
+    const { defaultOutOfStockMessage, showOutOfStockMessage, showBackorderMessage } =
+      settings?.inventory ?? {};
+
+    return productCardTransformer(
+      products,
+      format,
+      showOutOfStockMessage ? defaultOutOfStockMessage : undefined,
+      showBackorderMessage,
+    );
   });
 
   const streamableTotalCount = Streamable.from(async () => {

--- a/core/app/[locale]/(default)/(faceted)/search/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/search/page-data.ts
@@ -8,6 +8,11 @@ const SearchPageQuery = graphql(`
   query SearchPageQuery {
     site {
       settings {
+        inventory {
+          defaultOutOfStockMessage
+          showOutOfStockMessage
+          showBackorderMessage
+        }
         storefront {
           catalog {
             productComparisonsEnabled

--- a/core/app/[locale]/(default)/(faceted)/search/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/search/page.tsx
@@ -10,7 +10,7 @@ import { getFilterParsers } from '@/vibes/soul/sections/products-list-section/fi
 import { getSessionCustomerAccessToken } from '~/auth';
 import { facetsTransformer } from '~/data-transformers/facets-transformer';
 import { pageInfoTransformer } from '~/data-transformers/page-info-transformer';
-import { pricesTransformer } from '~/data-transformers/prices-transformer';
+import { productCardTransformer } from '~/data-transformers/product-card-transformer';
 import { getPreferredCurrencyCode } from '~/lib/currency';
 
 import { MAX_COMPARE_LIMIT } from '../../compare/page-data';
@@ -117,16 +117,15 @@ export default async function Search(props: Props) {
     const search = await streamableFacetedSearch;
     const products = search.products.items;
 
-    return products.map((product) => ({
-      id: product.entityId.toString(),
-      title: product.name,
-      href: product.path,
-      image: product.defaultImage
-        ? { src: product.defaultImage.url, alt: product.defaultImage.altText }
-        : undefined,
-      price: pricesTransformer(product.prices, format),
-      subtitle: product.brand?.name ?? undefined,
-    }));
+    const { defaultOutOfStockMessage, showOutOfStockMessage, showBackorderMessage } =
+      settings?.inventory ?? {};
+
+    return productCardTransformer(
+      products,
+      format,
+      showOutOfStockMessage ? defaultOutOfStockMessage : undefined,
+      showBackorderMessage,
+    );
   });
 
   const streamableTitle = Streamable.from(async () => {

--- a/core/app/[locale]/(default)/page-data.ts
+++ b/core/app/[locale]/(default)/page-data.ts
@@ -61,6 +61,13 @@ const HomePageQuery = graphql(
             }
           }
         }
+        settings {
+          inventory {
+            defaultOutOfStockMessage
+            showOutOfStockMessage
+            showBackorderMessage
+          }
+        }
       }
     }
   `,

--- a/core/app/[locale]/(default)/page.tsx
+++ b/core/app/[locale]/(default)/page.tsx
@@ -36,7 +36,15 @@ export default async function Home({ params }: Props) {
 
     const featuredProducts = removeEdgesAndNodes(data.site.featuredProducts);
 
-    return productCardTransformer(featuredProducts, format);
+    const { defaultOutOfStockMessage, showOutOfStockMessage, showBackorderMessage } =
+      data.site.settings?.inventory ?? {};
+
+    return productCardTransformer(
+      featuredProducts,
+      format,
+      showOutOfStockMessage ? defaultOutOfStockMessage : undefined,
+      showBackorderMessage,
+    );
   });
 
   const streamableNewestProducts = Streamable.from(async () => {
@@ -44,7 +52,15 @@ export default async function Home({ params }: Props) {
 
     const newestProducts = removeEdgesAndNodes(data.site.newestProducts);
 
-    return productCardTransformer(newestProducts, format);
+    const { defaultOutOfStockMessage, showOutOfStockMessage, showBackorderMessage } =
+      data.site.settings?.inventory ?? {};
+
+    return productCardTransformer(
+      newestProducts,
+      format,
+      showOutOfStockMessage ? defaultOutOfStockMessage : undefined,
+      showBackorderMessage,
+    );
   });
 
   return (

--- a/core/components/product-card/fragment.ts
+++ b/core/components/product-card/fragment.ts
@@ -15,9 +15,36 @@ export const ProductCardFragment = graphql(
         name
         path
       }
+      inventory {
+        hasVariantInventory
+        isInStock
+        aggregated {
+          availableForBackorder
+          unlimitedBackorder
+          availableOnHand
+        }
+      }
       reviewSummary {
         numberOfReviews
         averageRating
+      }
+      variants(first: 1) {
+        edges {
+          node {
+            entityId
+            sku
+            inventory {
+              byLocation {
+                edges {
+                  node {
+                    locationEntityId
+                    backorderMessage
+                  }
+                }
+              }
+            }
+          }
+        }
       }
       ...PricingFragment
     }

--- a/core/data-transformers/product-card-transformer.ts
+++ b/core/data-transformers/product-card-transformer.ts
@@ -1,3 +1,4 @@
+import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
 import { ResultOf } from 'gql.tada';
 import { getFormatter } from 'next-intl/server';
 
@@ -7,9 +8,48 @@ import { ProductCardFragment } from '~/components/product-card/fragment';
 
 import { pricesTransformer } from './prices-transformer';
 
+const getInventoryMessage = (
+  product: ResultOf<typeof ProductCardFragment>,
+  outOfStockMessage?: string,
+  showBackorderMessage?: boolean,
+) => {
+  if (!product.inventory.isInStock) {
+    return outOfStockMessage;
+  }
+
+  if (!showBackorderMessage || product.inventory.hasVariantInventory) {
+    return undefined;
+  }
+
+  const { availableForBackorder, unlimitedBackorder, availableOnHand } =
+    product.inventory.aggregated ?? {};
+
+  if (availableOnHand) {
+    return undefined;
+  }
+
+  const hasBackorderAvailablity = !!availableForBackorder || unlimitedBackorder;
+
+  if (!hasBackorderAvailablity) {
+    return undefined;
+  }
+
+  const baseVariant = removeEdgesAndNodes(product.variants).at(0);
+
+  if (!baseVariant?.inventory?.byLocation) {
+    return undefined;
+  }
+
+  const inventoryByLocation = removeEdgesAndNodes(baseVariant.inventory.byLocation).at(0);
+
+  return inventoryByLocation?.backorderMessage ?? undefined;
+};
+
 export const singleProductCardTransformer = (
   product: ResultOf<typeof ProductCardFragment>,
   format: ExistingResultType<typeof getFormatter>,
+  outOfStockMessage?: string,
+  showBackorderMessage?: boolean,
 ): Product => {
   return {
     id: product.entityId.toString(),
@@ -21,12 +61,17 @@ export const singleProductCardTransformer = (
     price: pricesTransformer(product.prices, format),
     subtitle: product.brand?.name ?? undefined,
     rating: product.reviewSummary.averageRating,
+    inventoryMessage: getInventoryMessage(product, outOfStockMessage, showBackorderMessage),
   };
 };
 
 export const productCardTransformer = (
   products: Array<ResultOf<typeof ProductCardFragment>>,
   format: ExistingResultType<typeof getFormatter>,
+  outOfStockMessage?: string,
+  showBackorderMessage?: boolean,
 ): Product[] => {
-  return products.map((product) => singleProductCardTransformer(product, format));
+  return products.map((product) =>
+    singleProductCardTransformer(product, format, outOfStockMessage, showBackorderMessage),
+  );
 };

--- a/core/vibes/soul/primitives/product-card/index.tsx
+++ b/core/vibes/soul/primitives/product-card/index.tsx
@@ -17,6 +17,7 @@ export interface Product {
   subtitle?: string;
   badge?: string;
   rating?: number;
+  inventoryMessage?: string;
 }
 
 export interface ProductCardProps {
@@ -43,16 +44,18 @@ export interface ProductCardProps {
  *   --product-card-light-background: hsl(var(--contrast-100));
  *   --product-card-light-title: hsl(var(--foreground));
  *   --product-card-light-subtitle: hsl(var(--foreground) / 75%);
+ *   --product-card-light-message: hsl(var(--foreground) / 75%);
  *   --product-card-dark-offset: hsl(var(--foreground));
  *   --product-card-dark-background: hsl(var(--contrast-500));
  *   --product-card-dark-title: hsl(var(--background));
  *   --product-card-dark-subtitle: hsl(var(--background) / 75%);
+ *   --product-card-dark-message: hsl(var(--background) / 75%);
  *   --product-card-font-family: var(--font-family-body);
  * }
  * ```
  */
 export function ProductCard({
-  product: { id, title, subtitle, badge, price, image, href },
+  product: { id, title, subtitle, badge, price, image, href, inventoryMessage },
   colorScheme = 'light',
   className,
   showCompare = false,
@@ -65,7 +68,7 @@ export function ProductCard({
   return (
     <article
       className={clsx(
-        'group flex min-w-0 max-w-md flex-col gap-2 font-[family-name:var(--card-font-family,var(--font-family-body))] @container',
+        'group flex min-w-0 max-w-md flex-col gap-3 font-[family-name:var(--card-font-family,var(--font-family-body))] @container',
         className,
       )}
     >
@@ -123,7 +126,7 @@ export function ProductCard({
           <div className="flex-1 text-sm @[16rem]:text-base">
             <span
               className={clsx(
-                'block font-semibold',
+                'line-clamp-2 font-semibold',
                 {
                   light: 'text-[var(--product-card-light-title,hsl(var(--foreground)))]',
                   dark: 'text-[var(--product-card-dark-title,hsl(var(--background)))]',
@@ -132,11 +135,10 @@ export function ProductCard({
             >
               {title}
             </span>
-
             {subtitle != null && subtitle !== '' && (
               <span
                 className={clsx(
-                  'mb-2 block text-sm font-normal',
+                  'mb-1.5 block text-sm font-normal',
                   {
                     light: 'text-[var(--product-card-light-subtitle,hsl(var(--foreground)/75%))]',
                     dark: 'text-[var(--product-card-dark-subtitle,hsl(var(--background)/75%))]',
@@ -147,6 +149,17 @@ export function ProductCard({
               </span>
             )}
             {price != null && <PriceLabel colorScheme={colorScheme} price={price} />}
+            <span
+              className={clsx(
+                'block text-sm font-normal',
+                {
+                  light: 'text-[var(--product-card-light-message,hsl(var(--foreground)/75%))]',
+                  dark: 'text-[var(--product-card-dark-message,hsl(var(--background)/75%))]',
+                }[colorScheme],
+              )}
+            >
+              {inventoryMessage}
+            </span>
           </div>
         </div>
         {href !== '#' && (
@@ -167,7 +180,7 @@ export function ProductCard({
         )}
       </div>
       {showCompare && (
-        <div className="mt-0.5 shrink-0">
+        <div className="mt-auto shrink-0">
           <Compare
             colorScheme={colorScheme}
             label={compareLabel}


### PR DESCRIPTION
## What/Why?
Display the backorder message or out-of-stock messages on the product card in different product lists according to the product stock status and the store settings.

## Testing
Screenshots
**Home page featured products lists**
<img width="1368" height="1036" alt="Screenshot 2025-12-02 at 3 41 24 pm" src="https://github.com/user-attachments/assets/6cce731e-0dcf-4ff3-af2e-81eda4f09a82" />

**Category PLP**
<img width="1389" height="1035" alt="Screenshot 2025-12-02 at 3 40 42 pm" src="https://github.com/user-attachments/assets/a9f39be9-7b06-488c-b797-cff5e4e0aa7a" />

**Brand PLP**
<img width="1378" height="1032" alt="Screenshot 2025-12-02 at 3 40 00 pm" src="https://github.com/user-attachments/assets/6492e122-9495-4bc1-8154-4aa6de5737b5" />

**Searc
<img width="1383" height="999" alt="Screenshot 2025-12-02 at 3 39 10 pm" src="https://github.com/user-attachments/assets/18d6f76a-a253-4c01-b2ab-7868aafaf3e0" />
h PLP**


## Migration
While rebasing, there might be some conflicts if there is some custom styling of the product card component. Those conflicts may occur in the following files:
- core/vibes/soul/primitives/product-card/index.tsx
