### PR TITLE
chore(ci): add --scope to vercel deploy and alias commands

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,7 +70,7 @@ jobs:
                     DEPLOY_ARGS+=(--env BIGCOMMERCE_ACCESS_TOKEN="$BIGCOMMERCE_ACCESS_TOKEN")
                   fi
 
-                  DEPLOYMENT_URL=$(vercel deploy "${DEPLOY_ARGS[@]}")
+                  DEPLOYMENT_URL=$(vercel deploy --scope="${{ vars.VERCEL_TEAM_SLUG }}" "${DEPLOY_ARGS[@]}")
                   echo "deployment_url=$DEPLOYMENT_URL" >> $GITHUB_OUTPUT
 
             - name: Set Vercel Domain Alias
@@ -78,4 +78,4 @@ jobs:
               env:
                   VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
               run: |
-                  vercel alias ${{ steps.deploy.outputs.deployment_url }} $DOMAIN --token="$VERCEL_TOKEN"
+                  vercel alias ${{ steps.deploy.outputs.deployment_url }} $DOMAIN --scope="${{ vars.VERCEL_TEAM_SLUG }}" --token="$VERCEL_TOKEN"


### PR DESCRIPTION
## What/Why?

Adds the `--scope` flag (set to `${{ vars.VERCEL_TEAM_SLUG }}`) to the `vercel deploy` and `vercel alias` commands in the production tag deployment workflow. This ensures deployments are scoped to the correct Vercel team.

## Testing

Tested locally:
<img width="1420" height="188" alt="Screenshot 2026-01-27 at 3 38 23 PM" src="https://github.com/user-attachments/assets/b40b2293-7edb-4edf-bb30-6da3767844e0" />

Added new GitHub Actions variable:
<img width="784" height="66" alt="Screenshot 2026-01-27 at 3 39 04 PM" src="https://github.com/user-attachments/assets/da5867f7-7973-498e-806c-c094411102cf" />

## Migration

N/A