### PR TITLE
fix(core): show success message when a subscribed user resubscribes

### DIFF
--- a/.changeset/tall-walls-tan.md
+++ b/.changeset/tall-walls-tan.md
@@ -73,9 +73,8 @@ Add the following translation keys to your locale files (e.g., `messages/en.json
       "title": "Sign up for our newsletter",
       "placeholder": "Enter your email",
       "description": "Stay up to date with the latest news and offers from our store.",
-      "success": "You have been subscribed to our newsletter.",
+      "subscribedToNewsletter": "You have been subscribed to our newsletter.",
       "Errors": {
-        "subcriberAlreadyExists": "You are already subscribed to our newsletter.",
         "invalidEmail": "Please enter a valid email address.",
         "somethingWentWrong": "Something went wrong. Please try again later."
       }

--- a/.changeset/upset-bushes-hang.md
+++ b/.changeset/upset-bushes-hang.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Show success message when a subscribed is already subscribed to newsletter.

--- a/.changeset/upset-bushes-hang.md
+++ b/.changeset/upset-bushes-hang.md
@@ -1,5 +1,0 @@
----
-"@bigcommerce/catalyst-core": minor
----
-
-Show success message when a subscribed is already subscribed to newsletter.

--- a/core/components/subscribe/_actions/subscribe.ts
+++ b/core/components/subscribe/_actions/subscribe.ts
@@ -57,11 +57,13 @@ export const subscribe = async (
 
     const errors = response.data.newsletter.subscribe.errors;
 
-    // If there are no errors or the error is that the email already exists, we want to reset the form and show the success message
-    if (
-      !errors.length ||
-      errors.some(({ __typename }) => __typename === 'CreateSubscriberAlreadyExistsError')
-    ) {
+    const subcriberAlreadyExists = errors.some(
+      ({ __typename }) => __typename === 'CreateSubscriberAlreadyExistsError',
+    );
+
+    // If there are no errors or the subscriber already exists, we want to reset the form and show the success message
+    // This is for privacy reasons, we don't want to show the error message to the user if they are already subscribed
+    if (!errors.length || subcriberAlreadyExists) {
       return {
         lastResult: submission.reply(),
         successMessage: t('subscribedToNewsletter'),
@@ -69,6 +71,7 @@ export const subscribe = async (
     }
 
     if (errors.length > 0) {
+      // If there are other errors, we want to show the error message to the user
       return {
         lastResult: submission.reply({
           formErrors: errors.map(({ __typename }) => {

--- a/core/components/subscribe/_actions/subscribe.ts
+++ b/core/components/subscribe/_actions/subscribe.ts
@@ -57,8 +57,15 @@ export const subscribe = async (
 
     const errors = response.data.newsletter.subscribe.errors;
 
-    if (!errors.length) {
-      return { lastResult: submission.reply({ resetForm: true }), successMessage: t('success') };
+    // If there are no errors or the error is that the email already exists, we want to reset the form and show the success message
+    if (
+      !errors.length ||
+      errors.some(({ __typename }) => __typename === 'CreateSubscriberAlreadyExistsError')
+    ) {
+      return {
+        lastResult: submission.reply(),
+        successMessage: t('subscribedToNewsletter'),
+      };
     }
 
     if (errors.length > 0) {
@@ -66,9 +73,6 @@ export const subscribe = async (
         lastResult: submission.reply({
           formErrors: errors.map(({ __typename }) => {
             switch (__typename) {
-              case 'CreateSubscriberAlreadyExistsError':
-                return t('Errors.subcriberAlreadyExists');
-
               case 'CreateSubscriberEmailInvalidError':
                 return t('Errors.invalidEmail');
 

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -504,9 +504,8 @@
       "title": "Sign up for our newsletter",
       "placeholder": "Enter your email",
       "description": "Stay up to date with the latest news and offers from our store.",
-      "success": "You have been subscribed to our newsletter.",
+      "subscribedToNewsletter": "You have been subscribed to our newsletter.",
       "Errors": {
-        "subcriberAlreadyExists": "You are already subscribed to our newsletter.",
         "invalidEmail": "Please enter a valid email address.",
         "somethingWentWrong": "Something went wrong. Please try again later."
       }

--- a/core/tests/ui/e2e/subscribe.spec.ts
+++ b/core/tests/ui/e2e/subscribe.spec.ts
@@ -30,7 +30,7 @@ test(
   },
 );
 
-test('Shows error when user tries to subscribe again with the same email', async ({
+test('Shows success message when user tries to subscribe again with the same email', async ({
   page,
   subscribe,
 }) => {

--- a/core/tests/ui/e2e/subscribe.spec.ts
+++ b/core/tests/ui/e2e/subscribe.spec.ts
@@ -24,7 +24,7 @@ test(
     await submitButton.click();
     await page.waitForLoadState('networkidle');
 
-    await expect(page.getByText(t('success'))).toBeVisible();
+    await expect(page.getByText(t('subscribedToNewsletter'))).toBeVisible();
 
     subscribe.trackSubscription(email);
   },
@@ -50,14 +50,14 @@ test('Shows error when user tries to subscribe again with the same email', async
   await submitButton.click();
   await page.waitForLoadState('networkidle');
 
-  await expect(page.getByText(t('success'))).toBeVisible();
+  await expect(page.getByText(t('subscribedToNewsletter'))).toBeVisible();
 
   // Try to subscribe again with the same email
   await emailInput.fill(email);
   await submitButton.click();
   await page.waitForLoadState('networkidle');
 
-  await expect(page.getByText(t('Errors.subcriberAlreadyExists'))).toBeVisible();
+  await expect(page.getByText(t('subscribedToNewsletter'))).toBeVisible();
 
   // Track that we attempted to subscribe this email
   subscribe.trackSubscription(email);


### PR DESCRIPTION
## What/Why?
Show same success message when a user subscribes for the first time, or is already subscribed.

## Testing
Locally

## Migration
Update `core/components/subscribe/_actions/subscribe.ts` action to include new logic for resubscribed use case.
