### PR TITLE
chore: set runtime to nodejs in middleware configuration

### DIFF
--- a/core/middleware.ts
+++ b/core/middleware.ts
@@ -29,4 +29,5 @@ export const config = {
      */
     '/((?!api|admin|_next/static|_next/image|_vercel|favicon.ico|xmlsitemap.php|sitemap.xml|robots.txt).*)',
   ],
+  runtime: 'nodejs',
 };


### PR DESCRIPTION
## What/Why?
Now that Catalyst is on Node.js 24, we can switch the middleware to node.js middleware. We needed `URLPattern()` in place which Node 24 unlocks.

Given that Node.js middleware will be the default environment in Next 16, this is a good incremental step to adjust to that runtime in advance of more significant changes in Next 16.

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->

## Migration
<!---
  If you have moved any files around, or made any breaking changes,
  please provide a migration guide for the developers to make rebases easier.
--->
