### PR TITLE
feat(core): filter out child cart line items

### DIFF
--- a/.changeset/bright-rules-chew.md
+++ b/.changeset/bright-rules-chew.md
@@ -1,0 +1,84 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Filter out child cart items (items with `parentEntityId`) from cart and cart analytics to prevent duplicate line items when products have parent-child relationships, such as product bundles.
+
+## Migration steps
+
+### Step 1: GraphQL Fragment Updates
+
+The `parentEntityId` field has been added to both physical and digital cart item fragments to identify child items.
+
+Update `core/app/[locale]/(default)/cart/page-data.ts`:
+
+```diff
+  export const PhysicalItemFragment = graphql(`
+    fragment PhysicalItemFragment on CartPhysicalItem {
+      entityId
+      quantity
+      productEntityId
+      variantEntityId
++     parentEntityId
+      listPrice {
+        currencyCode
+        value
+      }
+    }
+  `);
+
+  export const DigitalItemFragment = graphql(`
+    fragment DigitalItemFragment on CartDigitalItem {
+      entityId
+      quantity
+      productEntityId
+      variantEntityId
++     parentEntityId
+      listPrice {
+        currencyCode
+        value
+      }
+    }
+  `);
+```
+
+### Step 2: Cart Display Filtering
+
+Cart line items are now filtered to exclude child items when displaying the cart.
+
+Update `core/app/[locale]/(default)/cart/page.tsx`:
+
+```diff
+  const lineItems = [
+    ...cart.lineItems.giftCertificates,
+    ...cart.lineItems.physicalItems,
+    ...cart.lineItems.digitalItems,
+- ];
++ ].filter((item) => !('parentEntityId' in item) || !item.parentEntityId);
+```
+
+### Step 3: Analytics Data Filtering
+
+Analytics data collection now only includes top-level items to prevent duplicate tracking.
+
+Update `core/app/[locale]/(default)/cart/page.tsx` in the `getAnalyticsData` function:
+
+```diff
+- const lineItems = [...cart.lineItems.physicalItems, ...cart.lineItems.digitalItems];
++ const lineItems = [...cart.lineItems.physicalItems, ...cart.lineItems.digitalItems].filter(
++   (item) => !item.parentEntityId, // Only include top-level items
++ );
+```
+
+### Step 4: Styling Update
+
+Cart subtitle text color has been updated for improved contrast.
+
+Update `core/vibes/soul/sections/cart/client.tsx`:
+
+```diff
+-                  <span className="text-[var(--cart-subtext-text,hsl(var(--contrast-300)))] contrast-more:text-[var(--cart-subtitle-text,hsl(var(--contrast-500)))]">
++                  <span className="text-[var(--cart-subtext-text,hsl(var(--contrast-400)))] contrast-more:text-[var(--cart-subtitle-text,hsl(var(--contrast-500)))]">
+                     {lineItem.subtitle}
+                   </span>
+```

--- a/core/app/[locale]/(default)/cart/page-data.ts
+++ b/core/app/[locale]/(default)/cart/page-data.ts
@@ -19,6 +19,7 @@ export const PhysicalItemFragment = graphql(`
     quantity
     productEntityId
     variantEntityId
+    parentEntityId
     listPrice {
       currencyCode
       value
@@ -71,6 +72,7 @@ export const DigitalItemFragment = graphql(`
     quantity
     productEntityId
     variantEntityId
+    parentEntityId
     listPrice {
       currencyCode
       value

--- a/core/app/[locale]/(default)/cart/page.tsx
+++ b/core/app/[locale]/(default)/cart/page.tsx
@@ -41,7 +41,9 @@ const getAnalyticsData = async (cartId: string) => {
     return [];
   }
 
-  const lineItems = [...cart.lineItems.physicalItems, ...cart.lineItems.digitalItems];
+  const lineItems = [...cart.lineItems.physicalItems, ...cart.lineItems.digitalItems].filter(
+    (item) => !item.parentEntityId, // Only include top-level items
+  );
 
   return lineItems.map((item) => {
     return {
@@ -98,7 +100,7 @@ export default async function Cart({ params }: Props) {
     ...cart.lineItems.giftCertificates,
     ...cart.lineItems.physicalItems,
     ...cart.lineItems.digitalItems,
-  ];
+  ].filter((item) => !('parentEntityId' in item) || !item.parentEntityId);
 
   const formattedLineItems = lineItems.map((item) => {
     if (item.__typename === 'CartGiftCertificate') {

--- a/core/vibes/soul/sections/cart/client.tsx
+++ b/core/vibes/soul/sections/cart/client.tsx
@@ -451,7 +451,7 @@ export function CartClient<LineItem extends CartLineItem>({
               <div className="flex grow flex-col flex-wrap justify-between gap-y-2 @xl:flex-row">
                 <div className="flex w-full flex-1 flex-col @xl:w-1/2 @xl:pr-4">
                   <span className="font-medium">{lineItem.title}</span>
-                  <span className="text-[var(--cart-subtext-text,hsl(var(--contrast-300)))] contrast-more:text-[var(--cart-subtitle-text,hsl(var(--contrast-500)))]">
+                  <span className="text-[var(--cart-subtext-text,hsl(var(--contrast-400)))] contrast-more:text-[var(--cart-subtitle-text,hsl(var(--contrast-500)))]">
                     {lineItem.subtitle}
                   </span>
                 </div>


### PR DESCRIPTION
## What/Why?
Filter out child cart items (items with `parentEntityId`) from cart and cart analytics to prevent duplicate line items when products have parent-child relationships, such as product bundles.

Simplified this implementation over #2726 because it's not easy to know which `CartSelectedMultipleChoiceOption` from the product options/modifiers has attached this child product to the parent item, so we would get duplicate information (in the product options list, shown below, as well as a separate product item below the parent product). I opted for less duplication and code simplicity.

## Testing
<img width="1718" height="1225" alt="Screenshot 2026-01-20 at 3 09 56 PM" src="https://github.com/user-attachments/assets/1a1992f5-c869-49b3-aca8-1f97d50d394c" />

## Migration steps

### Step 1: GraphQL Fragment Updates

The `parentEntityId` field has been added to both physical and digital cart item fragments to identify child items.

Update `core/app/[locale]/(default)/cart/page-data.ts`:

```diff
  export const PhysicalItemFragment = graphql(`
    fragment PhysicalItemFragment on CartPhysicalItem {
      entityId
      quantity
      productEntityId
      variantEntityId
+     parentEntityId
      listPrice {
        currencyCode
        value
      }
    }
  `);

  export const DigitalItemFragment = graphql(`
    fragment DigitalItemFragment on CartDigitalItem {
      entityId
      quantity
      productEntityId
      variantEntityId
+     parentEntityId
      listPrice {
        currencyCode
        value
      }
    }
  `);
```

### Step 2: Cart Display Filtering

Cart line items are now filtered to exclude child items when displaying the cart.

Update `core/app/[locale]/(default)/cart/page.tsx`:

```diff
  const lineItems = [
    ...cart.lineItems.giftCertificates,
    ...cart.lineItems.physicalItems,
    ...cart.lineItems.digitalItems,
- ];
+ ].filter((item) => !('parentEntityId' in item) || !item.parentEntityId);
```

### Step 3: Analytics Data Filtering

Analytics data collection now only includes top-level items to prevent duplicate tracking.

Update `core/app/[locale]/(default)/cart/page.tsx` in the `getAnalyticsData` function:

```diff
- const lineItems = [...cart.lineItems.physicalItems, ...cart.lineItems.digitalItems];
+ const lineItems = [...cart.lineItems.physicalItems, ...cart.lineItems.digitalItems].filter(
+   (item) => !item.parentEntityId, // Only include top-level items
+ );
```

### Step 4: Styling Update

Cart subtitle text color has been updated for improved contrast.

Update `core/vibes/soul/sections/cart/client.tsx`:

```diff
-                  <span className="text-[var(--cart-subtext-text,hsl(var(--contrast-300)))] contrast-more:text-[var(--cart-subtitle-text,hsl(var(--contrast-500)))]">
+                  <span className="text-[var(--cart-subtext-text,hsl(var(--contrast-400)))] contrast-more:text-[var(--cart-subtitle-text,hsl(var(--contrast-500)))]">
                     {lineItem.subtitle}
                   </span>
```
