### PR TITLE
fix: order of `additionalProducts` in carousel

### DIFF
--- a/.changeset/heavy-hotels-lie.md
+++ b/.changeset/heavy-hotels-lie.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-makeswift": patch
+---
+
+Fix sort order of `additionalProducts` prop in `ProductsCarousel` Makeswift component.

--- a/core/lib/makeswift/utils/use-bc-product-to-vibes-product/use-bc-product-to-vibes-product.ts
+++ b/core/lib/makeswift/utils/use-bc-product-to-vibes-product/use-bc-product-to-vibes-product.ts
@@ -32,6 +32,8 @@ export const BcProductSchema = z.object({
 
 export type BcProductSchema = z.infer<typeof BcProductSchema>;
 
+export type { Product };
+
 export function useBcProductToVibesProduct(): (product: BcProductSchema) => Product {
   const format = useFormatter();
 

--- a/core/lib/makeswift/utils/use-products.ts
+++ b/core/lib/makeswift/utils/use-products.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 
 import {
   BcProductSchema,
+  Product,
   useBcProductToVibesProduct,
 } from './use-bc-product-to-vibes-product/use-bc-product-to-vibes-product';
 
@@ -23,7 +24,10 @@ interface Props {
   additionalProductIds: string[];
 }
 
-export function useProducts({ collection, collectionLimit = 20, additionalProductIds }: Props) {
+export function useProducts({ collection, collectionLimit = 20, additionalProductIds }: Props): {
+  products: Product[] | null;
+  isLoading: boolean;
+} {
   const bcProductToVibesProduct = useBcProductToVibesProduct();
   const locale = useLocale();
 
@@ -43,13 +47,17 @@ export function useProducts({ collection, collectionLimit = 20, additionalProduc
     additionalProductIds.length ? additionalProductsUrl : null,
     fetcher,
   );
+  const additionalProducts = useMemo(
+    () =>
+      additionalProductIds
+        .map((id) => additionalData?.products.find((product) => product.entityId.toString() === id))
+        .filter((product) => product != null),
+    [additionalData, additionalProductIds],
+  );
 
   const combinedProducts = useMemo(
-    () => [
-      ...(collectionData?.products.slice(0, collectionLimit) ?? []),
-      ...(additionalData?.products ?? []),
-    ],
-    [collectionData, additionalData, collectionLimit],
+    () => [...(collectionData?.products.slice(0, collectionLimit) ?? []), ...additionalProducts],
+    [collectionData, additionalProducts, collectionLimit],
   );
 
   const isLoading = isCollectionLoading || isAdditionalLoading;


### PR DESCRIPTION
## What/Why?
<!--- 
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
--->

Fixes #2790.

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->

### Before

https://github.com/user-attachments/assets/27a21c13-2e20-44db-a445-892f533dac88

### After

https://github.com/user-attachments/assets/db845aa9-a775-4ba1-96af-91ad4cd42d14

## Migration
<!---
  If you have moved any files around, or made any breaking changes,
  please provide a migration guide for the developers to make rebases easier.
--->

Apply this PR's changes to the `core/lib/makeswift/utils/use-bc-product-to-vibes-product/use-bc-product-to-vibes-product.ts` and `core/lib/makeswift/utils/use-products.ts` files.
