### PR TITLE
fix(reviews): default button label for review form

### DIFF
--- a/.changeset/common-queens-smoke.md
+++ b/.changeset/common-queens-smoke.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Passes `formButtonLabel` from `Reviews` to `ReviewsEmptyState` (was missing) and sets a default value for `formButtonLabel`

--- a/core/vibes/soul/sections/reviews/index.tsx
+++ b/core/vibes/soul/sections/reviews/index.tsx
@@ -49,7 +49,7 @@ export function Reviews({
   emptyStateMessage,
   reviewsLabel = 'Reviews',
   action,
-  formButtonLabel,
+  formButtonLabel = 'Write a review',
   formModalTitle,
   formSubmitLabel,
   formRatingLabel,
@@ -68,6 +68,7 @@ export function Reviews({
           return (
             <ReviewsEmptyState
               action={action}
+              formButtonLabel={formButtonLabel}
               formEmailLabel={formEmailLabel}
               formModalTitle={formModalTitle}
               formNameLabel={formNameLabel}
@@ -182,7 +183,7 @@ export function ReviewsEmptyState({
   reviewsLabel = 'Reviews',
   productId,
   action,
-  formButtonLabel,
+  formButtonLabel = 'Write a review',
   formModalTitle,
   formSubmitLabel,
   formRatingLabel,


### PR DESCRIPTION
## What/Why?

Adds a default value for the `formButtonLabel` prop in the reviews section components to prevent missing button labels.

**Changes:**
- Sets default `formButtonLabel` to `'Write a review'` in both `Reviews` and `ReviewsEmptyState`
- Passes `formButtonLabel` from `Reviews` to `ReviewsEmptyState` (was missing)

This ensures the review form button always displays a label, even when `formButtonLabel` isn't provided.

## Testing

#### Before
<img width="1490" height="801" alt="catalyst-1636-before" src="https://github.com/user-attachments/assets/ad60de74-7c65-4607-b53d-27e34ee70871" />

#### After
<img width="1488" height="798" alt="catalyst-1636-after" src="https://github.com/user-attachments/assets/a38699e7-2c37-46bf-9563-1b54a585eae0" />

## Migration

If you've customized the `Reviews` or `ReviewsEmptyState` components in `core/vibes/soul/sections/reviews/index.tsx`:

- **No action required** if you already pass `formButtonLabel` explicitly — your custom label will continue to work.
- If you weren't passing `formButtonLabel` and want a different default, pass `formButtonLabel` explicitly with your preferred text.
- The default is `'Write a review'`. If you want a different default, override it in your implementation.

Note: This pull request description was generated with the assistance of AI.