### PR TITLE
chore: generate changeset for 1.4.1 release

### DIFF
--- a/.changeset/blue-bees-mate.md
+++ b/.changeset/blue-bees-mate.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-makeswift": patch
+---
+
+Pulls in changes from the `@bigcommerce/catalyst-core@1.4.1` patch.


### PR DESCRIPTION
## What/Why?
Add changeset for `1.4.1` release.
