### PR TITLE
feat(reviews): conditionally enable reviews functionality based on store setting

### DIFF
--- a/.changeset/tiny-parts-call.md
+++ b/.changeset/tiny-parts-call.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Conditionally enable storefront reviews functionality based on `site.settings.reviews.enabled`. The storefront logic when this setting is enabled/disabled matches exactly the logic of Stencil + Cornerstone.

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page-data.ts
@@ -26,6 +26,9 @@ const BrandPageQuery = graphql(`
             productComparisonsEnabled
           }
         }
+        reviews {
+          enabled
+        }
       }
     }
   }

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
@@ -103,6 +103,8 @@ export default async function Brand(props: Props) {
     return notFound();
   }
 
+  const reviewsEnabled = settings?.reviews.enabled ?? false;
+
   const productComparisonsEnabled =
     settings?.storefront.catalog?.productComparisonsEnabled ?? false;
 
@@ -219,6 +221,7 @@ export default async function Brand(props: Props) {
       rangeFilterApplyLabel={t('FacetedSearch.Range.apply')}
       removeLabel={t('Compare.remove')}
       resetFiltersLabel={t('FacetedSearch.resetFilters')}
+      reviewsEnabled={reviewsEnabled}
       showCompare={productComparisonsEnabled}
       sortDefaultValue="featured"
       sortLabel={t('Search.title')}

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page-data.ts
@@ -45,6 +45,9 @@ const CategoryPageQuery = graphql(
               productComparisonsEnabled
             }
           }
+          reviews {
+            enabled
+          }
         }
       }
     }

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -113,6 +113,8 @@ export default async function Category(props: Props) {
     href: path ?? '#',
   }));
 
+  const reviewsEnabled = settings?.reviews.enabled ?? false;
+
   const productComparisonsEnabled =
     settings?.storefront.catalog?.productComparisonsEnabled ?? false;
 
@@ -255,6 +257,7 @@ export default async function Category(props: Props) {
         rangeFilterApplyLabel={t('FacetedSearch.Range.apply')}
         removeLabel={t('Compare.remove')}
         resetFiltersLabel={t('FacetedSearch.resetFilters')}
+        reviewsEnabled={reviewsEnabled}
         showCompare={productComparisonsEnabled}
         sortDefaultValue="featured"
         sortLabel={t('SortBy.sortBy')}

--- a/core/app/[locale]/(default)/(faceted)/search/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/search/page-data.ts
@@ -18,6 +18,9 @@ const SearchPageQuery = graphql(`
             productComparisonsEnabled
           }
         }
+        reviews {
+          enabled
+        }
       }
     }
   }

--- a/core/app/[locale]/(default)/(faceted)/search/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/search/page.tsx
@@ -78,6 +78,8 @@ export default async function Search(props: Props) {
 
   const { settings } = await getSearchPageData();
 
+  const reviewsEnabled = settings?.reviews.enabled ?? false;
+
   const productComparisonsEnabled =
     settings?.storefront.catalog?.productComparisonsEnabled ?? false;
 
@@ -251,6 +253,7 @@ export default async function Search(props: Props) {
       rangeFilterApplyLabel={t('FacetedSearch.Range.apply')}
       removeLabel={t('Compare.remove')}
       resetFiltersLabel={t('FacetedSearch.resetFilters')}
+      reviewsEnabled={reviewsEnabled}
       showCompare={productComparisonsEnabled}
       sortDefaultValue="featured"
       sortLabel={t('SortBy.sortBy')}

--- a/core/app/[locale]/(default)/product/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/product/[slug]/page-data.ts
@@ -171,6 +171,11 @@ const ProductQuery = graphql(
   `
     query ProductQuery($entityId: Int!) {
       site {
+        settings {
+          reviews {
+            enabled
+          }
+        }
         product(entityId: $entityId) {
           entityId
           name
@@ -199,7 +204,7 @@ export const getProduct = cache(async (entityId: number, customerAccessToken?: s
     fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
   });
 
-  return data.site.product;
+  return data.site;
 });
 
 const StreamableProductVariantBySkuQuery = graphql(`

--- a/core/app/[locale]/(default)/product/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/page.tsx
@@ -78,7 +78,9 @@ export default async function Product({ params, searchParams }: Props) {
 
   const productId = Number(slug);
 
-  const baseProduct = await getProduct(productId, customerAccessToken);
+  const { product: baseProduct, settings } = await getProduct(productId, customerAccessToken);
+
+  const reviewsEnabled = settings?.reviews.enabled ?? false;
 
   if (!baseProduct) {
     return notFound();
@@ -535,6 +537,7 @@ export default async function Product({ params, searchParams }: Props) {
             href: baseProduct.path,
             images: streamableImages,
             price: streamablePrices,
+            reviewsEnabled,
             subtitle: baseProduct.brand?.name,
             rating: baseProduct.reviewSummary.averageRating,
             accordions: streameableAccordions,
@@ -559,12 +562,14 @@ export default async function Product({ params, searchParams }: Props) {
         title={t('RelatedProducts.title')}
       />
 
-      <Reviews
-        productId={productId}
-        searchParams={searchParams}
-        streamableImages={streamableImages}
-        streamableProduct={streamableProduct}
-      />
+      {reviewsEnabled && (
+        <Reviews
+          productId={productId}
+          searchParams={searchParams}
+          streamableImages={streamableImages}
+          streamableProduct={streamableProduct}
+        />
+      )}
 
       <Stream
         fallback={null}

--- a/core/vibes/soul/primitives/product-card/index.tsx
+++ b/core/vibes/soul/primitives/product-card/index.tsx
@@ -6,6 +6,8 @@ import * as Skeleton from '@/vibes/soul/primitives/skeleton';
 import { Image } from '~/components/image';
 import { Link } from '~/components/link';
 
+import { Rating } from '../rating';
+
 import { Compare } from './compare';
 
 export interface Product {
@@ -30,6 +32,7 @@ export interface ProductCardProps {
   compareLabel?: string;
   compareParamName?: string;
   product: Product;
+  reviewsEnabled?: boolean;
 }
 
 // eslint-disable-next-line valid-jsdoc
@@ -55,7 +58,8 @@ export interface ProductCardProps {
  * ```
  */
 export function ProductCard({
-  product: { id, title, subtitle, badge, price, image, href, inventoryMessage },
+  product: { id, title, subtitle, badge, price, image, href, inventoryMessage, rating },
+  reviewsEnabled = false,
   colorScheme = 'light',
   className,
   showCompare = false,
@@ -149,6 +153,9 @@ export function ProductCard({
               </span>
             )}
             {price != null && <PriceLabel colorScheme={colorScheme} price={price} />}
+            {reviewsEnabled && typeof rating === 'number' && rating > 0 && (
+              <Rating rating={rating} />
+            )}
             <span
               className={clsx(
                 'block text-sm font-normal',

--- a/core/vibes/soul/sections/product-detail/index.tsx
+++ b/core/vibes/soul/sections/product-detail/index.tsx
@@ -25,6 +25,7 @@ interface ProductDetailProduct {
   subtitle?: string;
   badge?: string;
   rating?: Streamable<number | null>;
+  reviewsEnabled?: boolean;
   summary?: Streamable<string>;
   description?: Streamable<string | ReactNode | null>;
   accordions?: Streamable<
@@ -114,11 +115,13 @@ export function ProductDetail<F extends Field>({
                   <h1 className="mb-3 mt-2 font-[family-name:var(--product-detail-title-font-family,var(--font-family-heading))] text-2xl font-medium leading-none @xl:mb-4 @xl:text-3xl @4xl:text-4xl">
                     {product.title}
                   </h1>
-                  <div className="group/product-rating">
-                    <Stream fallback={<RatingSkeleton />} value={product.rating}>
-                      {(rating) => <Rating rating={rating ?? 0} />}
-                    </Stream>
-                  </div>
+                  {product.reviewsEnabled && (
+                    <div className="group/product-rating">
+                      <Stream fallback={<RatingSkeleton />} value={product.rating}>
+                        {(rating) => <Rating rating={rating ?? 0} />}
+                      </Stream>
+                    </div>
+                  )}
                   <div className="group/product-price">
                     <Stream fallback={<PriceLabelSkeleton />} value={product.price}>
                       {(price) => (

--- a/core/vibes/soul/sections/product-list/index.tsx
+++ b/core/vibes/soul/sections/product-list/index.tsx
@@ -11,6 +11,7 @@ import * as Skeleton from '@/vibes/soul/primitives/skeleton';
 
 interface ProductListProps {
   products: Streamable<Product[]>;
+  reviewsEnabled?: boolean;
   compareProducts?: Streamable<Product[]>;
   className?: string;
   colorScheme?: 'light' | 'dark';
@@ -45,6 +46,7 @@ interface ProductListProps {
  */
 export function ProductList({
   products: streamableProducts,
+  reviewsEnabled,
   className,
   colorScheme = 'light',
   aspectRatio = '5:6',
@@ -107,6 +109,7 @@ export function ProductList({
                     imageSizes="(min-width: 80rem) 20vw, (min-width: 64rem) 25vw, (min-width: 42rem) 33vw, (min-width: 24rem) 50vw, 100vw"
                     key={product.id}
                     product={product}
+                    reviewsEnabled={reviewsEnabled}
                     showCompare={showCompare}
                   />
                 ))}

--- a/core/vibes/soul/sections/products-list-section/index.tsx
+++ b/core/vibes/soul/sections/products-list-section/index.tsx
@@ -30,6 +30,7 @@ interface Props {
   filterLabel?: string;
   filtersPanelTitle?: Streamable<string>;
   resetFiltersLabel?: Streamable<string>;
+  reviewsEnabled?: boolean;
   rangeFilterApplyLabel?: Streamable<string>;
   sortLabel?: Streamable<string | null>;
   sortPlaceholder?: Streamable<string | null>;
@@ -49,6 +50,7 @@ export function ProductsListSection({
   title = 'Products',
   totalCount,
   products,
+  reviewsEnabled,
   compareProducts,
   sortOptions: streamableSortOptions,
   sortDefaultValue,
@@ -171,6 +173,7 @@ export function ProductsListSection({
               placeholderCount={placeholderCount}
               products={products}
               removeLabel={removeLabel}
+              reviewsEnabled={reviewsEnabled}
               showCompare={showCompare}
             />
 


### PR DESCRIPTION
## What/Why?

This PR conditionally enables storefront reviews functionality based on the `site.settings.reviews.enabled` GraphQL setting. The behavior matches Stencil + Cornerstone: when reviews are disabled, rating displays on PDP and PLP, submissions on PDP, and the reviews section on PDP are hidden.

- Added `reviews.enabled` queries to product, search, category, and brand page data fetchers
- Introduced `reviewsEnabled` prop throughout the product display component hierarchy:
  - `ProductCard` - conditionally renders rating display
  - `ProductDetail` - conditionally renders rating display
  - `ProductList` and `ProductsListSection` - pass `reviewsEnabled` to child `ProductCard` components
- Product detail page conditionally renders the `Reviews` component based on the setting
- All pages that display products (search, category, brand, product detail) fetch and propagate the `reviewsEnabled` flag

The implementation defaults to `false` when the setting is unavailable, ensuring backward compatibility and graceful degradation.

## Testing

1. **With Reviews Enabled:**
   - Navigate to a product detail page - verify rating displays in product header and reviews section is visible
   - Navigate to search/category/brand pages - verify product cards show ratings when available
   - Verify ratings only display when `rating > 0`

2. **With Reviews Disabled:**
   - Disable reviews in BigCommerce admin settings
   - Navigate to product detail page - verify no rating in header and no reviews section
   - Navigate to search/category/brand pages - verify product cards do not show ratings
   - Verify no GraphQL errors occur

3. **Edge Cases:**
   - Test with products that have no reviews (rating = 0 or null) - should not display rating even when reviews are enabled
   - Test with products that have reviews - should display rating when reviews are enabled

When reviews are disabled:
<img width="1510" height="946" alt="reviews-disabled-plp" src="https://github.com/user-attachments/assets/c2a12b08-8443-4065-b64d-dba65289f7a2" />
<img width="1510" height="946" alt="reviews-disabled-pdp-summary" src="https://github.com/user-attachments/assets/562b4645-7e1e-4b62-9092-46262145c215" />
<img width="1510" height="946" alt="reviews-disabled-pdp-details" src="https://github.com/user-attachments/assets/0b08cae2-050a-4aef-a1a8-e02c22919233" />

When reviews are enabled:
<img width="1510" height="946" alt="reviews-enabled-plp" src="https://github.com/user-attachments/assets/a71c0adc-7cd3-42c0-8a35-676022ceafac" />
<img width="1510" height="946" alt="reviews-enabled-pdp-details" src="https://github.com/user-attachments/assets/12d0fb7d-3ced-47fe-99e8-a958a35690d6" />
<img width="1510" height="946" alt="reviews-enabled-pdp-details" src="https://github.com/user-attachments/assets/bad9d796-e30e-4768-bba6-93573ebeb556" />

## Migration

**For developers with customized Catalyst forks:**

1. **GraphQL Queries:** If you've customized any of the following page data files, you'll need to add the `reviews.enabled` query:
   - `core/app/[locale]/(default)/product/[slug]/page-data.ts` - Add `reviews { enabled }` to `ProductQuery`
   - `core/app/[locale]/(default)/(faceted)/search/page-data.ts` - Already includes the query
   - `core/app/[locale]/(default)/(faceted)/category/[slug]/page-data.ts` - Already includes the query
   - `core/app/[locale]/(default)/(faceted)/brand/[slug]/page-data.ts` - Already includes the query

2. **Component Props:** If you've customized any of these components, you may need to add the `reviewsEnabled` prop:
   - `core/vibes/soul/primitives/product-card/index.tsx` - Optional prop, defaults to `false`
   - `core/vibes/soul/sections/product-detail/index.tsx` - Optional prop on product object
   - `core/vibes/soul/sections/product-list/index.tsx` - Optional prop, defaults to `undefined`
   - `core/vibes/soul/sections/products-list-section/index.tsx` - Optional prop, defaults to `undefined`

3. **Conditional Rendering:** If you've customized the product detail page (`core/app/[locale]/(default)/product/[slug]/page.tsx`), ensure the `Reviews` component is conditionally rendered:
   ```tsx
   {reviewsEnabled && (
     <Reviews ... />
   )}
   ```

4. **No Breaking Changes:** All `reviewsEnabled` props are optional with safe defaults, so existing customizations will continue to work (reviews will simply not display until the prop is added).

---

Note: This pull request description was generated with the assistance of AI.