### PR TITLE
chore(catalyst): CATALYST-1267 Translate form field errors

### DIFF
--- a/.changeset/hot-files-start.md
+++ b/.changeset/hot-files-start.md
@@ -1,0 +1,13 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Update forms to translate the form field validation errors
+
+## Migration
+
+Due to the amount of changes, it is recommended to just use the PR as a reference for migration.
+
+Detailed migration steps can be found on the PR here: 
+https://github.com/bigcommerce/catalyst/pull/2844
+

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -77,7 +77,8 @@ jobs:
 
       - name: Start server
         run: |
-          pnpm start &
+          mkdir -p ./.tests/reports/
+          pnpm start > ./.tests/reports/nextjs.app.log 2>&1 &
           npx wait-on http://localhost:3000 --timeout 60000
         working-directory: ./core
         env:

--- a/core/app/[locale]/(default)/(auth)/change-password/_actions/change-password.ts
+++ b/core/app/[locale]/(default)/(auth)/change-password/_actions/change-password.ts
@@ -4,8 +4,8 @@ import { BigCommerceGQLError } from '@bigcommerce/catalyst-client';
 import { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
 import { getTranslations } from 'next-intl/server';
+import { z } from 'zod';
 
-import { schema } from '@/vibes/soul/sections/reset-password-section/schema';
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
 
@@ -24,6 +24,10 @@ const ChangePasswordMutation = graphql(`
     }
   }
 `);
+
+const schema = z.object({
+  password: z.string(),
+});
 
 export async function changePassword(
   { token, customerEntityId }: { token: string; customerEntityId: string },

--- a/core/app/[locale]/(default)/(auth)/change-password/page-data.ts
+++ b/core/app/[locale]/(default)/(auth)/change-password/page-data.ts
@@ -1,0 +1,39 @@
+import { cache } from 'react';
+
+import { client } from '~/client';
+import { graphql } from '~/client/graphql';
+import { revalidate } from '~/client/revalidate-target';
+
+const ChangePasswordQuery = graphql(`
+  query ChangePasswordQuery {
+    site {
+      settings {
+        customers {
+          passwordComplexitySettings {
+            minimumNumbers
+            minimumPasswordLength
+            minimumSpecialCharacters
+            requireLowerCase
+            requireNumbers
+            requireSpecialCharacters
+            requireUpperCase
+          }
+        }
+      }
+    }
+  }
+`);
+
+export const getChangePasswordQuery = cache(async () => {
+  const response = await client.fetch({
+    document: ChangePasswordQuery,
+    fetchOptions: { next: { revalidate } },
+  });
+
+  const passwordComplexitySettings =
+    response.data.site.settings?.customers?.passwordComplexitySettings;
+
+  return {
+    passwordComplexitySettings,
+  };
+});

--- a/core/app/[locale]/(default)/(auth)/change-password/page.tsx
+++ b/core/app/[locale]/(default)/(auth)/change-password/page.tsx
@@ -3,6 +3,7 @@ import { Metadata } from 'next';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { ResetPasswordSection } from '@/vibes/soul/sections/reset-password-section';
+import { getChangePasswordQuery } from '~/app/[locale]/(default)/(auth)/change-password/page-data';
 import { redirect } from '~/i18n/routing';
 
 import { changePassword } from './_actions/change-password';
@@ -37,11 +38,14 @@ export default async function ChangePassword({ params, searchParams }: Props) {
     return redirect({ href: '/login', locale });
   }
 
+  const { passwordComplexitySettings } = await getChangePasswordQuery();
+
   return (
     <ResetPasswordSection
       action={changePassword.bind(null, { customerEntityId, token })}
       confirmPasswordLabel={t('confirmPassword')}
       newPasswordLabel={t('newPassword')}
+      passwordComplexitySettings={passwordComplexitySettings}
       title={t('title')}
     />
   );

--- a/core/app/[locale]/(default)/(auth)/register/page.tsx
+++ b/core/app/[locale]/(default)/(auth)/register/page.tsx
@@ -109,6 +109,49 @@ export default async function Register({ params }: Props) {
   return (
     <DynamicFormSection
       action={registerCustomer}
+      errorTranslations={{
+        firstName: {
+          invalid_type: t('FieldErrors.firstNameRequired'),
+        },
+        lastName: {
+          invalid_type: t('FieldErrors.lastNameRequired'),
+        },
+        email: {
+          invalid_type: t('FieldErrors.emailRequired'),
+          invalid_string: t('FieldErrors.emailInvalid'),
+        },
+        password: {
+          invalid_type: t('FieldErrors.passwordRequired'),
+          too_small: t('FieldErrors.passwordTooSmall', {
+            minLength: passwordComplexitySettings?.minimumPasswordLength ?? 0,
+          }),
+          lowercase_required: t('FieldErrors.passwordLowercaseRequired'),
+          uppercase_required: t('FieldErrors.passwordUppercaseRequired'),
+          number_required: t('FieldErrors.passwordNumberRequired', {
+            minNumbers: passwordComplexitySettings?.minimumNumbers ?? 1,
+          }),
+          special_character_required: t('FieldErrors.passwordSpecialCharacterRequired'),
+          passwords_must_match: t('FieldErrors.passwordsMustMatch'),
+        },
+        confirmPassword: {
+          invalid_type: t('FieldErrors.passwordRequired'),
+        },
+        address1: {
+          invalid_type: t('FieldErrors.addressLine1Required'),
+        },
+        city: {
+          invalid_type: t('FieldErrors.cityRequired'),
+        },
+        countryCode: {
+          invalid_type: t('FieldErrors.countryRequired'),
+        },
+        stateOrProvince: {
+          invalid_type: t('FieldErrors.stateRequired'),
+        },
+        postalCode: {
+          invalid_type: t('FieldErrors.postalCodeRequired'),
+        },
+      }}
       fields={fields}
       passwordComplexity={passwordComplexitySettings}
       submitLabel={t('cta')}

--- a/core/app/[locale]/(default)/account/settings/_actions/change-password.ts
+++ b/core/app/[locale]/(default)/account/settings/_actions/change-password.ts
@@ -3,9 +3,9 @@
 import { BigCommerceGQLError } from '@bigcommerce/catalyst-client';
 import { parseWithZod } from '@conform-to/zod';
 import { getTranslations } from 'next-intl/server';
+import { z } from 'zod';
 
 import { ChangePasswordAction } from '@/vibes/soul/sections/account-settings/change-password-form';
-import { changePasswordSchema } from '@/vibes/soul/sections/account-settings/schema';
 import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
@@ -34,11 +34,15 @@ const CustomerChangePasswordMutation = graphql(`
   }
 `);
 
+const schema = z.object({
+  currentPassword: z.string().trim(),
+  password: z.string(),
+});
+
 export const changePassword: ChangePasswordAction = async (prevState, formData) => {
   const t = await getTranslations('Account.Settings');
   const customerAccessToken = await getSessionCustomerAccessToken();
-
-  const submission = parseWithZod(formData, { schema: changePasswordSchema });
+  const submission = parseWithZod(formData, { schema });
 
   if (submission.status !== 'success') {
     return { lastResult: submission.reply() };

--- a/core/app/[locale]/(default)/account/settings/page-data.tsx
+++ b/core/app/[locale]/(default)/account/settings/page-data.tsx
@@ -35,6 +35,17 @@ const AccountSettingsQuery = graphql(
           newsletter {
             showNewsletterSignup
           }
+          customers {
+            passwordComplexitySettings {
+              minimumNumbers
+              minimumPasswordLength
+              minimumSpecialCharacters
+              requireLowerCase
+              requireNumbers
+              requireSpecialCharacters
+              requireUpperCase
+            }
+          }
         }
       }
     }
@@ -75,6 +86,8 @@ export const getAccountSettingsQuery = cache(async ({ address, customer }: Props
   const customerFields = response.data.site.settings?.formFields.customer;
   const customerInfo = response.data.customer;
   const newsletterSettings = response.data.site.settings?.newsletter;
+  const passwordComplexitySettings =
+    response.data.site.settings?.customers?.passwordComplexitySettings;
 
   if (!addressFields || !customerFields || !customerInfo) {
     return null;
@@ -85,5 +98,6 @@ export const getAccountSettingsQuery = cache(async ({ address, customer }: Props
     customerFields,
     customerInfo,
     newsletterSettings,
+    passwordComplexitySettings,
   };
 });

--- a/core/app/[locale]/(default)/account/settings/page.tsx
+++ b/core/app/[locale]/(default)/account/settings/page.tsx
@@ -61,6 +61,7 @@ export default async function Settings({ params }: Props) {
       newsletterSubscriptionEnabled={newsletterSubscriptionEnabled}
       newsletterSubscriptionLabel={t('NewsletterSubscription.label')}
       newsletterSubscriptionTitle={t('NewsletterSubscription.title')}
+      passwordComplexitySettings={accountSettings.passwordComplexitySettings}
       title={t('title')}
       updateAccountAction={updateCustomer}
       updateAccountSubmitLabel={t('cta')}

--- a/core/app/[locale]/(default)/cart/_actions/update-shipping-info.ts
+++ b/core/app/[locale]/(default)/cart/_actions/update-shipping-info.ts
@@ -23,7 +23,7 @@ export const updateShippingInfo = async (
   const t = await getTranslations('Cart.CheckoutSummary.Shipping');
 
   const submission = parseWithZod(formData, {
-    schema: shippingActionFormDataSchema,
+    schema: shippingActionFormDataSchema({ required_error: t('countryRequired') }),
   });
 
   const cartId = await getCartId();

--- a/core/app/[locale]/(default)/gift-certificates/purchase/_actions/add-to-cart.tsx
+++ b/core/app/[locale]/(default)/gift-certificates/purchase/_actions/add-to-cart.tsx
@@ -41,7 +41,7 @@ const GiftCertificateSettingsQuery = graphql(
 
 const schema = (
   giftCertificateSettings: ResultOf<typeof GiftCertificateSettingsFragment> | undefined,
-  t: ExistingResultType<typeof getTranslations>,
+  t: ExistingResultType<typeof getTranslations<'GiftCertificates.Purchase'>>,
 ) => {
   return z
     .object({

--- a/core/app/[locale]/(default)/gift-certificates/purchase/page.tsx
+++ b/core/app/[locale]/(default)/gift-certificates/purchase/page.tsx
@@ -18,20 +18,20 @@ interface Props {
 function getFields(
   giftCertificateSettings: ResultOf<typeof GiftCertificateSettingsFragment>,
   expiresAt: string | undefined,
-  t: ExistingResultType<typeof getTranslations>,
+  t: ExistingResultType<typeof getTranslations<'GiftCertificates'>>,
 ): Array<Field | FieldGroup<Field>> {
   const baseFields: Array<Field | FieldGroup<Field>> = [
     [
       {
         type: 'text',
         name: 'senderName',
-        label: `${t('Purchase.Form.senderNameLabel')} *`,
+        label: t('Purchase.Form.senderNameLabel'),
         required: true,
       },
       {
         type: 'email',
         name: 'senderEmail',
-        label: `${t('Purchase.Form.senderEmailLabel')} *`,
+        label: t('Purchase.Form.senderEmailLabel'),
         required: true,
       },
     ],
@@ -39,13 +39,13 @@ function getFields(
       {
         type: 'text',
         name: 'recipientName',
-        label: `${t('Purchase.Form.recipientNameLabel')} *`,
+        label: t('Purchase.Form.recipientNameLabel'),
         required: true,
       },
       {
         type: 'email',
         name: 'recipientEmail',
-        label: `${t('Purchase.Form.recipientEmailLabel')} *`,
+        label: t('Purchase.Form.recipientEmailLabel'),
         required: true,
       },
     ],
@@ -78,10 +78,10 @@ function getFields(
           {
             type: 'text',
             name: 'amount',
-            label: `${t('Purchase.Form.customAmountLabel', {
+            label: t('Purchase.Form.customAmountLabel', {
               minAmount: String(giftCertificateSettings.minimumAmount.value),
               maxAmount: String(giftCertificateSettings.maximumAmount.value),
-            })} *`,
+            }),
             pattern: '^[0-9]*\\.?[0-9]+$',
             required: true,
           },
@@ -90,7 +90,7 @@ function getFields(
           {
             type: 'select',
             name: 'amount',
-            label: `${t('Purchase.Form.amountLabel')} *`,
+            label: t('Purchase.Form.amountLabel'),
             defaultValue: '0',
             options: [
               {

--- a/core/components/subscribe/_actions/subscribe.ts
+++ b/core/components/subscribe/_actions/subscribe.ts
@@ -35,8 +35,11 @@ export const subscribe = async (
   formData: FormData,
 ) => {
   const t = await getTranslations('Components.Subscribe');
-
-  const submission = parseWithZod(formData, { schema });
+  const subscribeSchema = schema({
+    requiredMessage: t('Errors.emailRequired'),
+    invalidMessage: t('Errors.invalidEmail'),
+  });
+  const submission = parseWithZod(formData, { schema: subscribeSchema });
 
   if (submission.status !== 'success') {
     return { lastResult: submission.reply() };

--- a/core/i18n/utils.ts
+++ b/core/i18n/utils.ts
@@ -1,0 +1,29 @@
+import { parseWithZod as conformParseWithZod } from '@conform-to/zod';
+import { z, ZodIssueOptionalMessage } from 'zod';
+
+import { FormErrorTranslationMap } from '@/vibes/soul/form/dynamic-form/schema';
+
+export function createErrorMap(errorTranslations?: FormErrorTranslationMap) {
+  return (issue: ZodIssueOptionalMessage) => {
+    const field = issue.path[0];
+    const fieldKey = typeof field === 'string' ? field : '';
+    const errorMessage = errorTranslations?.[fieldKey]?.[issue.code];
+
+    return { message: errorMessage ?? issue.message ?? 'Invalid input' };
+  };
+}
+
+export function parseWithZodTranslatedErrors<Schema extends z.ZodType>(
+  formData: FormData,
+  options: {
+    schema: Schema;
+    errorTranslations?: FormErrorTranslationMap;
+  },
+) {
+  const errorMap = createErrorMap(options.errorTranslations);
+
+  return conformParseWithZod(formData, {
+    schema: options.schema,
+    errorMap,
+  });
+}

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -43,7 +43,17 @@
       "newPassword": "New password",
       "confirmPassword": "Confirm password",
       "passwordUpdated": "Password has been updated successfully!",
-      "somethingWentWrong": "Something went wrong. Please try again later."
+      "somethingWentWrong": "Something went wrong. Please try again later.",
+      "FieldErrors": {
+        "passwordRequired": "Password is required",
+        "passwordTooSmall": "Password must be at least {minLength, plural, =1 {1 character} other {# characters}} long",
+        "passwordLowercaseRequired": "Password must contain at least one lowercase letter",
+        "passwordUppercaseRequired": "Password must contain at least one uppercase letter",
+        "passwordNumberRequired": "Password must contain at least {minNumbers, plural, =1 {one number} other {# numbers}}",
+        "passwordSpecialCharacterRequired": "Password must contain at least one special character",
+        "passwordsMustMatch": "The passwords do not match",
+        "confirmPasswordRequired": "Please confirm your password"
+      }
     },
     "Login": {
       "title": "Login",
@@ -56,6 +66,12 @@
       "somethingWentWrong": "Something went wrong. Please try again later.",
       "passwordResetRequired": "Password reset required. Please check your email for instructions to reset your password.",
       "invalidToken": "Your login link is invalid or has expired. Please try logging in again.",
+      "FieldErrors": {
+        "emailRequired": "Email is required",
+        "emailInvalid": "Please enter a valid email address",
+        "passwordRequired": "Password is required",
+        "invalidInput": "Please check your input and try again."
+      },
       "CreateAccount": {
         "title": "New customer?",
         "accountBenefits": "Create an account with us and you'll be able to:",
@@ -70,14 +86,36 @@
         "title": "Forgot password",
         "subtitle": "Enter the email associated with your account below. We'll send you instructions to reset your password.",
         "confirmResetPassword": "If the email address {email} is linked to an account in our store, we have sent you a password reset email. Please check your inbox and spam folder if you don't see it.",
-        "somethingWentWrong": "Something went wrong. Please try again later."
+        "somethingWentWrong": "Something went wrong. Please try again later.",
+        "FieldErrors": {
+          "emailRequired": "Email is required",
+          "emailInvalid": "Please enter a valid email address"
+        }
       }
     },
     "Register": {
       "title": "Register account",
       "heading": "New account",
       "cta": "Create account",
-      "somethingWentWrong": "Something went wrong. Please try again later."
+      "somethingWentWrong": "Something went wrong. Please try again later.",
+      "FieldErrors": {
+        "firstNameRequired": "First name is required",
+        "lastNameRequired": "Last name is required",
+        "emailRequired": "Email is required",
+        "emailInvalid": "Please enter a valid email address",
+        "passwordRequired": "Password is required",
+        "passwordTooSmall": "Password must be at least {minLength, plural, =1 {1 character} other {# characters}} long",
+        "passwordLowercaseRequired": "Password must contain at least one lowercase letter",
+        "passwordUppercaseRequired": "Password must contain at least one uppercase letter",
+        "passwordNumberRequired": "Password must contain at least {minNumbers, plural, =1 {one number} other {# numbers}}",
+        "passwordSpecialCharacterRequired": "Password must contain at least one special character",
+        "passwordsMustMatch": "The passwords do not match",
+        "addressLine1Required": "Address line 1 is required",
+        "cityRequired": "City is required",
+        "countryRequired": "Country is required",
+        "stateRequired": "State/Province is required",
+        "postalCodeRequired": "Postal code is required"
+      }
     }
   },
   "Faceted": {
@@ -188,6 +226,15 @@
       "somethingWentWrong": "Something went wrong. Please try again later.",
       "EmptyState": {
         "title": "You don't have any addresses"
+      },
+      "FieldErrors": {
+        "firstNameRequired": "First name is required",
+        "lastNameRequired": "Last name is required",
+        "addressLine1Required": "Address line 1 is required",
+        "cityRequired": "City is required",
+        "countryRequired": "Country is required",
+        "stateRequired": "State/Province is required",
+        "postalCodeRequired": "Postal code is required"
       }
     },
     "Settings": {
@@ -205,6 +252,23 @@
         "label": "Subscribe to our newsletter.",
         "marketingPreferencesUpdated": "Marketing preferences have been updated successfully!",
         "somethingWentWrong": "Something went wrong. Please try again later."
+      },
+      "FieldErrors": {
+        "firstNameRequired": "First name is required",
+        "firstNameTooSmall": "First name must be at least 2 characters long",
+        "lastNameRequired": "Last name is required",
+        "lastNameTooSmall": "Last name must be at least 2 characters long",
+        "emailRequired": "Email is required",
+        "emailInvalid": "Please enter a valid email address",
+        "currentPasswordRequired": "Current password is required",
+        "passwordRequired": "Password is required",
+        "passwordTooSmall": "Password must be at least {minLength, plural, =1 {1 character} other {# characters}} long",
+        "passwordLowercaseRequired": "Password must contain at least one lowercase letter",
+        "passwordUppercaseRequired": "Password must contain at least one uppercase letter",
+        "passwordNumberRequired": "Password must contain at least {minNumbers, plural, =1 {one number} other {# numbers}}",
+        "passwordSpecialCharacterRequired": "Password must contain at least one special character",
+        "passwordsMustMatch": "The passwords do not match",
+        "confirmPasswordRequired": "Please confirm your password"
       }
     }
   },
@@ -335,7 +399,8 @@
         "updateShipping": "Update shipping",
         "addShipping": "Add shipping",
         "cartNotFound": "An error occurred when retrieving your cart",
-        "noShippingOptions": "There are no shipping options available for your address"
+        "noShippingOptions": "There are no shipping options available for your address",
+        "countryRequired": "Country is required"
       }
     },
     "GiftCertificate": {
@@ -427,13 +492,24 @@
         "button": "Write a review",
         "title": "Write a review",
         "submit": "Submit",
+        "cancel": "Cancel",
         "ratingLabel": "Rating",
         "titleLabel": "Title",
         "reviewLabel": "Review",
         "nameLabel": "Name",
         "emailLabel": "Email",
         "successMessage": "Your review has been submitted successfully!",
-        "somethingWentWrong": "Something went wrong. Please try again later."
+        "somethingWentWrong": "Something went wrong. Please try again later.",
+        "FieldErrors": {
+          "titleRequired": "Title is required",
+          "authorRequired": "Name is required",
+          "emailRequired": "Email is required",
+          "emailInvalid": "Please enter a valid email address",
+          "textRequired": "Review is required",
+          "ratingRequired": "Rating is required",
+          "ratingTooSmall": "Rating must be at least 1",
+          "ratingTooLarge": "Rating must be at most 5"
+        }
       }
     }
   },
@@ -515,7 +591,8 @@
       "description": "Stay up to date with the latest news and offers from our store.",
       "subscribedToNewsletter": "You have been subscribed to our newsletter!",
       "Errors": {
-        "invalidEmail": "Please enter a valid email address.",
+        "emailRequired": "Email is required",
+        "invalidEmail": "Please enter a valid email address",
         "somethingWentWrong": "Something went wrong. Please try again later."
       }
     },
@@ -607,15 +684,25 @@
         "expiryCheckboxLabel": "I acknowledge that this Gift Certificate will expire on {expiryDate}",
         "ctaLabel": "Add to cart",
         "Errors": {
-          "amountRequired": "Please select or enter a gift certificate amount.",
-          "amountInvalid": "Please select a valid gift certificate amount.",
-          "amountOutOfRange": "Please enter an amount between {minAmount} and {maxAmount}.",
-          "unexpectedSettingsError": "An unexpected error occurred while retrieving gift certificate settings. Please try again later."
+          "amountRequired": "Please select or enter a gift certificate amount",
+          "amountInvalid": "Please select a valid gift certificate amount",
+          "amountOutOfRange": "Please enter an amount between {minAmount} and {maxAmount}",
+          "unexpectedSettingsError": "An unexpected error occurred while retrieving gift certificate settings. Please try again later.",
+          "senderNameRequired": "Your name is required",
+          "senderEmailRequired": "Your email is required",
+          "recipientNameRequired": "Recipient's name is required",
+          "recipientEmailRequired": "Recipient's email is required",
+          "emailInvalid": "Please enter a valid email address",
+          "checkboxRequired": "You must check this box to continue"
         }
       }
     }
   },
   "Form": {
-    "optional": "optional"
+    "optional": "optional",
+    "Errors": {
+      "invalidInput": "Please check your input and try again",
+      "invalidFormat": "The value entered does not match the required format"
+    }
   }
 }

--- a/core/tests/ui/e2e/auth/forgot-password.spec.ts
+++ b/core/tests/ui/e2e/auth/forgot-password.spec.ts
@@ -26,6 +26,5 @@ test('Forgot password form displays error if email is not valid', async ({ page 
   await page.getByLabel('Email').fill('not-an-email');
   await page.getByRole('button', { name: 'Reset password' }).click();
 
-  // TODO: Forgot password form error message needs to be translated
-  await expect(page.getByText('Please enter a valid email.')).toBeVisible();
+  await expect(page.getByText(t('FieldErrors.emailInvalid'))).toBeVisible();
 });

--- a/core/vibes/soul/form/dynamic-form/index.tsx
+++ b/core/vibes/soul/form/dynamic-form/index.tsx
@@ -11,6 +11,7 @@ import {
   useInputControl,
 } from '@conform-to/react';
 import { getZodConstraint, parseWithZod } from '@conform-to/zod';
+import { useTranslations } from 'next-intl';
 import {
   FormEvent,
   MouseEvent,
@@ -36,7 +37,13 @@ import { SwatchRadioGroup } from '@/vibes/soul/form/swatch-radio-group';
 import { Textarea } from '@/vibes/soul/form/textarea';
 import { Button, ButtonProps } from '@/vibes/soul/primitives/button';
 
-import { Field, FieldGroup, PasswordComplexitySettings, schema } from './schema';
+import {
+  Field,
+  FieldGroup,
+  FormErrorTranslationMap,
+  PasswordComplexitySettings,
+  schema,
+} from './schema';
 import { removeOptionsFromFields } from './utils';
 
 export interface DynamicFormActionArgs<F extends Field> {
@@ -69,6 +76,7 @@ export interface DynamicFormProps<F extends Field> {
   onChange?: (e: FormEvent<HTMLFormElement>) => void;
   onSuccess?: (lastResult: SubmissionResult, successMessage: ReactNode) => void;
   passwordComplexity?: PasswordComplexitySettings | null;
+  errorTranslations?: FormErrorTranslationMap;
 }
 
 export function DynamicForm<F extends Field>({
@@ -83,7 +91,9 @@ export function DynamicForm<F extends Field>({
   onChange,
   onSuccess,
   passwordComplexity,
+  errorTranslations,
 }: DynamicFormProps<F>) {
+  const t = useTranslations('Form');
   // Remove options from fields before passing to action to reduce payload size
   // Options are only needed for rendering, not for processing form submissions
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
@@ -94,7 +104,7 @@ export function DynamicForm<F extends Field>({
     lastResult: null,
   });
 
-  const dynamicSchema = schema(fields, passwordComplexity);
+  const dynamicSchema = schema(fields, passwordComplexity, errorTranslations);
   const defaultValue = fields
     .flatMap((f) => (Array.isArray(f) ? f : [f]))
     .reduce<z.infer<typeof dynamicSchema>>(
@@ -104,11 +114,33 @@ export function DynamicForm<F extends Field>({
       }),
       {},
     );
+
   const [form, formFields] = useForm({
     lastResult,
     constraint: getZodConstraint(dynamicSchema),
     onValidate({ formData }) {
-      return parseWithZod(formData, { schema: dynamicSchema });
+      return parseWithZod(formData, {
+        schema: dynamicSchema,
+        errorMap: (issue) => {
+          if (
+            !errorTranslations &&
+            issue.code === z.ZodIssueCode.invalid_string &&
+            issue.validation === 'regex'
+          ) {
+            return { message: t('Errors.invalidFormat') };
+          }
+
+          if (!errorTranslations) {
+            return { message: issue.message ?? t('Errors.invalidInput') };
+          }
+
+          const field = issue.path[0];
+          const fieldKey = typeof field === 'string' ? field : '';
+          const errorMessage = errorTranslations[fieldKey]?.[issue.code];
+
+          return { message: errorMessage ?? issue.message ?? t('Errors.invalidInput') };
+        },
+      });
     },
     defaultValue,
     shouldValidate: 'onSubmit',

--- a/core/vibes/soul/form/dynamic-form/schema.ts
+++ b/core/vibes/soul/form/dynamic-form/schema.ts
@@ -10,6 +10,21 @@ export interface PasswordComplexitySettings {
   requireUpperCase?: boolean | null;
 }
 
+export type FormErrorTranslationMap = Record<
+  string,
+  Partial<
+    Record<
+      | z.ZodIssueCode
+      | 'lowercase_required'
+      | 'uppercase_required'
+      | 'number_required'
+      | 'special_character_required'
+      | 'passwords_must_match',
+      string
+    >
+  >
+>;
+
 interface FormField {
   name: string;
   label?: string;
@@ -159,17 +174,94 @@ export type SchemaRawShape = Record<
   | z.ZodOptional<z.ZodNumber>
   | z.ZodArray<z.ZodString>
   | z.ZodOptional<z.ZodArray<z.ZodString>>
+  | z.ZodLiteral<'true'>
+  | z.ZodEnum<['true', 'false']>
+  | z.ZodOptional<z.ZodEnum<['true', 'false']>>
 >;
 
 // eslint-disable-next-line complexity
-function getFieldSchema(field: Field, passwordComplexity?: PasswordComplexitySettings | null) {
+export function getPasswordSchema(
+  passwordComplexity?: PasswordComplexitySettings | null,
+  errorTranslations?: FormErrorTranslationMap,
+) {
+  const minLength = passwordComplexity?.minimumPasswordLength ?? 8;
+  const minNumbers = passwordComplexity?.minimumNumbers ?? 0;
+  const minSpecialChars = passwordComplexity?.minimumSpecialCharacters ?? 0;
+  const requireLowerCase = passwordComplexity?.requireLowerCase ?? false;
+  const requireUpperCase = passwordComplexity?.requireUpperCase ?? false;
+  const requireNumbers = passwordComplexity?.requireNumbers ?? true;
+  const requireSpecialChars = passwordComplexity?.requireSpecialCharacters ?? true;
+
+  let fieldSchema = z.string().trim();
+
+  fieldSchema = fieldSchema.min(minLength);
+
+  if (requireLowerCase) {
+    fieldSchema = fieldSchema.regex(/[a-z]/, {
+      message:
+        errorTranslations?.password?.lowercase_required ?? 'Contain at least one lowercase letter',
+    });
+  }
+
+  if (requireUpperCase) {
+    fieldSchema = fieldSchema.regex(/[A-Z]/, {
+      message:
+        errorTranslations?.password?.uppercase_required ?? 'Contain at least one uppercase letter',
+    });
+  }
+
+  if (requireNumbers && minNumbers > 0) {
+    const numberRegex = new RegExp(`(.*[0-9]){${minNumbers},}`);
+
+    fieldSchema = fieldSchema.regex(numberRegex, {
+      message:
+        errorTranslations?.password?.number_required ??
+        (minNumbers === 1
+          ? 'Contain at least one number'
+          : `Contain at least ${minNumbers} numbers`),
+    });
+  } else if (requireNumbers) {
+    fieldSchema = fieldSchema.regex(/[0-9]/, {
+      message: errorTranslations?.password?.number_required ?? 'Contain at least one number',
+    });
+  }
+
+  if (requireSpecialChars && minSpecialChars > 0) {
+    const specialCharRegex = new RegExp(`(.*[^a-zA-Z0-9]){${minSpecialChars},}`);
+
+    fieldSchema = fieldSchema.regex(specialCharRegex, {
+      message:
+        errorTranslations?.password?.special_character_required ??
+        (minSpecialChars === 1
+          ? 'Contain at least one special character'
+          : `Contain at least ${minSpecialChars} special characters`),
+    });
+  } else if (requireSpecialChars) {
+    fieldSchema = fieldSchema.regex(/[^a-zA-Z0-9]/, {
+      message:
+        errorTranslations?.password?.special_character_required ??
+        'Contain at least one special character',
+    });
+  }
+
+  return fieldSchema;
+}
+
+function getFieldSchema(
+  field: Field,
+  passwordComplexity?: PasswordComplexitySettings | null,
+  errorTranslations?: FormErrorTranslationMap,
+) {
   let fieldSchema:
     | z.ZodString
     | z.ZodNumber
+    | z.ZodLiteral<'true'>
     | z.ZodOptional<z.ZodString>
     | z.ZodOptional<z.ZodNumber>
+    | z.ZodOptional<z.ZodLiteral<'true'>>
     | z.ZodArray<z.ZodString, 'atleastone' | 'many'>
-    | z.ZodOptional<z.ZodArray<z.ZodString, 'atleastone' | 'many'>>;
+    | z.ZodOptional<z.ZodArray<z.ZodString, 'atleastone' | 'many'>>
+    | z.ZodOptional<z.ZodEnum<['true', 'false']>>;
 
   switch (field.type) {
     case 'number':
@@ -185,9 +277,7 @@ function getFieldSchema(field: Field, passwordComplexity?: PasswordComplexitySet
       fieldSchema = z.string();
 
       if (field.pattern != null) {
-        fieldSchema = fieldSchema.regex(new RegExp(field.pattern), {
-          message: 'Invalid format.',
-        });
+        fieldSchema = fieldSchema.regex(new RegExp(field.pattern));
       }
 
       if (field.required !== true) fieldSchema = fieldSchema.optional();
@@ -195,61 +285,7 @@ function getFieldSchema(field: Field, passwordComplexity?: PasswordComplexitySet
       break;
 
     case 'password': {
-      const minLength = passwordComplexity?.minimumPasswordLength ?? 8;
-      const minNumbers = passwordComplexity?.minimumNumbers ?? 0;
-      const minSpecialChars = passwordComplexity?.minimumSpecialCharacters ?? 0;
-      const requireLowerCase = passwordComplexity?.requireLowerCase ?? false;
-      const requireUpperCase = passwordComplexity?.requireUpperCase ?? false;
-      const requireNumbers = passwordComplexity?.requireNumbers ?? true;
-      const requireSpecialChars = passwordComplexity?.requireSpecialCharacters ?? true;
-
-      fieldSchema = z.string().trim();
-
-      fieldSchema = fieldSchema.min(minLength, {
-        message: `Be at least ${minLength} character${minLength !== 1 ? 's' : ''} long`,
-      });
-
-      if (requireLowerCase) {
-        fieldSchema = fieldSchema.regex(/[a-z]/, {
-          message: 'Contain at least one lowercase letter.',
-        });
-      }
-
-      if (requireUpperCase) {
-        fieldSchema = fieldSchema.regex(/[A-Z]/, {
-          message: 'Contain at least one uppercase letter.',
-        });
-      }
-
-      if (requireNumbers && minNumbers > 0) {
-        const numberRegex = new RegExp(`(.*[0-9]){${minNumbers},}`);
-
-        fieldSchema = fieldSchema.regex(numberRegex, {
-          message:
-            minNumbers === 1
-              ? 'Contain at least one number.'
-              : `Contain at least ${minNumbers} numbers.`,
-        });
-      } else if (requireNumbers) {
-        fieldSchema = fieldSchema.regex(/[0-9]/, {
-          message: 'Contain at least one number.',
-        });
-      }
-
-      if (requireSpecialChars && minSpecialChars > 0) {
-        const specialCharRegex = new RegExp(`(.*[^a-zA-Z0-9]){${minSpecialChars},}`);
-
-        fieldSchema = fieldSchema.regex(specialCharRegex, {
-          message:
-            minSpecialChars === 1
-              ? 'Contain at least one special character.'
-              : `Contain at least ${minSpecialChars} special characters.`,
-        });
-      } else if (requireSpecialChars) {
-        fieldSchema = fieldSchema.regex(/[^a-zA-Z0-9]/, {
-          message: 'Contain at least one special character.',
-        });
-      }
+      fieldSchema = getPasswordSchema(passwordComplexity, errorTranslations);
 
       if (field.required !== true) fieldSchema = fieldSchema.optional();
 
@@ -257,7 +293,7 @@ function getFieldSchema(field: Field, passwordComplexity?: PasswordComplexitySet
     }
 
     case 'email':
-      fieldSchema = z.string().email({ message: 'Please enter a valid email.' }).trim();
+      fieldSchema = z.string().email().trim();
 
       if (field.required !== true) fieldSchema = fieldSchema.optional();
 
@@ -267,6 +303,15 @@ function getFieldSchema(field: Field, passwordComplexity?: PasswordComplexitySet
       fieldSchema = z.string().array();
 
       if (field.required === true) fieldSchema = fieldSchema.nonempty();
+
+      break;
+
+    case 'checkbox':
+      if (field.required === true) {
+        fieldSchema = z.literal('true');
+      } else {
+        fieldSchema = z.enum(['true', 'false']).optional();
+      }
 
       break;
 
@@ -282,6 +327,7 @@ function getFieldSchema(field: Field, passwordComplexity?: PasswordComplexitySet
 export function schema(
   fields: Array<Field | FieldGroup<Field>>,
   passwordComplexity?: PasswordComplexitySettings | null,
+  errorTranslations?: FormErrorTranslationMap,
 ) {
   const shape: SchemaRawShape = {};
   let passwordFieldName: string | undefined;
@@ -290,13 +336,13 @@ export function schema(
   fields.forEach((field) => {
     if (Array.isArray(field)) {
       field.forEach((f) => {
-        shape[f.name] = getFieldSchema(f, passwordComplexity);
+        shape[f.name] = getFieldSchema(f, passwordComplexity, errorTranslations);
 
         if (f.type === 'password') passwordFieldName = f.name;
         if (f.type === 'confirm-password') confirmPasswordFieldName = f.name;
       });
     } else {
-      shape[field.name] = getFieldSchema(field, passwordComplexity);
+      shape[field.name] = getFieldSchema(field, passwordComplexity, errorTranslations);
 
       if (field.type === 'password') passwordFieldName = field.name;
       if (field.type === 'confirm-password') confirmPasswordFieldName = field.name;
@@ -311,7 +357,7 @@ export function schema(
     ) {
       ctx.addIssue({
         code: 'custom',
-        message: 'The passwords did not match',
+        message: errorTranslations?.password?.passwords_must_match ?? 'The passwords do not match',
         path: [confirmPasswordFieldName],
       });
     }

--- a/core/vibes/soul/primitives/inline-email-form/index.tsx
+++ b/core/vibes/soul/primitives/inline-email-form/index.tsx
@@ -4,6 +4,7 @@ import { getFormProps, getInputProps, SubmissionResult, useForm } from '@conform
 import { parseWithZod } from '@conform-to/zod';
 import { clsx } from 'clsx';
 import { ArrowRight } from 'lucide-react';
+import { useTranslations } from 'next-intl';
 import { useActionState } from 'react';
 
 import { FieldError } from '@/vibes/soul/form/field-error';
@@ -28,6 +29,12 @@ export function InlineEmailForm({
   submitLabel?: string;
   action: Action<{ lastResult: SubmissionResult | null; successMessage?: string }, FormData>;
 }) {
+  const t = useTranslations('Components.Subscribe');
+  const subscribeSchema = schema({
+    requiredMessage: t('Errors.emailRequired'),
+    invalidMessage: t('Errors.invalidEmail'),
+  });
+
   const [{ lastResult, successMessage }, formAction, isPending] = useActionState(action, {
     lastResult: null,
   });
@@ -35,7 +42,7 @@ export function InlineEmailForm({
   const [form, fields] = useForm({
     lastResult,
     onValidate({ formData }) {
-      return parseWithZod(formData, { schema });
+      return parseWithZod(formData, { schema: subscribeSchema });
     },
     shouldValidate: 'onSubmit',
     shouldRevalidate: 'onInput',

--- a/core/vibes/soul/primitives/inline-email-form/schema.ts
+++ b/core/vibes/soul/primitives/inline-email-form/schema.ts
@@ -1,5 +1,12 @@
 import { z } from 'zod';
 
-export const schema = z.object({
-  email: z.string().email(),
-});
+export const schema = ({
+  requiredMessage = 'Email is required',
+  invalidMessage = 'Please enter a valid email address',
+}: {
+  requiredMessage: string;
+  invalidMessage: string;
+}) =>
+  z.object({
+    email: z.string({ required_error: requiredMessage }).email({ message: invalidMessage }),
+  });

--- a/core/vibes/soul/sections/account-settings/change-password-form.tsx
+++ b/core/vibes/soul/sections/account-settings/change-password-form.tsx
@@ -1,15 +1,18 @@
 'use client';
 
 import { getFormProps, getInputProps, SubmissionResult, useForm } from '@conform-to/react';
-import { getZodConstraint, parseWithZod } from '@conform-to/zod';
+import { getZodConstraint } from '@conform-to/zod';
+import { useTranslations } from 'next-intl';
 import { ReactNode, useActionState, useEffect } from 'react';
 import { useFormStatus } from 'react-dom';
 
+import { PasswordComplexitySettings } from '@/vibes/soul/form/dynamic-form/schema';
 import { Input } from '@/vibes/soul/form/input';
 import { Button } from '@/vibes/soul/primitives/button';
 import { toast } from '@/vibes/soul/primitives/toaster';
+import { parseWithZodTranslatedErrors } from '~/i18n/utils';
 
-import { changePasswordSchema } from './schema';
+import { changePasswordErrorTranslations, changePasswordSchema } from './schema';
 
 type Action<S, P> = (state: Awaited<S>, payload: P) => S | Promise<S>;
 
@@ -26,6 +29,7 @@ export interface ChangePasswordFormProps {
   newPasswordLabel?: string;
   confirmPasswordLabel?: string;
   submitLabel?: string;
+  passwordComplexitySettings?: PasswordComplexitySettings | null;
 }
 
 export function ChangePasswordForm({
@@ -34,14 +38,18 @@ export function ChangePasswordForm({
   newPasswordLabel = 'New password',
   confirmPasswordLabel = 'Confirm password',
   submitLabel = 'Update',
+  passwordComplexitySettings,
 }: ChangePasswordFormProps) {
+  const t = useTranslations('Account.Settings');
+  const errorTranslations = changePasswordErrorTranslations(t, passwordComplexitySettings);
+  const schema = changePasswordSchema(passwordComplexitySettings, errorTranslations);
   const [state, formAction] = useActionState(action, { lastResult: null });
   const [form, fields] = useForm({
-    constraint: getZodConstraint(changePasswordSchema),
+    constraint: getZodConstraint(schema),
     shouldValidate: 'onBlur',
     shouldRevalidate: 'onInput',
     onValidate({ formData }) {
-      return parseWithZod(formData, { schema: changePasswordSchema });
+      return parseWithZodTranslatedErrors(formData, { schema, errorTranslations });
     },
   });
 

--- a/core/vibes/soul/sections/account-settings/index.tsx
+++ b/core/vibes/soul/sections/account-settings/index.tsx
@@ -1,3 +1,5 @@
+import { PasswordComplexitySettings } from '@/vibes/soul/form/dynamic-form/schema';
+
 import { ChangePasswordAction, ChangePasswordForm } from './change-password-form';
 import {
   NewsletterSubscriptionForm,
@@ -22,6 +24,7 @@ export interface AccountSettingsSectionProps {
   newsletterSubscriptionLabel?: string;
   newsletterSubscriptionCtaLabel?: string;
   updateNewsletterSubscriptionAction?: UpdateNewsletterSubscriptionAction;
+  passwordComplexitySettings?: PasswordComplexitySettings | null;
 }
 
 // eslint-disable-next-line valid-jsdoc
@@ -55,6 +58,7 @@ export function AccountSettingsSection({
   newsletterSubscriptionLabel = 'Opt-in to receive emails about new products and promotions.',
   newsletterSubscriptionCtaLabel = 'Save preferences',
   updateNewsletterSubscriptionAction,
+  passwordComplexitySettings,
 }: AccountSettingsSectionProps) {
   return (
     <section className="w-full @container">
@@ -81,6 +85,7 @@ export function AccountSettingsSection({
               confirmPasswordLabel={confirmPasswordLabel}
               currentPasswordLabel={currentPasswordLabel}
               newPasswordLabel={newPasswordLabel}
+              passwordComplexitySettings={passwordComplexitySettings}
               submitLabel={changePasswordSubmitLabel}
             />
           </div>

--- a/core/vibes/soul/sections/account-settings/schema.ts
+++ b/core/vibes/soul/sections/account-settings/schema.ts
@@ -1,32 +1,82 @@
+import { getTranslations } from 'next-intl/server';
 import { z } from 'zod';
 
+import {
+  FormErrorTranslationMap,
+  getPasswordSchema,
+  PasswordComplexitySettings,
+} from '@/vibes/soul/form/dynamic-form/schema';
+import { ExistingResultType } from '~/client/util';
+
 export const updateAccountSchema = z.object({
-  firstName: z.string().min(2, { message: 'Name must be at least 2 characters long.' }).trim(),
-  lastName: z.string().min(2, { message: 'Name must be at least 2 characters long.' }).trim(),
-  email: z.string().email({ message: 'Please enter a valid email.' }).trim(),
+  firstName: z.string().min(2).trim(),
+  lastName: z.string().min(2).trim(),
+  email: z.string().email().trim(),
   company: z.string().trim().optional(),
 });
 
-export const changePasswordSchema = z
-  .object({
-    currentPassword: z.string().trim(),
-    password: z
-      .string()
-      .min(8, { message: 'Be at least 8 characters long' })
-      .regex(/[a-zA-Z]/, { message: 'Contain at least one letter.' })
-      .regex(/[0-9]/, { message: 'Contain at least one number.' })
-      .regex(/[^a-zA-Z0-9]/, {
-        message: 'Contain at least one special character.',
-      })
-      .trim(),
-    confirmPassword: z.string(),
-  })
-  .superRefine(({ confirmPassword, password }, ctx) => {
-    if (confirmPassword !== password) {
-      ctx.addIssue({
-        code: 'custom',
-        message: 'The passwords did not match',
-        path: ['confirmPassword'],
-      });
-    }
-  });
+export const updateAccountErrorTranslations = (
+  t: ExistingResultType<typeof getTranslations<'Account.Settings'>>,
+): FormErrorTranslationMap => ({
+  firstName: {
+    invalid_type: t('FieldErrors.firstNameRequired'),
+    too_small: t('FieldErrors.firstNameTooSmall'),
+  },
+  lastName: {
+    invalid_type: t('FieldErrors.lastNameRequired'),
+    too_small: t('FieldErrors.lastNameTooSmall'),
+  },
+  email: {
+    invalid_type: t('FieldErrors.emailRequired'),
+    invalid_string: t('FieldErrors.emailInvalid'),
+  },
+});
+
+export const changePasswordErrorTranslations = (
+  t: ExistingResultType<typeof getTranslations<'Account.Settings'>>,
+  passwordComplexity?: PasswordComplexitySettings | null,
+): FormErrorTranslationMap => ({
+  currentPassword: {
+    invalid_type: t('FieldErrors.currentPasswordRequired'),
+  },
+  password: {
+    invalid_type: t('FieldErrors.passwordRequired'),
+    too_small: t('FieldErrors.passwordTooSmall', {
+      minLength: passwordComplexity?.minimumPasswordLength ?? 0,
+    }),
+    lowercase_required: t('FieldErrors.passwordLowercaseRequired'),
+    uppercase_required: t('FieldErrors.passwordUppercaseRequired'),
+    number_required: t('FieldErrors.passwordNumberRequired', {
+      minNumbers: passwordComplexity?.minimumNumbers ?? 1,
+    }),
+    special_character_required: t('FieldErrors.passwordSpecialCharacterRequired'),
+    passwords_must_match: t('FieldErrors.passwordsMustMatch'),
+  },
+  confirmPassword: {
+    invalid_type: t('FieldErrors.confirmPasswordRequired'),
+  },
+});
+
+export const changePasswordSchema = (
+  passwordComplexity?: PasswordComplexitySettings | null,
+  errorTranslations?: FormErrorTranslationMap,
+) => {
+  const passwordSchema = getPasswordSchema(passwordComplexity, errorTranslations);
+
+  return z
+    .object({
+      currentPassword: z.string().trim(),
+      password: passwordSchema,
+      confirmPassword: z.string(),
+    })
+    .superRefine(({ confirmPassword, password }, ctx) => {
+      if (confirmPassword !== password) {
+        ctx.addIssue({
+          code: 'custom',
+          message:
+            errorTranslations?.password?.passwords_must_match ?? 'The passwords do not match',
+          path: ['confirmPassword'],
+        });
+      }
+    });
+};

--- a/core/vibes/soul/sections/account-settings/update-account-form.tsx
+++ b/core/vibes/soul/sections/account-settings/update-account-form.tsx
@@ -1,15 +1,17 @@
 'use client';
 
 import { getFormProps, getInputProps, SubmissionResult, useForm } from '@conform-to/react';
-import { getZodConstraint, parseWithZod } from '@conform-to/zod';
+import { getZodConstraint } from '@conform-to/zod';
+import { useTranslations } from 'next-intl';
 import { useActionState, useEffect, useOptimistic, useTransition } from 'react';
 import { z } from 'zod';
 
 import { Input } from '@/vibes/soul/form/input';
 import { Button } from '@/vibes/soul/primitives/button';
 import { toast } from '@/vibes/soul/primitives/toaster';
+import { parseWithZodTranslatedErrors } from '~/i18n/utils';
 
-import { updateAccountSchema } from './schema';
+import { updateAccountErrorTranslations, updateAccountSchema } from './schema';
 
 type Action<S, P> = (state: Awaited<S>, payload: P) => S | Promise<S>;
 
@@ -42,6 +44,8 @@ export function UpdateAccountForm({
   companyLabel = 'Company',
   submitLabel = 'Update',
 }: UpdateAccountFormProps) {
+  const t = useTranslations('Account.Settings');
+  const errorTranslations = updateAccountErrorTranslations(t);
   const [state, formAction] = useActionState(action, { account, lastResult: null });
   const [pending, startTransition] = useTransition();
 
@@ -49,7 +53,10 @@ export function UpdateAccountForm({
     state,
     (prevState, formData) => {
       const intent = formData.get('intent');
-      const submission = parseWithZod(formData, { schema: updateAccountSchema });
+      const submission = parseWithZodTranslatedErrors(formData, {
+        schema: updateAccountSchema,
+        errorTranslations,
+      });
 
       if (submission.status !== 'success') return prevState;
 
@@ -74,7 +81,10 @@ export function UpdateAccountForm({
     shouldValidate: 'onBlur',
     shouldRevalidate: 'onInput',
     onValidate({ formData }) {
-      return parseWithZod(formData, { schema: updateAccountSchema });
+      return parseWithZodTranslatedErrors(formData, {
+        schema: updateAccountSchema,
+        errorTranslations,
+      });
     },
   });
 

--- a/core/vibes/soul/sections/address-list-section/index.tsx
+++ b/core/vibes/soul/sections/address-list-section/index.tsx
@@ -2,6 +2,7 @@
 
 import { getFormProps, getInputProps, SubmissionResult, useForm } from '@conform-to/react';
 import { getZodConstraint, parseWithZod } from '@conform-to/zod';
+import { useTranslations } from 'next-intl';
 import {
   ComponentProps,
   ReactNode,
@@ -21,7 +22,7 @@ import { Button } from '@/vibes/soul/primitives/button';
 import { Spinner } from '@/vibes/soul/primitives/spinner';
 import { toast } from '@/vibes/soul/primitives/toaster';
 
-import { schema } from './schema';
+import { addressFormErrorTranslations, schema } from './schema';
 
 export type Address = z.infer<typeof schema>;
 
@@ -96,6 +97,8 @@ export function AddressListSection<A extends Address, F extends Field>({
   setDefaultLabel = 'Set as default',
   emptyStateTitle = "You don't have any addresses",
 }: AddressListSectionProps<A, F>) {
+  const t = useTranslations('Account.Addresses');
+  const errorTranslations = addressFormErrorTranslations(t);
   const actionWithFields = addressAction.bind(null, fields);
 
   const [state, formAction] = useActionState(actionWithFields, {
@@ -194,6 +197,7 @@ export function AddressListSection<A extends Address, F extends Field>({
                 }}
                 buttonSize="small"
                 cancelLabel={cancelLabel}
+                errorTranslations={errorTranslations}
                 fields={fields.map((field) => {
                   if ('name' in field && field.name === 'id') {
                     return {
@@ -253,6 +257,7 @@ export function AddressListSection<A extends Address, F extends Field>({
                       }}
                       buttonSize="small"
                       cancelLabel={cancelLabel}
+                      errorTranslations={errorTranslations}
                       fields={addressFields}
                       onCancel={() =>
                         setActiveAddressIds((prev) => prev.filter((id) => id !== address.id))

--- a/core/vibes/soul/sections/address-list-section/schema.ts
+++ b/core/vibes/soul/sections/address-list-section/schema.ts
@@ -1,4 +1,34 @@
+import { getTranslations } from 'next-intl/server';
 import { z } from 'zod';
+
+import { FormErrorTranslationMap } from '@/vibes/soul/form/dynamic-form/schema';
+import { ExistingResultType } from '~/client/util';
+
+export const addressFormErrorTranslations = (
+  t: ExistingResultType<typeof getTranslations<'Account.Addresses'>>,
+): FormErrorTranslationMap => ({
+  firstName: {
+    invalid_type: t('FieldErrors.firstNameRequired'),
+  },
+  lastName: {
+    invalid_type: t('FieldErrors.lastNameRequired'),
+  },
+  address1: {
+    invalid_type: t('FieldErrors.addressLine1Required'),
+  },
+  city: {
+    invalid_type: t('FieldErrors.cityRequired'),
+  },
+  countryCode: {
+    invalid_type: t('FieldErrors.countryRequired'),
+  },
+  stateOrProvince: {
+    invalid_type: t('FieldErrors.stateRequired'),
+  },
+  postalCode: {
+    invalid_type: t('FieldErrors.postalCodeRequired'),
+  },
+});
 
 export const schema = z
   .object({

--- a/core/vibes/soul/sections/cart/coupon-code-form/index.tsx
+++ b/core/vibes/soul/sections/cart/coupon-code-form/index.tsx
@@ -2,6 +2,7 @@
 
 import { getFormProps, getInputProps, SubmissionResult, useForm } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
+import { useTranslations } from 'next-intl';
 import { startTransition, useActionState, useOptimistic } from 'react';
 import { useFormStatus } from 'react-dom';
 
@@ -28,7 +29,6 @@ export interface CouponCodeFormProps {
   label?: string;
   placeholder?: string;
   removeLabel?: string;
-  requiredErrorMessage?: string;
 }
 
 export function CouponCodeForm({
@@ -39,8 +39,9 @@ export function CouponCodeForm({
   label = 'Promo code',
   placeholder,
   removeLabel,
-  requiredErrorMessage,
 }: CouponCodeFormProps) {
+  const t = useTranslations('Cart.CheckoutSummary.CouponCode');
+  const schema = couponCodeActionFormDataSchema({ required_error: t('invalidCouponCode') });
   const [state, formAction] = useActionState(action, {
     couponCodes: couponCodes ?? [],
     lastResult: null,
@@ -49,9 +50,7 @@ export function CouponCodeForm({
   const [optimisticCouponCodes, setOptimisticCouponCodes] = useOptimistic<string[], FormData>(
     state.couponCodes,
     (prevState, formData) => {
-      const submission = parseWithZod(formData, {
-        schema: couponCodeActionFormDataSchema({ required_error: requiredErrorMessage }),
-      });
+      const submission = parseWithZod(formData, { schema });
 
       if (submission.status !== 'success') return prevState;
 
@@ -73,9 +72,7 @@ export function CouponCodeForm({
     shouldValidate: 'onBlur',
     shouldRevalidate: 'onInput',
     onValidate({ formData }) {
-      return parseWithZod(formData, {
-        schema: couponCodeActionFormDataSchema({ required_error: requiredErrorMessage }),
-      });
+      return parseWithZod(formData, { schema });
     },
     onSubmit(event, { formData }) {
       event.preventDefault();

--- a/core/vibes/soul/sections/cart/gift-certificate-code-form/index.tsx
+++ b/core/vibes/soul/sections/cart/gift-certificate-code-form/index.tsx
@@ -2,6 +2,7 @@
 
 import { getFormProps, getInputProps, SubmissionResult, useForm } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
+import { useTranslations } from 'next-intl';
 import { startTransition, useActionState, useOptimistic } from 'react';
 import { useFormStatus } from 'react-dom';
 
@@ -28,7 +29,6 @@ export interface GiftCertificateCodeFormProps {
   label?: string;
   placeholder?: string;
   removeLabel?: string;
-  requiredErrorMessage?: string;
 }
 
 export function GiftCertificateCodeForm({
@@ -39,14 +39,16 @@ export function GiftCertificateCodeForm({
   label = 'Gift certificate code',
   placeholder,
   removeLabel,
-  requiredErrorMessage,
 }: GiftCertificateCodeFormProps) {
+  const t = useTranslations('Cart.GiftCertificate');
   const [state, formAction] = useActionState(action, {
     giftCertificateCodes: giftCertificateCodes ?? [],
     lastResult: null,
   });
 
-  const schema = giftCertificateCodeActionFormDataSchema({ required_error: requiredErrorMessage });
+  const schema = giftCertificateCodeActionFormDataSchema({
+    required_error: t('invalidGiftCertificate'),
+  });
 
   const [optimisticGiftCertificateCodes, setOptimisticGiftCertificateCodes] = useOptimistic<
     string[],

--- a/core/vibes/soul/sections/cart/schema.ts
+++ b/core/vibes/soul/sections/cart/schema.ts
@@ -47,16 +47,21 @@ export const giftCertificateCodeActionFormDataSchema = ({
     }),
   ]);
 
-export const shippingActionFormDataSchema = z.discriminatedUnion('intent', [
-  z.object({
-    intent: z.literal('add-address'),
-    country: z.string(),
-    city: z.string().optional(),
-    state: z.string().optional(),
-    postalCode: z.string().optional(),
-  }),
-  z.object({
-    intent: z.literal('add-shipping'),
-    shippingOption: z.string(),
-  }),
-]);
+export const shippingActionFormDataSchema = ({
+  required_error = 'Country is required',
+}: {
+  required_error?: string;
+}) =>
+  z.discriminatedUnion('intent', [
+    z.object({
+      intent: z.literal('add-address'),
+      country: z.string({ required_error }),
+      city: z.string().optional(),
+      state: z.string().optional(),
+      postalCode: z.string().optional(),
+    }),
+    z.object({
+      intent: z.literal('add-shipping'),
+      shippingOption: z.string(),
+    }),
+  ]);

--- a/core/vibes/soul/sections/cart/shipping-form/index.tsx
+++ b/core/vibes/soul/sections/cart/shipping-form/index.tsx
@@ -9,6 +9,7 @@ import {
 } from '@conform-to/react';
 import { getZodConstraint, parseWithZod } from '@conform-to/zod';
 import { clsx } from 'clsx';
+import { useTranslations } from 'next-intl';
 import { startTransition, useActionState, useEffect, useMemo, useState } from 'react';
 import { useFormStatus } from 'react-dom';
 
@@ -106,6 +107,8 @@ export function ShippingForm({
   showShippingForm = false,
   noShippingOptionsLabel = 'There are no shipping options available for your address',
 }: Props) {
+  const t = useTranslations('Cart.CheckoutSummary.Shipping');
+  const schema = shippingActionFormDataSchema({ required_error: t('countryRequired') });
   const [showForms, setShowForms] = useState(showShippingForm);
   const [showAddressForm, setShowAddressForm] = useState(!address);
 
@@ -119,7 +122,7 @@ export function ShippingForm({
 
   const [addressForm, addressFields] = useForm({
     lastResult: state.form === 'address' ? state.lastResult : null,
-    constraint: getZodConstraint(shippingActionFormDataSchema),
+    constraint: getZodConstraint(schema),
     shouldValidate: 'onBlur',
     shouldRevalidate: 'onInput',
     defaultValue: {
@@ -129,7 +132,7 @@ export function ShippingForm({
       postalCode: state.address?.postalCode,
     },
     onValidate({ formData }) {
-      return parseWithZod(formData, { schema: shippingActionFormDataSchema });
+      return parseWithZod(formData, { schema });
     },
     onSubmit(event, { formData }) {
       event.preventDefault();
@@ -143,14 +146,14 @@ export function ShippingForm({
 
   const [shippingOptionsForm, shippingOptionsFields] = useForm({
     lastResult: state.form === 'shipping' ? state.lastResult : null,
-    constraint: getZodConstraint(shippingActionFormDataSchema),
+    constraint: getZodConstraint(schema),
     shouldValidate: 'onBlur',
     shouldRevalidate: 'onInput',
     defaultValue: {
       shippingOption: state.shippingOption?.value,
     },
     onValidate({ formData }) {
-      return parseWithZod(formData, { schema: shippingActionFormDataSchema });
+      return parseWithZod(formData, { schema });
     },
     onSubmit(event, { formData }) {
       event.preventDefault();

--- a/core/vibes/soul/sections/dynamic-form-section/index.tsx
+++ b/core/vibes/soul/sections/dynamic-form-section/index.tsx
@@ -4,6 +4,7 @@ import { DynamicForm, DynamicFormAction } from '@/vibes/soul/form/dynamic-form';
 import {
   Field,
   FieldGroup,
+  FormErrorTranslationMap,
   PasswordComplexitySettings,
 } from '@/vibes/soul/form/dynamic-form/schema';
 import { SectionLayout } from '@/vibes/soul/sections/section-layout';
@@ -16,6 +17,7 @@ interface Props<F extends Field> {
   submitLabel?: string;
   className?: string;
   passwordComplexity?: PasswordComplexitySettings | null;
+  errorTranslations?: FormErrorTranslationMap;
 }
 
 export function DynamicFormSection<F extends Field>({
@@ -26,6 +28,7 @@ export function DynamicFormSection<F extends Field>({
   submitLabel,
   action,
   passwordComplexity,
+  errorTranslations,
 }: Props<F>) {
   return (
     <SectionLayout className={clsx('mx-auto w-full max-w-4xl', className)} containerSize="lg">
@@ -41,6 +44,7 @@ export function DynamicFormSection<F extends Field>({
       )}
       <DynamicForm
         action={action}
+        errorTranslations={errorTranslations}
         fields={fields}
         passwordComplexity={passwordComplexity}
         submitLabel={submitLabel}

--- a/core/vibes/soul/sections/forgot-password-section/forgot-password-form.tsx
+++ b/core/vibes/soul/sections/forgot-password-section/forgot-password-form.tsx
@@ -1,15 +1,17 @@
 'use client';
 
 import { getFormProps, getInputProps, SubmissionResult, useForm } from '@conform-to/react';
-import { getZodConstraint, parseWithZod } from '@conform-to/zod';
+import { getZodConstraint } from '@conform-to/zod';
+import { useTranslations } from 'next-intl';
 import { useActionState } from 'react';
 import { useFormStatus } from 'react-dom';
 
 import { FormStatus } from '@/vibes/soul/form/form-status';
 import { Input } from '@/vibes/soul/form/input';
 import { Button } from '@/vibes/soul/primitives/button';
+import { parseWithZodTranslatedErrors } from '~/i18n/utils';
 
-import { schema } from './schema';
+import { forgotPasswordErrorTranslations, schema } from './schema';
 
 type Action<State, Payload> = (state: Awaited<State>, payload: Payload) => State | Promise<State>;
 
@@ -29,6 +31,8 @@ export function ForgotPasswordForm({
   emailLabel = 'Email',
   submitLabel = 'Reset password',
 }: Props) {
+  const t = useTranslations('Auth.Login.ForgotPassword');
+  const errorTranslations = forgotPasswordErrorTranslations(t);
   const [{ lastResult, successMessage }, formAction] = useActionState(action, { lastResult: null });
   const [form, fields] = useForm({
     lastResult,
@@ -36,7 +40,7 @@ export function ForgotPasswordForm({
     shouldValidate: 'onBlur',
     shouldRevalidate: 'onInput',
     onValidate({ formData }) {
-      return parseWithZod(formData, { schema });
+      return parseWithZodTranslatedErrors(formData, { schema, errorTranslations });
     },
   });
 

--- a/core/vibes/soul/sections/forgot-password-section/schema.ts
+++ b/core/vibes/soul/sections/forgot-password-section/schema.ts
@@ -1,5 +1,18 @@
+import { getTranslations } from 'next-intl/server';
 import { z } from 'zod';
 
+import { FormErrorTranslationMap } from '@/vibes/soul/form/dynamic-form/schema';
+import { ExistingResultType } from '~/client/util';
+
+export const forgotPasswordErrorTranslations = (
+  t: ExistingResultType<typeof getTranslations<'Auth.Login.ForgotPassword'>>,
+): FormErrorTranslationMap => ({
+  email: {
+    invalid_type: t('FieldErrors.emailRequired'),
+    invalid_string: t('FieldErrors.emailInvalid'),
+  },
+});
+
 export const schema = z.object({
-  email: z.string().email({ message: 'Please enter a valid email.' }).trim(),
+  email: z.string().email().trim(),
 });

--- a/core/vibes/soul/sections/gift-certificate-purchase-section/index.tsx
+++ b/core/vibes/soul/sections/gift-certificate-purchase-section/index.tsx
@@ -2,11 +2,11 @@
 
 import { SubmissionResult } from '@conform-to/react';
 import { clsx } from 'clsx';
-import { useFormatter } from 'next-intl';
+import { useFormatter, useTranslations } from 'next-intl';
 import { ReactNode, useCallback, useState } from 'react';
 
 import { DynamicForm, DynamicFormAction } from '@/vibes/soul/form/dynamic-form';
-import { Field, FieldGroup } from '@/vibes/soul/form/dynamic-form/schema';
+import { Field, FieldGroup, FormErrorTranslationMap } from '@/vibes/soul/form/dynamic-form/schema';
 import { Streamable } from '@/vibes/soul/lib/streamable';
 import { GiftCertificateCard } from '@/vibes/soul/primitives/gift-certificate-card';
 import { toast } from '@/vibes/soul/primitives/toaster';
@@ -58,8 +58,36 @@ export function GiftCertificatePurchaseSection({
   expiresAtLabel,
   ctaLabel = 'Add to cart',
 }: Props) {
+  const t = useTranslations('GiftCertificates.Purchase');
   const format = useFormatter();
   const [formattedAmount, setFormattedAmount] = useState<string | undefined>(undefined);
+  const errorTranslations: FormErrorTranslationMap = {
+    amount: {
+      invalid_type: t('Form.Errors.amountRequired'),
+      invalid_string: t('Form.Errors.amountInvalid'),
+    },
+    senderName: {
+      invalid_type: t('Form.Errors.senderNameRequired'),
+    },
+    senderEmail: {
+      invalid_type: t('Form.Errors.senderEmailRequired'),
+      invalid_string: t('Form.Errors.emailInvalid'),
+    },
+    recipientName: {
+      invalid_type: t('Form.Errors.recipientNameRequired'),
+    },
+    recipientEmail: {
+      invalid_type: t('Form.Errors.recipientEmailRequired'),
+      invalid_string: t('Form.Errors.emailInvalid'),
+    },
+    nonRefundable: {
+      invalid_literal: t('Form.Errors.checkboxRequired'),
+    },
+    expirationConsent: {
+      invalid_literal: t('Form.Errors.checkboxRequired'),
+    },
+  };
+
   const handleFormChange = (e: React.FormEvent<HTMLFormElement>) => {
     if (!(e.target instanceof HTMLInputElement || e.target instanceof HTMLSelectElement)) {
       return;
@@ -156,6 +184,7 @@ export function GiftCertificatePurchaseSection({
           </div>
           <DynamicForm
             action={action}
+            errorTranslations={errorTranslations}
             fields={formFields}
             key={JSON.stringify(formFields)}
             onChange={handleFormChange}

--- a/core/vibes/soul/sections/reset-password-section/index.tsx
+++ b/core/vibes/soul/sections/reset-password-section/index.tsx
@@ -1,3 +1,5 @@
+import { PasswordComplexitySettings } from '@/vibes/soul/form/dynamic-form/schema';
+
 import { ResetPasswordAction, ResetPasswordForm } from './reset-password-form';
 
 interface Props {
@@ -7,6 +9,7 @@ interface Props {
   submitLabel?: string;
   newPasswordLabel?: string;
   confirmPasswordLabel?: string;
+  passwordComplexitySettings?: PasswordComplexitySettings | null;
 }
 
 export function ResetPasswordSection({
@@ -15,6 +18,7 @@ export function ResetPasswordSection({
   submitLabel,
   newPasswordLabel,
   confirmPasswordLabel,
+  passwordComplexitySettings,
   action,
 }: Props) {
   return (
@@ -27,6 +31,7 @@ export function ResetPasswordSection({
             action={action}
             confirmPasswordLabel={confirmPasswordLabel}
             newPasswordLabel={newPasswordLabel}
+            passwordComplexitySettings={passwordComplexitySettings}
             submitLabel={submitLabel}
           />
         </div>

--- a/core/vibes/soul/sections/reset-password-section/reset-password-form.tsx
+++ b/core/vibes/soul/sections/reset-password-section/reset-password-form.tsx
@@ -1,14 +1,17 @@
 'use client';
 
 import { getFormProps, getInputProps, SubmissionResult, useForm } from '@conform-to/react';
-import { getZodConstraint, parseWithZod } from '@conform-to/zod';
+import { getZodConstraint } from '@conform-to/zod';
+import { useTranslations } from 'next-intl';
 import { useActionState } from 'react';
 
+import { PasswordComplexitySettings } from '@/vibes/soul/form/dynamic-form/schema';
 import { FormStatus } from '@/vibes/soul/form/form-status';
 import { Input } from '@/vibes/soul/form/input';
 import { Button } from '@/vibes/soul/primitives/button';
+import { parseWithZodTranslatedErrors } from '~/i18n/utils';
 
-import { schema } from './schema';
+import { resetPasswordErrorTranslations, resetPasswordSchema } from './schema';
 
 type Action<State, Payload> = (state: Awaited<State>, payload: Payload) => State | Promise<State>;
 
@@ -22,6 +25,7 @@ interface Props {
   submitLabel?: string;
   newPasswordLabel?: string;
   confirmPasswordLabel?: string;
+  passwordComplexitySettings?: PasswordComplexitySettings | null;
 }
 
 export function ResetPasswordForm({
@@ -29,7 +33,11 @@ export function ResetPasswordForm({
   newPasswordLabel = 'New password',
   confirmPasswordLabel = 'Confirm Password',
   submitLabel = 'Update',
+  passwordComplexitySettings,
 }: Props) {
+  const t = useTranslations('Auth.ChangePassword');
+  const errorTranslations = resetPasswordErrorTranslations(t, passwordComplexitySettings);
+  const schema = resetPasswordSchema(passwordComplexitySettings, errorTranslations);
   const [{ lastResult, successMessage }, formAction, isPending] = useActionState(action, {
     lastResult: null,
   });
@@ -39,7 +47,7 @@ export function ResetPasswordForm({
     shouldValidate: 'onBlur',
     shouldRevalidate: 'onInput',
     onValidate({ formData }) {
-      return parseWithZod(formData, { schema });
+      return parseWithZodTranslatedErrors(formData, { schema, errorTranslations });
     },
   });
 

--- a/core/vibes/soul/sections/reset-password-section/schema.ts
+++ b/core/vibes/soul/sections/reset-password-section/schema.ts
@@ -1,24 +1,55 @@
+import { getTranslations } from 'next-intl/server';
 import { z } from 'zod';
 
-export const schema = z
-  .object({
-    password: z
-      .string()
-      .min(8, { message: 'Be at least 8 characters long' })
-      .regex(/[a-zA-Z]/, { message: 'Contain at least one letter.' })
-      .regex(/[0-9]/, { message: 'Contain at least one number.' })
-      .regex(/[^a-zA-Z0-9]/, {
-        message: 'Contain at least one special character.',
-      })
-      .trim(),
-    confirmPassword: z.string(),
-  })
-  .superRefine(({ confirmPassword, password }, ctx) => {
-    if (confirmPassword !== password) {
-      ctx.addIssue({
-        code: 'custom',
-        message: 'The passwords did not match',
-        path: ['confirmPassword'],
-      });
-    }
-  });
+import {
+  FormErrorTranslationMap,
+  getPasswordSchema,
+  PasswordComplexitySettings,
+} from '@/vibes/soul/form/dynamic-form/schema';
+import { ExistingResultType } from '~/client/util';
+
+export const resetPasswordErrorTranslations = (
+  t: ExistingResultType<typeof getTranslations<'Auth.ChangePassword'>>,
+  passwordComplexity?: PasswordComplexitySettings | null,
+): FormErrorTranslationMap => ({
+  password: {
+    invalid_type: t('FieldErrors.passwordRequired'),
+    too_small: t('FieldErrors.passwordTooSmall', {
+      minLength: passwordComplexity?.minimumPasswordLength ?? 0,
+    }),
+    lowercase_required: t('FieldErrors.passwordLowercaseRequired'),
+    uppercase_required: t('FieldErrors.passwordUppercaseRequired'),
+    number_required: t('FieldErrors.passwordNumberRequired', {
+      minNumbers: passwordComplexity?.minimumNumbers ?? 1,
+    }),
+    special_character_required: t('FieldErrors.passwordSpecialCharacterRequired'),
+    passwords_must_match: t('FieldErrors.passwordsMustMatch'),
+  },
+  confirmPassword: {
+    invalid_type: t('FieldErrors.passwordRequired'),
+  },
+});
+
+export const resetPasswordSchema = (
+  passwordComplexity?: PasswordComplexitySettings | null,
+  errorTranslations?: FormErrorTranslationMap,
+) => {
+  const passwordSchema = getPasswordSchema(passwordComplexity, errorTranslations);
+
+  return z
+    .object({
+      currentPassword: z.string().trim(),
+      password: passwordSchema,
+      confirmPassword: z.string(),
+    })
+    .superRefine(({ confirmPassword, password }, ctx) => {
+      if (confirmPassword !== password) {
+        ctx.addIssue({
+          code: 'custom',
+          message:
+            errorTranslations?.password?.passwords_must_match ?? 'The passwords do not match',
+          path: ['confirmPassword'],
+        });
+      }
+    });
+};

--- a/core/vibes/soul/sections/reviews/index.tsx
+++ b/core/vibes/soul/sections/reviews/index.tsx
@@ -28,6 +28,7 @@ interface Props {
   formButtonLabel?: string;
   formModalTitle?: string;
   formSubmitLabel?: string;
+  formCancelLabel?: string;
   formRatingLabel?: string;
   formTitleLabel?: string;
   formReviewLabel?: string;
@@ -52,6 +53,7 @@ export function Reviews({
   formButtonLabel = 'Write a review',
   formModalTitle,
   formSubmitLabel,
+  formCancelLabel,
   formRatingLabel,
   formTitleLabel,
   formReviewLabel,
@@ -69,6 +71,7 @@ export function Reviews({
             <ReviewsEmptyState
               action={action}
               formButtonLabel={formButtonLabel}
+              formCancelLabel={formCancelLabel}
               formEmailLabel={formEmailLabel}
               formModalTitle={formModalTitle}
               formNameLabel={formNameLabel}
@@ -186,6 +189,7 @@ export function ReviewsEmptyState({
   formButtonLabel = 'Write a review',
   formModalTitle,
   formSubmitLabel,
+  formCancelLabel,
   formRatingLabel,
   formTitleLabel,
   formReviewLabel,
@@ -202,6 +206,7 @@ export function ReviewsEmptyState({
   formButtonLabel?: string;
   formModalTitle?: string;
   formSubmitLabel?: string;
+  formCancelLabel?: string;
   formRatingLabel?: string;
   formTitleLabel?: string;
   formReviewLabel?: string;
@@ -230,6 +235,7 @@ export function ReviewsEmptyState({
         <p className="text-center">{message}</p>
         <ReviewForm
           action={action}
+          formCancelLabel={formCancelLabel}
           formEmailLabel={formEmailLabel}
           formModalTitle={formModalTitle}
           formNameLabel={formNameLabel}

--- a/core/vibes/soul/sections/reviews/review-form.tsx
+++ b/core/vibes/soul/sections/reviews/review-form.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { getFormProps, SubmissionResult, useForm, useInputControl } from '@conform-to/react';
-import { getZodConstraint, parseWithZod } from '@conform-to/zod';
+import { getZodConstraint } from '@conform-to/zod';
+import { useTranslations } from 'next-intl';
 import { startTransition, useActionState, useEffect, useRef, useState } from 'react';
 import { useFormStatus } from 'react-dom';
 
@@ -14,8 +15,9 @@ import { Button } from '@/vibes/soul/primitives/button';
 import { Modal } from '@/vibes/soul/primitives/modal';
 import { toast } from '@/vibes/soul/primitives/toaster';
 import { Image } from '~/components/image';
+import { parseWithZodTranslatedErrors } from '~/i18n/utils';
 
-import { schema } from './schema';
+import { reviewFormErrorTranslations, schema } from './schema';
 
 type Action<S, P> = (state: Awaited<S>, payload: P) => S | Promise<S>;
 
@@ -30,6 +32,7 @@ interface Props {
   trigger: React.ReactNode;
   formModalTitle?: string;
   formSubmitLabel?: string;
+  formCancelLabel?: string;
   formRatingLabel?: string;
   formTitleLabel?: string;
   formReviewLabel?: string;
@@ -46,6 +49,7 @@ export const ReviewForm = ({
   trigger,
   formModalTitle = 'Write a review',
   formSubmitLabel = 'Submit',
+  formCancelLabel = 'Cancel',
   formRatingLabel = 'Rating',
   formTitleLabel = 'Title',
   formReviewLabel = 'Review',
@@ -55,6 +59,8 @@ export const ReviewForm = ({
   streamableImages,
   streamableUser,
 }: Props) => {
+  const t = useTranslations('Product.Reviews.Form');
+  const errorTranslations = reviewFormErrorTranslations(t);
   const [isOpen, setIsOpen] = useState(false);
   const [{ lastResult, successMessage }, formAction] = useActionState(action, {
     lastResult: null,
@@ -73,7 +79,7 @@ export const ReviewForm = ({
       author: user.name,
     },
     onValidate({ formData }) {
-      return parseWithZod(formData, { schema });
+      return parseWithZodTranslatedErrors(formData, { schema, errorTranslations });
     },
     onSubmit(event, { formData }) {
       event.preventDefault();
@@ -213,7 +219,7 @@ export const ReviewForm = ({
             ))}
             <div className="mt-auto flex justify-end gap-3">
               <Button onClick={() => setIsOpen(false)} size="small" type="button" variant="ghost">
-                Cancel
+                {formCancelLabel}
               </Button>
               <SubmitButton>{formSubmitLabel}</SubmitButton>
             </div>

--- a/core/vibes/soul/sections/reviews/schema.ts
+++ b/core/vibes/soul/sections/reviews/schema.ts
@@ -1,4 +1,31 @@
+import { getTranslations } from 'next-intl/server';
 import { z } from 'zod';
+
+import { FormErrorTranslationMap } from '@/vibes/soul/form/dynamic-form/schema';
+import { ExistingResultType } from '~/client/util';
+
+export const reviewFormErrorTranslations = (
+  t: ExistingResultType<typeof getTranslations<'Product.Reviews.Form'>>,
+): FormErrorTranslationMap => ({
+  title: {
+    invalid_type: t('FieldErrors.titleRequired'),
+  },
+  author: {
+    invalid_type: t('FieldErrors.authorRequired'),
+  },
+  email: {
+    invalid_type: t('FieldErrors.emailRequired'),
+    invalid_string: t('FieldErrors.emailInvalid'),
+  },
+  text: {
+    invalid_type: t('FieldErrors.textRequired'),
+  },
+  rating: {
+    invalid_type: t('FieldErrors.ratingRequired'),
+    too_small: t('FieldErrors.ratingTooSmall'),
+    too_big: t('FieldErrors.ratingTooLarge'),
+  },
+});
 
 export const schema = z.object({
   productEntityId: z.number(),

--- a/core/vibes/soul/sections/sign-in-section/schema.ts
+++ b/core/vibes/soul/sections/sign-in-section/schema.ts
@@ -1,4 +1,20 @@
+import { getTranslations } from 'next-intl/server';
 import { z } from 'zod';
+
+import { FormErrorTranslationMap } from '@/vibes/soul/form/dynamic-form/schema';
+import { ExistingResultType } from '~/client/util';
+
+export const loginErrorTranslations = (
+  t: ExistingResultType<typeof getTranslations<'Auth.Login'>>,
+): FormErrorTranslationMap => ({
+  email: {
+    invalid_type: t('FieldErrors.emailRequired'),
+    invalid_string: t('FieldErrors.emailInvalid'),
+  },
+  password: {
+    invalid_type: t('FieldErrors.passwordRequired'),
+  },
+});
 
 export const schema = z.object({
   email: z.string().email(),

--- a/core/vibes/soul/sections/sign-in-section/sign-in-form.tsx
+++ b/core/vibes/soul/sections/sign-in-section/sign-in-form.tsx
@@ -1,15 +1,17 @@
 'use client';
 
 import { getFormProps, getInputProps, SubmissionResult, useForm } from '@conform-to/react';
-import { getZodConstraint, parseWithZod } from '@conform-to/zod';
+import { getZodConstraint } from '@conform-to/zod';
+import { useTranslations } from 'next-intl';
 import { startTransition, useActionState, useEffect } from 'react';
 import { useFormStatus } from 'react-dom';
 
 import { FormStatus } from '@/vibes/soul/form/form-status';
 import { Input } from '@/vibes/soul/form/input';
 import { Button } from '@/vibes/soul/primitives/button';
+import { parseWithZodTranslatedErrors } from '~/i18n/utils';
 
-import { schema } from './schema';
+import { loginErrorTranslations, schema } from './schema';
 
 type Action<State, Payload> = (state: Awaited<State>, payload: Payload) => State | Promise<State>;
 
@@ -30,6 +32,8 @@ export function SignInForm({
   submitLabel = 'Sign in',
   error,
 }: Props) {
+  const t = useTranslations('Auth.Login');
+  const errorTranslations = loginErrorTranslations(t);
   const [lastResult, formAction] = useActionState(action, null);
   const [form, fields] = useForm({
     lastResult,
@@ -44,7 +48,7 @@ export function SignInForm({
       });
     },
     onValidate({ formData }) {
-      return parseWithZod(formData, { schema });
+      return parseWithZodTranslatedErrors(formData, { schema, errorTranslations });
     },
   });
 


### PR DESCRIPTION
## What/Why?
Update form field validation errors to be translated

## Testing
Tested manually


## Migration

Due to the amount of changes, it is recommended to just use the PR as a reference for migration.

### Key Changes Overview

1. **New translation utility functions** for form validation in `core/i18n/utils.ts`
2. **Updated form schemas** to remove hardcoded error messages and support translations
3. **New translation keys** added to `core/messages/en.json` for field-level validation errors
4. **Updated form components** to pass error translation maps
5. **Password complexity settings** now fetched and passed to forms requiring password validation
6. **Schema functions updated** to accept translation parameters
7. **Cart and newsletter forms** now use translated error messages

### Step-by-Step Migration

#### 1. Add Translation Utilities (New File)

Create `core/i18n/utils.ts` with two utility functions:
- `createErrorMap` - Maps Zod validation errors to translated messages
- `parseWithZodTranslatedErrors` - Wrapper around Conform's parseWithZod that uses translated errors

This file is essential for all forms to display translated error messages.

#### 2. Update Translation Files

Add new field error translation keys to your locale files (`core/messages/en.json` and others):

**New namespaces with FieldErrors:**
- `Auth.ChangePassword.FieldErrors` - Password reset error messages
- `Auth.Login.FieldErrors` - Login form errors
- `Auth.Login.ForgotPassword.FieldErrors` - Forgot password errors
- `Auth.Register.FieldErrors` - Registration form errors including address fields
- `Account.Addresses.FieldErrors` - Address management errors
- `Account.Settings.FieldErrors` - Account settings and password change errors
- `Product.Reviews.Form.FieldErrors` - Product review form errors
- `GiftCertificates.Purchase.Form.Errors` - Gift certificate purchase errors
- `Components.Subscribe.Errors` - Newsletter subscription errors
- `Cart.CheckoutSummary.CouponCode` - Coupon code validation
- `Cart.GiftCertificate` - Gift certificate code validation
- `Cart.CheckoutSummary.Shipping` - Shipping form errors
- `Form.Errors` - Generic fallback messages

**Reference the PR diff for exact translation keys** - each namespace includes contextual error messages with ICU MessageFormat support for pluralization.

#### 3. Update Form Schemas

**Pattern for schema files:**
1. Import necessary types: `FormErrorTranslationMap`, `getPasswordSchema`, `PasswordComplexitySettings`
2. Remove hardcoded error messages from Zod schemas
3. Export error translation map functions
4. Convert static schemas to functions that accept parameters

**Files requiring schema updates:**
- `core/vibes/soul/form/dynamic-form/schema.ts` - Add `FormErrorTranslationMap` type, `getPasswordSchema` function, update main schema function signature
- `core/vibes/soul/sections/account-settings/schema.ts` - Export `updateAccountErrorTranslations` and `changePasswordErrorTranslations`, convert `changePasswordSchema` to function
- `core/vibes/soul/sections/address-list-section/schema.ts` - Export `addressFormErrorTranslations`
- `core/vibes/soul/sections/forgot-password-section/schema.ts` - Export `forgotPasswordErrorTranslations`
- `core/vibes/soul/sections/reset-password-section/schema.ts` - Export `resetPasswordErrorTranslations`, convert schema to function
- `core/vibes/soul/sections/sign-in-section/schema.ts` - Export `loginErrorTranslations`
- `core/vibes/soul/sections/reviews/schema.ts` - Export `reviewFormErrorTranslations`
- `core/vibes/soul/sections/cart/schema.ts` - Update `shippingActionFormDataSchema` to accept error message parameter
- `core/vibes/soul/primitives/inline-email-form/schema.ts` - Convert to function accepting error message parameters

**Example pattern:**
```typescript
export const yourErrorTranslations = (
  t: ExistingResultType<typeof getTranslations<'Your.Namespace'>>,
): FormErrorTranslationMap => ({
  fieldName: {
    invalid_type: t('FieldErrors.fieldRequired'),
    invalid_string: t('FieldErrors.fieldInvalid'),
  },
});
```

#### 4. Update Form Components

**For each form component:**
1. Import `useTranslations` from `next-intl`
2. Import error translation function from schema
3. Call translation function with appropriate namespace
4. Replace `parseWithZod` with `parseWithZodTranslatedErrors` from `~/i18n/utils`
5. Pass `errorTranslations` to validation functions

**Files requiring form component updates:**
- `core/vibes/soul/form/dynamic-form/index.tsx` - Add inline errorMap to parseWithZod call
- `core/vibes/soul/sections/account-settings/change-password-form.tsx`
- `core/vibes/soul/sections/account-settings/update-account-form.tsx`
- `core/vibes/soul/sections/address-list-section/index.tsx`
- `core/vibes/soul/sections/forgot-password-section/forgot-password-form.tsx`
- `core/vibes/soul/sections/reset-password-section/reset-password-form.tsx`
- `core/vibes/soul/sections/sign-in-section/sign-in-form.tsx`
- `core/vibes/soul/sections/gift-certificate-purchase-section/index.tsx`
- `core/vibes/soul/sections/reviews/review-form.tsx`
- `core/vibes/soul/sections/cart/coupon-code-form/index.tsx` - Remove `requiredErrorMessage` prop, use translations
- `core/vibes/soul/sections/cart/gift-certificate-code-form/index.tsx` - Remove `requiredErrorMessage` prop, use translations
- `core/vibes/soul/sections/cart/shipping-form/index.tsx` - Use translated schema
- `core/vibes/soul/primitives/inline-email-form/index.tsx` - Build schema with translated messages

#### 5. Add Password Complexity Settings Support

For forms with password fields:

**Create new page-data files:**
- `core/app/[locale]/(default)/(auth)/change-password/page-data.ts` - Query password complexity settings

**Update existing page-data files:**
- `core/app/[locale]/(default)/account/settings/page-data.tsx` - Add passwordComplexitySettings to query and return

**Update page components:**
- `core/app/[locale]/(default)/(auth)/change-password/page.tsx` - Fetch and pass settings
- `core/app/[locale]/(default)/account/settings/page.tsx` - Pass settings to section

**Update server actions:**
- `core/app/[locale]/(default)/(auth)/change-password/_actions/change-password.ts` - Define schema inline (remove vibes import)
- `core/app/[locale]/(default)/account/settings/_actions/change-password.ts` - Define schema inline (remove vibes import)

**Important:** Server actions should define minimal schemas inline rather than importing complex schemas from vibes components. This keeps action payloads smaller and validation focused.

#### 6. Update Section Components

Add `errorTranslations` and `passwordComplexitySettings` props:
- `core/vibes/soul/sections/dynamic-form-section/index.tsx`
- `core/vibes/soul/sections/account-settings/index.tsx`
- `core/vibes/soul/sections/reset-password-section/index.tsx`

These section wrappers need to accept and forward the props to their child form components.

#### 7. Update Specialized Forms

**Register page:**
- `core/app/[locale]/(default)/(auth)/register/page.tsx` - Add large inline `errorTranslations` object mapping all field errors

**Gift certificate forms:**
- `core/app/[locale]/(default)/gift-certificates/purchase/page.tsx` - Remove hardcoded asterisks from labels
- `core/app/[locale]/(default)/gift-certificates/purchase/_actions/add-to-cart.tsx` - Fix type annotation

**Cart forms (removed requiredErrorMessage props):**
- Cart checkout summary components now fetch translations internally

**Review form:**
- `core/vibes/soul/sections/reviews/index.tsx` - Add `formCancelLabel` prop
- `core/vibes/soul/sections/reviews/review-form.tsx` - Use translated validation

#### 8. Update Page-Data Fetch Options

For consistency with caching strategy:
- Change `fetchOptions: { cache: 'no-store' }` to `fetchOptions: { next: { revalidate } }` in `core/app/[locale]/(default)/(auth)/change-password/page-data.ts`

### Resolving Merge Conflicts

**In schema files:**
1. Remove hardcoded error messages from `.min()`, `.email()`, `.regex()`, etc.
2. Add error translation function exports
3. Convert static schemas to functions accepting `passwordComplexity` and `errorTranslations` parameters
4. For password fields, use the shared `getPasswordSchema` utility

**In form components:**
```typescript
// Add at component start:
const t = useTranslations('Your.Namespace');
const errorTranslations = yourErrorTranslations(t);

// In useForm onValidate:
onValidate({ formData }) {
  return parseWithZodTranslatedErrors(formData, { schema, errorTranslations });
}
```

**In translation files:**
- Merge new `FieldErrors` objects under existing namespaces
- Preserve any custom translations you've added
- Use ICU MessageFormat for messages with variables: `{minLength, plural, =1 {1 character} other {# characters}}`

**In server actions:**
- If you customized actions, define schemas inline
- Import and use only basic types from schema files, not the full schemas

**In page components:**
- If you've added custom form pages, ensure they fetch and pass `passwordComplexitySettings`
- Add `errorTranslations` inline object or import translation function

### Testing Checklist

After migration, verify these scenarios:

- [ ] **Empty required fields** - All forms show translated "required" errors
- [ ] **Invalid email addresses** - Email fields show translated invalid format errors
- [ ] **Weak passwords** - Password fields show appropriate complexity requirement errors in your language
- [ ] **Password mismatch** - Confirm password fields show translated mismatch error
- [ ] **Address validation** - Address forms show translated errors for missing required fields
- [ ] **Gift certificate amounts** - Invalid amounts show translated errors
- [ ] **Coupon codes** - Invalid codes show translated errors
- [ ] **Review form** - All review fields validate with translated messages
- [ ] **Multiple locales** - If you support multiple languages, test forms in each locale
- [ ] **Password complexity** - Errors reflect your store's configured password rules
- [ ] **Custom fields** - Any custom form fields you added still validate correctly

### Breaking Changes

**API Changes:**
- Form schemas now accept `errorTranslations` parameter
- Password schemas require `passwordComplexity` and `errorTranslations` parameters
- Vibes form components expect `errorTranslations` prop
- Cart form components no longer accept `requiredErrorMessage` prop
- Inline email form schema is now a function, not a static object

**Import Changes:**
- Server actions should not import schemas from vibes section files
- Use `parseWithZodTranslatedErrors` instead of `parseWithZod` for client forms

**Behavior Changes:**
- All validation errors now require translation keys
- Missing translation keys fall back to generic messages
- Password validation messages dynamically reflect store settings

### Custom Fields and Forms

If you've added custom fields or forms:

1. **Add translation keys** for your custom fields under appropriate namespace
2. **Create error translation functions** following the pattern shown
3. **Update custom schemas** to remove hardcoded messages
4. **Pass errorTranslations** to your custom form components
5. **Test thoroughly** - custom validation logic may need adjustment

### Optional Enhancements

When implementing this migration, consider:

1. **Translate all locale files** - Add translations for languages beyond English
2. **Customize error messages** - Adjust wording to match your brand voice
3. **Add contextual help** - Use descriptive error messages that guide users
4. **Implement field-level hints** - Add helpful placeholder text
5. **Create validation mixins** - If you have many custom forms, create reusable validation utilities
6. **Test accessibility** - Ensure error messages are announced by screen readers

### Getting Help

If you encounter issues during migration:

1. **Check the PR diff** - The full changeset shows exact implementations
2. **Review schema patterns** - Look at how existing forms were updated
3. **Verify translation keys** - Ensure your keys match the namespace structure
4. **Test incrementally** - Update one form at a time and test before proceeding
5. **Check console errors** - Missing translations will show warnings in development

