### PR TITLE
feat(catalyst): CATALYST-1665 Hide "Exclusive Offers" field from account registration [temporary]

### DIFF
--- a/.changeset/five-corners-try.md
+++ b/.changeset/five-corners-try.md
@@ -1,0 +1,30 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Remove "Exclusive Offers" field temporarily. Currently, the field is not fully implemented in GraphQL, so it may be misleading to display it on the storefront if it's not actually doing anything when registering a customer.
+
+Once the Register Customer operation takes this field into account, we can display it again.
+
+## Migration
+
+Update `core/app/[locale]/(default)/(auth)/register/page.tsx` and add the function:
+```ts
+// There is currently a GraphQL gap where the "Exclusive Offers" field isn't accounted for
+// during customer registration, so the field should not be shown on the Catalyst storefront until it is hooked up.
+function removeExlusiveOffersField(field: Field | Field[]): boolean {
+  if (Array.isArray(field)) {
+    // Exclusive offers field will always have ID '25', since it is made upon store creation and is also read-only.
+    return !field.some((f) => f.id === '25');
+  }
+
+  return field.id !== '25';
+}
+```
+
+Then, add the following code at the end of the `const fields` declaration:
+```ts
+    })
+    .filter(exists)
+    .filter(removeExlusiveOffersField); // <---
+```

--- a/core/app/[locale]/(default)/(auth)/register/page.tsx
+++ b/core/app/[locale]/(default)/(auth)/register/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 
+import { Field } from '@/vibes/soul/form/dynamic-form/schema';
 import { DynamicFormSection } from '@/vibes/soul/sections/dynamic-form-section';
 import {
   formFieldTransformer,
@@ -30,6 +31,17 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return {
     title: t('title'),
   };
+}
+
+// There is currently a GraphQL gap where the "Exclusive Offers" field isn't accounted for
+// during customer registration, so the field should not be shown on the Catalyst storefront until it is hooked up.
+function removeExlusiveOffersField(field: Field | Field[]): boolean {
+  if (Array.isArray(field)) {
+    // Exclusive offers field will always have ID '25', since it is made upon store creation and is also read-only.
+    return !field.some((f) => f.id === '25');
+  }
+
+  return field.id !== '25';
 }
 
 export default async function Register({ params }: Props) {
@@ -90,7 +102,8 @@ export default async function Register({ params }: Props) {
 
       return injectCountryCodeOptions(field, countries ?? []);
     })
-    .filter(exists);
+    .filter(exists)
+    .filter(removeExlusiveOffersField);
 
   return (
     <DynamicFormSection


### PR DESCRIPTION
## What/Why?
Hide the "Exclusive Offers" field from the Account Registration form.

Currently, the field is not fully implemented in GraphQL, so it may be misleading to display it on the storefront if it's not actually doing anything when registering a customer.

Once the Register Customer operation takes this field into account, we can display it again.

## Testing
Tested locally

## Migration

Update `core/app/[locale]/(default)/(auth)/register/page.tsx` and add the function:
```ts
// There is currently a GraphQL gap where the "Exclusive Offers" field isn't accounted for
// during customer registration, so the field should not be shown on the Catalyst storefront until it is hooked up.
function removeExlusiveOffersField(field: Field | Field[]): boolean {
  if (Array.isArray(field)) {
    // Exclusive offers field will always have ID '25', since it is made upon store creation and is also read-only.
    return !field.some((f) => f.id === '25');
  }

  return field.id !== '25';
}
```

Then, add the following code at the end of the `const fields` declaration:
```ts
    })
    .filter(exists)
    .filter(removeExlusiveOffersField); // <---
```
