### PR TITLE
fix(core): allow optional text fields in dynamic form

### DIFF
--- a/.changeset/pink-zoos-attend.md
+++ b/.changeset/pink-zoos-attend.md
@@ -1,0 +1,24 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Add missing check for optional text field in `core/vibes/soul/form/dynamic-form/schema.ts`.
+
+## Migration
+
+Add `if (field.required !== true) fieldSchema = fieldSchema.optional();` to `text` case in `core/vibes/soul/form/dynamic-form/schema.ts`:
+
+```typescript
+case 'text':
+    fieldSchema = z.string();
+
+    if (field.pattern != null) {
+    fieldSchema = fieldSchema.regex(new RegExp(field.pattern), {
+        message: 'Invalid format.',
+    });
+    }
+
+    if (field.required !== true) fieldSchema = fieldSchema.optional();
+
+    break;
+```

--- a/core/vibes/soul/form/dynamic-form/schema.ts
+++ b/core/vibes/soul/form/dynamic-form/schema.ts
@@ -179,6 +179,8 @@ function getFieldSchema(field: Field) {
         });
       }
 
+      if (field.required !== true) fieldSchema = fieldSchema.optional();
+
       break;
 
     case 'password':


### PR DESCRIPTION
## What/Why?
Add missing check for optional text field in `core/vibes/soul/form/dynamic-form/schema.ts`.

Closes #2781 

## Testing
Before
<img width="3972" height="4940" alt="screencapture-localhost-3000-register-2025-12-15-11_47_08" src="https://github.com/user-attachments/assets/e24d4774-9915-4cb0-b1ec-0baa5d619f17" />

After
<img width="3972" height="4766" alt="screencapture-localhost-3000-register-2025-12-15-11_46_38" src="https://github.com/user-attachments/assets/15858af6-6e7c-47cf-9f94-77f2258f1c0f" />


## Migration

Add `if (field.required !== true) fieldSchema = fieldSchema.optional();` to `text` case in `core/vibes/soul/form/dynamic-form/schema.ts`:

```typescript
case 'text':
    fieldSchema = z.string();

    if (field.pattern != null) {
    fieldSchema = fieldSchema.regex(new RegExp(field.pattern), {
        message: 'Invalid format.',
    });
    }

    if (field.required !== true) fieldSchema = fieldSchema.optional();

    break;
```