### PR TITLE
fix(core): add root level not-found page

### DIFF
--- a/.changeset/large-trams-rule.md
+++ b/.changeset/large-trams-rule.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Adds a root level not-found page for scenarios where a redirect to `notFound` is used outside the `[locale]` path.

--- a/core/app/not-found.tsx
+++ b/core/app/not-found.tsx
@@ -1,0 +1,31 @@
+import { clsx } from 'clsx';
+import { getTranslations } from 'next-intl/server';
+
+import '../globals.css';
+
+import { SectionLayout } from '@/vibes/soul/sections/section-layout';
+import { fonts } from '~/app/fonts';
+import { defaultLocale } from '~/i18n/locales';
+
+export default async function NotFound() {
+  const t = await getTranslations({ namespace: 'NotFound', locale: defaultLocale });
+
+  return (
+    <html className={clsx(fonts.map((f) => f.variable))} lang={defaultLocale}>
+      <body className="flex min-h-screen flex-col">
+        <div className="flex flex-1 flex-col place-content-center">
+          <SectionLayout containerSize="2xl">
+            <header className="font-[family-name:var(--not-found-font-family,var(--font-family-body))]">
+              <h1 className="mb-3 font-[family-name:var(--not-found-title-font-family,var(--font-family-heading))] text-3xl font-medium leading-none text-[var(--not-found-title,hsl(var(--foreground)))] @xl:text-4xl @4xl:text-5xl">
+                {t('title')}
+              </h1>
+              <p className="mb-4 text-lg text-[var(--not-found-subtitle,hsl(var(--contrast-500)))]">
+                {t('subtitle')}
+              </p>
+            </header>
+          </SectionLayout>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/core/app/not-found.tsx
+++ b/core/app/not-found.tsx
@@ -1,6 +1,8 @@
 import { defaultLocale } from '~/i18n/locales';
 import { redirect } from '~/i18n/routing';
 
+// For scenarios where a redirect to `notFound` is used outside the `[locale]` path.
+// We still need to redirect to the `[locale]/not-found` path so that the page is rendered with the correct locale.
 export default function Page() {
   redirect({ href: '/not-found', locale: defaultLocale });
 }

--- a/core/app/not-found.tsx
+++ b/core/app/not-found.tsx
@@ -1,8 +1,8 @@
-import { defaultLocale } from '~/i18n/locales';
-import { redirect } from '~/i18n/routing';
+import { notFound } from 'next/navigation';
 
 // For scenarios where a redirect to `notFound` is used outside the `[locale]` path.
 // We still need to redirect to the `[locale]/not-found` path so that the page is rendered with the correct locale.
 export default function Page() {
-  redirect({ href: '/not-found', locale: defaultLocale });
+  // redirect({ href: '/not-found', locale: defaultLocale });
+  notFound();
 }

--- a/core/app/not-found.tsx
+++ b/core/app/not-found.tsx
@@ -1,31 +1,6 @@
-import { clsx } from 'clsx';
-import { getTranslations } from 'next-intl/server';
-
-import '../globals.css';
-
-import { SectionLayout } from '@/vibes/soul/sections/section-layout';
-import { fonts } from '~/app/fonts';
 import { defaultLocale } from '~/i18n/locales';
+import { redirect } from '~/i18n/routing';
 
-export default async function NotFound() {
-  const t = await getTranslations({ namespace: 'NotFound', locale: defaultLocale });
-
-  return (
-    <html className={clsx(fonts.map((f) => f.variable))} lang={defaultLocale}>
-      <body className="flex min-h-screen flex-col">
-        <div className="flex flex-1 flex-col place-content-center">
-          <SectionLayout containerSize="2xl">
-            <header className="font-[family-name:var(--not-found-font-family,var(--font-family-body))]">
-              <h1 className="mb-3 font-[family-name:var(--not-found-title-font-family,var(--font-family-heading))] text-3xl font-medium leading-none text-[var(--not-found-title,hsl(var(--foreground)))] @xl:text-4xl @4xl:text-5xl">
-                {t('title')}
-              </h1>
-              <p className="mb-4 text-lg text-[var(--not-found-subtitle,hsl(var(--contrast-500)))]">
-                {t('subtitle')}
-              </p>
-            </header>
-          </SectionLayout>
-        </div>
-      </body>
-    </html>
-  );
+export default function Page() {
+  redirect({ href: '/not-found', locale: defaultLocale });
 }

--- a/core/middlewares/with-routes.ts
+++ b/core/middlewares/with-routes.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
+import { defaultLocale } from '~/i18n/locales';
 import { getVisitIdCookie, getVisitorIdCookie } from '~/lib/analytics/bigcommerce';
 import { sendProductViewedEvent } from '~/lib/analytics/bigcommerce/data-events';
 import { kvKey, STORE_STATUS_KEY } from '~/lib/kv/keys';
@@ -291,6 +292,14 @@ export const withRoutes: MiddlewareFactory = () => {
     const locale = request.headers.get('x-bc-locale') ?? '';
 
     const { route, status } = await getRouteInfo(request, event);
+
+    if (request.url === '/404' || request.url === '/404/') {
+      const notFoundRewriteUrl = new URL(`/${locale}/not-found-2`, request.url);
+
+      notFoundRewriteUrl.search = request.nextUrl.search;
+
+      return NextResponse.rewrite(notFoundRewriteUrl);
+    }
 
     if (status === 'MAINTENANCE') {
       // 503 status code not working - https://github.com/vercel/next.js/issues/50155

--- a/core/middlewares/with-routes.ts
+++ b/core/middlewares/with-routes.ts
@@ -4,7 +4,6 @@ import { z } from 'zod';
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
-import { defaultLocale } from '~/i18n/locales';
 import { getVisitIdCookie, getVisitorIdCookie } from '~/lib/analytics/bigcommerce';
 import { sendProductViewedEvent } from '~/lib/analytics/bigcommerce/data-events';
 import { kvKey, STORE_STATUS_KEY } from '~/lib/kv/keys';


### PR DESCRIPTION
## What/Why?
Adds a root level `core/app/not-found.tsx` that redirects to our catch all route, which in turns renders the `core/app/[locale]/not-found.tsx`.

This is to circumvent the issue that `/404` is handled by Vercel in the edge and looks for a `not-found` page at the root level.

## Testing
<img width="1184" height="816" alt="Screenshot 2026-01-27 at 4 32 59 PM" src="https://github.com/user-attachments/assets/1629e4af-fa62-472f-8171-1faeaedae9d7" />

## Migration
Add new `core/app/not-found.tsx` page.
