### PR TITLE
[CATALYST-1735] Show required login message for review form

### DIFF
--- a/.changeset/fifty-symbols-find.md
+++ b/.changeset/fifty-symbols-find.md
@@ -1,0 +1,7 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Previously, users could fill out the review form and attempt to submit it without being logged in. They then received an error message saying they needed to be logged in. This would require them to leave the form to go to the login page which resulted in losing all entered information. They would then manually need to navigate back to the PDP.
+
+To improve user experience, this PR implements a notification that informs users they must be logged in before being able to access the review form. This includes a link to the log in page which will handle redirecting the user back to the appropriate PDP after successful login.

--- a/core/app/[locale]/(default)/product/[slug]/_components/reviews.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/_components/reviews.tsx
@@ -75,6 +75,7 @@ const getReviews = cache(async (productId: number, paginationArgs: object) => {
 });
 
 interface Props {
+  formLoginHref?: string;
   productId: number;
   searchParams: Promise<SearchParams>;
   streamableImages: Streamable<Array<{ src: string; alt: string }>>;
@@ -82,6 +83,7 @@ interface Props {
 }
 
 export const Reviews = async ({
+  formLoginHref = '/login',
   productId,
   searchParams,
   streamableProduct,
@@ -176,6 +178,9 @@ export const Reviews = async ({
         emptyStateMessage={t('empty')}
         formButtonLabel={t('Form.button')}
         formEmailLabel={t('Form.emailLabel')}
+        formLoginRequiredMessage={t('Form.loginRequired')}
+        formLoginHref={formLoginHref}
+        formLoginButtonLabel={t('Form.loginButton')}
         formModalTitle={t('Form.title')}
         formNameLabel={t('Form.nameLabel')}
         formRatingLabel={t('Form.ratingLabel')}

--- a/core/app/[locale]/(default)/product/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/page.tsx
@@ -12,6 +12,7 @@ import { pricesTransformer } from '~/data-transformers/prices-transformer';
 import { productCardTransformer } from '~/data-transformers/product-card-transformer';
 import { productOptionsTransformer } from '~/data-transformers/product-options-transformer';
 import { getPreferredCurrencyCode } from '~/lib/currency';
+import { defaultLocale } from '~/i18n/locales';
 
 import { addToCart } from './_actions/add-to-cart';
 import { submitReview } from './_actions/submit-review';
@@ -527,6 +528,10 @@ export default async function Product({ params, searchParams }: Props) {
     return { email: session?.user?.email ?? '', name: obfuscatedName };
   });
 
+  const currentPath = locale === defaultLocale ? `/product/${slug}` : `/${locale}/product/${slug}`;
+  const loginRedirectPath = `${currentPath}#reviews`;
+  const loginHref = `/login?redirectTo=${encodeURIComponent(loginRedirectPath)}`;
+
   return (
     <>
       <ProductAnalyticsProvider data={streamableAnalyticsData}>
@@ -586,6 +591,7 @@ export default async function Product({ params, searchParams }: Props) {
       {showRating && (
         <div id="reviews">
           <Reviews
+            formLoginHref={loginHref}
             productId={productId}
             searchParams={searchParams}
             streamableImages={streamableImages}

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -425,6 +425,8 @@
       "next": "Next reviews",
       "Form": {
         "button": "Write a review",
+        "loginRequired": "You must be logged in to submit a review.",
+        "loginButton": "Log in",
         "title": "Write a review",
         "submit": "Submit",
         "ratingLabel": "Rating",

--- a/core/vibes/soul/sections/reviews/index.tsx
+++ b/core/vibes/soul/sections/reviews/index.tsx
@@ -4,6 +4,8 @@ import { CursorPagination, CursorPaginationInfo } from '@/vibes/soul/primitives/
 import { Rating } from '@/vibes/soul/primitives/rating';
 import { StickySidebarLayout } from '@/vibes/soul/sections/sticky-sidebar-layout';
 
+import { Link } from '~/components/link';
+
 import { ReviewForm, SubmitReviewAction } from './review-form';
 
 interface Review {
@@ -33,6 +35,9 @@ interface Props {
   formReviewLabel?: string;
   formNameLabel?: string;
   formEmailLabel?: string;
+  formLoginRequiredMessage?: string;
+  formLoginHref?: string;
+  formLoginButtonLabel?: string;
   streamableImages: Streamable<Array<{ src: string; alt: string }>>;
   streamableProduct: Streamable<{ name: string }>;
   streamableUser: Streamable<{ email: string; name: string }>;
@@ -57,6 +62,9 @@ export function Reviews({
   formReviewLabel,
   formNameLabel,
   formEmailLabel,
+  formLoginRequiredMessage = 'You must be logged in to submit a review.',
+  formLoginHref = '/login',
+  formLoginButtonLabel = 'Log in',
   streamableProduct,
   streamableImages,
   streamableUser,
@@ -70,6 +78,9 @@ export function Reviews({
               action={action}
               formButtonLabel={formButtonLabel}
               formEmailLabel={formEmailLabel}
+              formLoginRequiredMessage={formLoginRequiredMessage}
+              formLoginHref={formLoginHref}
+              formLoginButtonLabel={formLoginButtonLabel}
               formModalTitle={formModalTitle}
               formNameLabel={formNameLabel}
               formRatingLabel={formRatingLabel}
@@ -123,25 +134,37 @@ export function Reviews({
                     </>
                   )}
                 </Stream>
-                <ReviewForm
-                  action={action}
-                  formEmailLabel={formEmailLabel}
-                  formModalTitle={formModalTitle}
-                  formNameLabel={formNameLabel}
-                  formRatingLabel={formRatingLabel}
-                  formReviewLabel={formReviewLabel}
-                  formSubmitLabel={formSubmitLabel}
-                  formTitleLabel={formTitleLabel}
-                  productId={productId}
-                  streamableImages={streamableImages}
-                  streamableProduct={streamableProduct}
-                  streamableUser={streamableUser}
-                  trigger={
-                    <Button className="mx-auto mt-8" size="small" variant="tertiary">
-                      {formButtonLabel}
-                    </Button>
+                <Stream fallback={null} value={streamableUser}>
+                  {(user) =>
+                    user.email ? (
+                      <ReviewForm
+                        action={action}
+                        formEmailLabel={formEmailLabel}
+                        formModalTitle={formModalTitle}
+                        formNameLabel={formNameLabel}
+                        formRatingLabel={formRatingLabel}
+                        formReviewLabel={formReviewLabel}
+                        formSubmitLabel={formSubmitLabel}
+                        formTitleLabel={formTitleLabel}
+                        productId={productId}
+                        streamableImages={streamableImages}
+                        streamableProduct={streamableProduct}
+                        streamableUser={streamableUser}
+                        trigger={
+                          <Button className="mx-auto mt-8" size="small" variant="tertiary">
+                            {formButtonLabel}
+                          </Button>
+                        }
+                      />
+                    ) : (
+                      <LoginRequiredMessage
+                        loginHref={formLoginHref}
+                        loginLabel={formLoginButtonLabel}
+                        message={formLoginRequiredMessage}
+                      />
+                    )
                   }
-                />
+                </Stream>
               </>
             }
             sidebarSize="medium"
@@ -191,6 +214,9 @@ export function ReviewsEmptyState({
   formReviewLabel,
   formNameLabel,
   formEmailLabel,
+  formLoginRequiredMessage = 'You must be logged in to submit a review',
+  formLoginHref = '/login',
+  formLoginButtonLabel = 'Log in',
   streamableProduct,
   streamableImages,
   streamableUser,
@@ -207,6 +233,9 @@ export function ReviewsEmptyState({
   formReviewLabel?: string;
   formNameLabel?: string;
   formEmailLabel?: string;
+  formLoginRequiredMessage?: string;
+  formLoginHref?: string;
+  formLoginButtonLabel?: string;
   streamableImages: Streamable<Array<{ src: string; alt: string }>>;
   streamableProduct: Streamable<{ name: string }>;
   streamableUser: Streamable<{ email: string; name: string }>;
@@ -222,31 +251,43 @@ export function ReviewsEmptyState({
             0
           </div>
           <Rating rating={0} showRating={false} />
+          <Stream fallback={null} value={streamableUser}>
+            {(user) =>
+              user.email ? (
+                <ReviewForm
+                  action={action}
+                  formEmailLabel={formEmailLabel}
+                  formModalTitle={formModalTitle}
+                  formNameLabel={formNameLabel}
+                  formRatingLabel={formRatingLabel}
+                  formReviewLabel={formReviewLabel}
+                  formSubmitLabel={formSubmitLabel}
+                  formTitleLabel={formTitleLabel}
+                  productId={productId}
+                  streamableImages={streamableImages}
+                  streamableProduct={streamableProduct}
+                  streamableUser={streamableUser}
+                  trigger={
+                    <Button className="mx-auto mt-8" size="small" variant="tertiary">
+                      {formButtonLabel}
+                    </Button>
+                  }
+                />
+              ) : (
+                <LoginRequiredMessage
+                  loginHref={formLoginHref}
+                  loginLabel={formLoginButtonLabel}
+                  message={formLoginRequiredMessage}
+                />
+              )
+            }
+          </Stream>
         </>
       }
       sidebarSize="medium"
     >
       <div className="flex flex-1 flex-col border-t border-contrast-100 py-12">
         <p className="text-center">{message}</p>
-        <ReviewForm
-          action={action}
-          formEmailLabel={formEmailLabel}
-          formModalTitle={formModalTitle}
-          formNameLabel={formNameLabel}
-          formRatingLabel={formRatingLabel}
-          formReviewLabel={formReviewLabel}
-          formSubmitLabel={formSubmitLabel}
-          formTitleLabel={formTitleLabel}
-          productId={productId}
-          streamableImages={streamableImages}
-          streamableProduct={streamableProduct}
-          streamableUser={streamableUser}
-          trigger={
-            <Button className="mx-auto mt-8" size="small" variant="tertiary">
-              {formButtonLabel}
-            </Button>
-          }
-        />
       </div>
     </StickySidebarLayout>
   );
@@ -275,5 +316,31 @@ export function ReviewsSkeleton({ reviewsLabel = 'Reviews' }: { reviewsLabel?: s
         ))}
       </div>
     </StickySidebarLayout>
+  );
+}
+
+function LoginRequiredMessage({
+  message = 'You must be logged in to submit a review',
+  loginHref = '/login',
+  loginLabel = 'Log in',
+}: {
+  message?: string;
+  loginHref?: string;
+  loginLabel?: string;
+}) {
+  return (
+    <div className="mt-8 flex flex-wrap items-baseline gap-x-2 gap-y-1 text-left">
+      <p className="text-sm text-contrast-500">
+        {message}
+        {loginHref ? (
+          <Link
+            className="ml-1 text-sm font-medium text-foreground underline hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+            href={loginHref}
+          >
+            {loginLabel}
+          </Link>
+        ) : null}
+      </p>
+    </div>
   );
 }


### PR DESCRIPTION
## What/Why?
Currently, users can fill out the review form and attempt to submit it without being logged in, which results in losing all entered information. To improve user experience, this PR implements a notification that informs users they must be logged in before being able to access the review form.

![CleanShot 2026-01-28 at 14 12 53@2x](https://github.com/user-attachments/assets/641b46d8-5853-4285-a9a3-f909662cf60d)

Here is a video showing the new workflow.

https://github.com/user-attachments/assets/aaa5bfd8-c8ea-458d-a3e2-f4a6c75021e8

## Testing
- When not logged in, navigate to a PDP review section, and you should see a message saying you must be logged in to submit a review and you should not be able to trigger the review form
- After clicking the `Log in` link from the not logged in message, you should be redirected to the correct PDP
- When logged in, navigate to a PDP review section, and you should be able to submit review forms as usual

## Migration
All parameters are optional so there are no steps necessary to migate.
