### PR TITLE
refactor: decouple fields from state in DynamicForms

### DIFF
--- a/.changeset/quiet-heads-heal.md
+++ b/.changeset/quiet-heads-heal.md
@@ -1,0 +1,135 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Refactor DynamicForm actions to decouple fields and passwordComplexity from state, passing them as separate arguments instead. This reduces state payload size by removing fields from state objects and stripping options from fields before passing them to actions (options are only needed for rendering, not processing). All form actions now accept a `DynamicFormActionArgs` object as the first parameter containing fields and optional passwordComplexity, followed by the previous state and formData.
+
+## Migration steps
+
+### Step 1: Changes to DynamicForm component
+
+The `DynamicForm` component and related utilities have been updated to support the new action signature pattern:
+
+**`core/vibes/soul/form/dynamic-form/index.tsx`**:
+- Added `DynamicFormActionArgs<F>` interface that contains `fields` and optional `passwordComplexity`
+- Updated `DynamicFormAction<F>` type to accept `DynamicFormActionArgs<F>` as the first parameter
+- Removed `fields` and `passwordComplexity` from the `State` interface
+- Added automatic removal of `options` from fields before passing to actions (options are only needed for rendering)
+- Updated action binding to use `action.bind(null, { fields: fieldsWithoutOptions, passwordComplexity })`
+
+**`core/vibes/soul/form/dynamic-form/utils.ts`** (new file):
+- Added `removeOptionsFromFields()` utility function that strips the `options` property from field definitions before passing them to actions, reducing the state payload size
+
+```diff
++ export interface DynamicFormActionArgs<F extends Field> {
++   fields: Array<F | FieldGroup<F>>;
++   passwordComplexity?: PasswordComplexitySettings | null;
++ }
++
++ type Action<F extends Field, S, P> = (
++   args: DynamicFormActionArgs<F>,
++   state: Awaited<S>,
++   payload: P,
++ ) => S | Promise<S>;
++
+  interface State {
+    lastResult: SubmissionResult | null;
+-   fields: Array<F | FieldGroup<F>>;
+-   passwordComplexity?: PasswordComplexitySettings | null;
+  }
+```
+
+### Step 2: Update DynamicForm action signatures
+
+All form actions that use `DynamicForm` must be updated to accept `DynamicFormActionArgs<F>` as the first parameter instead of including fields in the state.
+
+Update your form action function signature:
+
+```diff
++ import { DynamicFormActionArgs } from '@/vibes/soul/form/dynamic-form';
+  import { Field, FieldGroup, schema } from '@/vibes/soul/form/dynamic-form/schema';
+
+- export async function myFormAction<F extends Field>(
+-   prevState: {
+-     lastResult: SubmissionResult | null;
+-     fields: Array<F | FieldGroup<F>>;
+-     passwordComplexity?: PasswordComplexitySettings | null;
+-   },
+-   formData: FormData,
+- ) {
++ export async function myFormAction<F extends Field>(
++   { fields, passwordComplexity }: DynamicFormActionArgs<F>,
++   _prevState: {
++     lastResult: SubmissionResult | null;
++   },
++   formData: FormData,
++ ) {
+```
+
+### Step 2: Remove fields and passwordComplexity from state interfaces
+
+Update state interfaces to remove fields and passwordComplexity properties:
+
+```diff
+  interface State {
+    lastResult: SubmissionResult | null;
+-   fields: Array<Field | FieldGroup<Field>>;
+-   passwordComplexity?: PasswordComplexitySettings | null;
+  }
+```
+
+### Step 3: Update action implementations
+
+Remove references to `prevState.fields` and `prevState.passwordComplexity` in action implementations:
+
+```diff
+  const submission = parseWithZod(formData, {
+-   schema: schema(prevState.fields, prevState.passwordComplexity),
++   schema: schema(fields, passwordComplexity),
+  });
+
+  if (submission.status !== 'success') {
+    return {
+      lastResult: submission.reply(),
+-     fields: prevState.fields,
+-     passwordComplexity: prevState.passwordComplexity,
+    };
+  }
+```
+
+### Step 4: Update action calls in components
+
+For actions used with `AddressListSection`, update the action signature to accept fields as the first parameter:
+
+```diff
+- export async function addressAction(
+-   prevState: Awaited<State>,
+-   formData: FormData,
+- ): Promise<State> {
++ export async function addressAction(
++   fields: Array<Field | FieldGroup<Field>>,
++   prevState: Awaited<State>,
++   formData: FormData,
++ ): Promise<State> {
+```
+
+### Step 5: Update DynamicForm usage
+
+No changes needed to `DynamicForm` component usage. The component automatically handles binding fields and passwordComplexity to actions. The `DynamicForm` component now:
+- Automatically removes options from fields before passing them to actions (reducing payload size)
+- Binds fields and passwordComplexity to the action using `action.bind()`
+- Maintains the same props interface, so existing usage continues to work
+
+### Affected files
+
+The following files were updated in this refactor:
+- `core/vibes/soul/form/dynamic-form/index.tsx` - Added `DynamicFormActionArgs` type and updated action binding
+- `core/vibes/soul/form/dynamic-form/utils.ts` - Added `removeOptionsFromFields` utility function
+- `core/app/[locale]/(default)/(auth)/register/_actions/register-customer.ts`
+- `core/app/[locale]/(default)/account/addresses/_actions/address-action.ts`
+- `core/app/[locale]/(default)/account/addresses/_actions/create-address.ts`
+- `core/app/[locale]/(default)/account/addresses/_actions/update-address.ts`
+- `core/app/[locale]/(default)/account/addresses/_actions/delete-address.ts`
+- `core/app/[locale]/(default)/gift-certificates/purchase/_actions/add-to-cart.tsx`
+- `core/app/[locale]/(default)/webpages/[id]/contact/_actions/submit-contact-form.ts`
+- `core/vibes/soul/sections/address-list-section/index.tsx`

--- a/core/app/[locale]/(default)/(auth)/register/_actions/register-customer.ts
+++ b/core/app/[locale]/(default)/(auth)/register/_actions/register-customer.ts
@@ -335,9 +335,9 @@ function parseRegisterCustomerInput(
 }
 
 export async function registerCustomer<F extends Field>(
+  fields: Array<F | FieldGroup<F>>,
   prevState: {
     lastResult: SubmissionResult | null;
-    fields: Array<F | FieldGroup<F>>;
     passwordComplexity?: Parameters<typeof schema>[1];
   },
   formData: FormData,
@@ -347,19 +347,18 @@ export async function registerCustomer<F extends Field>(
   const cartId = await getCartId();
 
   const submission = parseWithZod(formData, {
-    schema: schema(prevState.fields, prevState.passwordComplexity),
+    schema: schema(fields, prevState.passwordComplexity),
   });
 
   if (submission.status !== 'success') {
     return {
       lastResult: submission.reply(),
-      fields: prevState.fields,
       passwordComplexity: prevState.passwordComplexity,
     };
   }
 
   try {
-    const input = parseRegisterCustomerInput(submission.value, prevState.fields);
+    const input = parseRegisterCustomerInput(submission.value, fields);
     const response = await client.fetch({
       document: RegisterCustomerMutation,
       variables: {
@@ -375,7 +374,6 @@ export async function registerCustomer<F extends Field>(
         lastResult: submission.reply({
           formErrors: response.data.customer.registerCustomer.errors.map((error) => error.message),
         }),
-        fields: prevState.fields,
         passwordComplexity: prevState.passwordComplexity,
       };
     }
@@ -397,7 +395,6 @@ export async function registerCustomer<F extends Field>(
         lastResult: submission.reply({
           formErrors: error.errors.map(({ message }) => message),
         }),
-        fields: prevState.fields,
         passwordComplexity: prevState.passwordComplexity,
       };
     }
@@ -405,14 +402,12 @@ export async function registerCustomer<F extends Field>(
     if (error instanceof Error) {
       return {
         lastResult: submission.reply({ formErrors: [error.message] }),
-        fields: prevState.fields,
         passwordComplexity: prevState.passwordComplexity,
       };
     }
 
     return {
       lastResult: submission.reply({ formErrors: [t('somethingWentWrong')] }),
-      fields: prevState.fields,
       passwordComplexity: prevState.passwordComplexity,
     };
   }

--- a/core/app/[locale]/(default)/(auth)/register/_actions/register-customer.ts
+++ b/core/app/[locale]/(default)/(auth)/register/_actions/register-customer.ts
@@ -6,6 +6,7 @@ import { parseWithZod } from '@conform-to/zod';
 import { getLocale, getTranslations } from 'next-intl/server';
 import { z } from 'zod';
 
+import { DynamicFormActionArgs } from '@/vibes/soul/form/dynamic-form';
 import { Field, FieldGroup, schema } from '@/vibes/soul/form/dynamic-form/schema';
 import { signIn } from '~/auth';
 import { client } from '~/client';
@@ -335,10 +336,9 @@ function parseRegisterCustomerInput(
 }
 
 export async function registerCustomer<F extends Field>(
-  fields: Array<F | FieldGroup<F>>,
-  prevState: {
+  { fields, passwordComplexity }: DynamicFormActionArgs<F>,
+  _prevState: {
     lastResult: SubmissionResult | null;
-    passwordComplexity?: Parameters<typeof schema>[1];
   },
   formData: FormData,
 ) {
@@ -347,13 +347,12 @@ export async function registerCustomer<F extends Field>(
   const cartId = await getCartId();
 
   const submission = parseWithZod(formData, {
-    schema: schema(fields, prevState.passwordComplexity),
+    schema: schema(fields, passwordComplexity),
   });
 
   if (submission.status !== 'success') {
     return {
       lastResult: submission.reply(),
-      passwordComplexity: prevState.passwordComplexity,
     };
   }
 
@@ -374,7 +373,6 @@ export async function registerCustomer<F extends Field>(
         lastResult: submission.reply({
           formErrors: response.data.customer.registerCustomer.errors.map((error) => error.message),
         }),
-        passwordComplexity: prevState.passwordComplexity,
       };
     }
 
@@ -395,20 +393,17 @@ export async function registerCustomer<F extends Field>(
         lastResult: submission.reply({
           formErrors: error.errors.map(({ message }) => message),
         }),
-        passwordComplexity: prevState.passwordComplexity,
       };
     }
 
     if (error instanceof Error) {
       return {
         lastResult: submission.reply({ formErrors: [error.message] }),
-        passwordComplexity: prevState.passwordComplexity,
       };
     }
 
     return {
       lastResult: submission.reply({ formErrors: [t('somethingWentWrong')] }),
-      passwordComplexity: prevState.passwordComplexity,
     };
   }
 

--- a/core/app/[locale]/(default)/account/addresses/_actions/address-action.ts
+++ b/core/app/[locale]/(default)/account/addresses/_actions/address-action.ts
@@ -11,21 +11,24 @@ export interface State {
   addresses: Address[];
   lastResult: SubmissionResult | null;
   defaultAddress?: DefaultAddressConfiguration;
-  fields: Array<Field | FieldGroup<Field>>;
 }
 
-export async function addressAction(prevState: Awaited<State>, formData: FormData): Promise<State> {
+export async function addressAction(
+  fields: Array<Field | FieldGroup<Field>>,
+  prevState: Awaited<State>,
+  formData: FormData,
+): Promise<State> {
   'use server';
 
   const intent = formData.get('intent');
 
   switch (intent) {
     case 'create': {
-      return await createAddress(prevState, formData);
+      return await createAddress(fields, prevState, formData);
     }
 
     case 'update': {
-      return await updateAddress(prevState, formData);
+      return await updateAddress(fields, prevState, formData);
     }
 
     case 'delete': {

--- a/core/app/[locale]/(default)/account/addresses/_actions/create-address.ts
+++ b/core/app/[locale]/(default)/account/addresses/_actions/create-address.ts
@@ -196,7 +196,11 @@ function parseAddAddressInput(
   return inputSchema.parse(mappedInput);
 }
 
-export async function createAddress(prevState: Awaited<State>, formData: FormData): Promise<State> {
+export async function createAddress(
+  fields: Array<Field | FieldGroup<Field>>,
+  prevState: Awaited<State>,
+  formData: FormData,
+): Promise<State> {
   const t = await getTranslations('Account.Addresses');
   const customerAccessToken = await getSessionCustomerAccessToken();
 
@@ -210,7 +214,7 @@ export async function createAddress(prevState: Awaited<State>, formData: FormDat
   }
 
   try {
-    const input = parseAddAddressInput(submission.value, prevState.fields);
+    const input = parseAddAddressInput(submission.value, fields);
 
     const response = await client.fetch({
       document: AddCustomerAddressMutation,
@@ -242,7 +246,6 @@ export async function createAddress(prevState: Awaited<State>, formData: FormDat
       ],
       lastResult: submission.reply({ resetForm: true }),
       defaultAddress: prevState.defaultAddress,
-      fields: prevState.fields,
     };
   } catch (error) {
     // eslint-disable-next-line no-console

--- a/core/app/[locale]/(default)/account/addresses/_actions/delete-address.ts
+++ b/core/app/[locale]/(default)/account/addresses/_actions/delete-address.ts
@@ -86,7 +86,6 @@ export async function deleteAddress(prevState: Awaited<State>, formData: FormDat
       ),
       lastResult: submission.reply({ resetForm: true }),
       defaultAddress: prevState.defaultAddress,
-      fields: prevState.fields,
     };
   } catch (error) {
     // eslint-disable-next-line no-console

--- a/core/app/[locale]/(default)/account/addresses/_actions/update-address.ts
+++ b/core/app/[locale]/(default)/account/addresses/_actions/update-address.ts
@@ -209,7 +209,11 @@ function parseUpdateAddressInput(
   return inputSchema.parse(mappedInput);
 }
 
-export async function updateAddress(prevState: Awaited<State>, formData: FormData): Promise<State> {
+export async function updateAddress(
+  fields: Array<Field | FieldGroup<Field>>,
+  prevState: Awaited<State>,
+  formData: FormData,
+): Promise<State> {
   const t = await getTranslations('Account.Addresses');
   const customerAccessToken = await getSessionCustomerAccessToken();
 
@@ -223,7 +227,7 @@ export async function updateAddress(prevState: Awaited<State>, formData: FormDat
   }
 
   try {
-    const input = parseUpdateAddressInput(submission.value, prevState.fields);
+    const input = parseUpdateAddressInput(submission.value, fields);
 
     const response = await client.fetch({
       document: UpdateCustomerAddressMutation,
@@ -251,7 +255,6 @@ export async function updateAddress(prevState: Awaited<State>, formData: FormDat
       ),
       lastResult: submission.reply({ resetForm: true }),
       defaultAddress: prevState.defaultAddress,
-      fields: prevState.fields,
     };
   } catch (error) {
     // eslint-disable-next-line no-console

--- a/core/app/[locale]/(default)/gift-certificates/purchase/_actions/add-to-cart.tsx
+++ b/core/app/[locale]/(default)/gift-certificates/purchase/_actions/add-to-cart.tsx
@@ -19,7 +19,6 @@ import { getPreferredCurrencyCode } from '~/lib/currency';
 import { GiftCertificateSettingsFragment } from '../fragment';
 
 interface State {
-  fields: Array<Field | FieldGroup<Field>>;
   lastResult: SubmissionResult | null;
   successMessage?: ReactNode;
 }
@@ -101,7 +100,8 @@ const schema = (
 };
 
 export async function addGiftCertificateToCart(
-  prevState: State,
+  _fields: Array<Field | FieldGroup<Field>>,
+  _prevState: State,
   formData: FormData,
 ): Promise<State> {
   const t = await getTranslations('GiftCertificates.Purchase');
@@ -117,7 +117,7 @@ export async function addGiftCertificateToCart(
   });
 
   if (submission.status !== 'success') {
-    return { lastResult: submission.reply(), fields: prevState.fields };
+    return { lastResult: submission.reply() };
   }
 
   const amountFormatted = format.number(submission.value.amount, {
@@ -148,7 +148,6 @@ export async function addGiftCertificateToCart(
 
     return {
       lastResult: submission.reply(),
-      fields: prevState.fields,
       successMessage: t.rich('successMessage', {
         cartLink: (chunks) => (
           <Link className="underline" href="/cart" prefetch="viewport" prefetchKind="full">
@@ -168,27 +167,23 @@ export async function addGiftCertificateToCart(
             return message;
           }),
         }),
-        fields: prevState.fields,
       };
     }
 
     if (error instanceof MissingCartError) {
       return {
         lastResult: submission.reply({ formErrors: [t('missingCart')] }),
-        fields: prevState.fields,
       };
     }
 
     if (error instanceof Error) {
       return {
         lastResult: submission.reply({ formErrors: [error.message] }),
-        fields: prevState.fields,
       };
     }
 
     return {
       lastResult: submission.reply({ formErrors: [t('unknownError')] }),
-      fields: prevState.fields,
     };
   }
 }

--- a/core/app/[locale]/(default)/gift-certificates/purchase/_actions/add-to-cart.tsx
+++ b/core/app/[locale]/(default)/gift-certificates/purchase/_actions/add-to-cart.tsx
@@ -7,7 +7,8 @@ import { getFormatter, getTranslations } from 'next-intl/server';
 import { ReactNode } from 'react';
 import { z } from 'zod';
 
-import { Field, FieldGroup } from '@/vibes/soul/form/dynamic-form/schema';
+import { DynamicFormActionArgs } from '@/vibes/soul/form/dynamic-form';
+import { Field } from '@/vibes/soul/form/dynamic-form/schema';
 import { client } from '~/client';
 import { graphql, ResultOf } from '~/client/graphql';
 import { ExistingResultType } from '~/client/util';
@@ -99,8 +100,8 @@ const schema = (
     });
 };
 
-export async function addGiftCertificateToCart(
-  _fields: Array<Field | FieldGroup<Field>>,
+export async function addGiftCertificateToCart<F extends Field>(
+  _args: DynamicFormActionArgs<F>,
   _prevState: State,
   formData: FormData,
 ): Promise<State> {

--- a/core/app/[locale]/(default)/webpages/[id]/contact/_actions/submit-contact-form.ts
+++ b/core/app/[locale]/(default)/webpages/[id]/contact/_actions/submit-contact-form.ts
@@ -58,18 +58,19 @@ function parseContactFormInput(
 }
 
 export async function submitContactForm<F extends Field>(
-  prevState: { lastResult: SubmissionResult | null; fields: Array<F | FieldGroup<F>> },
+  fields: Array<F | FieldGroup<F>>,
+  _prevState: { lastResult: SubmissionResult | null },
   formData: FormData,
 ) {
   const t = await getTranslations('WebPages.ContactUs.Form');
   const locale = await getLocale();
 
-  const submission = parseWithZod(formData, { schema: schema(prevState.fields) });
+  const submission = parseWithZod(formData, { schema: schema(fields) });
 
   if (submission.status !== 'success') {
     return {
       lastResult: submission.reply(),
-      fields: prevState.fields,
+      fields,
     };
   }
 
@@ -88,7 +89,7 @@ export async function submitContactForm<F extends Field>(
     if (result.errors.length > 0) {
       return {
         lastResult: submission.reply({ formErrors: result.errors.map((error) => error.message) }),
-        fields: prevState.fields,
+        fields,
       };
     }
   } catch (error) {
@@ -100,20 +101,20 @@ export async function submitContactForm<F extends Field>(
         lastResult: submission.reply({
           formErrors: error.errors.map(({ message }) => message),
         }),
-        fields: prevState.fields,
+        fields,
       };
     }
 
     if (error instanceof Error) {
       return {
         lastResult: submission.reply({ formErrors: [error.message] }),
-        fields: prevState.fields,
+        fields,
       };
     }
 
     return {
       lastResult: submission.reply({ formErrors: [t('somethingWentWrong')] }),
-      fields: prevState.fields,
+      fields,
     };
   }
 

--- a/core/app/[locale]/(default)/webpages/[id]/contact/_actions/submit-contact-form.ts
+++ b/core/app/[locale]/(default)/webpages/[id]/contact/_actions/submit-contact-form.ts
@@ -6,7 +6,8 @@ import { parseWithZod } from '@conform-to/zod';
 import { getLocale, getTranslations } from 'next-intl/server';
 import { z } from 'zod';
 
-import { Field, FieldGroup, schema } from '@/vibes/soul/form/dynamic-form/schema';
+import { DynamicFormActionArgs } from '@/vibes/soul/form/dynamic-form';
+import { Field, schema } from '@/vibes/soul/form/dynamic-form/schema';
 import { client } from '~/client';
 import { graphql, VariablesOf } from '~/client/graphql';
 import { redirect } from '~/i18n/routing';
@@ -58,7 +59,7 @@ function parseContactFormInput(
 }
 
 export async function submitContactForm<F extends Field>(
-  fields: Array<F | FieldGroup<F>>,
+  { fields }: DynamicFormActionArgs<F>,
   _prevState: { lastResult: SubmissionResult | null },
   formData: FormData,
 ) {

--- a/core/app/[locale]/(default)/webpages/[id]/contact/_actions/submit-contact-form.ts
+++ b/core/app/[locale]/(default)/webpages/[id]/contact/_actions/submit-contact-form.ts
@@ -71,7 +71,6 @@ export async function submitContactForm<F extends Field>(
   if (submission.status !== 'success') {
     return {
       lastResult: submission.reply(),
-      fields,
     };
   }
 
@@ -90,7 +89,6 @@ export async function submitContactForm<F extends Field>(
     if (result.errors.length > 0) {
       return {
         lastResult: submission.reply({ formErrors: result.errors.map((error) => error.message) }),
-        fields,
       };
     }
   } catch (error) {
@@ -102,20 +100,17 @@ export async function submitContactForm<F extends Field>(
         lastResult: submission.reply({
           formErrors: error.errors.map(({ message }) => message),
         }),
-        fields,
       };
     }
 
     if (error instanceof Error) {
       return {
         lastResult: submission.reply({ formErrors: [error.message] }),
-        fields,
       };
     }
 
     return {
       lastResult: submission.reply({ formErrors: [t('somethingWentWrong')] }),
-      fields,
     };
   }
 

--- a/core/vibes/soul/form/dynamic-form/index.tsx
+++ b/core/vibes/soul/form/dynamic-form/index.tsx
@@ -38,16 +38,19 @@ import { Button, ButtonProps } from '@/vibes/soul/primitives/button';
 
 import { Field, FieldGroup, PasswordComplexitySettings, schema } from './schema';
 
-type Action<S, P> = (state: Awaited<S>, payload: P) => S | Promise<S>;
+type Action<F extends Field, S, P> = (
+  fields: Array<F | FieldGroup<F>>,
+  state: Awaited<S>,
+  payload: P,
+) => S | Promise<S>;
 
-interface State<F extends Field> {
-  fields: Array<F | FieldGroup<F>>;
+interface State {
   lastResult: SubmissionResult | null;
   successMessage?: ReactNode;
   passwordComplexity?: PasswordComplexitySettings | null;
 }
 
-export type DynamicFormAction<F extends Field> = Action<State<F>, FormData>;
+export type DynamicFormAction<F extends Field> = Action<F, State, FormData>;
 
 export interface DynamicFormProps<F extends Field> {
   fields: Array<F | FieldGroup<F>>;
@@ -65,7 +68,7 @@ export interface DynamicFormProps<F extends Field> {
 
 export function DynamicForm<F extends Field>({
   action,
-  fields: defaultFields,
+  fields,
   buttonSize = 'medium',
   cancelLabel = 'Cancel',
   submitLabel = 'Submit',
@@ -76,10 +79,11 @@ export function DynamicForm<F extends Field>({
   onSuccess,
   passwordComplexity: defaultPasswordComplexity,
 }: DynamicFormProps<F>) {
-  const [{ lastResult, fields, successMessage, passwordComplexity }, formAction] = useActionState(
-    action,
+  const actionWithFields = action.bind(null, fields);
+
+  const [{ lastResult, successMessage, passwordComplexity }, formAction] = useActionState(
+    actionWithFields,
     {
-      fields: defaultFields,
       lastResult: null,
       passwordComplexity: defaultPasswordComplexity,
     },

--- a/core/vibes/soul/form/dynamic-form/index.tsx
+++ b/core/vibes/soul/form/dynamic-form/index.tsx
@@ -39,8 +39,13 @@ import { Button, ButtonProps } from '@/vibes/soul/primitives/button';
 import { Field, FieldGroup, PasswordComplexitySettings, schema } from './schema';
 import { removeOptionsFromFields } from './utils';
 
+export interface DynamicFormActionArgs<F extends Field> {
+  fields: Array<F | FieldGroup<F>>;
+  passwordComplexity?: PasswordComplexitySettings | null;
+}
+
 type Action<F extends Field, S, P> = (
-  fields: Array<F | FieldGroup<F>>,
+  args: DynamicFormActionArgs<F>,
   state: Awaited<S>,
   payload: P,
 ) => S | Promise<S>;
@@ -48,7 +53,6 @@ type Action<F extends Field, S, P> = (
 interface State {
   lastResult: SubmissionResult | null;
   successMessage?: ReactNode;
-  passwordComplexity?: PasswordComplexitySettings | null;
 }
 
 export type DynamicFormAction<F extends Field> = Action<F, State, FormData>;
@@ -78,21 +82,17 @@ export function DynamicForm<F extends Field>({
   onCancel,
   onChange,
   onSuccess,
-  passwordComplexity: defaultPasswordComplexity,
+  passwordComplexity,
 }: DynamicFormProps<F>) {
   // Remove options from fields before passing to action to reduce payload size
   // Options are only needed for rendering, not for processing form submissions
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const fieldsWithoutOptions = removeOptionsFromFields(fields) as Array<F | FieldGroup<F>>;
-  const actionWithFields = action.bind(null, fieldsWithoutOptions);
+  const actionWithFields = action.bind(null, { fields: fieldsWithoutOptions, passwordComplexity });
 
-  const [{ lastResult, successMessage, passwordComplexity }, formAction] = useActionState(
-    actionWithFields,
-    {
-      lastResult: null,
-      passwordComplexity: defaultPasswordComplexity,
-    },
-  );
+  const [{ lastResult, successMessage }, formAction] = useActionState(actionWithFields, {
+    lastResult: null,
+  });
 
   const dynamicSchema = schema(fields, passwordComplexity);
   const defaultValue = fields

--- a/core/vibes/soul/form/dynamic-form/index.tsx
+++ b/core/vibes/soul/form/dynamic-form/index.tsx
@@ -37,6 +37,7 @@ import { Textarea } from '@/vibes/soul/form/textarea';
 import { Button, ButtonProps } from '@/vibes/soul/primitives/button';
 
 import { Field, FieldGroup, PasswordComplexitySettings, schema } from './schema';
+import { removeOptionsFromFields } from './utils';
 
 type Action<F extends Field, S, P> = (
   fields: Array<F | FieldGroup<F>>,
@@ -79,7 +80,11 @@ export function DynamicForm<F extends Field>({
   onSuccess,
   passwordComplexity: defaultPasswordComplexity,
 }: DynamicFormProps<F>) {
-  const actionWithFields = action.bind(null, fields);
+  // Remove options from fields before passing to action to reduce payload size
+  // Options are only needed for rendering, not for processing form submissions
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  const fieldsWithoutOptions = removeOptionsFromFields(fields) as Array<F | FieldGroup<F>>;
+  const actionWithFields = action.bind(null, fieldsWithoutOptions);
 
   const [{ lastResult, successMessage, passwordComplexity }, formAction] = useActionState(
     actionWithFields,

--- a/core/vibes/soul/form/dynamic-form/utils.ts
+++ b/core/vibes/soul/form/dynamic-form/utils.ts
@@ -1,0 +1,26 @@
+import { Field, FieldGroup } from './schema';
+
+function removeOptionsFromField<T extends Field>(field: T) {
+  // Only remove the options property if it exists on the field
+  if ('options' in field) {
+    // Type assertion is used because not all Field types have 'options'
+    // and to satisfy TypeScript that we are only spreading valid props
+    const { options, ...fieldWithoutOptions } = field;
+
+    return fieldWithoutOptions;
+  }
+
+  return field;
+}
+
+export function removeOptionsFromFields<F extends Field>(fields: Array<F | FieldGroup<F>>) {
+  return fields.map((field) => {
+    if (Array.isArray(field)) {
+      // Handle field groups (arrays of fields)
+      return field.map(removeOptionsFromField);
+    }
+
+    // Handle individual fields
+    return removeOptionsFromField(field);
+  });
+}

--- a/core/vibes/soul/form/dynamic-form/utils.ts
+++ b/core/vibes/soul/form/dynamic-form/utils.ts
@@ -1,10 +1,8 @@
 import { Field, FieldGroup } from './schema';
 
-function removeOptionsFromField<T extends Field>(field: T) {
+function removeOptionsFromField<F extends Field>(field: F) {
   // Only remove the options property if it exists on the field
   if ('options' in field) {
-    // Type assertion is used because not all Field types have 'options'
-    // and to satisfy TypeScript that we are only spreading valid props
     const { options, ...fieldWithoutOptions } = field;
 
     return fieldWithoutOptions;
@@ -16,11 +14,9 @@ function removeOptionsFromField<T extends Field>(field: T) {
 export function removeOptionsFromFields<F extends Field>(fields: Array<F | FieldGroup<F>>) {
   return fields.map((field) => {
     if (Array.isArray(field)) {
-      // Handle field groups (arrays of fields)
       return field.map(removeOptionsFromField);
     }
 
-    // Handle individual fields
     return removeOptionsFromField(field);
   });
 }

--- a/core/vibes/soul/sections/address-list-section/index.tsx
+++ b/core/vibes/soul/sections/address-list-section/index.tsx
@@ -180,7 +180,7 @@ export function AddressListSection<A extends Address, F extends Field>({
           <div className="border-b border-[var(--address-list-section-border,hsl(var(--contrast-100)))] pb-6 pt-5">
             <div className="w-[480px] space-y-4">
               <DynamicForm
-                action={(_fields, _prevState, formData) => {
+                action={(_args, _prevState, formData) => {
                   setShowNewAddressForm(false);
 
                   startTransition(() => {
@@ -239,7 +239,7 @@ export function AddressListSection<A extends Address, F extends Field>({
                 {activeAddressIds.includes(address.id) ? (
                   <div className="w-[480px] space-y-4">
                     <DynamicForm
-                      action={(_fields, _prevState, formData) => {
+                      action={(_args, _prevState, formData) => {
                         setActiveAddressIds((prev) => prev.filter((id) => id !== address.id));
 
                         startTransition(() => {

--- a/core/vibes/soul/sections/address-list-section/index.tsx
+++ b/core/vibes/soul/sections/address-list-section/index.tsx
@@ -29,14 +29,23 @@ export interface DefaultAddressConfiguration {
   id: string | null;
 }
 
-type Action<S, P> = (state: Awaited<S>, payload: P) => S | Promise<S>;
+type Action<F extends Field, S, P> = (
+  fields: Array<F | FieldGroup<F>>,
+  state: Awaited<S>,
+  payload: P,
+) => S | Promise<S>;
 
-interface State<A extends Address, F extends Field> {
+interface State<A extends Address> {
   addresses: A[];
   defaultAddress?: DefaultAddressConfiguration;
   lastResult: SubmissionResult | null;
-  fields: Array<F | FieldGroup<F>>;
 }
+
+type DynamicAddressListFormAction<F extends Field, A extends Address> = Action<
+  F,
+  State<A>,
+  FormData
+>;
 
 export interface AddressListSectionProps<A extends Address, F extends Field> {
   title?: string;
@@ -44,7 +53,7 @@ export interface AddressListSectionProps<A extends Address, F extends Field> {
   fields: Array<F | FieldGroup<F>>;
   minimumAddressCount?: number;
   defaultAddress?: DefaultAddressConfiguration;
-  addressAction: Action<State<A, F>, FormData>;
+  addressAction: DynamicAddressListFormAction<F, A>;
   editLabel?: string;
   deleteLabel?: string;
   updateLabel?: string;
@@ -87,14 +96,15 @@ export function AddressListSection<A extends Address, F extends Field>({
   setDefaultLabel = 'Set as default',
   emptyStateTitle = "You don't have any addresses",
 }: AddressListSectionProps<A, F>) {
-  const [state, formAction] = useActionState(addressAction, {
+  const actionWithFields = addressAction.bind(null, fields);
+
+  const [state, formAction] = useActionState(actionWithFields, {
     addresses,
     defaultAddress,
     lastResult: null,
-    fields,
   });
 
-  const [optimisticState, setOptimisticState] = useOptimistic<State<Address, F>, FormData>(
+  const [optimisticState, setOptimisticState] = useOptimistic<State<Address>, FormData>(
     state,
     (prevState, formData) => {
       const intent = formData.get('intent');
@@ -170,7 +180,7 @@ export function AddressListSection<A extends Address, F extends Field>({
           <div className="border-b border-[var(--address-list-section-border,hsl(var(--contrast-100)))] pb-6 pt-5">
             <div className="w-[480px] space-y-4">
               <DynamicForm
-                action={(_prevState, formData) => {
+                action={(_fields, _prevState, formData) => {
                   setShowNewAddressForm(false);
 
                   startTransition(() => {
@@ -179,13 +189,12 @@ export function AddressListSection<A extends Address, F extends Field>({
                   });
 
                   return {
-                    fields: optimisticState.fields,
                     lastResult: optimisticState.lastResult,
                   };
                 }}
                 buttonSize="small"
                 cancelLabel={cancelLabel}
-                fields={optimisticState.fields.map((field) => {
+                fields={fields.map((field) => {
                   if ('name' in field && field.name === 'id') {
                     return {
                       ...field,
@@ -206,7 +215,7 @@ export function AddressListSection<A extends Address, F extends Field>({
         )}
         {!isEmpty ? (
           optimisticState.addresses.map((address) => {
-            const addressFields = optimisticState.fields.map<F | FieldGroup<F>>((field) => {
+            const addressFields = fields.map((field) => {
               if (Array.isArray(field)) {
                 return field.map((f) => {
                   return {
@@ -230,7 +239,7 @@ export function AddressListSection<A extends Address, F extends Field>({
                 {activeAddressIds.includes(address.id) ? (
                   <div className="w-[480px] space-y-4">
                     <DynamicForm
-                      action={(_prevState, formData) => {
+                      action={(_fields, _prevState, formData) => {
                         setActiveAddressIds((prev) => prev.filter((id) => id !== address.id));
 
                         startTransition(() => {
@@ -239,7 +248,6 @@ export function AddressListSection<A extends Address, F extends Field>({
                         });
 
                         return {
-                          fields: optimisticState.fields,
                           lastResult: optimisticState.lastResult,
                         };
                       }}


### PR DESCRIPTION
## What/Why?
Refactor DynamicForm actions to decouple fields and passwordComplexity from state, passing them as separate arguments instead. This reduces state payload size by removing fields from state objects and stripping options from fields before passing them to actions (options are only needed for rendering, not processing). All form actions now accept a `DynamicFormActionArgs` object as the first parameter containing fields and optional passwordComplexity, followed by the previous state and formData.

## Testing
Locally

<img width="993" height="1010" alt="Screenshot 2026-01-14 at 2 56 49 PM" src="https://github.com/user-attachments/assets/a8431b27-7aa4-46b4-92be-78e31e849cf0" />

## Migration steps

### Step 1: Changes to DynamicForm component

The `DynamicForm` component and related utilities have been updated to support the new action signature pattern:

**`core/vibes/soul/form/dynamic-form/index.tsx`**:
- Added `DynamicFormActionArgs<F>` interface that contains `fields` and optional `passwordComplexity`
- Updated `DynamicFormAction<F>` type to accept `DynamicFormActionArgs<F>` as the first parameter
- Removed `fields` and `passwordComplexity` from the `State` interface
- Added automatic removal of `options` from fields before passing to actions (options are only needed for rendering)
- Updated action binding to use `action.bind(null, { fields: fieldsWithoutOptions, passwordComplexity })`

**`core/vibes/soul/form/dynamic-form/utils.ts`** (new file):
- Added `removeOptionsFromFields()` utility function that strips the `options` property from field definitions before passing them to actions, reducing the state payload size

```diff
+ export interface DynamicFormActionArgs<F extends Field> {
+   fields: Array<F | FieldGroup<F>>;
+   passwordComplexity?: PasswordComplexitySettings | null;
+ }
+
+ type Action<F extends Field, S, P> = (
+   args: DynamicFormActionArgs<F>,
+   state: Awaited<S>,
+   payload: P,
+ ) => S | Promise<S>;
+
  interface State {
    lastResult: SubmissionResult | null;
-   fields: Array<F | FieldGroup<F>>;
-   passwordComplexity?: PasswordComplexitySettings | null;
  }
```

### Step 2: Update DynamicForm action signatures

All form actions that use `DynamicForm` must be updated to accept `DynamicFormActionArgs<F>` as the first parameter instead of including fields in the state.

Update your form action function signature:

```diff
+ import { DynamicFormActionArgs } from '@/vibes/soul/form/dynamic-form';
  import { Field, FieldGroup, schema } from '@/vibes/soul/form/dynamic-form/schema';

- export async function myFormAction<F extends Field>(
-   prevState: {
-     lastResult: SubmissionResult | null;
-     fields: Array<F | FieldGroup<F>>;
-     passwordComplexity?: PasswordComplexitySettings | null;
-   },
-   formData: FormData,
- ) {
+ export async function myFormAction<F extends Field>(
+   { fields, passwordComplexity }: DynamicFormActionArgs<F>,
+   _prevState: {
+     lastResult: SubmissionResult | null;
+   },
+   formData: FormData,
+ ) {
```

### Step 2: Remove fields and passwordComplexity from state interfaces

Update state interfaces to remove fields and passwordComplexity properties:

```diff
  interface State {
    lastResult: SubmissionResult | null;
-   fields: Array<Field | FieldGroup<Field>>;
-   passwordComplexity?: PasswordComplexitySettings | null;
  }
```

### Step 3: Update action implementations

Remove references to `prevState.fields` and `prevState.passwordComplexity` in action implementations:

```diff
  const submission = parseWithZod(formData, {
-   schema: schema(prevState.fields, prevState.passwordComplexity),
+   schema: schema(fields, passwordComplexity),
  });

  if (submission.status !== 'success') {
    return {
      lastResult: submission.reply(),
-     fields: prevState.fields,
-     passwordComplexity: prevState.passwordComplexity,
    };
  }
```

### Step 4: Update action calls in components

For actions used with `AddressListSection`, update the action signature to accept fields as the first parameter:

```diff
- export async function addressAction(
-   prevState: Awaited<State>,
-   formData: FormData,
- ): Promise<State> {
+ export async function addressAction(
+   fields: Array<Field | FieldGroup<Field>>,
+   prevState: Awaited<State>,
+   formData: FormData,
+ ): Promise<State> {
```

### Step 5: Update DynamicForm usage

No changes needed to `DynamicForm` component usage. The component automatically handles binding fields and passwordComplexity to actions. The `DynamicForm` component now:
- Automatically removes options from fields before passing them to actions (reducing payload size)
- Binds fields and passwordComplexity to the action using `action.bind()`
- Maintains the same props interface, so existing usage continues to work

### Affected files

The following files were updated in this refactor:
- `core/vibes/soul/form/dynamic-form/index.tsx` - Added `DynamicFormActionArgs` type and updated action binding
- `core/vibes/soul/form/dynamic-form/utils.ts` - Added `removeOptionsFromFields` utility function
- `core/app/[locale]/(default)/(auth)/register/_actions/register-customer.ts`
- `core/app/[locale]/(default)/account/addresses/_actions/address-action.ts`
- `core/app/[locale]/(default)/account/addresses/_actions/create-address.ts`
- `core/app/[locale]/(default)/account/addresses/_actions/update-address.ts`
- `core/app/[locale]/(default)/account/addresses/_actions/delete-address.ts`
- `core/app/[locale]/(default)/gift-certificates/purchase/_actions/add-to-cart.tsx`
- `core/app/[locale]/(default)/webpages/[id]/contact/_actions/submit-contact-form.ts`
- `core/vibes/soul/sections/address-list-section/index.tsx`