### PR TITLE
fix: Fix successMessage translations

### DIFF
--- a/core/messages/da.json
+++ b/core/messages/da.json
@@ -373,7 +373,7 @@
         "otherDetails": "Andre oplysninger",
         "noOtherDetails": "Der er ingen andre oplysninger.",
         "viewOptions": "Se muligheder",
-        "successMessage": "<cartLink>{CartItems, plural, =1 {1 vare} other {# varer}} tilføjet til din indkøbskurv</cartLink>",
+        "successMessage": "{cartItems, plural, =1 {1 vare} other {# varer}} tilføjet til <cartLink>din indkøbskurv</cartLink>",
         "missingCart": "Indkøbskurven blev ikke fundet. Prøv igen senere.",
         "unknownError": "Ukendt fejl. Prøv igen senere."
     },
@@ -383,7 +383,7 @@
             "increaseQuantity": "Øg mængden",
             "decreaseQuantity": "Reducer mængden",
             "emptySelectPlaceholder": "Vælg en valgmulighed",
-            "successMessage": "<cartLink>{CartItems, plural, =1 {1 vare} other {# varer}} tilføjet til din indkøbskurv</cartLink>",
+            "successMessage": "{cartItems, plural, =1 {1 vare} other {# varer}} tilføjet til <cartLink>din indkøbskurv</cartLink>",
             "missingCart": "Indkøbskurven blev ikke fundet. Prøv igen senere.",
             "unknownError": "Ukendt fejl. Prøv igen senere.",
             "variantRequiredError": "Dette produkt kræver, at der vælges muligheder for at kunne lægges i indkøbskurven.",

--- a/core/messages/fr.json
+++ b/core/messages/fr.json
@@ -373,7 +373,7 @@
         "otherDetails": "Autres informations",
         "noOtherDetails": "Aucune information supplémentaire.",
         "viewOptions": "Afficher les options",
-        "successMessage": "<cartLink>{CartItems, plural, =1 {1 article} other {# articles}} ajouté(s) à votre panier</cartLink>",
+        "successMessage": "{cartItems, plural, =1 {1 article} other {# articles}} ajouté(s) à <cartLink>votre panier</cartLink>",
         "missingCart": "Panier introuvable. Veuillez réessayer plus tard.",
         "unknownError": "Erreur inconnue. Veuillez réessayer plus tard."
     },
@@ -383,7 +383,7 @@
             "increaseQuantity": "Augmenter la quantité :",
             "decreaseQuantity": "Réduire la quantité",
             "emptySelectPlaceholder": "Sélectionner une option",
-            "successMessage": "<cartLink>{CartItems, plural, =1 {1 article} other {# articles}} ajouté(s) à votre panier</cartLink>",
+            "successMessage": "{cartItems, plural, =1 {1 article} other {# articles}} ajouté(s) à <cartLink>votre panier</cartLink>",
             "missingCart": "Panier introuvable. Veuillez réessayer plus tard !",
             "unknownError": "Erreur inconnue. Veuillez réessayer plus tard.",
             "variantRequiredError": "Ce produit nécessite de sélectionner des options pour pouvoir être ajouté au panier.",


### PR DESCRIPTION
## What/Why?

https://bigcommercecloud.atlassian.net/browse/LOCAL-3042

This PR fixes translation issues in French and Danish JSON files where `CartItems` (capital C) was used instead of `cartItems` (lowercase), and where `<cartLink>` incorrectly wrapped the entire message.


## Root Cause
The code in `core/app/[locale]/(default)/product/[slug]/_actions/add-to-cart.tsx` (passes `cartItems: quantity` (lowercase) to the translation function. When translation files used `CartItems` (capital C), the pluralization failed because the variable name didn't match.

Additionally, the `<cartLink>` tag should only wrap the clickable text (like "your cart"), not the entire message including the plural variable.

## Testing


### Before
<img width="1295" height="810" alt="image" src="https://github.com/user-attachments/assets/a6b092f6-9712-48ff-b931-017f849c3a0a" />

### After
<img width="1854" height="1408" alt="image" src="https://github.com/user-attachments/assets/1340761f-81ff-4c1f-9c79-4e75956d9fcd" />

<img width="1290" height="852" alt="image" src="https://github.com/user-attachments/assets/304e1916-b3fc-46fc-9e44-42f5588f018e" />


- The cart link is clickable and navigates to `/cart`
## Migration
None