### PR TITLE
feat(core): add toggle for newsletter in account settings

### DIFF
--- a/.changeset/hot-plums-give.md
+++ b/.changeset/hot-plums-give.md
@@ -1,5 +1,5 @@
 ---
-"@bigcommerce/catalyst-core": patch
+"@bigcommerce/catalyst-core": minor 
 ---
 
 Make newsletter signup component on homepage render conditionally based on BigCommerce settings.

--- a/.changeset/tall-walls-tan.md
+++ b/.changeset/tall-walls-tan.md
@@ -1,5 +1,5 @@
 ---
-"@bigcommerce/catalyst-core": patch
+"@bigcommerce/catalyst-core": minor 
 ---
 
 Implement functional newsletter subscription feature with BigCommerce GraphQL API integration.

--- a/.changeset/tall-walls-tan.md
+++ b/.changeset/tall-walls-tan.md
@@ -73,7 +73,7 @@ Add the following translation keys to your locale files (e.g., `messages/en.json
       "title": "Sign up for our newsletter",
       "placeholder": "Enter your email",
       "description": "Stay up to date with the latest news and offers from our store.",
-      "subscribedToNewsletter": "You have been subscribed to our newsletter.",
+      "subscribedToNewsletter": "You have been subscribed to our newsletter!",
       "Errors": {
         "invalidEmail": "Please enter a valid email address.",
         "somethingWentWrong": "Something went wrong. Please try again later."

--- a/.changeset/violet-adults-do.md
+++ b/.changeset/violet-adults-do.md
@@ -1,0 +1,181 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Add newsletter subscription toggle to account settings page, allowing customers to manage their marketing preferences directly from their account.
+
+## What Changed
+
+- Added `NewsletterSubscriptionForm` component with a toggle switch for subscribing/unsubscribing to newsletters
+- Created `updateNewsletterSubscription` server action that handles both subscribe and unsubscribe operations via BigCommerce GraphQL API
+- Updated `AccountSettingsSection` to conditionally display the newsletter subscription form when enabled
+- Enhanced `CustomerSettingsQuery` to fetch `isSubscribedToNewsletter` status and `showNewsletterSignup` store setting
+- Updated account settings page to pass newsletter subscription props and bind customer info to the action
+- Added translation keys for newsletter subscription UI in `Account.Settings.NewsletterSubscription` namespace
+- Added E2E tests for subscribing and unsubscribing functionality
+
+## Migration Guide
+
+To add the newsletter subscription toggle to your account settings page:
+
+### Step 1: Copy the server action
+
+Copy the new server action file to your account settings directory:
+
+```bash
+cp core/app/[locale]/(default)/account/settings/_actions/update-newsletter-subscription.ts \
+   your-app/app/[locale]/(default)/account/settings/_actions/update-newsletter-subscription.ts
+```
+
+### Step 2: Update the GraphQL query
+
+Update `core/app/[locale]/(default)/account/settings/page-data.tsx` to include newsletter subscription fields:
+
+```tsx
+// Renamed CustomerSettingsQuery to AccountSettingsQuery
+const AccountSettingsQuery = graphql(`
+  query AccountSettingsQuery(...) {
+    customer {
+      ...
+      isSubscribedToNewsletter  # Add this field
+    }
+    site {
+      settings {
+        ...
+        newsletter {            # Add this section
+          showNewsletterSignup
+        }
+      }
+    }
+  }
+`);
+```
+
+Also update the return statement to include `newsletterSettings`:
+
+```tsx
+const newsletterSettings = response.data.site.settings?.newsletter;
+
+return {
+  ...
+  newsletterSettings,  // Add this
+};
+```
+
+### Step 3: Copy the NewsletterSubscriptionForm component
+
+Copy the new form component:
+
+```bash
+cp core/vibes/soul/sections/account-settings/newsletter-subscription-form.tsx \
+   your-app/vibes/soul/sections/account-settings/newsletter-subscription-form.tsx
+```
+
+### Step 4: Update AccountSettingsSection
+
+Update `core/vibes/soul/sections/account-settings/index.tsx`:
+
+1. Import the new component:
+```tsx
+import {
+  NewsletterSubscriptionForm,
+  UpdateNewsletterSubscriptionAction,
+} from './newsletter-subscription-form';
+```
+
+2. Add props to the interface:
+```tsx
+export interface AccountSettingsSectionProps {
+  ...
+  newsletterSubscriptionEnabled?: boolean;
+  isAccountSubscribed?: boolean;
+  newsletterSubscriptionTitle?: string;
+  newsletterSubscriptionLabel?: string;
+  newsletterSubscriptionCtaLabel?: string;
+  updateNewsletterSubscriptionAction?: UpdateNewsletterSubscriptionAction;
+}
+```
+
+3. Add the form section in the component (after the change password form):
+```tsx
+{newsletterSubscriptionEnabled && updateNewsletterSubscriptionAction && (
+  <div className="border-t border-[var(--account-settings-section-border,hsl(var(--contrast-100)))] pt-12">
+    <h1 className="mb-10 font-[family-name:var(--account-settings-section-font-family,var(--font-family-heading))] text-2xl font-medium leading-none text-[var(--account-settings-section-text,var(--foreground))] @xl:text-2xl">
+      {newsletterSubscriptionTitle}
+    </h1>
+    <NewsletterSubscriptionForm
+      action={updateNewsletterSubscriptionAction}
+      ctaLabel={newsletterSubscriptionCtaLabel}
+      isAccountSubscribed={isAccountSubscribed}
+      label={newsletterSubscriptionLabel}
+    />
+  </div>
+)}
+```
+
+### Step 5: Update the account settings page
+
+Update `core/app/[locale]/(default)/account/settings/page.tsx`:
+
+1. Import the action:
+```tsx
+import { updateNewsletterSubscription } from './_actions/update-newsletter-subscription';
+```
+
+2. Extract newsletter settings from the query:
+```tsx
+const newsletterSubscriptionEnabled = accountSettings.storeSettings?.showNewsletterSignup;
+const isAccountSubscribed = accountSettings.customerInfo.isSubscribedToNewsletter;
+```
+
+3. Bind customer info to the action:
+```tsx
+const updateNewsletterSubscriptionActionWithCustomerInfo = updateNewsletterSubscription.bind(
+  null,
+  {
+    customerInfo: accountSettings.customerInfo,
+  },
+);
+```
+
+4. Pass props to `AccountSettingsSection`:
+```tsx
+<AccountSettingsSection
+  ...
+  isAccountSubscribed={isAccountSubscribed}
+  newsletterSubscriptionCtaLabel={t('cta')}
+  newsletterSubscriptionEnabled={newsletterSubscriptionEnabled}
+  newsletterSubscriptionLabel={t('NewsletterSubscription.label')}
+  newsletterSubscriptionTitle={t('NewsletterSubscription.title')}
+  updateNewsletterSubscriptionAction={updateNewsletterSubscriptionActionWithCustomerInfo}
+/>
+```
+
+### Step 6: Add translation keys
+
+Add the following keys to your locale files (e.g., `messages/en.json`):
+
+```json
+{
+  "Account": {
+    "Settings": {
+      ...
+      "NewsletterSubscription": {
+        "title": "Marketing preferences",
+        "label": "Opt-in to receive emails about new products and promotions.",
+        "marketingPreferencesUpdated": "Marketing preferences have been updated successfully!",
+        "somethingWentWrong": "Something went wrong. Please try again later."
+      }
+    }
+  }
+}
+```
+
+### Step 7: Verify the feature
+
+1. Ensure your BigCommerce store has newsletter signup enabled in store settings
+2. Navigate to `/account/settings` as a logged-in customer
+3. Verify the newsletter subscription toggle appears below the change password form
+4. Test subscribing and unsubscribing functionality
+
+The newsletter subscription form will only display if `newsletterSubscriptionEnabled` is `true` (controlled by the `showNewsletterSignup` store setting).

--- a/core/app/[locale]/(default)/account/settings/_actions/update-newsletter-subscription.ts
+++ b/core/app/[locale]/(default)/account/settings/_actions/update-newsletter-subscription.ts
@@ -1,0 +1,151 @@
+'use server';
+
+import { BigCommerceGQLError } from '@bigcommerce/catalyst-client';
+import { SubmissionResult } from '@conform-to/react';
+import { parseWithZod } from '@conform-to/zod';
+import { unstable_expireTag } from 'next/cache';
+import { getTranslations } from 'next-intl/server';
+import { z } from 'zod';
+
+import { client } from '~/client';
+import { graphql } from '~/client/graphql';
+import { TAGS } from '~/client/tags';
+
+const updateNewsletterSubscriptionSchema = z.object({
+  intent: z.enum(['subscribe', 'unsubscribe']),
+});
+
+const SubscribeToNewsletterMutation = graphql(`
+  mutation SubscribeToNewsletterMutation($input: CreateSubscriberInput!) {
+    newsletter {
+      subscribe(input: $input) {
+        errors {
+          __typename
+          ... on CreateSubscriberAlreadyExistsError {
+            message
+          }
+          ... on CreateSubscriberEmailInvalidError {
+            message
+          }
+          ... on CreateSubscriberUnexpectedError {
+            message
+          }
+          ... on CreateSubscriberLastNameInvalidError {
+            message
+          }
+          ... on CreateSubscriberFirstNameInvalidError {
+            message
+          }
+        }
+      }
+    }
+  }
+`);
+
+const UnsubscribeFromNewsletterMutation = graphql(`
+  mutation UnsubscribeFromNewsletterMutation($input: RemoveSubscriberInput!) {
+    newsletter {
+      unsubscribe(input: $input) {
+        errors {
+          __typename
+          ... on RemoveSubscriberEmailInvalidError {
+            message
+          }
+          ... on RemoveSubscriberUnexpectedError {
+            message
+          }
+        }
+      }
+    }
+  }
+`);
+
+export const updateNewsletterSubscription = async (
+  {
+    customerInfo,
+  }: {
+    customerInfo: {
+      email: string;
+      firstName: string;
+      lastName: string;
+    };
+  },
+  _prevState: { lastResult: SubmissionResult | null },
+  formData: FormData,
+) => {
+  const t = await getTranslations('Account.Settings.NewsletterSubscription');
+
+  const submission = parseWithZod(formData, { schema: updateNewsletterSubscriptionSchema });
+
+  if (submission.status !== 'success') {
+    return { lastResult: submission.reply() };
+  }
+
+  try {
+    let errors;
+
+    if (submission.value.intent === 'subscribe') {
+      const response = await client.fetch({
+        document: SubscribeToNewsletterMutation,
+        variables: {
+          input: {
+            email: customerInfo.email,
+            firstName: customerInfo.firstName,
+            lastName: customerInfo.lastName,
+          },
+        },
+      });
+
+      errors = response.data.newsletter.subscribe.errors;
+    } else {
+      const response = await client.fetch({
+        document: UnsubscribeFromNewsletterMutation,
+        variables: {
+          input: {
+            email: customerInfo.email,
+          },
+        },
+      });
+
+      errors = response.data.newsletter.unsubscribe.errors;
+    }
+
+    if (errors.length > 0) {
+      // Not handling returned errors from API since we will display a generic error message to the user
+      // Still returning the errors to the client for debugging purposes
+      return {
+        lastResult: submission.reply({
+          formErrors: errors.map(({ message }) => message),
+        }),
+      };
+    }
+
+    unstable_expireTag(TAGS.customer);
+
+    return {
+      lastResult: submission.reply(),
+      successMessage: t('marketingPreferencesUpdated'),
+    };
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(error);
+
+    if (error instanceof BigCommerceGQLError) {
+      return {
+        lastResult: submission.reply({
+          formErrors: error.errors.map(({ message }) => message),
+        }),
+      };
+    }
+
+    if (error instanceof Error) {
+      return {
+        lastResult: submission.reply({ formErrors: [error.message] }),
+      };
+    }
+
+    return {
+      lastResult: submission.reply({ formErrors: [String(error)] }),
+    };
+  }
+};

--- a/core/app/[locale]/(default)/account/settings/page-data.tsx
+++ b/core/app/[locale]/(default)/account/settings/page-data.tsx
@@ -6,9 +6,9 @@ import { graphql, VariablesOf } from '~/client/graphql';
 import { TAGS } from '~/client/tags';
 import { FormFieldsFragment } from '~/data-transformers/form-field-transformer/fragment';
 
-const CustomerSettingsQuery = graphql(
+const AccountSettingsQuery = graphql(
   `
-    query CustomerSettingsQuery(
+    query AccountSettingsQuery(
       $customerFilters: FormFieldFiltersInput
       $customerSortBy: FormFieldSortInput
       $addressFilters: FormFieldFiltersInput
@@ -20,6 +20,7 @@ const CustomerSettingsQuery = graphql(
         firstName
         lastName
         company
+        isSubscribedToNewsletter
       }
       site {
         settings {
@@ -31,6 +32,9 @@ const CustomerSettingsQuery = graphql(
               ...FormFieldsFragment
             }
           }
+          newsletter {
+            showNewsletterSignup
+          }
         }
       }
     }
@@ -38,7 +42,7 @@ const CustomerSettingsQuery = graphql(
   [FormFieldsFragment],
 );
 
-type Variables = VariablesOf<typeof CustomerSettingsQuery>;
+type Variables = VariablesOf<typeof AccountSettingsQuery>;
 
 interface Props {
   address?: {
@@ -52,11 +56,11 @@ interface Props {
   };
 }
 
-export const getCustomerSettingsQuery = cache(async ({ address, customer }: Props = {}) => {
+export const getAccountSettingsQuery = cache(async ({ address, customer }: Props = {}) => {
   const customerAccessToken = await getSessionCustomerAccessToken();
 
   const response = await client.fetch({
-    document: CustomerSettingsQuery,
+    document: AccountSettingsQuery,
     variables: {
       addressFilters: address?.filters,
       addressSortBy: address?.sortBy,
@@ -70,6 +74,7 @@ export const getCustomerSettingsQuery = cache(async ({ address, customer }: Prop
   const addressFields = response.data.site.settings?.formFields.shippingAddress;
   const customerFields = response.data.site.settings?.formFields.customer;
   const customerInfo = response.data.customer;
+  const newsletterSettings = response.data.site.settings?.newsletter;
 
   if (!addressFields || !customerFields || !customerInfo) {
     return null;
@@ -79,5 +84,6 @@ export const getCustomerSettingsQuery = cache(async ({ address, customer }: Prop
     addressFields,
     customerFields,
     customerInfo,
+    newsletterSettings,
   };
 });

--- a/core/app/[locale]/(default)/account/settings/page.tsx
+++ b/core/app/[locale]/(default)/account/settings/page.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-no-bind */
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
@@ -6,7 +7,8 @@ import { AccountSettingsSection } from '@/vibes/soul/sections/account-settings';
 
 import { changePassword } from './_actions/change-password';
 import { updateCustomer } from './_actions/update-customer';
-import { getCustomerSettingsQuery } from './page-data';
+import { updateNewsletterSubscription } from './_actions/update-newsletter-subscription';
+import { getAccountSettingsQuery } from './page-data';
 
 interface Props {
   params: Promise<{ locale: string }>;
@@ -29,24 +31,40 @@ export default async function Settings({ params }: Props) {
 
   const t = await getTranslations('Account.Settings');
 
-  const customerSettings = await getCustomerSettingsQuery();
+  const accountSettings = await getAccountSettingsQuery();
 
-  if (!customerSettings) {
+  if (!accountSettings) {
     notFound();
   }
 
+  const newsletterSubscriptionEnabled = accountSettings.newsletterSettings?.showNewsletterSignup;
+  const isAccountSubscribed = accountSettings.customerInfo.isSubscribedToNewsletter;
+
+  const updateNewsletterSubscriptionActionWithCustomerInfo = updateNewsletterSubscription.bind(
+    null,
+    {
+      customerInfo: accountSettings.customerInfo,
+    },
+  );
+
   return (
     <AccountSettingsSection
-      account={customerSettings.customerInfo}
+      account={accountSettings.customerInfo}
       changePasswordAction={changePassword}
       changePasswordSubmitLabel={t('cta')}
       changePasswordTitle={t('changePassword')}
       confirmPasswordLabel={t('confirmPassword')}
       currentPasswordLabel={t('currentPassword')}
+      isAccountSubscribed={isAccountSubscribed}
       newPasswordLabel={t('newPassword')}
+      newsletterSubscriptionCtaLabel={t('cta')}
+      newsletterSubscriptionEnabled={newsletterSubscriptionEnabled}
+      newsletterSubscriptionLabel={t('NewsletterSubscription.label')}
+      newsletterSubscriptionTitle={t('NewsletterSubscription.title')}
       title={t('title')}
       updateAccountAction={updateCustomer}
       updateAccountSubmitLabel={t('cta')}
+      updateNewsletterSubscriptionAction={updateNewsletterSubscriptionActionWithCustomerInfo}
     />
   );
 }

--- a/core/components/subscribe/_actions/subscribe.ts
+++ b/core/components/subscribe/_actions/subscribe.ts
@@ -61,9 +61,9 @@ export const subscribe = async (
       ({ __typename }) => __typename === 'CreateSubscriberAlreadyExistsError',
     );
 
-    // If there are no errors or the subscriber already exists, we want to reset the form and show the success message
+    // If subscriber already exists, we want to reset the form and show the success message as if this was the first time they subscribed
     // This is for privacy reasons, we don't want to show the error message to the user if they are already subscribed
-    if (!errors.length || subcriberAlreadyExists) {
+    if (subcriberAlreadyExists) {
       return {
         lastResult: submission.reply(),
         successMessage: t('subscribedToNewsletter'),
@@ -87,7 +87,10 @@ export const subscribe = async (
       };
     }
 
-    return { lastResult: submission.reply({ formErrors: [t('Errors.somethingWentWrong')] }) };
+    return {
+      lastResult: submission.reply(),
+      successMessage: t('subscribedToNewsletter'),
+    };
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error(error);
@@ -104,6 +107,6 @@ export const subscribe = async (
       return { lastResult: submission.reply({ formErrors: [error.message] }) };
     }
 
-    return { lastResult: submission.reply({ formErrors: [t('Errors.somethingWentWrong')] }) };
+    return { lastResult: submission.reply({ formErrors: [String(error)] }) };
   }
 };

--- a/core/components/subscribe/_actions/subscribe.ts
+++ b/core/components/subscribe/_actions/subscribe.ts
@@ -57,13 +57,13 @@ export const subscribe = async (
 
     const errors = response.data.newsletter.subscribe.errors;
 
-    const subcriberAlreadyExists = errors.some(
+    // If subscriber already exists, treat it as success for privacy reasons
+    // We don't want to reveal that the email is already subscribed
+    const subscriberAlreadyExists = errors.some(
       ({ __typename }) => __typename === 'CreateSubscriberAlreadyExistsError',
     );
 
-    // If subscriber already exists, we want to reset the form and show the success message as if this was the first time they subscribed
-    // This is for privacy reasons, we don't want to show the error message to the user if they are already subscribed
-    if (subcriberAlreadyExists) {
+    if (subscriberAlreadyExists) {
       return {
         lastResult: submission.reply(),
         successMessage: t('subscribedToNewsletter'),
@@ -87,6 +87,7 @@ export const subscribe = async (
       };
     }
 
+    // If there are no errors, we want to show the success message to the user
     return {
       lastResult: submission.reply(),
       successMessage: t('subscribedToNewsletter'),

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -198,7 +198,13 @@
       "currentPassword": "Current password",
       "newPassword": "New password",
       "confirmPassword": "Confirm password",
-      "cta": "Update"
+      "cta": "Update",
+      "NewsletterSubscription": {
+        "title": "Marketing preferences",
+        "label": "Opt-in to receive emails about new products and promotions.",
+        "marketingPreferencesUpdated": "Marketing preferences have been updated successfully!",
+        "somethingWentWrong": "Something went wrong. Please try again later."
+      }
     }
   },
   "Wishlist": {

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -510,7 +510,7 @@
       "title": "Sign up for our newsletter",
       "placeholder": "Enter your email",
       "description": "Stay up to date with the latest news and offers from our store.",
-      "subscribedToNewsletter": "You have been subscribed to our newsletter.",
+      "subscribedToNewsletter": "You have been subscribed to our newsletter!",
       "Errors": {
         "invalidEmail": "Please enter a valid email address.",
         "somethingWentWrong": "Something went wrong. Please try again later."

--- a/core/tests/fixtures/subscribe/index.ts
+++ b/core/tests/fixtures/subscribe/index.ts
@@ -7,6 +7,20 @@ export class SubscribeFixture extends Fixture {
     this.subscribedEmails.push(email);
   }
 
+  async subscribe(email: string, firstName: string, lastName: string): Promise<void> {
+    this.skipIfReadonly();
+
+    await this.api.subscribe.subscribe(email, firstName, lastName);
+
+    this.trackSubscription(email);
+  }
+
+  async unsubscribe(email: string): Promise<void> {
+    this.skipIfReadonly();
+
+    await this.api.subscribe.unsubscribe(email);
+  }
+
   async cleanup(): Promise<void> {
     this.skipIfReadonly();
 

--- a/core/tests/fixtures/utils/api/subscribe/http.ts
+++ b/core/tests/fixtures/utils/api/subscribe/http.ts
@@ -3,6 +3,13 @@ import { httpClient } from '../client';
 import { SubscribeApi } from '.';
 
 export const subscribeHttpClient: SubscribeApi = {
+  subscribe: async (email: string, firstName: string, lastName: string) => {
+    await httpClient.post('/v3/customers/subscribers', {
+      email,
+      first_name: firstName,
+      last_name: lastName,
+    });
+  },
   unsubscribe: async (email: string) => {
     await httpClient.delete(`/v3/customers/subscribers?email=${encodeURIComponent(email)}`);
   },

--- a/core/tests/fixtures/utils/api/subscribe/index.ts
+++ b/core/tests/fixtures/utils/api/subscribe/index.ts
@@ -1,4 +1,5 @@
 export interface SubscribeApi {
+  subscribe(email: string, firstName: string, lastName: string): Promise<void>;
   unsubscribe(email: string): Promise<void>;
 }
 

--- a/core/tests/ui/e2e/subscribe.spec.ts
+++ b/core/tests/ui/e2e/subscribe.spec.ts
@@ -26,6 +26,7 @@ test(
 
     await expect(page.getByText(t('subscribedToNewsletter'))).toBeVisible();
 
+    // Track that we attempted to subscribe this email
     subscribe.trackSubscription(email);
   },
 );

--- a/core/vibes/soul/sections/account-settings/index.tsx
+++ b/core/vibes/soul/sections/account-settings/index.tsx
@@ -1,4 +1,8 @@
 import { ChangePasswordAction, ChangePasswordForm } from './change-password-form';
+import {
+  NewsletterSubscriptionForm,
+  UpdateNewsletterSubscriptionAction,
+} from './newsletter-subscription-form';
 import { Account, UpdateAccountAction, UpdateAccountForm } from './update-account-form';
 
 export interface AccountSettingsSectionProps {
@@ -12,6 +16,12 @@ export interface AccountSettingsSectionProps {
   confirmPasswordLabel?: string;
   currentPasswordLabel?: string;
   newPasswordLabel?: string;
+  newsletterSubscriptionEnabled?: boolean;
+  isAccountSubscribed?: boolean;
+  newsletterSubscriptionTitle?: string;
+  newsletterSubscriptionLabel?: string;
+  newsletterSubscriptionCtaLabel?: string;
+  updateNewsletterSubscriptionAction?: UpdateNewsletterSubscriptionAction;
 }
 
 // eslint-disable-next-line valid-jsdoc
@@ -39,6 +49,12 @@ export function AccountSettingsSection({
   confirmPasswordLabel,
   currentPasswordLabel,
   newPasswordLabel,
+  newsletterSubscriptionEnabled = false,
+  isAccountSubscribed = false,
+  newsletterSubscriptionTitle = 'Marketing preferences',
+  newsletterSubscriptionLabel = 'Opt-in to receive emails about new products and promotions.',
+  newsletterSubscriptionCtaLabel = 'Save preferences',
+  updateNewsletterSubscriptionAction,
 }: AccountSettingsSectionProps) {
   return (
     <section className="w-full @container">
@@ -56,7 +72,7 @@ export function AccountSettingsSection({
               submitLabel={updateAccountSubmitLabel}
             />
           </div>
-          <div className="border-t border-[var(--account-settings-section-border,hsl(var(--contrast-100)))] pt-12">
+          <div className="border-t border-[var(--account-settings-section-border,hsl(var(--contrast-100)))] py-12">
             <h1 className="mb-10 font-[family-name:var(--account-settings-section-font-family,var(--font-family-heading))] text-2xl font-medium leading-none text-[var(--account-settings-section-text,var(--foreground))] @xl:text-2xl">
               {changePasswordTitle}
             </h1>
@@ -68,6 +84,19 @@ export function AccountSettingsSection({
               submitLabel={changePasswordSubmitLabel}
             />
           </div>
+          {newsletterSubscriptionEnabled && updateNewsletterSubscriptionAction && (
+            <div className="border-t border-[var(--account-settings-section-border,hsl(var(--contrast-100)))] pt-12">
+              <h1 className="mb-10 font-[family-name:var(--account-settings-section-font-family,var(--font-family-heading))] text-2xl font-medium leading-none text-[var(--account-settings-section-text,var(--foreground))] @xl:text-2xl">
+                {newsletterSubscriptionTitle}
+              </h1>
+              <NewsletterSubscriptionForm
+                action={updateNewsletterSubscriptionAction}
+                ctaLabel={newsletterSubscriptionCtaLabel}
+                isAccountSubscribed={isAccountSubscribed}
+                label={newsletterSubscriptionLabel}
+              />
+            </div>
+          )}
         </div>
       </div>
     </section>

--- a/core/vibes/soul/sections/account-settings/newsletter-subscription-form.tsx
+++ b/core/vibes/soul/sections/account-settings/newsletter-subscription-form.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { SubmissionResult } from '@conform-to/react';
+import { useTranslations } from 'next-intl';
+import { useActionState, useEffect, useState } from 'react';
+
+import { Switch } from '@/vibes/soul/form/switch';
+import { Button } from '@/vibes/soul/primitives/button';
+import { toast } from '@/vibes/soul/primitives/toaster';
+
+type Action<S, P> = (state: Awaited<S>, payload: P) => S | Promise<S>;
+
+interface State {
+  lastResult: SubmissionResult | null;
+  successMessage?: string;
+}
+
+export type UpdateNewsletterSubscriptionAction = Action<State, FormData>;
+
+export interface NewsletterSubscriptionFormProps {
+  action: UpdateNewsletterSubscriptionAction;
+  isAccountSubscribed: boolean;
+  label?: string;
+  ctaLabel?: string;
+}
+
+export function NewsletterSubscriptionForm({
+  action,
+  isAccountSubscribed,
+  label = 'Opt-in to receive emails about new products and promotions.',
+  ctaLabel = 'Update',
+}: NewsletterSubscriptionFormProps) {
+  const t = useTranslations('Account.Settings.NewsletterSubscription');
+
+  const [checked, setChecked] = useState(isAccountSubscribed);
+  const [state, formAction, isPending] = useActionState(action, {
+    lastResult: null,
+  });
+
+  const onCheckedChange = (value: boolean) => {
+    setChecked(value);
+  };
+
+  useEffect(() => {
+    if (state.lastResult?.status === 'success' && state.successMessage != null) {
+      toast.success(state.successMessage);
+    }
+
+    if (state.lastResult?.error) {
+      // eslint-disable-next-line no-console
+      console.log(state.lastResult.error);
+      toast.error(t('somethingWentWrong'));
+    }
+  }, [state, t]);
+
+  return (
+    <form action={formAction} className="space-y-5">
+      <input name="intent" type="hidden" value={checked ? 'subscribe' : 'unsubscribe'} />
+      <Switch checked={checked} label={label} onCheckedChange={onCheckedChange} />
+      <Button
+        disabled={isAccountSubscribed === checked}
+        loading={isPending}
+        size="small"
+        type="submit"
+        variant="secondary"
+      >
+        {ctaLabel}
+      </Button>
+    </form>
+  );
+}


### PR DESCRIPTION
## What/Why?
Add newsletter subscription toggle to account settings page, allowing customers to manage their marketing preferences directly from their account.

## What Changed

- Added `NewsletterSubscriptionForm` component with a toggle switch for subscribing/unsubscribing to newsletters
- Created `updateNewsletterSubscription` server action that handles both subscribe and unsubscribe operations via BigCommerce GraphQL API
- Updated `AccountSettingsSection` to conditionally display the newsletter subscription form when enabled
- Enhanced `CustomerSettingsQuery` to fetch `isSubscribedToNewsletter` status and `showNewsletterSignup` store setting
- Updated account settings page to pass newsletter subscription props and bind customer info to the action
- Added translation keys for newsletter subscription UI in `Account.Settings.NewsletterSubscription` namespace
- Added E2E tests for subscribing and unsubscribing functionality

## Testing
Locally and added end to end tests.

https://github.com/user-attachments/assets/b5a0334a-34fb-4a2a-bf3d-4a2746d99c95

## Migration
To add the newsletter subscription toggle to your account settings page:

### Step 1: Copy the server action

Copy the new server action file to your account settings directory:

```bash
cp core/app/[locale]/(default)/account/settings/_actions/update-newsletter-subscription.ts \
   your-app/app/[locale]/(default)/account/settings/_actions/update-newsletter-subscription.ts
```

### Step 2: Update the GraphQL query

Update `core/app/[locale]/(default)/account/settings/page-data.tsx` to include newsletter subscription fields:

```tsx
// Renamed CustomerSettingsQuery to AccountSettingsQuery
const AccountSettingsQuery = graphql(`
  query AccountSettingsQuery(...) {
    customer {
      ...
      isSubscribedToNewsletter  # Add this field
    }
    site {
      settings {
        ...
        newsletter {            # Add this section
          showNewsletterSignup
        }
      }
    }
  }
`);
```

Also update the return statement to include `newsletterSettings`:

```tsx
const newsletterSettings = response.data.site.settings?.newsletter;

return {
  ...
  newsletterSettings,  // Add this
};
```

### Step 3: Copy the NewsletterSubscriptionForm component

Copy the new form component:

```bash
cp core/vibes/soul/sections/account-settings/newsletter-subscription-form.tsx \
   your-app/vibes/soul/sections/account-settings/newsletter-subscription-form.tsx
```

### Step 4: Update AccountSettingsSection

Update `core/vibes/soul/sections/account-settings/index.tsx`:

1. Import the new component:
```tsx
import {
  NewsletterSubscriptionForm,
  UpdateNewsletterSubscriptionAction,
} from './newsletter-subscription-form';
```

2. Add props to the interface:
```tsx
export interface AccountSettingsSectionProps {
  ...
  newsletterSubscriptionEnabled?: boolean;
  isAccountSubscribed?: boolean;
  newsletterSubscriptionTitle?: string;
  newsletterSubscriptionLabel?: string;
  newsletterSubscriptionCtaLabel?: string;
  updateNewsletterSubscriptionAction?: UpdateNewsletterSubscriptionAction;
}
```

3. Add the form section in the component (after the change password form):
```tsx
{newsletterSubscriptionEnabled && updateNewsletterSubscriptionAction && (
  <div className="border-t border-[var(--account-settings-section-border,hsl(var(--contrast-100)))] pt-12">
    <h1 className="mb-10 font-[family-name:var(--account-settings-section-font-family,var(--font-family-heading))] text-2xl font-medium leading-none text-[var(--account-settings-section-text,var(--foreground))] @xl:text-2xl">
      {newsletterSubscriptionTitle}
    </h1>
    <NewsletterSubscriptionForm
      action={updateNewsletterSubscriptionAction}
      ctaLabel={newsletterSubscriptionCtaLabel}
      isAccountSubscribed={isAccountSubscribed}
      label={newsletterSubscriptionLabel}
    />
  </div>
)}
```

### Step 5: Update the account settings page

Update `core/app/[locale]/(default)/account/settings/page.tsx`:

1. Import the action:
```tsx
import { updateNewsletterSubscription } from './_actions/update-newsletter-subscription';
```

2. Extract newsletter settings from the query:
```tsx
const newsletterSubscriptionEnabled = accountSettings.storeSettings?.showNewsletterSignup;
const isAccountSubscribed = accountSettings.customerInfo.isSubscribedToNewsletter;
```

3. Bind customer info to the action:
```tsx
const updateNewsletterSubscriptionActionWithCustomerInfo = updateNewsletterSubscription.bind(
  null,
  {
    customerInfo: accountSettings.customerInfo,
  },
);
```

4. Pass props to `AccountSettingsSection`:
```tsx
<AccountSettingsSection
  ...
  isAccountSubscribed={isAccountSubscribed}
  newsletterSubscriptionCtaLabel={t('cta')}
  newsletterSubscriptionEnabled={newsletterSubscriptionEnabled}
  newsletterSubscriptionLabel={t('NewsletterSubscription.label')}
  newsletterSubscriptionTitle={t('NewsletterSubscription.title')}
  updateNewsletterSubscriptionAction={updateNewsletterSubscriptionActionWithCustomerInfo}
/>
```

### Step 6: Add translation keys

Add the following keys to your locale files (e.g., `messages/en.json`):

```json
{
  "Account": {
    "Settings": {
      ...
      "NewsletterSubscription": {
        "title": "Marketing preferences",
        "label": "Opt-in to receive emails about new products and promotions.",
        "marketingPreferencesUpdated": "Marketing preferences have been updated successfully!",
        "somethingWentWrong": "Something went wrong. Please try again later."
      }
    }
  }
}
```

### Step 7: Verify the feature

1. Ensure your BigCommerce store has newsletter signup enabled in store settings
2. Navigate to `/account/settings` as a logged-in customer
3. Verify the newsletter subscription toggle appears below the change password form
4. Test subscribing and unsubscribing functionality

The newsletter subscription form will only display if `newsletterSubscriptionEnabled` is `true` (controlled by the `showNewsletterSignup` store setting).
