### PR TITLE
chore: add changeset for 1.3.6 release

### DIFF
--- a/.changeset/public-ducks-unite.md
+++ b/.changeset/public-ducks-unite.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-makeswift": patch
+---
+
+Pulls in changes from the `@bigcommerce/catalyst-core@1.3.5` patch.


### PR DESCRIPTION
## What/Why?
Adds a changeset for the 1.3.6 release.

## Testing
N/A

## Migration
N/A