### PR TITLE
fix(core): persist checkbox modifier in PDP

### DIFF
--- a/.changeset/shy-owls-move.md
+++ b/.changeset/shy-owls-move.md
@@ -1,0 +1,141 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Persist the checkbox product modifier since it can modify pricing and other product data. By persisting this and tracking in the url, this will trigger a product refetch when added or removed. Incidentally, now we manually control what fields are persisted, since `option.isVariantOption` doesn't apply to `checkbox`, additionally multi options modifiers that are not variant options can also modify price and other product data.
+
+## Migration
+
+### Step 1
+
+Update `product-options-transformer.ts` to manually track persisted fields:
+
+```ts
+case 'DropdownList': {
+    return {
+        // before
+        persist: option.isVariantOption,
+        // after (manually persist)
+        persist: true,
+        type: 'select',
+        label: option.displayName,
+        required: option.isRequired,
+        name: option.entityId.toString(),
+        defaultValue: values.find((value) => value.isDefault)?.entityId.toString(),
+        options: values.map((value) => ({
+        label: value.label,
+        value: value.entityId.toString(),
+        })),
+    };
+}
+```
+
+Fields that persist and can affect product pricing when selected:
+- Swatch
+- RectangleBoxes
+- RadioButtons
+- ProductPickList
+- ProductPickListWithImages
+- CheckboxOption
+
+### Step 2
+
+Remove `isVariantOption` from GQL query since we no longer use it:
+
+```ts
+export const ProductOptionsFragment = graphql(
+  `
+    fragment ProductOptionsFragment on Product {
+      entityId
+      productOptions(first: 50) {
+        edges {
+          node {
+            __typename
+            entityId
+            displayName
+            isRequired
+            isVariantOption // remove this
+            ...MultipleChoiceFieldFragment
+            ...CheckboxFieldFragment
+            ...NumberFieldFragment
+            ...TextFieldFragment
+            ...MultiLineTextFieldFragment
+            ...DateFieldFragment
+          }
+        }
+      }
+    }
+  `,
+  [
+    MultipleChoiceFieldFragment,
+    CheckboxFieldFragment,
+    NumberFieldFragment,
+    TextFieldFragment,
+    MultiLineTextFieldFragment,
+    DateFieldFragment,
+  ],
+);
+```
+
+### Step 3
+Update `product-detail-form.tsx` to handle checkbox persist logic:
+
+```ts
+case 'checkbox':
+    return (
+        <Checkbox
+            checked={controls.value === field.checkedValue} // add this
+            errors={formField.errors}
+            key={formField.id}
+            label={field.label}
+            name={formField.name}
+            onBlur={controls.blur}
+            onCheckedChange=(value) => handleChange(value ? field.checkedValue.toString() : ''); // add this
+            onFocus={controls.focus}
+            required={formField.required}
+            value={controls.value ?? ''}
+        />
+    );
+```
+
+Simplify `handleChange`:
+
+```ts
+const handleChange = useCallback(
+    (value: string) => {
+        void setParams({ [field.name]: value || null }); // Passing `null` to remove the value from the query params if fieldValue is falsey
+        controls.change(value || ''); // If fieldValue is falsey, we set it to an empty string
+    },
+    [setParams, field, controls],
+);
+```
+
+### Step 4
+
+Include update schema in `core/vibes/soul/sections/product-detail/schema.ts`:
+
+```ts
+type CheckboxField = {
+  type: 'checkbox';
+  defaultValue?: string;
+  checkedValue: string;
+  uncheckedValue: string;
+} & FormField;
+```
+
+### Step 5
+Simplify `core/app/[locale]/(default)/product/[slug]/_actions/add-to-cart.tsx`:
+
+```ts
+case 'checkbox':
+    checkboxOptionInput = {
+        optionEntityId: Number(field.name),
+        optionValueEntityId: Number(optionValueEntityId),
+    };
+
+    if (accum.checkboxes) {
+        return { ...accum, checkboxes: [...accum.checkboxes, checkboxOptionInput] };
+    }
+
+    return { ...accum, checkboxes: [checkboxOptionInput] };
+```

--- a/.changeset/shy-owls-move.md
+++ b/.changeset/shy-owls-move.md
@@ -14,7 +14,7 @@ Update `product-options-transformer.ts` to manually track persisted fields:
 case 'DropdownList': {
     return {
         // before
-        persist: option.isVariantOption,
+        // persist: option.isVariantOption,
         // after (manually persist)
         persist: true,
         type: 'select',

--- a/.changeset/shy-owls-move.md
+++ b/.changeset/shy-owls-move.md
@@ -110,6 +110,31 @@ const handleChange = useCallback(
 );
 ```
 
+Update default value logic to handle checkbox case:
+
+```ts
+const defaultValue = fields.reduce<{
+  [Key in keyof SchemaRawShape]?: z.infer<SchemaRawShape[Key]>;
+}>(
+  (acc, field) => {
+    // Checkbox fields need to be handled differently since we keep track of the checkedValue and not the boolean value of the default value.
+    if (field.type === 'checkbox') {
+      return {
+        ...acc,
+        [field.name]:
+          (params[field.name] ?? field.defaultValue === 'true') ? field.checkedValue : '',
+      };
+    }
+
+    return {
+      ...acc,
+      [field.name]: params[field.name] ?? field.defaultValue,
+    };
+  },
+  { quantity: minQuantity ?? 1 },
+);
+```
+
 ### Step 4
 
 Include update schema in `core/vibes/soul/sections/product-detail/schema.ts`:

--- a/core/app/[locale]/(default)/product/[slug]/_actions/add-to-cart.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/_actions/add-to-cart.tsx
@@ -75,12 +75,7 @@ export const addToCart = async (
       case 'checkbox':
         checkboxOptionInput = {
           optionEntityId: Number(field.name),
-          optionValueEntityId:
-            optionValueEntityId === 'true'
-              ? // @ts-expect-error Types from custom fields are not yet available, pending fix
-                Number(field.checkedValue)
-              : // @ts-expect-error Types from custom fields are not yet available, pending fix
-                Number(field.uncheckedValue),
+          optionValueEntityId: Number(optionValueEntityId),
         };
 
         if (accum.checkboxes) {

--- a/core/app/[locale]/(default)/product/[slug]/_actions/add-to-cart.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/_actions/add-to-cart.tsx
@@ -75,7 +75,10 @@ export const addToCart = async (
       case 'checkbox':
         checkboxOptionInput = {
           optionEntityId: Number(field.name),
-          optionValueEntityId: Number(optionValueEntityId),
+          optionValueEntityId:
+            optionValueEntityId === 'true'
+              ? Number(field.checkedValue)
+              : Number(field.uncheckedValue),
         };
 
         if (accum.checkboxes) {

--- a/core/app/[locale]/(default)/product/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/product/[slug]/page-data.ts
@@ -112,7 +112,6 @@ export const ProductOptionsFragment = graphql(
             entityId
             displayName
             isRequired
-            isVariantOption
             ...MultipleChoiceFieldFragment
             ...CheckboxFieldFragment
             ...NumberFieldFragment

--- a/core/data-transformers/product-options-transformer.ts
+++ b/core/data-transformers/product-options-transformer.ts
@@ -18,7 +18,7 @@ export const productOptionsTransformer = async (
         switch (option.displayStyle) {
           case 'Swatch': {
             return {
-              persist: option.isVariantOption,
+              persist: true,
               type: 'swatch-radio-group',
               label: option.displayName,
               required: option.isRequired,
@@ -50,7 +50,7 @@ export const productOptionsTransformer = async (
 
           case 'RectangleBoxes': {
             return {
-              persist: option.isVariantOption,
+              persist: true,
               type: 'button-radio-group',
               label: option.displayName,
               required: option.isRequired,
@@ -65,7 +65,7 @@ export const productOptionsTransformer = async (
 
           case 'RadioButtons': {
             return {
-              persist: option.isVariantOption,
+              persist: true,
               type: 'radio-group',
               label: option.displayName,
               required: option.isRequired,
@@ -80,7 +80,7 @@ export const productOptionsTransformer = async (
 
           case 'DropdownList': {
             return {
-              persist: option.isVariantOption,
+              persist: true,
               type: 'select',
               label: option.displayName,
               required: option.isRequired,
@@ -95,7 +95,7 @@ export const productOptionsTransformer = async (
 
           case 'ProductPickList': {
             return {
-              persist: option.isVariantOption,
+              persist: true,
               type: 'card-radio-group',
               label: option.displayName,
               required: option.isRequired,
@@ -115,7 +115,7 @@ export const productOptionsTransformer = async (
 
           case 'ProductPickListWithImages': {
             return {
-              persist: option.isVariantOption,
+              persist: true,
               type: 'card-radio-group',
               label: option.displayName,
               required: option.isRequired,
@@ -144,7 +144,7 @@ export const productOptionsTransformer = async (
 
       if (option.__typename === 'CheckboxOption') {
         return {
-          persist: option.isVariantOption,
+          persist: true,
           type: 'checkbox',
           label: option.displayName,
           required: option.isRequired,
@@ -157,7 +157,7 @@ export const productOptionsTransformer = async (
 
       if (option.__typename === 'NumberFieldOption') {
         return {
-          persist: option.isVariantOption,
+          persist: false,
           type: 'number',
           label: option.displayName,
           required: option.isRequired,
@@ -174,7 +174,7 @@ export const productOptionsTransformer = async (
 
       if (option.__typename === 'MultiLineTextFieldOption') {
         return {
-          persist: option.isVariantOption,
+          persist: false,
           type: 'textarea',
           label: option.displayName,
           required: option.isRequired,
@@ -187,7 +187,7 @@ export const productOptionsTransformer = async (
 
       if (option.__typename === 'TextFieldOption') {
         return {
-          persist: option.isVariantOption,
+          persist: false,
           type: 'text',
           label: option.displayName,
           required: option.isRequired,
@@ -198,7 +198,7 @@ export const productOptionsTransformer = async (
 
       if (option.__typename === 'DateFieldOption') {
         return {
-          persist: option.isVariantOption,
+          persist: false,
           type: 'date',
           label: option.displayName,
           required: option.isRequired,

--- a/core/vibes/soul/sections/product-detail/product-detail-form.tsx
+++ b/core/vibes/soul/sections/product-detail/product-detail-form.tsx
@@ -118,10 +118,21 @@ export function ProductDetailForm<F extends Field>({
   const defaultValue = fields.reduce<{
     [Key in keyof SchemaRawShape]?: z.infer<SchemaRawShape[Key]>;
   }>(
-    (acc, field) => ({
-      ...acc,
-      [field.name]: params[field.name] ?? field.defaultValue,
-    }),
+    (acc, field) => {
+      // Checkbox fields need to be handled differently since we keep track of the checkedValue and not the boolean value of the default value.
+      if (field.type === 'checkbox') {
+        return {
+          ...acc,
+          [field.name]:
+            (params[field.name] ?? field.defaultValue === 'true') ? field.checkedValue : '',
+        };
+      }
+
+      return {
+        ...acc,
+        [field.name]: params[field.name] ?? field.defaultValue,
+      };
+    },
     { quantity: minQuantity ?? 1 },
   );
 

--- a/core/vibes/soul/sections/product-detail/product-detail-form.tsx
+++ b/core/vibes/soul/sections/product-detail/product-detail-form.tsx
@@ -327,20 +327,16 @@ function FormField({
 }) {
   const controls = useInputControl(formField);
 
-  const [params, setParams] = useQueryStates(
+  const [, setParams] = useQueryStates(
     field.persist === true ? { [field.name]: parseAsString.withOptions({ shallow: false }) } : {},
   );
 
   const handleChange = useCallback(
     (value: string) => {
-      // Ensure that if page is reached without a full reload, we are still setting the selection properly based on query params.
-      const fieldValue = value || params[field.name];
-
-      void setParams({ [field.name]: fieldValue || null }); // Passing `null` to remove the value from the query params if fieldValue is falsey
-
-      controls.change(fieldValue ?? ''); // If fieldValue is falsey, we set it to an empty string
+      void setParams({ [field.name]: value || null }); // Passing `null` to remove the value from the query params if fieldValue is falsey
+      controls.change(value || ''); // If fieldValue is falsey, we set it to an empty string
     },
-    [setParams, field, controls, params],
+    [setParams, field, controls],
   );
 
   const handleOnOptionMouseEnter = (value: string) => {
@@ -417,13 +413,13 @@ function FormField({
     case 'checkbox':
       return (
         <Checkbox
-          checked={controls.value === 'true'}
+          checked={controls.value === field.checkedValue}
           errors={formField.errors}
           key={formField.id}
           label={field.label}
           name={formField.name}
           onBlur={controls.blur}
-          onCheckedChange={(value) => handleChange(value ? 'true' : '')}
+          onCheckedChange={(value) => handleChange(value ? field.checkedValue.toString() : '')}
           onFocus={controls.focus}
           required={formField.required}
           value={controls.value ?? ''}

--- a/core/vibes/soul/sections/product-detail/schema.ts
+++ b/core/vibes/soul/sections/product-detail/schema.ts
@@ -23,6 +23,8 @@ type SelectField = {
 type CheckboxField = {
   type: 'checkbox';
   defaultValue?: string;
+  checkedValue: string;
+  uncheckedValue: string;
 } & FormField;
 
 type NumberInputField = {


### PR DESCRIPTION
## What/Why?
Persist the checkbox product modifier since it can modify pricing and other product data. By persisting this and tracking in the url, this will trigger a product refetch when added or removed. Incidentally, now we manually control what fields are persisted, since `option.isVariantOption` doesn't apply to `checkbox`, additionally multi options modifiers that are not variant options can also modify price and other product data.

## Testing
Without insurance:
<img width="1360" height="1272" alt="Screenshot 2026-01-08 at 3 03 16 PM" src="https://github.com/user-attachments/assets/620670f2-138a-4326-b717-7b717e75e387" />

With insurance (insurance is $100 in this example):
<img width="1361" height="1272" alt="Screenshot 2026-01-08 at 3 03 28 PM" src="https://github.com/user-attachments/assets/ed21e6bb-a6ad-416e-9294-27d790c877da" />

## Migration

### Step 1

Update `product-options-transformer.ts` to manually track persisted fields:

```ts
case 'DropdownList': {
    return {
        // before
        // persist: option.isVariantOption,
        // after (manually persist)
        persist: true,
        type: 'select',
        label: option.displayName,
        required: option.isRequired,
        name: option.entityId.toString(),
        defaultValue: values.find((value) => value.isDefault)?.entityId.toString(),
        options: values.map((value) => ({
        label: value.label,
        value: value.entityId.toString(),
        })),
    };
}
```

Fields that persist and can affect product pricing when selected:
- Swatch
- RectangleBoxes
- RadioButtons
- ProductPickList
- ProductPickListWithImages
- CheckboxOption

### Step 2

Remove `isVariantOption` from GQL query since we no longer use it:

```ts
export const ProductOptionsFragment = graphql(
  `
    fragment ProductOptionsFragment on Product {
      entityId
      productOptions(first: 50) {
        edges {
          node {
            __typename
            entityId
            displayName
            isRequired
            isVariantOption // remove this
            ...MultipleChoiceFieldFragment
            ...CheckboxFieldFragment
            ...NumberFieldFragment
            ...TextFieldFragment
            ...MultiLineTextFieldFragment
            ...DateFieldFragment
          }
        }
      }
    }
  `,
  [
    MultipleChoiceFieldFragment,
    CheckboxFieldFragment,
    NumberFieldFragment,
    TextFieldFragment,
    MultiLineTextFieldFragment,
    DateFieldFragment,
  ],
);
```

### Step 3
Update `product-detail-form.tsx` to include separate handing of the checkbox field:

```ts
const defaultValue = fields.reduce<{
  [Key in keyof SchemaRawShape]?: z.infer<SchemaRawShape[Key]>;
}>(
  (acc, field) => {
    // Checkbox field has to be handled separately because we want to convert checked or unchecked value to true or undefined respectively.
    // This is because the form expects a boolean value, but we want to store the checked or unchecked value in the query params.
    if (field.type === 'checkbox') {
      if (params[field.name] === field.checkedValue) {
        return {
          ...acc,
          [field.name]: 'true',
        };
      }

      if (params[field.name] === field.uncheckedValue) {
        return {
          ...acc,
          [field.name]: undefined,
        };
      }

      return {
        ...acc,
        [field.name]: field.defaultValue, // Default value is either 'true' or undefined
      };
    }

    return {
      ...acc,
      [field.name]: params[field.name] ?? field.defaultValue,
    };
  },
  { quantity: minQuantity ?? 1 },
);

...

const handleChange = useCallback(
  (value: string) => {
    // Checkbox field has to be handled separately because we want to convert 'true' or '' to the checked or unchecked value respectively.
    if (field.type === 'checkbox') {
      void setParams({ [field.name]: value ? field.checkedValue : field.uncheckedValue });
    } else {
      void setParams({ [field.name]: value || null }); // Passing `null` to remove the value from the query params if fieldValue is falsey
    }

    controls.change(value || ''); // If fieldValue is falsey, we set it to an empty string
  },
  [setParams, field, controls],
);
```

### Step 4

Update schema in `core/vibes/soul/sections/product-detail/schema.ts`:

```ts
type CheckboxField = {
  type: 'checkbox';
  defaultValue?: string;
  checkedValue: string; // add
  uncheckedValue: string; // add
} & FormField;
```