### PR TITLE
[Catalyst 1677] Dont reset login form data

### DIFF
--- a/.changeset/thirty-coins-look.md
+++ b/.changeset/thirty-coins-look.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+The login form input data will no longer reset on a failed login attempt.

--- a/core/vibes/soul/sections/sign-in-section/sign-in-form.tsx
+++ b/core/vibes/soul/sections/sign-in-section/sign-in-form.tsx
@@ -2,7 +2,7 @@
 
 import { getFormProps, getInputProps, SubmissionResult, useForm } from '@conform-to/react';
 import { getZodConstraint, parseWithZod } from '@conform-to/zod';
-import { useActionState, useEffect } from 'react';
+import { startTransition, useActionState, useEffect } from 'react';
 import { useFormStatus } from 'react-dom';
 
 import { FormStatus } from '@/vibes/soul/form/form-status';
@@ -37,6 +37,12 @@ export function SignInForm({
     constraint: getZodConstraint(schema),
     shouldValidate: 'onBlur',
     shouldRevalidate: 'onInput',
+    onSubmit(event, { formData }) {
+      event.preventDefault();
+      startTransition(() => {
+        formAction(formData);
+      });
+    },
     onValidate({ formData }) {
       return parseWithZod(formData, { schema });
     },

--- a/core/vibes/soul/sections/sign-in-section/sign-in-form.tsx
+++ b/core/vibes/soul/sections/sign-in-section/sign-in-form.tsx
@@ -76,7 +76,7 @@ export function SignInForm({
   };
 
   return (
-    <form {...getFormProps(form)} action={formAction} className="flex grow flex-col gap-5">
+    <form {...getFormProps(form)} className="flex grow flex-col gap-5">
       <Input
         {...getInputProps(fields.email, { type: 'text' })}
         errors={fields.email.errors}


### PR DESCRIPTION
## What/Why?
Don't reset login form data on a failed login attempt. This way the user doesn't have to enter their email address again from scratch,

## Testing
Navigate to `/login` and attempt to login with invalid credentials. You should see an error message but the form data should be maintained.

https://github.com/user-attachments/assets/ef56e270-3e68-42bb-bb4c-9b5792874e2c


## Migration
Added a call to `event.preventDefault()` in the `onSubmission` callback to ensure default resetting of form data doesn't not happen in the sign up form.

```ts
const [form, fields] = useForm({
  //...
  onSubmit(event, { formData }) {
    event.preventDefault();
    startTransition(() => {
      formAction(formData);
    });
  }
});
```