### PR TITLE
fix: Sort product IDs before sending requests to BC so cache can be utilized

### DIFF
--- a/.changeset/heavy-hotels-lie.md
+++ b/.changeset/heavy-hotels-lie.md
@@ -3,3 +3,4 @@
 ---
 
 Fix sort order of `additionalProducts` prop in `ProductsCarousel` Makeswift component.
+Sort product IDs before sending requests to BC so cache can be utilized in `ProductCarousel`

--- a/core/lib/makeswift/utils/use-products.ts
+++ b/core/lib/makeswift/utils/use-products.ts
@@ -38,7 +38,7 @@ export function useProducts({ collection, collectionLimit = 20, additionalProduc
 
   const searchParams = new URLSearchParams();
 
-  searchParams.append('ids', additionalProductIds.join(','));
+  searchParams.append('ids', additionalProductIds.sort().join(','));
   searchParams.append('locale', locale);
 
   const additionalProductsUrl = `/api/products/ids?${searchParams.toString()}`;


### PR DESCRIPTION
## What/Why?
Fixes https://github.com/bigcommerce/catalyst/issues/2790.

- This sorted ID creates fetch URL always same if products are same so it will reduce BC api calls to fetch product because of caching.

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->

## Migration
<!---
  If you have moved any files around, or made any breaking changes,
  please provide a migration guide for the developers to make rebases easier.
--->
