### PR TITLE
feat(reviews): conditionally display reviews based on display settings

### DIFF
--- a/.changeset/cute-trees-swim.md
+++ b/.changeset/cute-trees-swim.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Conditionally display product ratings in the storefront based on `site.settings.display.showProductRating`. The storefront logic when this setting is enabled/disabled matches exactly the logic of Stencil + Cornerstone.

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page-data.ts
@@ -26,6 +26,9 @@ const BrandPageQuery = graphql(`
             productComparisonsEnabled
           }
         }
+        display {
+          showProductRating
+        }
         reviews {
           enabled
         }

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
@@ -103,7 +103,7 @@ export default async function Brand(props: Props) {
     return notFound();
   }
 
-  const reviewsEnabled = settings?.reviews.enabled ?? false;
+  const showRating = Boolean(settings?.reviews.enabled && settings.display.showProductRating);
 
   const productComparisonsEnabled =
     settings?.storefront.catalog?.productComparisonsEnabled ?? false;
@@ -221,8 +221,8 @@ export default async function Brand(props: Props) {
       rangeFilterApplyLabel={t('FacetedSearch.Range.apply')}
       removeLabel={t('Compare.remove')}
       resetFiltersLabel={t('FacetedSearch.resetFilters')}
-      reviewsEnabled={reviewsEnabled}
       showCompare={productComparisonsEnabled}
+      showRating={showRating}
       sortDefaultValue="featured"
       sortLabel={t('Search.title')}
       sortOptions={[

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page-data.ts
@@ -45,6 +45,9 @@ const CategoryPageQuery = graphql(
               productComparisonsEnabled
             }
           }
+          display {
+            showProductRating
+          }
           reviews {
             enabled
           }

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -113,7 +113,7 @@ export default async function Category(props: Props) {
     href: path ?? '#',
   }));
 
-  const reviewsEnabled = settings?.reviews.enabled ?? false;
+  const showRating = Boolean(settings?.reviews.enabled && settings.display.showProductRating);
 
   const productComparisonsEnabled =
     settings?.storefront.catalog?.productComparisonsEnabled ?? false;
@@ -257,8 +257,8 @@ export default async function Category(props: Props) {
         rangeFilterApplyLabel={t('FacetedSearch.Range.apply')}
         removeLabel={t('Compare.remove')}
         resetFiltersLabel={t('FacetedSearch.resetFilters')}
-        reviewsEnabled={reviewsEnabled}
         showCompare={productComparisonsEnabled}
+        showRating={showRating}
         sortDefaultValue="featured"
         sortLabel={t('SortBy.sortBy')}
         sortOptions={[

--- a/core/app/[locale]/(default)/(faceted)/search/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/search/page-data.ts
@@ -18,6 +18,9 @@ const SearchPageQuery = graphql(`
             productComparisonsEnabled
           }
         }
+        display {
+          showProductRating
+        }
         reviews {
           enabled
         }

--- a/core/app/[locale]/(default)/(faceted)/search/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/search/page.tsx
@@ -78,7 +78,7 @@ export default async function Search(props: Props) {
 
   const { settings } = await getSearchPageData();
 
-  const reviewsEnabled = settings?.reviews.enabled ?? false;
+  const showRating = Boolean(settings?.reviews.enabled && settings.display.showProductRating);
 
   const productComparisonsEnabled =
     settings?.storefront.catalog?.productComparisonsEnabled ?? false;
@@ -253,8 +253,8 @@ export default async function Search(props: Props) {
       rangeFilterApplyLabel={t('FacetedSearch.Range.apply')}
       removeLabel={t('Compare.remove')}
       resetFiltersLabel={t('FacetedSearch.resetFilters')}
-      reviewsEnabled={reviewsEnabled}
       showCompare={productComparisonsEnabled}
+      showRating={showRating}
       sortDefaultValue="featured"
       sortLabel={t('SortBy.sortBy')}
       sortOptions={[

--- a/core/app/[locale]/(default)/product/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/product/[slug]/page-data.ts
@@ -175,6 +175,9 @@ const ProductQuery = graphql(
           reviews {
             enabled
           }
+          display {
+            showProductRating
+          }
         }
         product(entityId: $entityId) {
           entityId

--- a/core/vibes/soul/primitives/product-card/index.tsx
+++ b/core/vibes/soul/primitives/product-card/index.tsx
@@ -32,7 +32,7 @@ export interface ProductCardProps {
   compareLabel?: string;
   compareParamName?: string;
   product: Product;
-  reviewsEnabled?: boolean;
+  showRating?: boolean;
 }
 
 // eslint-disable-next-line valid-jsdoc
@@ -59,7 +59,7 @@ export interface ProductCardProps {
  */
 export function ProductCard({
   product: { id, title, subtitle, badge, price, image, href, inventoryMessage, rating },
-  reviewsEnabled = false,
+  showRating = false,
   colorScheme = 'light',
   className,
   showCompare = false,
@@ -153,9 +153,7 @@ export function ProductCard({
               </span>
             )}
             {price != null && <PriceLabel colorScheme={colorScheme} price={price} />}
-            {reviewsEnabled && typeof rating === 'number' && rating > 0 && (
-              <Rating rating={rating} />
-            )}
+            {showRating && typeof rating === 'number' && rating > 0 && <Rating rating={rating} />}
             <span
               className={clsx(
                 'block text-sm font-normal',

--- a/core/vibes/soul/sections/product-detail/index.tsx
+++ b/core/vibes/soul/sections/product-detail/index.tsx
@@ -2,11 +2,13 @@ import { ReactNode } from 'react';
 
 import { Stream, Streamable } from '@/vibes/soul/lib/streamable';
 import { Accordion, AccordionItem } from '@/vibes/soul/primitives/accordion';
+import { AnimatedUnderline } from '@/vibes/soul/primitives/animated-underline';
 import { Price, PriceLabel } from '@/vibes/soul/primitives/price-label';
 import { Rating } from '@/vibes/soul/primitives/rating';
 import * as Skeleton from '@/vibes/soul/primitives/skeleton';
 import { type Breadcrumb, Breadcrumbs } from '@/vibes/soul/sections/breadcrumbs';
 import { ProductGallery } from '@/vibes/soul/sections/product-detail/product-gallery';
+import { ReviewForm, SubmitReviewAction } from '@/vibes/soul/sections/reviews/review-form';
 
 import {
   BackorderDisplayData,
@@ -26,6 +28,7 @@ interface ProductDetailProduct {
   badge?: string;
   rating?: Streamable<number | null>;
   reviewsEnabled?: boolean;
+  showRating?: boolean;
   summary?: Streamable<string>;
   description?: Streamable<string | ReactNode | null>;
   accordions?: Streamable<
@@ -55,6 +58,15 @@ export interface ProductDetailProps<F extends Field> {
   thumbnailLabel?: string;
   additionalInformationTitle?: string;
   additionalActions?: ReactNode;
+  reviewFormEmailLabel?: string;
+  reviewFormModalTitle?: string;
+  reviewFormNameLabel?: string;
+  reviewFormRatingLabel?: string;
+  reviewFormReviewLabel?: string;
+  reviewFormSubmitLabel?: string;
+  reviewFormTitleLabel?: string;
+  reviewFormAction: SubmitReviewAction;
+  user: Streamable<{ email: string; name: string }>;
 }
 
 // eslint-disable-next-line valid-jsdoc
@@ -87,6 +99,15 @@ export function ProductDetail<F extends Field>({
   thumbnailLabel,
   additionalInformationTitle = 'Additional information',
   additionalActions,
+  reviewFormEmailLabel,
+  reviewFormModalTitle,
+  reviewFormNameLabel,
+  reviewFormRatingLabel,
+  reviewFormReviewLabel,
+  reviewFormSubmitLabel,
+  reviewFormTitleLabel,
+  reviewFormAction,
+  user,
 }: ProductDetailProps<F>) {
   return (
     <section className="@container">
@@ -116,6 +137,29 @@ export function ProductDetail<F extends Field>({
                     {product.title}
                   </h1>
                   {product.reviewsEnabled && (
+                    <div className="group/product-rating">
+                      <ReviewForm
+                        action={reviewFormAction}
+                        formEmailLabel={reviewFormEmailLabel}
+                        formModalTitle={reviewFormModalTitle}
+                        formNameLabel={reviewFormNameLabel}
+                        formRatingLabel={reviewFormRatingLabel}
+                        formReviewLabel={reviewFormReviewLabel}
+                        formSubmitLabel={reviewFormSubmitLabel}
+                        formTitleLabel={reviewFormTitleLabel}
+                        productId={Number(product.id)}
+                        streamableImages={product.images}
+                        streamableProduct={{ name: product.title }}
+                        streamableUser={user}
+                        trigger={
+                          <AnimatedUnderline className="cursor-pointer">
+                            Write a review
+                          </AnimatedUnderline>
+                        }
+                      />
+                    </div>
+                  )}
+                  {product.showRating && (
                     <div className="group/product-rating">
                       <Stream fallback={<RatingSkeleton />} value={product.rating}>
                         {(rating) => <Rating rating={rating ?? 0} />}

--- a/core/vibes/soul/sections/product-list/index.tsx
+++ b/core/vibes/soul/sections/product-list/index.tsx
@@ -11,7 +11,7 @@ import * as Skeleton from '@/vibes/soul/primitives/skeleton';
 
 interface ProductListProps {
   products: Streamable<Product[]>;
-  reviewsEnabled?: boolean;
+  showRating?: boolean;
   compareProducts?: Streamable<Product[]>;
   className?: string;
   colorScheme?: 'light' | 'dark';
@@ -46,7 +46,7 @@ interface ProductListProps {
  */
 export function ProductList({
   products: streamableProducts,
-  reviewsEnabled,
+  showRating,
   className,
   colorScheme = 'light',
   aspectRatio = '5:6',
@@ -109,8 +109,8 @@ export function ProductList({
                     imageSizes="(min-width: 80rem) 20vw, (min-width: 64rem) 25vw, (min-width: 42rem) 33vw, (min-width: 24rem) 50vw, 100vw"
                     key={product.id}
                     product={product}
-                    reviewsEnabled={reviewsEnabled}
                     showCompare={showCompare}
+                    showRating={showRating}
                   />
                 ))}
               </div>

--- a/core/vibes/soul/sections/products-list-section/index.tsx
+++ b/core/vibes/soul/sections/products-list-section/index.tsx
@@ -30,7 +30,7 @@ interface Props {
   filterLabel?: string;
   filtersPanelTitle?: Streamable<string>;
   resetFiltersLabel?: Streamable<string>;
-  reviewsEnabled?: boolean;
+  showRating?: boolean;
   rangeFilterApplyLabel?: Streamable<string>;
   sortLabel?: Streamable<string | null>;
   sortPlaceholder?: Streamable<string | null>;
@@ -50,7 +50,7 @@ export function ProductsListSection({
   title = 'Products',
   totalCount,
   products,
-  reviewsEnabled,
+  showRating,
   compareProducts,
   sortOptions: streamableSortOptions,
   sortDefaultValue,
@@ -173,8 +173,8 @@ export function ProductsListSection({
               placeholderCount={placeholderCount}
               products={products}
               removeLabel={removeLabel}
-              reviewsEnabled={reviewsEnabled}
               showCompare={showCompare}
+              showRating={showRating}
             />
 
             {paginationInfo && <CursorPagination info={paginationInfo} />}


### PR DESCRIPTION
> [!WARNING]
> Depends on #2752 and #2753

## What/Why?
Conditionally display product ratings based on `site.settings.display.showProductRating`. Ratings only show when both `reviews.enabled` and `display.showProductRating` are true, matching Stencil + Cornerstone behavior.

Updates brand, category, search, and product pages to query and respect the display setting. Product detail page separates review form visibility (`reviewsEnabled`) from rating display (`showRating`).

## Testing
- Verify ratings appear on product cards when `showProductRating` is enabled
- Verify ratings are hidden when `showProductRating` is disabled
- Verify review form remains functional regardless of rating display setting
- Test across brand, category, search, and product detail pages

https://github.com/user-attachments/assets/873d2b05-0eab-429b-9f33-50ec02c5a878


https://github.com/user-attachments/assets/4cec968f-da88-4c53-b78d-e724b327ba05


https://github.com/user-attachments/assets/bc0955f8-6d39-44dc-8547-37bc13165a90

## Migration
No migration needed. This adds a new GraphQL field (`display.showProductRating`) and conditional logic. Existing behavior unchanged if setting not configured.

Note: This pull request description was generated with the assistance of AI.