### PR TITLE
fix(core): handle reset password case during login

### DIFF
--- a/.changeset/red-crews-move.md
+++ b/.changeset/red-crews-move.md
@@ -1,0 +1,49 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Improved login error handling to display a custom error message when BigCommerce indicates a password reset is required, instead of showing a generic error message.
+
+## What's Fixed
+
+When attempting to log in with an account that requires a password reset, users now see an informative error message: "Password reset required. Please check your email for instructions to reset your password."
+
+**Before**: Generic "something went wrong" error message  
+**After**: Clear error message explaining the password reset requirement
+
+## Migration
+
+### Step 1: Update Translation Files
+
+Add this translation key to your locale files (e.g., `core/messages/en.json`):
+
+```json
+{
+  "Auth": {
+    "Login": {
+      "passwordResetRequired": "Password reset required. Please check your email for instructions to reset your password.",
+    }
+  }
+}
+```
+
+Repeat for all supported locales if you maintain custom translations.
+
+### Step 2: Update Login Server Action
+
+In your login server action (e.g., `core/app/[locale]/(default)/(auth)/login/_actions/login.ts`):
+
+Add the password reset error handling block:
+```typescript
+if (
+  error instanceof AuthError &&
+  error.type === 'CallbackRouteError' &&
+  error.cause &&
+  error.cause.err instanceof BigCommerceGQLError &&
+  error.cause.err.message.includes('Reset password"')
+) {
+  return submission.reply({ formErrors: [t('passwordResetRequired')] });
+}
+```
+
+This should be placed in your error handling, before the generic "Invalid credentials" check.

--- a/core/app/[locale]/(default)/(auth)/login/_actions/login.ts
+++ b/core/app/[locale]/(default)/(auth)/login/_actions/login.ts
@@ -48,6 +48,16 @@ export const login = async (
       error.type === 'CallbackRouteError' &&
       error.cause &&
       error.cause.err instanceof BigCommerceGQLError &&
+      error.cause.err.message.includes('Reset password"')
+    ) {
+      return submission.reply({ formErrors: [t('passwordResetRequired')] });
+    }
+
+    if (
+      error instanceof AuthError &&
+      error.type === 'CallbackRouteError' &&
+      error.cause &&
+      error.cause.err instanceof BigCommerceGQLError &&
       error.cause.err.message.includes('Invalid credentials')
     ) {
       return submission.reply({ formErrors: [t('invalidCredentials')] });

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -54,6 +54,7 @@
       "password": "Password",
       "invalidCredentials": "Your email address or password is incorrect. Try signing in again or reset your password",
       "somethingWentWrong": "Something went wrong. Please try again later.",
+      "passwordResetRequired": "Password reset required. Please check your email for instructions to reset your password.",
       "CreateAccount": {
         "title": "New customer?",
         "accountBenefits": "Create an account with us and you'll be able to:",


### PR DESCRIPTION
## What/Why?
Improved login error handling to display a custom error message when BigCommerce indicates a password reset is required, instead of showing a generic error message.

## Testing
Locally
<img width="527" height="584" alt="Screenshot 2025-12-04 at 2 36 35 PM" src="https://github.com/user-attachments/assets/d66c725f-8b1c-45b9-b921-19f15acd8b98" />


## Migration
### Step 1: Update Translation Files

Add this translation key to your locale files (e.g., `core/messages/en.json`):

```json
{
  "Auth": {
    "Login": {
      "passwordResetRequired": "Password reset required. Please check your email for instructions to reset your password.",
    }
  }
}
```

Repeat for all supported locales if you maintain custom translations.

### Step 2: Update Login Server Action

In your login server action (e.g., `core/app/[locale]/(default)/(auth)/login/_actions/login.ts`):

Add the password reset error handling block:
```typescript
if (
  error instanceof AuthError &&
  error.type === 'CallbackRouteError' &&
  error.cause &&
  error.cause.err instanceof BigCommerceGQLError &&
  error.cause.err.message.includes('Reset password"')
) {
  return submission.reply({ formErrors: [t('passwordResetRequired')] });
}
```

This should be placed in your error handling, before the generic "Invalid credentials" check.

