### PR TITLE
fix(core): use state abbreviation instead of entityId on shipping form

### DIFF
--- a/.changeset/hip-women-design.md
+++ b/.changeset/hip-women-design.md
@@ -2,40 +2,98 @@
 "@bigcommerce/catalyst-core": patch
 ---
 
-Use state abbreviation instead of entityId for cart shipping form state values. The shipping API expects state abbreviations, not entityIds. Since some states share the same abbreviation across countries (causing Radix UI duplicate key issues), we use a composite value format (`entityId-abbreviation`) and extract the abbreviation when submitting.
+Use state abbreviation instead of entityId for cart shipping form state values. The shipping API expects state abbreviations, not entityIds. Since some states share the same abbreviation across countries (causing Radix UI duplicate key issues), we use a composite value format (`entityId|abbreviation`) and extract the abbreviation when submitting.
 
 ## Migration steps
 
 ### Step 1
 
-Update `core/app/[locale]/(default)/cart/_actions/update-shipping-info.ts` to extract the abbreviation from the composite value (in both the add and update consignment branches):
+Create a new utility file `core/lib/state-utils.ts` with helper functions for handling composite state values:
+
+```typescript
+/**
+ * Separator used in composite state values.
+ * We use a pipe character to avoid conflicts with hyphens that may appear in abbreviations.
+ */
+const STATE_VALUE_SEPARATOR = '|';
+
+/**
+ * Creates a composite state value from entityId and abbreviation.
+ * This format ensures unique values for Radix UI Select components.
+ *
+ * @param {number} entityId - The state entity ID
+ * @param {string} abbreviation - The state abbreviation
+ * @returns {string} A composite value in the format "entityId|abbreviation"
+ */
+export function createStateValue(entityId: number, abbreviation: string): string {
+  return `${entityId}${STATE_VALUE_SEPARATOR}${abbreviation}`;
+}
+
+/**
+ * Extracts the state abbreviation from a composite state value.
+ *
+ * @param {string | undefined} compositeValue - The composite value in format "entityId|abbreviation"
+ * @returns {string | undefined} The state abbreviation, or undefined if the value is invalid
+ */
+export function parseStateAbbreviation(compositeValue: string | undefined): string | undefined {
+  if (!compositeValue) {
+    return undefined;
+  }
+
+  const separatorIndex = compositeValue.indexOf(STATE_VALUE_SEPARATOR);
+
+  if (separatorIndex === -1) {
+    return undefined;
+  }
+
+  return compositeValue.slice(separatorIndex + 1);
+}
+```
+
+### Step 2
+
+Update `core/app/[locale]/(default)/cart/_actions/update-shipping-info.ts` to import and use the utility function:
+
+```diff
++ import { parseStateAbbreviation } from '~/lib/state-utils';
+```
+
+Then update both address objects (in the add and update consignment branches):
 
 ```diff
             address: {
               countryCode: submission.value.country,
               city: submission.value.city,
 -             stateOrProvince: submission.value.state,
-+             stateOrProvince: submission.value.state?.split('-')[1],
++             stateOrProvince: parseStateAbbreviation(submission.value.state),
               postalCode: submission.value.postalCode,
             },
 ```
 
-### Step 2
+### Step 3
 
-Update the state select options in `core/app/[locale]/(default)/cart/page.tsx` to use composite values:
+Update `core/app/[locale]/(default)/cart/page.tsx` to import the utility functions:
+
+```diff
++ import { createStateValue, parseStateAbbreviation } from '~/lib/state-utils';
+```
+
+### Step 4
+
+Update the state select options in `core/app/[locale]/(default)/cart/page.tsx` to use the utility function:
 
 ```diff
   const statesOrProvinces = shippingCountries.map((country) => ({
     country: country.code,
     states: country.statesOrProvinces.map((state) => ({
 -     value: state.entityId.toString(),
-+     value: `${state.entityId}-${state.abbreviation}`,
++     value: createStateValue(state.entityId, state.abbreviation),
       label: state.name,
     })),
   }));
 ```
 
-### Step 3
+### Step 5
 
 Add the selected state mapping logic in `core/app/[locale]/(default)/cart/page.tsx` before the return statement to properly initialize the form with the saved shipping address:
 
@@ -45,7 +103,8 @@ Add the selected state mapping logic in `core/app/[locale]/(default)/cart/page.t
 + const selectedStateOrProvince = statesOrProvinces
 +   .find((country) => country.country === shippingConsignment?.address.countryCode)
 +   ?.states.find(
-+     (state) => state.value.split('-')[1] === shippingConsignment?.address.stateOrProvince,
++     (state) =>
++       parseStateAbbreviation(state.value) === shippingConsignment?.address.stateOrProvince,
 +   )?.value;
 +
 + const selectedAddress = shippingConsignment?.address
@@ -67,7 +126,7 @@ Add the selected state mapping logic in `core/app/[locale]/(default)/cart/page.t
   return (
 ```
 
-### Step 4
+### Step 6
 
 Update the `ShippingEstimator` address prop in `core/app/[locale]/(default)/cart/page.tsx`:
 

--- a/.changeset/hip-women-design.md
+++ b/.changeset/hip-women-design.md
@@ -1,0 +1,96 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Use state abbreviation instead of entityId for cart shipping form state values. The shipping API expects state abbreviations, not entityIds. Since some states share the same abbreviation across countries (causing Radix UI duplicate key issues), we use a composite value format (`entityId-abbreviation`) and extract the abbreviation when submitting.
+
+## Migration steps
+
+### Step 1
+
+Update `core/app/[locale]/(default)/cart/_actions/update-shipping-info.ts` to extract the abbreviation from the composite value (in both the add and update consignment branches):
+
+```diff
+            address: {
+              countryCode: submission.value.country,
+              city: submission.value.city,
+-             stateOrProvince: submission.value.state,
++             stateOrProvince: submission.value.state?.split('-')[1],
+              postalCode: submission.value.postalCode,
+            },
+```
+
+### Step 2
+
+Update the state select options in `core/app/[locale]/(default)/cart/page.tsx` to use composite values:
+
+```diff
+  const statesOrProvinces = shippingCountries.map((country) => ({
+    country: country.code,
+    states: country.statesOrProvinces.map((state) => ({
+-     value: state.entityId.toString(),
++     value: `${state.entityId}-${state.abbreviation}`,
+      label: state.name,
+    })),
+  }));
+```
+
+### Step 3
+
+Add the selected state mapping logic in `core/app/[locale]/(default)/cart/page.tsx` before the return statement to properly initialize the form with the saved shipping address:
+
+```diff
+  const checkoutUrl = data.site.settings?.url.checkoutUrl;
+
++ const selectedStateOrProvince = statesOrProvinces
++   .find((country) => country.country === shippingConsignment?.address.countryCode)
++   ?.states.find(
++     (state) => state.value.split('-')[1] === shippingConsignment?.address.stateOrProvince,
++   )?.value;
++
++ const selectedAddress = shippingConsignment?.address
++   ? {
++       country: shippingConsignment.address.countryCode,
++       city:
++         shippingConsignment.address.city !== ''
++           ? (shippingConsignment.address.city ?? undefined)
++           : undefined,
++       state:
++         shippingConsignment.address.stateOrProvince !== '' ? selectedStateOrProvince : undefined,
++       postalCode:
++         shippingConsignment.address.postalCode !== ''
++           ? (shippingConsignment.address.postalCode ?? undefined)
++           : undefined,
++     }
++   : undefined;
+
+  return (
+```
+
+### Step 4
+
+Update the `ShippingEstimator` address prop in `core/app/[locale]/(default)/cart/page.tsx`:
+
+```diff
+            action: updateShippingInfo,
+            countries,
+            states: statesOrProvinces,
+-           address: shippingConsignment?.address
+-             ? {
+-                 country: shippingConsignment.address.countryCode,
+-                 city:
+-                   shippingConsignment.address.city !== ''
+-                     ? (shippingConsignment.address.city ?? undefined)
+-                     : undefined,
+-                 state:
+-                   shippingConsignment.address.stateOrProvince !== ''
+-                     ? (shippingConsignment.address.stateOrProvince ?? undefined)
+-                     : undefined,
+-                 postalCode:
+-                   shippingConsignment.address.postalCode !== ''
+-                     ? (shippingConsignment.address.postalCode ?? undefined)
+-                     : undefined,
+-               }
+-             : undefined,
++           address: selectedAddress,
+```

--- a/core/app/[locale]/(default)/cart/_actions/update-shipping-info.ts
+++ b/core/app/[locale]/(default)/cart/_actions/update-shipping-info.ts
@@ -7,6 +7,7 @@ import { getTranslations } from 'next-intl/server';
 import { shippingActionFormDataSchema } from '@/vibes/soul/sections/cart/schema';
 import { ShippingFormState } from '@/vibes/soul/sections/cart/shipping-form';
 import { getCartId } from '~/lib/cart';
+import { parseStateAbbreviation } from '~/lib/state-utils';
 
 import { getCart } from '../page-data';
 
@@ -75,9 +76,7 @@ export const updateShippingInfo = async (
               address: {
                 countryCode: submission.value.country,
                 city: submission.value.city,
-                // Split the state value to get the abbreviation
-                // Workaround until statesOrProvince are unique values
-                stateOrProvince: submission.value.state?.split('-')[1],
+                stateOrProvince: parseStateAbbreviation(submission.value.state),
                 postalCode: submission.value.postalCode,
               },
               lineItems,
@@ -88,9 +87,7 @@ export const updateShippingInfo = async (
               address: {
                 countryCode: submission.value.country,
                 city: submission.value.city,
-                // Split the state value to get the abbreviation
-                // Workaround until statesOrProvince are unique values
-                stateOrProvince: submission.value.state?.split('-')[1],
+                stateOrProvince: parseStateAbbreviation(submission.value.state),
                 postalCode: submission.value.postalCode,
               },
               lineItems,

--- a/core/app/[locale]/(default)/cart/_actions/update-shipping-info.ts
+++ b/core/app/[locale]/(default)/cart/_actions/update-shipping-info.ts
@@ -75,7 +75,9 @@ export const updateShippingInfo = async (
               address: {
                 countryCode: submission.value.country,
                 city: submission.value.city,
-                stateOrProvince: submission.value.state,
+                // Split the state value to get the abbreviation
+                // Workaround until statesOrProvince are unique values
+                stateOrProvince: submission.value.state?.split('-')[1],
                 postalCode: submission.value.postalCode,
               },
               lineItems,
@@ -86,7 +88,9 @@ export const updateShippingInfo = async (
               address: {
                 countryCode: submission.value.country,
                 city: submission.value.city,
-                stateOrProvince: submission.value.state,
+                // Split the state value to get the abbreviation
+                // Workaround until statesOrProvince are unique values
+                stateOrProvince: submission.value.state?.split('-')[1],
                 postalCode: submission.value.postalCode,
               },
               lineItems,

--- a/core/app/[locale]/(default)/cart/page.tsx
+++ b/core/app/[locale]/(default)/cart/page.tsx
@@ -195,7 +195,9 @@ export default async function Cart({ params }: Props) {
   const statesOrProvinces = shippingCountries.map((country) => ({
     country: country.code,
     states: country.statesOrProvinces.map((state) => ({
-      value: state.entityId.toString(),
+      // Use abbreviation and entityId as value to avoid duplicate values (Radix uses value as key)
+      // Workaround until all statesOrProvince are unique values
+      value: `${state.entityId}-${state.abbreviation}`,
       label: state.name,
     })),
   }));
@@ -204,6 +206,30 @@ export default async function Cart({ params }: Props) {
     shippingConsignment?.address && !shippingConsignment.selectedShippingOption;
 
   const checkoutUrl = data.site.settings?.url.checkoutUrl;
+
+  // Map a non-unique stateOrProvince to a unique value used in the select field
+  // Workaround until all statesOrProvince are unique values
+  const selectedStateOrProvince = statesOrProvinces
+    .find((country) => country.country === shippingConsignment?.address.countryCode)
+    ?.states.find(
+      (state) => state.value.split('-')[1] === shippingConsignment?.address.stateOrProvince,
+    )?.value;
+
+  const selectedAddress = shippingConsignment?.address
+    ? {
+        country: shippingConsignment.address.countryCode,
+        city:
+          shippingConsignment.address.city !== ''
+            ? (shippingConsignment.address.city ?? undefined)
+            : undefined,
+        state:
+          shippingConsignment.address.stateOrProvince !== '' ? selectedStateOrProvince : undefined,
+        postalCode:
+          shippingConsignment.address.postalCode !== ''
+            ? (shippingConsignment.address.postalCode ?? undefined)
+            : undefined,
+      }
+    : undefined;
 
   return (
     <>
@@ -295,23 +321,7 @@ export default async function Cart({ params }: Props) {
             action: updateShippingInfo,
             countries,
             states: statesOrProvinces,
-            address: shippingConsignment?.address
-              ? {
-                  country: shippingConsignment.address.countryCode,
-                  city:
-                    shippingConsignment.address.city !== ''
-                      ? (shippingConsignment.address.city ?? undefined)
-                      : undefined,
-                  state:
-                    shippingConsignment.address.stateOrProvince !== ''
-                      ? (shippingConsignment.address.stateOrProvince ?? undefined)
-                      : undefined,
-                  postalCode:
-                    shippingConsignment.address.postalCode !== ''
-                      ? (shippingConsignment.address.postalCode ?? undefined)
-                      : undefined,
-                }
-              : undefined,
+            address: selectedAddress,
             shippingOptions: shippingConsignment?.availableShippingOptions
               ? shippingConsignment.availableShippingOptions.map((option) => ({
                   label: option.description,

--- a/core/app/[locale]/(default)/cart/page.tsx
+++ b/core/app/[locale]/(default)/cart/page.tsx
@@ -6,6 +6,7 @@ import { Cart as CartComponent, CartEmptyState } from '@/vibes/soul/sections/car
 import { CartAnalyticsProvider } from '~/app/[locale]/(default)/cart/_components/cart-analytics-provider';
 import { getCartId } from '~/lib/cart';
 import { getPreferredCurrencyCode } from '~/lib/currency';
+import { createStateValue, parseStateAbbreviation } from '~/lib/state-utils';
 import { exists } from '~/lib/utils';
 
 import { updateCouponCode } from './_actions/update-coupon-code';
@@ -195,9 +196,7 @@ export default async function Cart({ params }: Props) {
   const statesOrProvinces = shippingCountries.map((country) => ({
     country: country.code,
     states: country.statesOrProvinces.map((state) => ({
-      // Use abbreviation and entityId as value to avoid duplicate values (Radix uses value as key)
-      // Workaround until all statesOrProvince are unique values
-      value: `${state.entityId}-${state.abbreviation}`,
+      value: createStateValue(state.entityId, state.abbreviation),
       label: state.name,
     })),
   }));
@@ -207,12 +206,11 @@ export default async function Cart({ params }: Props) {
 
   const checkoutUrl = data.site.settings?.url.checkoutUrl;
 
-  // Map a non-unique stateOrProvince to a unique value used in the select field
-  // Workaround until all statesOrProvince are unique values
   const selectedStateOrProvince = statesOrProvinces
     .find((country) => country.country === shippingConsignment?.address.countryCode)
     ?.states.find(
-      (state) => state.value.split('-')[1] === shippingConsignment?.address.stateOrProvince,
+      (state) =>
+        parseStateAbbreviation(state.value) === shippingConsignment?.address.stateOrProvince,
     )?.value;
 
   const selectedAddress = shippingConsignment?.address

--- a/core/lib/state-utils.ts
+++ b/core/lib/state-utils.ts
@@ -1,0 +1,37 @@
+/**
+ * Separator used in composite state values.
+ * We use a pipe character to avoid conflicts with hyphens that may appear in abbreviations.
+ */
+const STATE_VALUE_SEPARATOR = '|';
+
+/**
+ * Creates a composite state value from entityId and abbreviation.
+ * This format ensures unique values for Radix UI Select components.
+ *
+ * @param {number} entityId - The state entity ID
+ * @param {string} abbreviation - The state abbreviation
+ * @returns {string} A composite value in the format "entityId|abbreviation"
+ */
+export function createStateValue(entityId: number, abbreviation: string): string {
+  return `${entityId}${STATE_VALUE_SEPARATOR}${abbreviation}`;
+}
+
+/**
+ * Extracts the state abbreviation from a composite state value.
+ *
+ * @param {string | undefined} compositeValue - The composite value in format "entityId|abbreviation"
+ * @returns {string | undefined} The state abbreviation, or undefined if the value is invalid
+ */
+export function parseStateAbbreviation(compositeValue: string | undefined): string | undefined {
+  if (!compositeValue) {
+    return undefined;
+  }
+
+  const separatorIndex = compositeValue.indexOf(STATE_VALUE_SEPARATOR);
+
+  if (separatorIndex === -1) {
+    return undefined;
+  }
+
+  return compositeValue.slice(separatorIndex + 1);
+}

--- a/core/package.json
+++ b/core/package.json
@@ -32,7 +32,7 @@
     "@radix-ui/react-popover": "^1.1.14",
     "@radix-ui/react-portal": "^1.1.9",
     "@radix-ui/react-radio-group": "^1.3.7",
-    "@radix-ui/react-select": "^2.2.5",
+    "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-switch": "^1.2.5",
     "@radix-ui/react-toggle": "^1.1.9",
     "@radix-ui/react-toggle-group": "^1.1.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
         specifier: ^1.3.7
         version: 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.5(react@19.1.5))(react@19.1.5)
       '@radix-ui/react-select':
-        specifier: ^2.2.5
-        version: 2.2.5(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.5(react@19.1.5))(react@19.1.5)
+        specifier: ^2.2.6
+        version: 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.5(react@19.1.5))(react@19.1.5)
       '@radix-ui/react-switch':
         specifier: ^1.2.5
         version: 1.2.5(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.5(react@19.1.5))(react@19.1.5)
@@ -3034,6 +3034,9 @@ packages:
   '@radix-ui/primitive@1.1.2':
     resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
 
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
   '@radix-ui/react-accordion@1.2.11':
     resolution: {integrity: sha512-l3W5D54emV2ues7jjeG1xcyN7S3jnK3zE2zHqgn0CmMsy9lNJwmgcrmaxS+7ipw15FAivzKNzH3d5EcGoFKw0A==}
     peerDependencies:
@@ -3191,6 +3194,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-dropdown-menu@2.1.15':
     resolution: {integrity: sha512-mIBnOjgwo9AH3FyKaSWoSu/dYj6VdhJ7frEPiGTeXCdUFHjl9h3mFh2wwhEtINOmYXWhdpf1rY2minFsmaNgVQ==}
     peerDependencies:
@@ -3206,6 +3222,15 @@ packages:
 
   '@radix-ui/react-focus-guards@1.1.2':
     resolution: {integrity: sha512-fyjAACV62oPV925xFCrH8DR5xWhg9KYtJT4s3u54jxp+L/hbpTY2kIeEFFbFe+a/HCE94zGQMZLIpVTPVZDhaA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -3289,6 +3314,19 @@ packages:
 
   '@radix-ui/react-popper@1.2.7':
     resolution: {integrity: sha512-IUFAccz1JyKcf/RjB552PlWwxjeCJB8/4KxT7EhBHOJM+mN7LdW+B3kacJXILm32xawcMMjb2i0cIZpo+f9kiQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popper@1.2.8':
+    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3391,8 +3429,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-select@2.2.5':
-    resolution: {integrity: sha512-HnMTdXEVuuyzx63ME0ut4+sEMYW6oouHWNGUZc7ddvUWIcfCva/AMoqEW/3wnEllriMWBa0RHspCYnfCWJQYmA==}
+  '@radix-ui/react-select@2.2.6':
+    resolution: {integrity: sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -8701,7 +8739,6 @@ packages:
   puppeteer@24.10.0:
     resolution: {integrity: sha512-Oua9VkGpj0S2psYu5e6mCer6W9AU9POEQh22wRgSXnLXASGH+MwLUVWgLCLeP9QPHHcJ7tySUlg4Sa9OJmaLpw==}
     engines: {node: '>=18'}
-    deprecated: < 24.15.0 is no longer supported
     hasBin: true
 
   pure-rand@6.1.0:
@@ -13728,6 +13765,8 @@ snapshots:
 
   '@radix-ui/primitive@1.1.2': {}
 
+  '@radix-ui/primitive@1.1.3': {}
+
   '@radix-ui/react-accordion@1.2.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.5(react@19.1.5))(react@19.1.5)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
@@ -13896,6 +13935,19 @@ snapshots:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.5(react@19.1.5))(react@19.1.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.1.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.5(react@19.1.5))(react@19.1.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.7)(react@19.1.5)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.7)(react@19.1.5)
+      react: 19.1.5
+      react-dom: 19.1.5(react@19.1.5)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
   '@radix-ui/react-dropdown-menu@2.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.5(react@19.1.5))(react@19.1.5)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
@@ -13912,6 +13964,12 @@ snapshots:
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
   '@radix-ui/react-focus-guards@1.1.2(@types/react@19.2.7)(react@19.1.5)':
+    dependencies:
+      react: 19.1.5
+    optionalDependencies:
+      '@types/react': 19.2.7
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.7)(react@19.1.5)':
     dependencies:
       react: 19.1.5
     optionalDependencies:
@@ -14033,6 +14091,24 @@ snapshots:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.5(react@19.1.5))(react@19.1.5)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.3(react-dom@19.1.5(react@19.1.5))(react@19.1.5)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.5(react@19.1.5))(react@19.1.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.1.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.7)(react@19.1.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.5(react@19.1.5))(react@19.1.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.7)(react@19.1.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.7)(react@19.1.5)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.7)(react@19.1.5)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.7)(react@19.1.5)
+      '@radix-ui/rect': 1.1.1
+      react: 19.1.5
+      react-dom: 19.1.5(react@19.1.5)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
   '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.5(react@19.1.5))(react@19.1.5)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.5(react@19.1.5))(react@19.1.5)
@@ -14116,19 +14192,19 @@ snapshots:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
-  '@radix-ui/react-select@2.2.5(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.5(react@19.1.5))(react@19.1.5)':
+  '@radix-ui/react-select@2.2.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.5(react@19.1.5))(react@19.1.5)':
     dependencies:
       '@radix-ui/number': 1.1.1
-      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/primitive': 1.1.3
       '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.5(react@19.1.5))(react@19.1.5)
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.1.5)
       '@radix-ui/react-context': 1.1.2(@types/react@19.2.7)(react@19.1.5)
       '@radix-ui/react-direction': 1.1.1(@types/react@19.2.7)(react@19.1.5)
-      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.5(react@19.1.5))(react@19.1.5)
-      '@radix-ui/react-focus-guards': 1.1.2(@types/react@19.2.7)(react@19.1.5)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.5(react@19.1.5))(react@19.1.5)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.7)(react@19.1.5)
       '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.5(react@19.1.5))(react@19.1.5)
       '@radix-ui/react-id': 1.1.1(@types/react@19.2.7)(react@19.1.5)
-      '@radix-ui/react-popper': 1.2.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.5(react@19.1.5))(react@19.1.5)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.5(react@19.1.5))(react@19.1.5)
       '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.5(react@19.1.5))(react@19.1.5)
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.5(react@19.1.5))(react@19.1.5)
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.7)(react@19.1.5)


### PR DESCRIPTION
## What/Why?
Use state abbreviation instead of entityId for cart shipping form state values. The shipping API expects state abbreviations, not entityIds. Since some states share the same abbreviation across countries (causing Radix UI duplicate key issues), we use a composite value format (`entityId-abbreviation`) and extract the abbreviation when submitting.

## Testing
Alaska has a specific state shipping rate compared to other states.
<img width="564" height="960" alt="Screenshot 2026-01-30 at 2 21 14 PM" src="https://github.com/user-attachments/assets/3078b9c0-c6d9-4221-98dc-d1bd4b3525b0" />

## Migration steps

### Step 1

Update `core/app/[locale]/(default)/cart/_actions/update-shipping-info.ts` to extract the abbreviation from the composite value (in both the add and update consignment branches):

```diff
            address: {
              countryCode: submission.value.country,
              city: submission.value.city,
-             stateOrProvince: submission.value.state,
+             stateOrProvince: submission.value.state?.split('-')[1],
              postalCode: submission.value.postalCode,
            },
```

### Step 2

Update the state select options in `core/app/[locale]/(default)/cart/page.tsx` to use composite values:

```diff
  const statesOrProvinces = shippingCountries.map((country) => ({
    country: country.code,
    states: country.statesOrProvinces.map((state) => ({
-     value: state.entityId.toString(),
+     value: `${state.entityId}-${state.abbreviation}`,
      label: state.name,
    })),
  }));
```

### Step 3

Add the selected state mapping logic in `core/app/[locale]/(default)/cart/page.tsx` before the return statement to properly initialize the form with the saved shipping address:

```diff
  const checkoutUrl = data.site.settings?.url.checkoutUrl;

+ const selectedStateOrProvince = statesOrProvinces
+   .find((country) => country.country === shippingConsignment?.address.countryCode)
+   ?.states.find(
+     (state) => state.value.split('-')[1] === shippingConsignment?.address.stateOrProvince,
+   )?.value;
+
+ const selectedAddress = shippingConsignment?.address
+   ? {
+       country: shippingConsignment.address.countryCode,
+       city:
+         shippingConsignment.address.city !== ''
+           ? (shippingConsignment.address.city ?? undefined)
+           : undefined,
+       state:
+         shippingConsignment.address.stateOrProvince !== '' ? selectedStateOrProvince : undefined,
+       postalCode:
+         shippingConsignment.address.postalCode !== ''
+           ? (shippingConsignment.address.postalCode ?? undefined)
+           : undefined,
+     }
+   : undefined;

  return (
```

### Step 4

Update the `ShippingEstimator` address prop in `core/app/[locale]/(default)/cart/page.tsx`:

```diff
            action: updateShippingInfo,
            countries,
            states: statesOrProvinces,
-           address: shippingConsignment?.address
-             ? {
-                 country: shippingConsignment.address.countryCode,
-                 city:
-                   shippingConsignment.address.city !== ''
-                     ? (shippingConsignment.address.city ?? undefined)
-                     : undefined,
-                 state:
-                   shippingConsignment.address.stateOrProvince !== ''
-                     ? (shippingConsignment.address.stateOrProvince ?? undefined)
-                     : undefined,
-                 postalCode:
-                   shippingConsignment.address.postalCode !== ''
-                     ? (shippingConsignment.address.postalCode ?? undefined)
-                     : undefined,
-               }
-             : undefined,
+           address: selectedAddress,
```
