### PR TITLE
chore(core): update newsletter label in account settings

### DIFF
--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -201,7 +201,7 @@
       "cta": "Update",
       "NewsletterSubscription": {
         "title": "Marketing preferences",
-        "label": "Opt-in to receive emails about new products and promotions.",
+        "label": "Subscribe to our newsletter.",
         "marketingPreferencesUpdated": "Marketing preferences have been updated successfully!",
         "somethingWentWrong": "Something went wrong. Please try again later."
       }


### PR DESCRIPTION
## What/Why?
Update label.

## Testing
<img width="477" height="245" alt="Screenshot 2025-12-24 at 8 03 47 PM" src="https://github.com/user-attachments/assets/f5550125-70a1-4c94-b06e-9b36b3e2cca9" />


## Migration
Update

```
  "Account": {
    "Settings": {
      "NewsletterSubscription": {
        "label": "Subscribe to our newsletter.",
      }
    }
  },