### PR TITLE
fix: clear pagination cursors when sort option changes

### DIFF
--- a/.changeset/clear-pagination-on-sort.md
+++ b/.changeset/clear-pagination-on-sort.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Fix pagination cursor persistence when changing sort order. The `before` and `after` query parameters are now cleared when the sort option changes, preventing stale pagination cursors from causing incorrect results or empty pages.

--- a/core/vibes/soul/sections/products-list-section/sorting.tsx
+++ b/core/vibes/soul/sections/products-list-section/sorting.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { parseAsString, useQueryState } from 'nuqs';
+import { parseAsString, useQueryStates } from 'nuqs';
 import { useOptimistic, useTransition } from 'react';
 
 import { SelectField } from '@/vibes/soul/form/select-field';
@@ -24,11 +24,15 @@ export function Sorting({
   defaultValue?: string;
   placeholder?: Streamable<string | null>;
 }) {
-  const [param, setParam] = useQueryState(
-    paramName,
-    parseAsString.withDefault(defaultValue).withOptions({ shallow: false, history: 'push' }),
+  const [params, setParams] = useQueryStates(
+    {
+      [paramName]: parseAsString.withDefault(defaultValue),
+      before: parseAsString,
+      after: parseAsString,
+    },
+    { shallow: false, history: 'push' },
   );
-  const [optimisticParam, setOptimisticParam] = useOptimistic(param);
+  const [optimisticParam, setOptimisticParam] = useOptimistic(params[paramName] ?? defaultValue);
   const [isPending, startTransition] = useTransition();
   const options = useStreamable(streamableOptions);
   const label = useStreamable(streamableLabel) ?? 'Sort';
@@ -42,7 +46,11 @@ export function Sorting({
       onValueChange={(value) => {
         startTransition(async () => {
           setOptimisticParam(value);
-          await setParam(value);
+          await setParams({
+            [paramName]: value,
+            before: null,
+            after: null,
+          });
         });
       }}
       options={options}


### PR DESCRIPTION
## What/Why?
When the sort option is changed in the product filter, the before/after pagination query params are now removed. This prevents stale pagination cursors from being used with the new sort order, which could lead to incorrect results or empty pages.

Changes:
- Updated Sorting component to use useQueryStates instead of useQueryState
- Now manages sort, before, and after params together
- Clears before and after params when sort value changes

## Testing
https://github.com/user-attachments/assets/ea582027-561a-4a03-b9e3-33396e754878


## Migration
Change the import from `useQueryState` to `useQueryStates`, update the state management to `const [params, setParams] = useQueryStates({ [paramName]: parseAsString.withDefault(defaultValue), before: parseAsString, after: parseAsString }, { shallow: false, history: 'push' })`, change the optimistic state to use `params[paramName]`, and update the `onValueChange` handler to call `setParams({ [paramName]: value, before: null, after: null })` instead of `setParam(value)`. If you haven't customized this file, simply pulling the changes will work without any additional action.

