### PR TITLE
fix(core): minor UX improvements for Reviews components

### DIFF
--- a/.changeset/two-years-flow.md
+++ b/.changeset/two-years-flow.md
@@ -1,0 +1,8 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Minor UX improvements for the Reviews section:
+- Show `totalCount` for reviews.
+- Show `averageRating` up to the first decimal.
+- Hide `averageRating` next to rating stars when there are no reviews.

--- a/core/app/[locale]/(default)/product/[slug]/_components/reviews.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/_components/reviews.tsx
@@ -35,6 +35,7 @@ const ReviewsQuery = graphql(
         product(entityId: $entityId) {
           reviewSummary {
             averageRating
+            numberOfReviews
           }
           reviews(first: $first, after: $after, before: $before, last: $last) {
             pageInfo {
@@ -161,6 +162,12 @@ export const Reviews = async ({
     return { email: session?.user?.email ?? '', name: obfuscatedName };
   });
 
+  const streamableTotalCount = Streamable.from(async () => {
+    const product = await streamableReviewsData;
+
+    return product?.reviewSummary.numberOfReviews ?? 0;
+  });
+
   return (
     <>
       <ReviewsSection
@@ -184,6 +191,7 @@ export const Reviews = async ({
         streamableImages={streamableImages}
         streamableProduct={streamableProductName}
         streamableUser={streamableUser}
+        totalCount={streamableTotalCount}
       />
       <Stream fallback={null} value={streamableReviewsData}>
         {(product) =>

--- a/core/vibes/soul/sections/reviews/index.tsx
+++ b/core/vibes/soul/sections/reviews/index.tsx
@@ -17,7 +17,7 @@ interface Review {
 interface Props {
   reviews: Streamable<Review[]>;
   averageRating: Streamable<number>;
-  totalCount?: Streamable<string>;
+  totalCount?: Streamable<number>;
   paginationInfo?: Streamable<CursorPaginationInfo>;
   nextLabel?: Streamable<string>;
   previousLabel?: Streamable<string>;
@@ -117,7 +117,7 @@ export function Reviews({
                   {(averageRating) => (
                     <>
                       <div className="mb-2 font-heading text-5xl leading-none tracking-tighter @2xl:text-6xl">
-                        {averageRating}
+                        {parseFloat(averageRating.toFixed(1))}
                       </div>
                       <Rating rating={averageRating} showRating={false} />
                     </>
@@ -221,7 +221,7 @@ export function ReviewsEmptyState({
           <div className="mb-2 font-heading text-5xl leading-none tracking-tighter @2xl:text-6xl">
             0
           </div>
-          <Rating rating={0} />
+          <Rating rating={0} showRating={false} />
         </>
       }
       sidebarSize="medium"


### PR DESCRIPTION
## What/Why?
Minor UX improvements for the Reviews section:
- Show `totalCount` for reviews.
- Show `averageRating` up to the first decimal.
- Hide `averageRating` next to rating stars when there are no reviews.

## Testing
Locally
Empty state:
<img width="1204" height="267" alt="Screenshot 2026-01-06 at 11 35 28 AM" src="https://github.com/user-attachments/assets/3e0dff74-c08f-4fb8-8bb0-a7d4e691c954" />

Non empty state:
<img width="1197" height="401" alt="Screenshot 2026-01-06 at 11 35 50 AM" src="https://github.com/user-attachments/assets/6f780422-7dfc-4e34-b9ad-92b39786ccd1" />
