### PR TITLE
chore(ci): pass channel-specific env vars to vercel deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,6 +43,8 @@ jobs:
                   echo "CHANNEL_ID=${{ vars.B2B_MAKESWIFT_BIGCOMMERCE_CHANNEL_ID }}" >> $GITHUB_ENV
                   echo "STOREFRONT_TOKEN=${{ secrets.B2B_MAKESWIFT_BIGCOMMERCE_STOREFRONT_TOKEN }}" >> $GITHUB_ENV
                   echo "MAKESWIFT_KEY=${{ secrets.B2B_MAKESWIFT_SITE_API_KEY }}" >> $GITHUB_ENV
+                  echo "B2B_API_HOST=${{ vars.B2B_API_HOST }}" >> $GITHUB_ENV
+                  echo "BIGCOMMERCE_ACCESS_TOKEN=${{ secrets.B2B_BIGCOMMERCE_ACCESS_TOKEN }}" >> $GITHUB_ENV
 
             - name: Deploy to Vercel
               id: deploy
@@ -58,6 +60,14 @@ jobs:
 
                   if [[ -n "$MAKESWIFT_KEY" ]]; then
                     DEPLOY_ARGS+=(--env MAKESWIFT_SITE_API_KEY="$MAKESWIFT_KEY")
+                  fi
+
+                  if [[ -n "$B2B_API_HOST" ]]; then
+                    DEPLOY_ARGS+=(--env B2B_API_HOST="$B2B_API_HOST")
+                  fi
+
+                  if [[ -n "$BIGCOMMERCE_ACCESS_TOKEN" ]]; then
+                    DEPLOY_ARGS+=(--env BIGCOMMERCE_ACCESS_TOKEN="$BIGCOMMERCE_ACCESS_TOKEN")
                   fi
 
                   DEPLOYMENT_URL=$(vercel deploy "${DEPLOY_ARGS[@]}")

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ on:
             - "@bigcommerce/catalyst-b2b-makeswift@latest"
 jobs:
     deploy-tag:
-        name: Deploy `{{ github.ref_name }}` tag
+        name: Deploy `${{ github.ref_name }}` tag
         runs-on: ubuntu-latest
         concurrency:
             group: ${{ github.workflow }}-${{ github.ref_name }}
@@ -21,23 +21,52 @@ jobs:
             - name: Install Vercel CLI
               run: npm install --global vercel@latest
 
-            - name: Parse Tag and Build Domain
+            - name: Parse Tag and Build Configuration
               id: parse-tag
               run: |
                   TAG="${{ github.ref_name }}"
                   PACKAGE_NAME=$(echo "$TAG" | sed -E 's/^@bigcommerce\/([^@]+)@.*$/\1/')
+
                   case "$PACKAGE_NAME" in
-                    "catalyst-core") DOMAIN="catalyst-demo.site" ;;
-                    "catalyst-makeswift") DOMAIN="makeswift.catalyst-demo.site" ;;
-                    "catalyst-b2b-makeswift") DOMAIN="b2b-makeswift.catalyst-demo.site" ;;
-                    *) echo "Error: Unknown package name: $PACKAGE_NAME"; exit 1 ;;
+                    "catalyst-core")
+                      echo "domain=catalyst-demo.site" >> $GITHUB_OUTPUT
+                      echo "env_prefix=CORE" >> $GITHUB_OUTPUT
+                      echo "is_makeswift=false" >> $GITHUB_OUTPUT
+                      ;;
+                    "catalyst-makeswift")
+                      echo "domain=makeswift.catalyst-demo.site" >> $GITHUB_OUTPUT
+                      echo "env_prefix=MAKESWIFT" >> $GITHUB_OUTPUT
+                      echo "is_makeswift=true" >> $GITHUB_OUTPUT
+                      ;;
+                    "catalyst-b2b-makeswift")
+                      echo "domain=b2b-makeswift.catalyst-demo.site" >> $GITHUB_OUTPUT
+                      echo "env_prefix=B2B_MAKESWIFT" >> $GITHUB_OUTPUT
+                      echo "is_makeswift=true" >> $GITHUB_OUTPUT
+                      ;;
+                    *)
+                      echo "Error: Unknown package name: $PACKAGE_NAME"
+                      exit 1
+                      ;;
                   esac
-                  echo "domain=$DOMAIN" >> $GITHUB_OUTPUT
 
             - name: Deploy to Vercel
               id: deploy
+              env:
+                  CHANNEL_ID: ${{ steps.parse-tag.outputs.env_prefix == 'CORE' && vars.CORE_BIGCOMMERCE_CHANNEL_ID || steps.parse-tag.outputs.env_prefix == 'MAKESWIFT' && vars.MAKESWIFT_BIGCOMMERCE_CHANNEL_ID || vars.B2B_MAKESWIFT_BIGCOMMERCE_CHANNEL_ID }}
+                  STOREFRONT_TOKEN: ${{ steps.parse-tag.outputs.env_prefix == 'CORE' && secrets.CORE_BIGCOMMERCE_STOREFRONT_TOKEN || steps.parse-tag.outputs.env_prefix == 'MAKESWIFT' && secrets.MAKESWIFT_BIGCOMMERCE_STOREFRONT_TOKEN || secrets.B2B_MAKESWIFT_BIGCOMMERCE_STOREFRONT_TOKEN }}
+                  MAKESWIFT_KEY: ${{ steps.parse-tag.outputs.env_prefix == 'MAKESWIFT' && secrets.MAKESWIFT_SITE_API_KEY || secrets.B2B_MAKESWIFT_SITE_API_KEY }}
               run: |
-                  DEPLOYMENT_URL=$(vercel deploy --token=${{ secrets.VERCEL_TOKEN }})
+                  # Build deploy command with env vars
+                  DEPLOY_CMD="vercel deploy --token=${{ secrets.VERCEL_TOKEN }}"
+                  DEPLOY_CMD="$DEPLOY_CMD --env BIGCOMMERCE_CHANNEL_ID=$CHANNEL_ID"
+                  DEPLOY_CMD="$DEPLOY_CMD --env BIGCOMMERCE_STOREFRONT_TOKEN=$STOREFRONT_TOKEN"
+
+                  # Add Makeswift-specific env var if applicable
+                  if [[ "${{ steps.parse-tag.outputs.is_makeswift }}" == "true" ]]; then
+                    DEPLOY_CMD="$DEPLOY_CMD --env MAKESWIFT_SITE_API_KEY=$MAKESWIFT_KEY"
+                  fi
+
+                  DEPLOYMENT_URL=$(eval $DEPLOY_CMD)
                   echo "deployment_url=$DEPLOYMENT_URL" >> $GITHUB_OUTPUT
 
             - name: Set Vercel Domain Alias

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,54 +21,51 @@ jobs:
             - name: Install Vercel CLI
               run: npm install --global vercel@latest
 
-            - name: Parse Tag and Build Configuration
-              id: parse-tag
+            - name: Configure catalyst-core deployment
+              if: contains(github.ref_name, 'catalyst-core@')
               run: |
-                  TAG="${{ github.ref_name }}"
-                  PACKAGE_NAME=$(echo "$TAG" | sed -E 's/^@bigcommerce\/([^@]+)@.*$/\1/')
+                  echo "DOMAIN=catalyst-demo.site" >> $GITHUB_ENV
+                  echo "CHANNEL_ID=${{ vars.CORE_BIGCOMMERCE_CHANNEL_ID }}" >> $GITHUB_ENV
+                  echo "STOREFRONT_TOKEN=${{ secrets.CORE_BIGCOMMERCE_STOREFRONT_TOKEN }}" >> $GITHUB_ENV
 
-                  case "$PACKAGE_NAME" in
-                    "catalyst-core")
-                      echo "domain=catalyst-demo.site" >> $GITHUB_OUTPUT
-                      echo "env_prefix=CORE" >> $GITHUB_OUTPUT
-                      echo "is_makeswift=false" >> $GITHUB_OUTPUT
-                      ;;
-                    "catalyst-makeswift")
-                      echo "domain=makeswift.catalyst-demo.site" >> $GITHUB_OUTPUT
-                      echo "env_prefix=MAKESWIFT" >> $GITHUB_OUTPUT
-                      echo "is_makeswift=true" >> $GITHUB_OUTPUT
-                      ;;
-                    "catalyst-b2b-makeswift")
-                      echo "domain=b2b-makeswift.catalyst-demo.site" >> $GITHUB_OUTPUT
-                      echo "env_prefix=B2B_MAKESWIFT" >> $GITHUB_OUTPUT
-                      echo "is_makeswift=true" >> $GITHUB_OUTPUT
-                      ;;
-                    *)
-                      echo "Error: Unknown package name: $PACKAGE_NAME"
-                      exit 1
-                      ;;
-                  esac
+            - name: Configure catalyst-makeswift deployment
+              if: contains(github.ref_name, 'catalyst-makeswift@')
+              run: |
+                  echo "DOMAIN=makeswift.catalyst-demo.site" >> $GITHUB_ENV
+                  echo "CHANNEL_ID=${{ vars.MAKESWIFT_BIGCOMMERCE_CHANNEL_ID }}" >> $GITHUB_ENV
+                  echo "STOREFRONT_TOKEN=${{ secrets.MAKESWIFT_BIGCOMMERCE_STOREFRONT_TOKEN }}" >> $GITHUB_ENV
+                  echo "MAKESWIFT_KEY=${{ secrets.MAKESWIFT_SITE_API_KEY }}" >> $GITHUB_ENV
+
+            - name: Configure catalyst-b2b-makeswift deployment
+              if: contains(github.ref_name, 'catalyst-b2b-makeswift@')
+              run: |
+                  echo "DOMAIN=b2b-makeswift.catalyst-demo.site" >> $GITHUB_ENV
+                  echo "CHANNEL_ID=${{ vars.B2B_MAKESWIFT_BIGCOMMERCE_CHANNEL_ID }}" >> $GITHUB_ENV
+                  echo "STOREFRONT_TOKEN=${{ secrets.B2B_MAKESWIFT_BIGCOMMERCE_STOREFRONT_TOKEN }}" >> $GITHUB_ENV
+                  echo "MAKESWIFT_KEY=${{ secrets.B2B_MAKESWIFT_SITE_API_KEY }}" >> $GITHUB_ENV
 
             - name: Deploy to Vercel
               id: deploy
+              timeout-minutes: 15
               env:
-                  CHANNEL_ID: ${{ steps.parse-tag.outputs.env_prefix == 'CORE' && vars.CORE_BIGCOMMERCE_CHANNEL_ID || steps.parse-tag.outputs.env_prefix == 'MAKESWIFT' && vars.MAKESWIFT_BIGCOMMERCE_CHANNEL_ID || vars.B2B_MAKESWIFT_BIGCOMMERCE_CHANNEL_ID }}
-                  STOREFRONT_TOKEN: ${{ steps.parse-tag.outputs.env_prefix == 'CORE' && secrets.CORE_BIGCOMMERCE_STOREFRONT_TOKEN || steps.parse-tag.outputs.env_prefix == 'MAKESWIFT' && secrets.MAKESWIFT_BIGCOMMERCE_STOREFRONT_TOKEN || secrets.B2B_MAKESWIFT_BIGCOMMERCE_STOREFRONT_TOKEN }}
-                  MAKESWIFT_KEY: ${{ steps.parse-tag.outputs.env_prefix == 'MAKESWIFT' && secrets.MAKESWIFT_SITE_API_KEY || secrets.B2B_MAKESWIFT_SITE_API_KEY }}
+                  VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
               run: |
-                  # Build deploy command with env vars
-                  DEPLOY_CMD="vercel deploy --token=${{ secrets.VERCEL_TOKEN }}"
-                  DEPLOY_CMD="$DEPLOY_CMD --env BIGCOMMERCE_CHANNEL_ID=$CHANNEL_ID"
-                  DEPLOY_CMD="$DEPLOY_CMD --env BIGCOMMERCE_STOREFRONT_TOKEN=$STOREFRONT_TOKEN"
+                  DEPLOY_ARGS=(
+                    --token="$VERCEL_TOKEN"
+                    --env BIGCOMMERCE_CHANNEL_ID="$CHANNEL_ID"
+                    --env BIGCOMMERCE_STOREFRONT_TOKEN="$STOREFRONT_TOKEN"
+                  )
 
-                  # Add Makeswift-specific env var if applicable
-                  if [[ "${{ steps.parse-tag.outputs.is_makeswift }}" == "true" ]]; then
-                    DEPLOY_CMD="$DEPLOY_CMD --env MAKESWIFT_SITE_API_KEY=$MAKESWIFT_KEY"
+                  if [[ -n "$MAKESWIFT_KEY" ]]; then
+                    DEPLOY_ARGS+=(--env MAKESWIFT_SITE_API_KEY="$MAKESWIFT_KEY")
                   fi
 
-                  DEPLOYMENT_URL=$(eval $DEPLOY_CMD)
+                  DEPLOYMENT_URL=$(vercel deploy "${DEPLOY_ARGS[@]}")
                   echo "deployment_url=$DEPLOYMENT_URL" >> $GITHUB_OUTPUT
 
             - name: Set Vercel Domain Alias
+              timeout-minutes: 5
+              env:
+                  VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
               run: |
-                  vercel alias ${{ steps.deploy.outputs.deployment_url }} ${{ steps.parse-tag.outputs.domain }} --token=${{ secrets.VERCEL_TOKEN }}
+                  vercel alias ${{ steps.deploy.outputs.deployment_url }} $DOMAIN --token="$VERCEL_TOKEN"


### PR DESCRIPTION
## What/Why?

Updates the GitHub Actions deploy workflow to pass channel-specific environment variables to Vercel deployments. Previously, the workflow only parsed the tag to determine the deployment domain. Now it also:

- Determines the appropriate `env_prefix` based on package name (`CORE`, `MAKESWIFT`, or `B2B_MAKESWIFT`)
- Passes `BIGCOMMERCE_CHANNEL_ID` and `BIGCOMMERCE_STOREFRONT_TOKEN` from channel-specific secrets
- Conditionally passes `MAKESWIFT_SITE_API_KEY` for Makeswift-based deployments

This allows each deployment channel to use its own BigCommerce store configuration rather than relying on environment variables that may already be set in Vercel.

Also fixes a typo in the job name (`{{ github.ref_name }}` → `${{ github.ref_name }}`).

## Testing

This change affects the CI deploy workflow. To test:
- Trigger a deployment by publishing a tag matching one of the supported patterns
- Verify the deployment uses the correct environment variables for each channel

## Migration

This change adds a new workflow file. No migration needed for developers with forks—this file can be accepted as-is or customized to match your own deployment secrets.