### PR TITLE
feat: Remove caching on fetching product inventory data

### DIFF
--- a/.changeset/eager-nails-bake.md
+++ b/.changeset/eager-nails-bake.md
@@ -1,0 +1,10 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Fetch product inventory data with a separate GQL query with no caching
+
+## Migration
+The files to be rebased for this change to be applied are:
+- core/app/[locale]/(default)/product/[slug]/page-data.ts
+- core/app/[locale]/(default)/product/[slug]/page.tsx

--- a/core/app/[locale]/(default)/product/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/product/[slug]/page-data.ts
@@ -210,7 +210,7 @@ export const getProduct = cache(async (entityId: number, customerAccessToken?: s
   return data.site;
 });
 
-const StreamableProductVariantBySkuQuery = graphql(`
+const StreamableProductVariantInventoryBySkuQuery = graphql(`
   query ProductVariantBySkuQuery($productId: Int!, $sku: String!) {
     site {
       product(entityId: $productId) {
@@ -246,15 +246,15 @@ const StreamableProductVariantBySkuQuery = graphql(`
   }
 `);
 
-type VariantVariables = VariablesOf<typeof StreamableProductVariantBySkuQuery>;
+type VariantInventoryVariables = VariablesOf<typeof StreamableProductVariantInventoryBySkuQuery>;
 
-export const getStreamableProductVariant = cache(
-  async (variables: VariantVariables, customerAccessToken?: string) => {
+export const getStreamableProductVariantInventory = cache(
+  async (variables: VariantInventoryVariables, customerAccessToken?: string) => {
     const { data } = await client.fetch({
-      document: StreamableProductVariantBySkuQuery,
+      document: StreamableProductVariantInventoryBySkuQuery,
       variables,
       customerAccessToken,
-      fetchOptions: { cache: 'no-store' },
+      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate: 60 } },
     });
 
     return data.site.product?.variants;
@@ -370,7 +370,7 @@ export const getStreamableProductInventory = cache(
       document: StreamableProductInventoryQuery,
       variables,
       customerAccessToken,
-      fetchOptions: { cache: 'no-store' },
+      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate: 60 } },
     });
 
     return data.site.product;

--- a/core/app/[locale]/(default)/product/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/product/[slug]/page-data.ts
@@ -254,7 +254,7 @@ export const getStreamableProductVariant = cache(
       document: StreamableProductVariantBySkuQuery,
       variables,
       customerAccessToken,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
+      fetchOptions: { cache: 'no-store' },
     });
 
     return data.site.product?.variants;
@@ -310,6 +310,36 @@ const StreamableProductQuery = graphql(
           minPurchaseQuantity
           maxPurchaseQuantity
           warranty
+          ...ProductViewedFragment
+          ...ProductSchemaFragment
+        }
+      }
+    }
+  `,
+  [ProductViewedFragment, ProductSchemaFragment],
+);
+
+type Variables = VariablesOf<typeof StreamableProductQuery>;
+
+export const getStreamableProduct = cache(
+  async (variables: Variables, customerAccessToken?: string) => {
+    const { data } = await client.fetch({
+      document: StreamableProductQuery,
+      variables,
+      customerAccessToken,
+      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
+    });
+
+    return data.site.product;
+  },
+);
+
+const StreamableProductInventoryQuery = graphql(
+  `
+    query StreamableProductInventoryQuery($entityId: Int!) {
+      site {
+        product(entityId: $entityId) {
+          sku
           inventory {
             hasVariantInventory
             isInStock
@@ -324,25 +354,23 @@ const StreamableProductQuery = graphql(
           availabilityV2 {
             status
           }
-          ...ProductViewedFragment
           ...ProductVariantsInventoryFragment
-          ...ProductSchemaFragment
         }
       }
     }
   `,
-  [ProductViewedFragment, ProductSchemaFragment, ProductVariantsInventoryFragment],
+  [ProductVariantsInventoryFragment],
 );
 
-type Variables = VariablesOf<typeof StreamableProductQuery>;
+type ProductInventoryVariables = VariablesOf<typeof StreamableProductQuery>;
 
-export const getStreamableProduct = cache(
-  async (variables: Variables, customerAccessToken?: string) => {
+export const getStreamableProductInventory = cache(
+  async (variables: ProductInventoryVariables, customerAccessToken?: string) => {
     const { data } = await client.fetch({
-      document: StreamableProductQuery,
+      document: StreamableProductInventoryQuery,
       variables,
       customerAccessToken,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
+      fetchOptions: { cache: 'no-store' },
     });
 
     return data.site.product;

--- a/core/app/[locale]/(default)/product/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/page.tsx
@@ -28,6 +28,7 @@ import {
   getProductPricingAndRelatedProducts,
   getStreamableInventorySettingsQuery,
   getStreamableProduct,
+  getStreamableProductInventory,
   getStreamableProductVariant,
 } from './page-data';
 
@@ -118,8 +119,22 @@ export default async function Product({ params, searchParams }: Props) {
 
   const streamableProductSku = Streamable.from(async () => (await streamableProduct).sku);
 
+  const streamableProductInventory = Streamable.from(async () => {
+    const variables = {
+      entityId: Number(productId),
+    };
+
+    const product = await getStreamableProductInventory(variables, customerAccessToken);
+
+    if (!product) {
+      return notFound();
+    }
+
+    return product;
+  });
+
   const streamableProductVariant = Streamable.from(async () => {
-    const product = await streamableProduct;
+    const product = await streamableProductInventory;
 
     if (!product.inventory.hasVariantInventory) {
       return undefined;
@@ -192,7 +207,7 @@ export default async function Product({ params, searchParams }: Props) {
   });
 
   const streameableCtaLabel = Streamable.from(async () => {
-    const product = await streamableProduct;
+    const product = await streamableProductInventory;
 
     if (product.availabilityV2.status === 'Unavailable') {
       return t('ProductDetails.Submit.unavailable');
@@ -210,7 +225,7 @@ export default async function Product({ params, searchParams }: Props) {
   });
 
   const streameableCtaDisabled = Streamable.from(async () => {
-    const product = await streamableProduct;
+    const product = await streamableProductInventory;
 
     if (product.availabilityV2.status === 'Unavailable') {
       return true;
@@ -257,7 +272,7 @@ export default async function Product({ params, searchParams }: Props) {
 
   const streamableStockDisplayData = Streamable.from(async () => {
     const [product, variant, inventorySetting] = await Streamable.all([
-      streamableProduct,
+      streamableProductInventory,
       streamableProductVariant,
       streamableInventorySettings,
     ]);
@@ -347,7 +362,7 @@ export default async function Product({ params, searchParams }: Props) {
 
   const streamableBackorderDisplayData = Streamable.from(async () => {
     const [product, variant, inventorySetting] = await Streamable.all([
-      streamableProduct,
+      streamableProductInventory,
       streamableProductVariant,
       streamableInventorySettings,
     ]);

--- a/core/app/[locale]/(default)/product/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/page.tsx
@@ -29,7 +29,7 @@ import {
   getStreamableInventorySettingsQuery,
   getStreamableProduct,
   getStreamableProductInventory,
-  getStreamableProductVariant,
+  getStreamableProductVariantInventory,
 } from './page-data';
 
 interface Props {
@@ -133,7 +133,7 @@ export default async function Product({ params, searchParams }: Props) {
     return product;
   });
 
-  const streamableProductVariant = Streamable.from(async () => {
+  const streamableProductVariantInventory = Streamable.from(async () => {
     const product = await streamableProductInventory;
 
     if (!product.inventory.hasVariantInventory) {
@@ -145,7 +145,7 @@ export default async function Product({ params, searchParams }: Props) {
       sku: product.sku,
     };
 
-    const variants = await getStreamableProductVariant(variables, customerAccessToken);
+    const variants = await getStreamableProductVariantInventory(variables, customerAccessToken);
 
     if (!variants) {
       return undefined;
@@ -273,7 +273,7 @@ export default async function Product({ params, searchParams }: Props) {
   const streamableStockDisplayData = Streamable.from(async () => {
     const [product, variant, inventorySetting] = await Streamable.all([
       streamableProductInventory,
-      streamableProductVariant,
+      streamableProductVariantInventory,
       streamableInventorySettings,
     ]);
 
@@ -363,7 +363,7 @@ export default async function Product({ params, searchParams }: Props) {
   const streamableBackorderDisplayData = Streamable.from(async () => {
     const [product, variant, inventorySetting] = await Streamable.all([
       streamableProductInventory,
-      streamableProductVariant,
+      streamableProductVariantInventory,
       streamableInventorySettings,
     ]);
 


### PR DESCRIPTION
## What/Why?
Changes in a product inventory does not reflect right away on product details page due GQL caching in Catalyst. To fix this issue, we will fetch the product/variant inventory data separately with no caching.

## Testing
Screen record
https://github.com/user-attachments/assets/e060094d-c076-49c9-86e6-cc0797c1aac1

## Migration
Rebase
