### PR TITLE
feat: pass in additional attributes for script tags

### DIFF
--- a/.changeset/script-attributes-support.md
+++ b/.changeset/script-attributes-support.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Add support for additional HTML attributes on script tags. The scripts transformer now extracts and passes through attributes like `async`, `defer`, `crossorigin`, and `data-*` attributes from BigCommerce script tags to the C15T consent manager, ensuring scripts load with their intended behavior.


### PR DESCRIPTION
## What/Why?

This PR enhances the `scripts-transformer.ts` to properly handle HTML attributes from BigCommerce script tags beyond just `src` attributes.

### What Changed

- Added new `extractAttributes()` function that parses and extracts all HTML attributes from script tags (e.g., `async`, `defer`, `data-*`, `crossorigin`)
- Modified `extractScriptInfo()` to preserve additional attributes when transforming scripts
- Updated the transformer logic to merge extracted attributes with consent-based attributes

### Why This Matters

Previously, the transformer only extracted `src` and inline content from BigCommerce script tags, losing important attributes like `async`, `defer`, or custom data attributes. This caused scripts to lose their intended loading behavior and metadata during transformation.

**Technical Details:**

- The new `extractAttributes()` function uses regex to parse the opening `<script>` tag
- Handles both boolean attributes (e.g., `async`, `defer`) and key-value attributes (e.g., `data-category="analytics"`)
- Boolean attributes are stored with empty string values per HTML spec
- The `src` attribute is explicitly excluded since it's already handled separately
- Extracted attributes are merged with consent manager attributes, with consent attributes taking precedence

## Testing

<img width="729" height="182" alt="Screenshot 2026-01-08 at 11 10 56" src="https://github.com/user-attachments/assets/da729703-8bc1-4e7a-8c66-884157b17f5b" />
<img width="476" height="682" alt="Screenshot 2026-01-08 at 11 11 07" src="https://github.com/user-attachments/assets/d6032a7a-17d0-4289-8ff1-6fa6ae7eafc3" />

## Migration

Rebase the `scripts-transformer.ts` file.
