### PR TITLE
feat(core): add canonical URLs and hreflang alternates for SEO

### DIFF
--- a/.changeset/new-onions-flash.md
+++ b/.changeset/new-onions-flash.md
@@ -95,3 +95,108 @@ For entity pages (product, category, brand, blog, blog post, webpage), add the i
     };
   }
 ```
+
+### Step 4: Gift certificates pages
+
+Update `core/app/[locale]/(default)/gift-certificates/page.tsx`:
+
+```diff
++ import { getMetadataAlternates } from '~/lib/seo/canonical';
+  ...
+  export async function generateMetadata({ params }: Props): Promise<Metadata> {
+    const { locale } = await params;
+    const t = await getTranslations({ locale, namespace: 'GiftCertificates' });
+
+    return {
+      title: t('title') || 'Gift certificates',
++     alternates: getMetadataAlternates({ path: '/gift-certificates', locale }),
+    };
+  }
+```
+
+Update `core/app/[locale]/(default)/gift-certificates/balance/page.tsx`:
+
+```diff
++ import { getMetadataAlternates } from '~/lib/seo/canonical';
+  ...
+    return {
+      title: t('title') || 'Gift certificates - Check balance',
++     alternates: getMetadataAlternates({ path: '/gift-certificates/balance', locale }),
+    };
+```
+
+Add `generateMetadata` to `core/app/[locale]/(default)/gift-certificates/purchase/page.tsx`:
+
+```diff
++ import { Metadata } from 'next';
+  import { getFormatter, getTranslations } from 'next-intl/server';
+  ...
++ import { getMetadataAlternates } from '~/lib/seo/canonical';
+  ...
++ export async function generateMetadata({ params }: Props): Promise<Metadata> {
++   const { locale } = await params;
++   const t = await getTranslations({ locale, namespace: 'GiftCertificates' });
++
++   return {
++     title: t('Purchase.title'),
++     alternates: getMetadataAlternates({ path: '/gift-certificates/purchase', locale }),
++   };
++ }
+```
+
+### Step 5: Contact page
+
+Update `core/app/[locale]/(default)/webpages/[id]/contact/page.tsx`:
+
+```diff
++ import { getMetadataAlternates } from '~/lib/seo/canonical';
+  ...
+  export async function generateMetadata({ params }: Props): Promise<Metadata> {
+-   const { id } = await params;
++   const { id, locale } = await params;
+    const webpage = await getWebPage(id);
+    const { pageTitle, metaDescription, metaKeywords } = webpage.seo;
+
+    return {
+      title: pageTitle || webpage.title,
+      description: metaDescription,
+      keywords: metaKeywords ? metaKeywords.split(',') : null,
++     alternates: getMetadataAlternates({ path: webpage.path, locale }),
+    };
+  }
+```
+
+### Step 6: Public wishlist page
+
+Update `core/app/[locale]/(default)/wishlist/[token]/page.tsx`:
+
+```diff
++ import { getMetadataAlternates } from '~/lib/seo/canonical';
+  ...
+  export async function generateMetadata({ params, searchParams }: Props): Promise<Metadata> {
+    const { locale, token } = await params;
+    ...
+    return {
+      title: wishlist?.name ?? t('title'),
++     alternates: getMetadataAlternates({ path: `/wishlist/${token}`, locale }),
+    };
+  }
+```
+
+### Step 7: Compare page
+
+Update `core/app/[locale]/(default)/compare/page.tsx`:
+
+```diff
++ import { getMetadataAlternates } from '~/lib/seo/canonical';
+  ...
+  export async function generateMetadata({ params }: Props): Promise<Metadata> {
+    const { locale } = await params;
+    const t = await getTranslations({ locale, namespace: 'Compare' });
+
+    return {
+      title: t('title'),
++     alternates: getMetadataAlternates({ path: '/compare', locale }),
+    };
+  }
+```

--- a/.changeset/new-onions-flash.md
+++ b/.changeset/new-onions-flash.md
@@ -2,23 +2,21 @@
 "@bigcommerce/catalyst-core": patch
 ---
 
-Add canonical URLs and hreflang alternates for SEO. Pages now set `alternates.canonical` and `alternates.languages` in `generateMetadata` via the new `getMetadataAlternates` helper in `core/lib/seo/canonical.ts`. The default locale uses no path prefix; other locales use `/{locale}/path`. The root locale layout sets `metadataBase` to the configured vanity URL so canonical URLs resolve correctly.
+Add canonical URLs and hreflang alternates for SEO. Pages now set `alternates.canonical` and `alternates.languages` in `generateMetadata` via the new `getMetadataAlternates` helper in `core/lib/seo/canonical.ts`. The helper fetches the vanity URL via GraphQL (`site.settings.url.vanityUrl`) and is cached per request. The default locale uses no path prefix; other locales use `/{locale}/path`. The root locale layout sets `metadataBase` to the configured vanity URL so canonical URLs resolve correctly.
 
 ## Migration steps
 
 ### Step 1: Root layout metadata base
 
-Set `metadataBase` in the root locale layout so canonical URLs resolve to your vanity URL.
+The root locale layout now sets `metadataBase` from the vanity URL fetched via GraphQL. This is already included in the `RootLayoutMetadataQuery`.
 
 Update `core/app/[locale]/layout.tsx`:
 
 ```diff
-  import { Providers } from '~/app/providers';
-+ import { buildConfig } from '~/build-config/reader';
-  import { client } from '~/client';
-  ...
++ const vanityUrl = data.site.settings?.url.vanityUrl;
++
   return {
-+   metadataBase: new URL(buildConfig.get('urls').vanityUrl),
++   metadataBase: vanityUrl ? new URL(vanityUrl) : undefined,
     title: {
 ```
 
@@ -58,7 +56,7 @@ Update `core/app/[locale]/(default)/product/[slug]/page-data.ts` (in the metadat
 
 ### Step 3: Page metadata alternates
 
-Add the `getMetadataAlternates` import and set `alternates` in `generateMetadata` for each page. Ensure `core/lib/seo/canonical.ts` exists (it is included in this release).
+Add the `getMetadataAlternates` import and set `alternates` in `generateMetadata` for each page. The function is async and must be awaited. Ensure `core/lib/seo/canonical.ts` exists (it is included in this release).
 
 Update `core/app/[locale]/(default)/page.tsx` (home):
 
@@ -71,7 +69,7 @@ Update `core/app/[locale]/(default)/page.tsx` (home):
 + export async function generateMetadata({ params }: Props): Promise<Metadata> {
 +   const { locale } = await params;
 +   return {
-+     alternates: getMetadataAlternates({ path: '/', locale }),
++     alternates: await getMetadataAlternates({ path: '/', locale }),
 +   };
 + }
 +
@@ -91,7 +89,7 @@ For entity pages (product, category, brand, blog, blog post, webpage), add the i
       title: pageTitle || brand.name,
       description: metaDescription,
       keywords: metaKeywords ? metaKeywords.split(',') : null,
-+     alternates: getMetadataAlternates({ path: brand.path, locale }),
++     alternates: await getMetadataAlternates({ path: brand.path, locale }),
     };
   }
 ```
@@ -109,7 +107,7 @@ Update `core/app/[locale]/(default)/gift-certificates/page.tsx`:
 
     return {
       title: t('title') || 'Gift certificates',
-+     alternates: getMetadataAlternates({ path: '/gift-certificates', locale }),
++     alternates: await getMetadataAlternates({ path: '/gift-certificates', locale }),
     };
   }
 ```
@@ -121,7 +119,7 @@ Update `core/app/[locale]/(default)/gift-certificates/balance/page.tsx`:
   ...
     return {
       title: t('title') || 'Gift certificates - Check balance',
-+     alternates: getMetadataAlternates({ path: '/gift-certificates/balance', locale }),
++     alternates: await getMetadataAlternates({ path: '/gift-certificates/balance', locale }),
     };
 ```
 
@@ -139,7 +137,7 @@ Add `generateMetadata` to `core/app/[locale]/(default)/gift-certificates/purchas
 +
 +   return {
 +     title: t('Purchase.title'),
-+     alternates: getMetadataAlternates({ path: '/gift-certificates/purchase', locale }),
++     alternates: await getMetadataAlternates({ path: '/gift-certificates/purchase', locale }),
 +   };
 + }
 ```
@@ -161,7 +159,7 @@ Update `core/app/[locale]/(default)/webpages/[id]/contact/page.tsx`:
       title: pageTitle || webpage.title,
       description: metaDescription,
       keywords: metaKeywords ? metaKeywords.split(',') : null,
-+     alternates: getMetadataAlternates({ path: webpage.path, locale }),
++     alternates: await getMetadataAlternates({ path: webpage.path, locale }),
     };
   }
 ```
@@ -178,7 +176,7 @@ Update `core/app/[locale]/(default)/wishlist/[token]/page.tsx`:
     ...
     return {
       title: wishlist?.name ?? t('title'),
-+     alternates: getMetadataAlternates({ path: `/wishlist/${token}`, locale }),
++     alternates: await getMetadataAlternates({ path: `/wishlist/${token}`, locale }),
     };
   }
 ```
@@ -196,7 +194,7 @@ Update `core/app/[locale]/(default)/compare/page.tsx`:
 
     return {
       title: t('title'),
-+     alternates: getMetadataAlternates({ path: '/compare', locale }),
++     alternates: await getMetadataAlternates({ path: '/compare', locale }),
     };
   }
 ```

--- a/.changeset/new-onions-flash.md
+++ b/.changeset/new-onions-flash.md
@@ -1,0 +1,97 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Add canonical URLs and hreflang alternates for SEO. Pages now set `alternates.canonical` and `alternates.languages` in `generateMetadata` via the new `getMetadataAlternates` helper in `core/lib/seo/canonical.ts`. The default locale uses no path prefix; other locales use `/{locale}/path`. The root locale layout sets `metadataBase` to the configured vanity URL so canonical URLs resolve correctly.
+
+## Migration steps
+
+### Step 1: Root layout metadata base
+
+Set `metadataBase` in the root locale layout so canonical URLs resolve to your vanity URL.
+
+Update `core/app/[locale]/layout.tsx`:
+
+```diff
+  import { Providers } from '~/app/providers';
++ import { buildConfig } from '~/build-config/reader';
+  import { client } from '~/client';
+  ...
+  return {
++   metadataBase: new URL(buildConfig.get('urls').vanityUrl),
+    title: {
+```
+
+### Step 2: GraphQL fragment updates
+
+Add the `path` field to brand, blog post, and product queries so metadata can build canonical URLs.
+
+Update `core/app/[locale]/(default)/(faceted)/brand/[slug]/page-data.ts`:
+
+```diff
+  site {
+    brand(entityId: $entityId) {
+      name
++     path
+      seo {
+```
+
+Update `core/app/[locale]/(default)/blog/[blogId]/page-data.ts`:
+
+```diff
+  author
+  htmlBody
+  name
++ path
+  publishedDate {
+```
+
+Update `core/app/[locale]/(default)/product/[slug]/page-data.ts` (in the metadata query):
+
+```diff
+  site {
+    product(entityId: $entityId) {
+      name
++     path
+      defaultImage {
+```
+
+### Step 3: Page metadata alternates
+
+Add the `getMetadataAlternates` import and set `alternates` in `generateMetadata` for each page. Ensure `core/lib/seo/canonical.ts` exists (it is included in this release).
+
+Update `core/app/[locale]/(default)/page.tsx` (home):
+
+```diff
++ import { Metadata } from 'next';
+  import { getFormatter, getTranslations, setRequestLocale } from 'next-intl/server';
+  ...
++ import { getMetadataAlternates } from '~/lib/seo/canonical';
+  ...
++ export async function generateMetadata({ params }: Props): Promise<Metadata> {
++   const { locale } = await params;
++   return {
++     alternates: getMetadataAlternates({ path: '/', locale }),
++   };
++ }
++
+  export default async function Home({ params }: Props) {
+```
+
+For entity pages (product, category, brand, blog, blog post, webpage), add the import and include `alternates` in the existing `generateMetadata` return value using the entity `path` (or breadcrumb-derived path for category and webpage). Example for a brand page:
+
+```diff
++ import { getMetadataAlternates } from '~/lib/seo/canonical';
+  ...
+  export async function generateMetadata(props: Props): Promise<Metadata> {
+-   const { slug } = await props.params;
++   const { slug, locale } = await props.params;
+    ...
+    return {
+      title: pageTitle || brand.name,
+      description: metaDescription,
+      keywords: metaKeywords ? metaKeywords.split(',') : null,
++     alternates: getMetadataAlternates({ path: brand.path, locale }),
+    };
+  }
+```

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page-data.ts
@@ -9,6 +9,7 @@ const BrandPageQuery = graphql(`
     site {
       brand(entityId: $entityId) {
         name
+        path
         seo {
           pageTitle
           metaDescription

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
@@ -85,7 +85,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
     title: pageTitle || brand.name,
     description: metaDescription,
     keywords: metaKeywords ? metaKeywords.split(',') : null,
-    alternates: getMetadataAlternates({ path: brand.path, locale }),
+    alternates: await getMetadataAlternates({ path: brand.path, locale }),
   };
 }
 

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
@@ -13,6 +13,7 @@ import { facetsTransformer } from '~/data-transformers/facets-transformer';
 import { pageInfoTransformer } from '~/data-transformers/page-info-transformer';
 import { productCardTransformer } from '~/data-transformers/product-card-transformer';
 import { getPreferredCurrencyCode } from '~/lib/currency';
+import { getMetadataAlternates } from '~/lib/seo/canonical';
 
 import { MAX_COMPARE_LIMIT } from '../../../compare/page-data';
 import { getCompareProducts as getCompareProductsData } from '../../fetch-compare-products';
@@ -67,7 +68,7 @@ interface Props {
 }
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
-  const { slug } = await props.params;
+  const { slug, locale } = await props.params;
   const customerAccessToken = await getSessionCustomerAccessToken();
 
   const brandId = Number(slug);
@@ -84,6 +85,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
     title: pageTitle || brand.name,
     description: metaDescription,
     keywords: metaKeywords ? metaKeywords.split(',') : null,
+    alternates: getMetadataAlternates({ path: brand.path, locale }),
   };
 }
 

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -14,6 +14,7 @@ import { facetsTransformer } from '~/data-transformers/facets-transformer';
 import { pageInfoTransformer } from '~/data-transformers/page-info-transformer';
 import { productCardTransformer } from '~/data-transformers/product-card-transformer';
 import { getPreferredCurrencyCode } from '~/lib/currency';
+import { getMetadataAlternates } from '~/lib/seo/canonical';
 
 import { MAX_COMPARE_LIMIT } from '../../../compare/page-data';
 import { getCompareProducts } from '../../fetch-compare-products';
@@ -69,7 +70,7 @@ interface Props {
 }
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
-  const { slug } = await props.params;
+  const { slug, locale } = await props.params;
   const customerAccessToken = await getSessionCustomerAccessToken();
 
   const categoryId = Number(slug);
@@ -82,10 +83,14 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 
   const { pageTitle, metaDescription, metaKeywords } = category.seo;
 
+  const breadcrumbs = removeEdgesAndNodes(category.breadcrumbs);
+  const categoryPath = breadcrumbs[breadcrumbs.length - 1]?.path;
+
   return {
     title: pageTitle || category.name,
     description: metaDescription,
     keywords: metaKeywords ? metaKeywords.split(',') : null,
+    ...(categoryPath && { alternates: getMetadataAlternates({ path: categoryPath, locale }) }),
   };
 }
 

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -90,7 +90,9 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
     title: pageTitle || category.name,
     description: metaDescription,
     keywords: metaKeywords ? metaKeywords.split(',') : null,
-    ...(categoryPath && { alternates: getMetadataAlternates({ path: categoryPath, locale }) }),
+    ...(categoryPath && {
+      alternates: await getMetadataAlternates({ path: categoryPath, locale }),
+    }),
   };
 }
 

--- a/core/app/[locale]/(default)/blog/[blogId]/page-data.ts
+++ b/core/app/[locale]/(default)/blog/[blogId]/page-data.ts
@@ -15,6 +15,7 @@ const BlogPageQuery = graphql(`
             author
             htmlBody
             name
+            path
             publishedDate {
               utc
             }

--- a/core/app/[locale]/(default)/blog/[blogId]/page.tsx
+++ b/core/app/[locale]/(default)/blog/[blogId]/page.tsx
@@ -5,6 +5,7 @@ import { cache } from 'react';
 
 import { BlogPostContent, BlogPostContentBlogPost } from '@/vibes/soul/sections/blog-post-content';
 import { Breadcrumb } from '@/vibes/soul/sections/breadcrumbs';
+import { getMetadataAlternates } from '~/lib/seo/canonical';
 
 import { getBlogPageData } from './page-data';
 
@@ -18,7 +19,7 @@ interface Props {
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { blogId } = await params;
+  const { blogId, locale } = await params;
 
   const variables = cachedBlogPageDataVariables(blogId);
 
@@ -35,6 +36,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     title: pageTitle || blogPost.name,
     description: metaDescription,
     keywords: metaKeywords ? metaKeywords.split(',') : null,
+    ...(blogPost.path && { alternates: getMetadataAlternates({ path: blogPost.path, locale }) }),
   };
 }
 

--- a/core/app/[locale]/(default)/blog/[blogId]/page.tsx
+++ b/core/app/[locale]/(default)/blog/[blogId]/page.tsx
@@ -36,7 +36,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     title: pageTitle || blogPost.name,
     description: metaDescription,
     keywords: metaKeywords ? metaKeywords.split(',') : null,
-    ...(blogPost.path && { alternates: getMetadataAlternates({ path: blogPost.path, locale }) }),
+    ...(blogPost.path && {
+      alternates: await getMetadataAlternates({ path: blogPost.path, locale }),
+    }),
   };
 }
 

--- a/core/app/[locale]/(default)/blog/page.tsx
+++ b/core/app/[locale]/(default)/blog/page.tsx
@@ -7,6 +7,7 @@ import { createSearchParamsCache, parseAsInteger, parseAsString } from 'nuqs/ser
 import { Streamable } from '@/vibes/soul/lib/streamable';
 import { FeaturedBlogPostList } from '@/vibes/soul/sections/featured-blog-post-list';
 import { defaultPageInfo, pageInfoTransformer } from '~/data-transformers/page-info-transformer';
+import { getMetadataAlternates } from '~/lib/seo/canonical';
 
 import { getBlog, getBlogPosts } from './page-data';
 
@@ -36,6 +37,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       blog?.description && blog.description.length > 150
         ? `${blog.description.substring(0, 150)}...`
         : blog?.description,
+    ...(blog?.path && { alternates: getMetadataAlternates({ path: blog.path, locale }) }),
   };
 }
 

--- a/core/app/[locale]/(default)/blog/page.tsx
+++ b/core/app/[locale]/(default)/blog/page.tsx
@@ -37,7 +37,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       blog?.description && blog.description.length > 150
         ? `${blog.description.substring(0, 150)}...`
         : blog?.description,
-    ...(blog?.path && { alternates: getMetadataAlternates({ path: blog.path, locale }) }),
+    ...(blog?.path && { alternates: await getMetadataAlternates({ path: blog.path, locale }) }),
   };
 }
 

--- a/core/app/[locale]/(default)/compare/page.tsx
+++ b/core/app/[locale]/(default)/compare/page.tsx
@@ -45,7 +45,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   return {
     title: t('title'),
-    alternates: getMetadataAlternates({ path: '/compare', locale }),
+    alternates: await getMetadataAlternates({ path: '/compare', locale }),
   };
 }
 

--- a/core/app/[locale]/(default)/compare/page.tsx
+++ b/core/app/[locale]/(default)/compare/page.tsx
@@ -8,6 +8,7 @@ import { CompareSection } from '@/vibes/soul/sections/compare-section';
 import { getSessionCustomerAccessToken } from '~/auth';
 import { pricesTransformer } from '~/data-transformers/prices-transformer';
 import { getPreferredCurrencyCode } from '~/lib/currency';
+import { getMetadataAlternates } from '~/lib/seo/canonical';
 
 import { addToCart } from './_actions/add-to-cart';
 import { CompareAnalyticsProvider } from './_components/compare-analytics-provider';
@@ -44,6 +45,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   return {
     title: t('title'),
+    alternates: getMetadataAlternates({ path: '/compare', locale }),
   };
 }
 

--- a/core/app/[locale]/(default)/gift-certificates/balance/page.tsx
+++ b/core/app/[locale]/(default)/gift-certificates/balance/page.tsx
@@ -4,6 +4,7 @@ import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { GiftCertificateCheckBalanceSection } from '@/vibes/soul/sections/gift-certificate-balance-section';
 import { redirect } from '~/i18n/routing';
 import { getPreferredCurrencyCode } from '~/lib/currency';
+import { getMetadataAlternates } from '~/lib/seo/canonical';
 
 import { getGiftCertificatesData } from '../page-data';
 
@@ -20,6 +21,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   return {
     title: t('title') || 'Gift certificates - Check balance',
+    alternates: getMetadataAlternates({ path: '/gift-certificates/balance', locale }),
   };
 }
 

--- a/core/app/[locale]/(default)/gift-certificates/balance/page.tsx
+++ b/core/app/[locale]/(default)/gift-certificates/balance/page.tsx
@@ -21,7 +21,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   return {
     title: t('title') || 'Gift certificates - Check balance',
-    alternates: getMetadataAlternates({ path: '/gift-certificates/balance', locale }),
+    alternates: await getMetadataAlternates({ path: '/gift-certificates/balance', locale }),
   };
 }
 

--- a/core/app/[locale]/(default)/gift-certificates/page.tsx
+++ b/core/app/[locale]/(default)/gift-certificates/page.tsx
@@ -19,7 +19,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   return {
     title: t('title') || 'Gift certificates',
-    alternates: getMetadataAlternates({ path: '/gift-certificates', locale }),
+    alternates: await getMetadataAlternates({ path: '/gift-certificates', locale }),
   };
 }
 

--- a/core/app/[locale]/(default)/gift-certificates/page.tsx
+++ b/core/app/[locale]/(default)/gift-certificates/page.tsx
@@ -4,6 +4,7 @@ import { getFormatter, getTranslations, setRequestLocale } from 'next-intl/serve
 import { GiftCertificatesSection } from '@/vibes/soul/sections/gift-certificates-section';
 import { redirect } from '~/i18n/routing';
 import { getPreferredCurrencyCode } from '~/lib/currency';
+import { getMetadataAlternates } from '~/lib/seo/canonical';
 
 import { getGiftCertificatesData } from './page-data';
 
@@ -18,6 +19,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   return {
     title: t('title') || 'Gift certificates',
+    alternates: getMetadataAlternates({ path: '/gift-certificates', locale }),
   };
 }
 

--- a/core/app/[locale]/(default)/gift-certificates/purchase/page.tsx
+++ b/core/app/[locale]/(default)/gift-certificates/purchase/page.tsx
@@ -1,4 +1,5 @@
 import { ResultOf } from 'gql.tada';
+import { Metadata } from 'next';
 import { getFormatter, getTranslations } from 'next-intl/server';
 
 import { Field, FieldGroup } from '@/vibes/soul/form/dynamic-form/schema';
@@ -7,12 +8,24 @@ import { GiftCertificateSettingsFragment } from '~/app/[locale]/(default)/gift-c
 import { ExistingResultType } from '~/client/util';
 import { redirect } from '~/i18n/routing';
 import { getPreferredCurrencyCode } from '~/lib/currency';
+import { getMetadataAlternates } from '~/lib/seo/canonical';
 
 import { addGiftCertificateToCart } from './_actions/add-to-cart';
 import { getGiftCertificatePurchaseData } from './page-data';
 
 interface Props {
   params: Promise<{ locale: string }>;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+
+  const t = await getTranslations({ locale, namespace: 'GiftCertificates' });
+
+  return {
+    title: t('Purchase.title'),
+    alternates: getMetadataAlternates({ path: '/gift-certificates/purchase', locale }),
+  };
 }
 
 function getFields(

--- a/core/app/[locale]/(default)/gift-certificates/purchase/page.tsx
+++ b/core/app/[locale]/(default)/gift-certificates/purchase/page.tsx
@@ -24,7 +24,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   return {
     title: t('Purchase.title'),
-    alternates: getMetadataAlternates({ path: '/gift-certificates/purchase', locale }),
+    alternates: await getMetadataAlternates({ path: '/gift-certificates/purchase', locale }),
   };
 }
 

--- a/core/app/[locale]/(default)/page.tsx
+++ b/core/app/[locale]/(default)/page.tsx
@@ -1,4 +1,5 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
+import { Metadata } from 'next';
 import { getFormatter, getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { Stream, Streamable } from '@/vibes/soul/lib/streamable';
@@ -8,12 +9,21 @@ import { getSessionCustomerAccessToken } from '~/auth';
 import { Subscribe } from '~/components/subscribe';
 import { productCardTransformer } from '~/data-transformers/product-card-transformer';
 import { getPreferredCurrencyCode } from '~/lib/currency';
+import { getMetadataAlternates } from '~/lib/seo/canonical';
 
 import { Slideshow } from './_components/slideshow';
 import { getPageData } from './page-data';
 
 interface Props {
   params: Promise<{ locale: string }>;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+
+  return {
+    alternates: getMetadataAlternates({ path: '/', locale }),
+  };
 }
 
 export default async function Home({ params }: Props) {

--- a/core/app/[locale]/(default)/page.tsx
+++ b/core/app/[locale]/(default)/page.tsx
@@ -22,7 +22,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale } = await params;
 
   return {
-    alternates: getMetadataAlternates({ path: '/', locale }),
+    alternates: await getMetadataAlternates({ path: '/', locale }),
   };
 }
 

--- a/core/app/[locale]/(default)/product/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/product/[slug]/page-data.ts
@@ -138,6 +138,7 @@ const ProductPageMetadataQuery = graphql(`
     site {
       product(entityId: $entityId) {
         name
+        path
         defaultImage {
           altText
           url: urlTemplate(lossy: true)

--- a/core/app/[locale]/(default)/product/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/page.tsx
@@ -56,7 +56,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     title: pageTitle || product.name,
     description: metaDescription || `${product.plainTextDescription.slice(0, 150)}...`,
     keywords: metaKeywords ? metaKeywords.split(',') : null,
-    alternates: getMetadataAlternates({ path: product.path, locale }),
+    alternates: await getMetadataAlternates({ path: product.path, locale }),
     openGraph: url
       ? {
           images: [

--- a/core/app/[locale]/(default)/product/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/page.tsx
@@ -12,6 +12,7 @@ import { pricesTransformer } from '~/data-transformers/prices-transformer';
 import { productCardTransformer } from '~/data-transformers/product-card-transformer';
 import { productOptionsTransformer } from '~/data-transformers/product-options-transformer';
 import { getPreferredCurrencyCode } from '~/lib/currency';
+import { getMetadataAlternates } from '~/lib/seo/canonical';
 
 import { addToCart } from './_actions/add-to-cart';
 import { getMoreProductImages } from './_actions/get-more-images';
@@ -37,7 +38,7 @@ interface Props {
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { slug } = await params;
+  const { slug, locale } = await params;
   const customerAccessToken = await getSessionCustomerAccessToken();
 
   const productId = Number(slug);
@@ -55,6 +56,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     title: pageTitle || product.name,
     description: metaDescription || `${product.plainTextDescription.slice(0, 150)}...`,
     keywords: metaKeywords ? metaKeywords.split(',') : null,
+    alternates: getMetadataAlternates({ path: product.path, locale }),
     openGraph: url
       ? {
           images: [

--- a/core/app/[locale]/(default)/webpages/[id]/contact/page.tsx
+++ b/core/app/[locale]/(default)/webpages/[id]/contact/page.tsx
@@ -162,7 +162,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     title: pageTitle || webpage.title,
     description: metaDescription,
     keywords: metaKeywords ? metaKeywords.split(',') : null,
-    alternates: getMetadataAlternates({ path: webpage.path, locale }),
+    alternates: await getMetadataAlternates({ path: webpage.path, locale }),
   };
 }
 

--- a/core/app/[locale]/(default)/webpages/[id]/contact/page.tsx
+++ b/core/app/[locale]/(default)/webpages/[id]/contact/page.tsx
@@ -12,6 +12,7 @@ import {
   breadcrumbsTransformer,
   truncateBreadcrumbs,
 } from '~/data-transformers/breadcrumbs-transformer';
+import { getMetadataAlternates } from '~/lib/seo/canonical';
 
 import { WebPage, WebPageContent } from '../_components/web-page';
 
@@ -153,7 +154,7 @@ async function getContactFields(id: string) {
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { id } = await params;
+  const { id, locale } = await params;
   const webpage = await getWebPage(id);
   const { pageTitle, metaDescription, metaKeywords } = webpage.seo;
 
@@ -161,6 +162,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     title: pageTitle || webpage.title,
     description: metaDescription,
     keywords: metaKeywords ? metaKeywords.split(',') : null,
+    alternates: getMetadataAlternates({ path: webpage.path, locale }),
   };
 }
 

--- a/core/app/[locale]/(default)/webpages/[id]/normal/page.tsx
+++ b/core/app/[locale]/(default)/webpages/[id]/normal/page.tsx
@@ -9,6 +9,7 @@ import {
   breadcrumbsTransformer,
   truncateBreadcrumbs,
 } from '~/data-transformers/breadcrumbs-transformer';
+import { getMetadataAlternates } from '~/lib/seo/canonical';
 
 import { WebPageContent, WebPage as WebPageData } from '../_components/web-page';
 
@@ -57,14 +58,18 @@ async function getWebPageBreadcrumbs(id: string): Promise<Breadcrumb[]> {
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { id } = await params;
+  const { id, locale } = await params;
   const webpage = await getWebPage(id);
   const { pageTitle, metaDescription, metaKeywords } = webpage.seo;
+
+  // Get the path from the last breadcrumb
+  const pagePath = webpage.breadcrumbs[webpage.breadcrumbs.length - 1]?.href;
 
   return {
     title: pageTitle || webpage.title,
     description: metaDescription,
     keywords: metaKeywords ? metaKeywords.split(',') : null,
+    ...(pagePath && { alternates: getMetadataAlternates({ path: pagePath, locale }) }),
   };
 }
 

--- a/core/app/[locale]/(default)/webpages/[id]/normal/page.tsx
+++ b/core/app/[locale]/(default)/webpages/[id]/normal/page.tsx
@@ -69,7 +69,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     title: pageTitle || webpage.title,
     description: metaDescription,
     keywords: metaKeywords ? metaKeywords.split(',') : null,
-    ...(pagePath && { alternates: getMetadataAlternates({ path: pagePath, locale }) }),
+    ...(pagePath && { alternates: await getMetadataAlternates({ path: pagePath, locale }) }),
   };
 }
 

--- a/core/app/[locale]/(default)/wishlist/[token]/page.tsx
+++ b/core/app/[locale]/(default)/wishlist/[token]/page.tsx
@@ -74,7 +74,7 @@ export async function generateMetadata({ params, searchParams }: Props): Promise
 
   return {
     title: wishlist?.name ?? t('title'),
-    alternates: getMetadataAlternates({ path: `/wishlist/${token}`, locale }),
+    alternates: await getMetadataAlternates({ path: `/wishlist/${token}`, locale }),
   };
 }
 

--- a/core/app/[locale]/(default)/wishlist/[token]/page.tsx
+++ b/core/app/[locale]/(default)/wishlist/[token]/page.tsx
@@ -19,6 +19,7 @@ import {
 } from '~/components/wishlist/share-button';
 import { defaultPageInfo, pageInfoTransformer } from '~/data-transformers/page-info-transformer';
 import { publicWishlistDetailsTransformer } from '~/data-transformers/wishlists-transformer';
+import { getMetadataAlternates } from '~/lib/seo/canonical';
 import { isMobileUser } from '~/lib/user-agent';
 
 import { getPublicWishlist } from './page-data';
@@ -73,6 +74,7 @@ export async function generateMetadata({ params, searchParams }: Props): Promise
 
   return {
     title: wishlist?.name ?? t('title'),
+    alternates: getMetadataAlternates({ path: `/wishlist/${token}`, locale }),
   };
 }
 

--- a/core/app/[locale]/layout.tsx
+++ b/core/app/[locale]/layout.tsx
@@ -13,6 +13,7 @@ import '../../globals.css';
 import { fonts } from '~/app/fonts';
 import { CookieNotifications } from '~/app/notifications';
 import { Providers } from '~/app/providers';
+import { buildConfig } from '~/build-config/reader';
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
@@ -69,6 +70,7 @@ export async function generateMetadata(): Promise<Metadata> {
   const { pageTitle, metaDescription, metaKeywords } = data.site.settings?.seo || {};
 
   return {
+    metadataBase: new URL(buildConfig.get('urls').vanityUrl),
     title: {
       template: `%s - ${storeName}`,
       default: pageTitle || storeName,

--- a/core/app/[locale]/layout.tsx
+++ b/core/app/[locale]/layout.tsx
@@ -13,7 +13,6 @@ import '../../globals.css';
 import { fonts } from '~/app/fonts';
 import { CookieNotifications } from '~/app/notifications';
 import { Providers } from '~/app/providers';
-import { buildConfig } from '~/build-config/reader';
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
@@ -31,6 +30,9 @@ const RootLayoutMetadataQuery = graphql(
     query RootLayoutMetadataQuery {
       site {
         settings {
+          url {
+            vanityUrl
+          }
           privacy {
             cookieConsentEnabled
             privacyPolicyUrl
@@ -69,8 +71,10 @@ export async function generateMetadata(): Promise<Metadata> {
 
   const { pageTitle, metaDescription, metaKeywords } = data.site.settings?.seo || {};
 
+  const vanityUrl = data.site.settings?.url.vanityUrl;
+
   return {
-    metadataBase: new URL(buildConfig.get('urls').vanityUrl),
+    metadataBase: vanityUrl ? new URL(vanityUrl) : undefined,
     title: {
       template: `%s - ${storeName}`,
       default: pageTitle || storeName,

--- a/core/lib/seo/canonical.ts
+++ b/core/lib/seo/canonical.ts
@@ -25,6 +25,9 @@ interface CanonicalUrlOptions {
  * - Default locale: no prefix (e.g., https://example.com/product/)
  * - Other locales: with prefix (e.g., https://example.com/fr/product/)
  * - Respects TRAILING_SLASH environment variable
+ *
+ * @param {CanonicalUrlOptions} options - The options for generating canonical URLs
+ * @returns {object} The metadata alternates object with canonical URL and optional language alternates
  */
 export function getMetadataAlternates(options: CanonicalUrlOptions) {
   const { path, locale, includeAlternates = true } = options;
@@ -38,11 +41,11 @@ export function getMetadataAlternates(options: CanonicalUrlOptions) {
     return { canonical };
   }
 
-  const languages: Record<string, string> = {};
+  const languages = locales.reduce<Record<string, string>>((acc, loc) => {
+    acc[loc] = buildLocalizedUrl(vanityUrl, normalizedPath, loc);
 
-  for (const loc of locales) {
-    languages[loc] = buildLocalizedUrl(vanityUrl, normalizedPath, loc);
-  }
+    return acc;
+  }, {});
 
   languages['x-default'] = buildLocalizedUrl(vanityUrl, normalizedPath, defaultLocale);
 

--- a/core/lib/seo/canonical.ts
+++ b/core/lib/seo/canonical.ts
@@ -1,0 +1,65 @@
+import { buildConfig } from '~/build-config/reader';
+import { defaultLocale, locales } from '~/i18n/locales';
+
+interface CanonicalUrlOptions {
+  /**
+   * The path from BigCommerce (e.g., product.path, category.path)
+   * or a manually constructed path for static pages (e.g., '/')
+   */
+  path: string;
+  /**
+   * Current locale from params
+   */
+  locale: string;
+  /**
+   * Whether to include hreflang alternates for all locales
+   * @default true
+   */
+  includeAlternates?: boolean;
+}
+
+/**
+ * Generates metadata alternates object for Next.js Metadata API
+ *
+ * Rules:
+ * - Default locale: no prefix (e.g., https://example.com/product/)
+ * - Other locales: with prefix (e.g., https://example.com/fr/product/)
+ * - Respects TRAILING_SLASH environment variable
+ */
+export function getMetadataAlternates(options: CanonicalUrlOptions) {
+  const { path, locale, includeAlternates = true } = options;
+
+  const vanityUrl = buildConfig.get('urls').vanityUrl.replace(/\/$/, '');
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+
+  const canonical = buildLocalizedUrl(vanityUrl, normalizedPath, locale);
+
+  if (!includeAlternates) {
+    return { canonical };
+  }
+
+  const languages: Record<string, string> = {};
+
+  for (const loc of locales) {
+    languages[loc] = buildLocalizedUrl(vanityUrl, normalizedPath, loc);
+  }
+
+  languages['x-default'] = buildLocalizedUrl(vanityUrl, normalizedPath, defaultLocale);
+
+  return { canonical, languages };
+}
+
+function buildLocalizedUrl(baseUrl: string, path: string, locale: string): string {
+  const isDefault = locale === defaultLocale;
+  const trailingSlash = process.env.TRAILING_SLASH !== 'false';
+
+  let localizedPath = isDefault ? path : `/${locale}${path}`;
+
+  if (trailingSlash && !localizedPath.endsWith('/')) {
+    localizedPath = `${localizedPath}/`;
+  } else if (!trailingSlash && localizedPath.endsWith('/') && localizedPath !== '/') {
+    localizedPath = localizedPath.slice(0, -1);
+  }
+
+  return `${baseUrl}${localizedPath}`;
+}

--- a/core/lib/seo/canonical.ts
+++ b/core/lib/seo/canonical.ts
@@ -45,7 +45,7 @@ const VanityUrlQuery = graphql(`
   }
 `);
 
-const getVanityUrl = cache(async (): Promise<string> => {
+const getVanityUrl = cache(async () => {
   const { data } = await client.fetch({
     document: VanityUrlQuery,
     fetchOptions: { next: { revalidate } },
@@ -57,43 +57,43 @@ const getVanityUrl = cache(async (): Promise<string> => {
     throw new Error('Vanity URL not found in site settings');
   }
 
-  return vanityUrl.replace(/\/$/, '');
+  return vanityUrl;
 });
 
 export async function getMetadataAlternates(options: CanonicalUrlOptions) {
   const { path, locale, includeAlternates = true } = options;
 
-  const vanityUrl = await getVanityUrl();
-  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  const baseUrl = await getVanityUrl();
 
-  const canonical = buildLocalizedUrl(vanityUrl, normalizedPath, locale);
+  const canonical = buildLocalizedUrl(baseUrl, path, locale);
 
   if (!includeAlternates) {
     return { canonical };
   }
 
   const languages = locales.reduce<Record<string, string>>((acc, loc) => {
-    acc[loc] = buildLocalizedUrl(vanityUrl, normalizedPath, loc);
+    acc[loc] = buildLocalizedUrl(baseUrl, path, loc);
 
     return acc;
   }, {});
 
-  languages['x-default'] = buildLocalizedUrl(vanityUrl, normalizedPath, defaultLocale);
+  languages['x-default'] = buildLocalizedUrl(baseUrl, path, defaultLocale);
 
   return { canonical, languages };
 }
 
-function buildLocalizedUrl(baseUrl: string, path: string, locale: string): string {
-  const isDefault = locale === defaultLocale;
+function buildLocalizedUrl(baseUrl: string, pathname: string, locale: string): string {
   const trailingSlash = process.env.TRAILING_SLASH !== 'false';
 
-  let localizedPath = isDefault ? path : `/${locale}${path}`;
+  const url = new URL(pathname, baseUrl);
 
-  if (trailingSlash && !localizedPath.endsWith('/')) {
-    localizedPath = `${localizedPath}/`;
-  } else if (!trailingSlash && localizedPath.endsWith('/') && localizedPath !== '/') {
-    localizedPath = localizedPath.slice(0, -1);
+  url.pathname = locale === defaultLocale ? url.pathname : `/${locale}${url.pathname}`;
+
+  if (trailingSlash && !url.pathname.endsWith('/')) {
+    url.pathname += '/';
+  } else if (!trailingSlash && url.pathname.endsWith('/') && url.pathname !== '/') {
+    url.pathname = url.pathname.slice(0, -1);
   }
 
-  return `${baseUrl}${localizedPath}`;
+  return url.href;
 }

--- a/core/lib/seo/canonical.ts
+++ b/core/lib/seo/canonical.ts
@@ -1,4 +1,8 @@
-import { buildConfig } from '~/build-config/reader';
+import { cache } from 'react';
+
+import { client } from '~/client';
+import { graphql } from '~/client/graphql';
+import { revalidate } from '~/client/revalidate-target';
 import { defaultLocale, locales } from '~/i18n/locales';
 
 interface CanonicalUrlOptions {
@@ -29,10 +33,37 @@ interface CanonicalUrlOptions {
  * @param {CanonicalUrlOptions} options - The options for generating canonical URLs
  * @returns {object} The metadata alternates object with canonical URL and optional language alternates
  */
-export function getMetadataAlternates(options: CanonicalUrlOptions) {
+const VanityUrlQuery = graphql(`
+  query VanityUrlQuery {
+    site {
+      settings {
+        url {
+          vanityUrl
+        }
+      }
+    }
+  }
+`);
+
+const getVanityUrl = cache(async (): Promise<string> => {
+  const { data } = await client.fetch({
+    document: VanityUrlQuery,
+    fetchOptions: { next: { revalidate } },
+  });
+
+  const vanityUrl = data.site.settings?.url.vanityUrl;
+
+  if (!vanityUrl) {
+    throw new Error('Vanity URL not found in site settings');
+  }
+
+  return vanityUrl.replace(/\/$/, '');
+});
+
+export async function getMetadataAlternates(options: CanonicalUrlOptions) {
   const { path, locale, includeAlternates = true } = options;
 
-  const vanityUrl = buildConfig.get('urls').vanityUrl.replace(/\/$/, '');
+  const vanityUrl = await getVanityUrl();
   const normalizedPath = path.startsWith('/') ? path : `/${path}`;
 
   const canonical = buildLocalizedUrl(vanityUrl, normalizedPath, locale);


### PR DESCRIPTION
## What/Why?
Add canonical URLs and hreflang alternates for SEO. Pages now set `alternates.canonical` and `alternates.languages` in `generateMetadata` via the new `getMetadataAlternates` helper in `core/lib/seo/canonical.ts`. The default locale uses no path prefix; other locales use `/{locale}/path`. The root locale layout sets `metadataBase` to the configured vanity URL so canonical URLs resolve correctly.

## Testing
<img width="2209" height="904" alt="Screenshot 2026-01-30 at 3 22 42 PM" src="https://github.com/user-attachments/assets/4f3a3610-7be1-4fee-b1f5-24299d49bd7f" />
<img width="2211" height="1117" alt="Screenshot 2026-01-30 at 3 23 17 PM" src="https://github.com/user-attachments/assets/c63eeef9-1374-479f-bfc1-9d532bd3f724" />
<img width="2212" height="1100" alt="Screenshot 2026-01-30 at 3 23 26 PM" src="https://github.com/user-attachments/assets/0cae22c6-47ed-4829-a068-f1369620fd24" />
<img width="2210" height="1094" alt="Screenshot 2026-01-30 at 3 24 15 PM" src="https://github.com/user-attachments/assets/793e46c5-19a3-47e3-9dba-d92cdb93ed01" />
<img width="2209" height="1059" alt="Screenshot 2026-01-30 at 3 24 41 PM" src="https://github.com/user-attachments/assets/661735e7-6579-4833-8cc1-595c57093691" />

## Migration steps

### Step 1: Root layout metadata base

Set `metadataBase` in the root locale layout so canonical URLs resolve to your vanity URL.

Update `core/app/[locale]/layout.tsx`:

```diff
  import { Providers } from '~/app/providers';
+ import { buildConfig } from '~/build-config/reader';
  import { client } from '~/client';
  ...
  return {
+   metadataBase: new URL(buildConfig.get('urls').vanityUrl),
    title: {
```

### Step 2: GraphQL fragment updates

Add the `path` field to brand, blog post, and product queries so metadata can build canonical URLs.

Update `core/app/[locale]/(default)/(faceted)/brand/[slug]/page-data.ts`:

```diff
  site {
    brand(entityId: $entityId) {
      name
+     path
      seo {
```

Update `core/app/[locale]/(default)/blog/[blogId]/page-data.ts`:

```diff
  author
  htmlBody
  name
+ path
  publishedDate {
```

Update `core/app/[locale]/(default)/product/[slug]/page-data.ts` (in the metadata query):

```diff
  site {
    product(entityId: $entityId) {
      name
+     path
      defaultImage {
```

### Step 3: Page metadata alternates

Add the `getMetadataAlternates` import and set `alternates` in `generateMetadata` for each page. Ensure `core/lib/seo/canonical.ts` exists (it is included in this release).

Update `core/app/[locale]/(default)/page.tsx` (home):

```diff
+ import { Metadata } from 'next';
  import { getFormatter, getTranslations, setRequestLocale } from 'next-intl/server';
  ...
+ import { getMetadataAlternates } from '~/lib/seo/canonical';
  ...
+ export async function generateMetadata({ params }: Props): Promise<Metadata> {
+   const { locale } = await params;
+   return {
+     alternates: getMetadataAlternates({ path: '/', locale }),
+   };
+ }
+
  export default async function Home({ params }: Props) {
```

For entity pages (product, category, brand, blog, blog post, webpage), add the import and include `alternates` in the existing `generateMetadata` return value using the entity `path` (or breadcrumb-derived path for category and webpage). Example for a brand page:

```diff
+ import { getMetadataAlternates } from '~/lib/seo/canonical';
  ...
  export async function generateMetadata(props: Props): Promise<Metadata> {
-   const { slug } = await props.params;
+   const { slug, locale } = await props.params;
    ...
    return {
      title: pageTitle || brand.name,
      description: metaDescription,
      keywords: metaKeywords ? metaKeywords.split(',') : null,
+     alternates: getMetadataAlternates({ path: brand.path, locale }),
    };
  }
```

### Step 4: Gift certificates pages

Update `core/app/[locale]/(default)/gift-certificates/page.tsx`:

```diff
+ import { getMetadataAlternates } from '~/lib/seo/canonical';
  ...
  export async function generateMetadata({ params }: Props): Promise<Metadata> {
    const { locale } = await params;
    const t = await getTranslations({ locale, namespace: 'GiftCertificates' });

    return {
      title: t('title') || 'Gift certificates',
+     alternates: getMetadataAlternates({ path: '/gift-certificates', locale }),
    };
  }
```

Update `core/app/[locale]/(default)/gift-certificates/balance/page.tsx`:

```diff
+ import { getMetadataAlternates } from '~/lib/seo/canonical';
  ...
    return {
      title: t('title') || 'Gift certificates - Check balance',
+     alternates: getMetadataAlternates({ path: '/gift-certificates/balance', locale }),
    };
```

Add `generateMetadata` to `core/app/[locale]/(default)/gift-certificates/purchase/page.tsx`:

```diff
+ import { Metadata } from 'next';
  import { getFormatter, getTranslations } from 'next-intl/server';
  ...
+ import { getMetadataAlternates } from '~/lib/seo/canonical';
  ...
+ export async function generateMetadata({ params }: Props): Promise<Metadata> {
+   const { locale } = await params;
+   const t = await getTranslations({ locale, namespace: 'GiftCertificates' });
+
+   return {
+     title: t('Purchase.title'),
+     alternates: getMetadataAlternates({ path: '/gift-certificates/purchase', locale }),
+   };
+ }
```

### Step 5: Contact page

Update `core/app/[locale]/(default)/webpages/[id]/contact/page.tsx`:

```diff
+ import { getMetadataAlternates } from '~/lib/seo/canonical';
  ...
  export async function generateMetadata({ params }: Props): Promise<Metadata> {
-   const { id } = await params;
+   const { id, locale } = await params;
    const webpage = await getWebPage(id);
    const { pageTitle, metaDescription, metaKeywords } = webpage.seo;

    return {
      title: pageTitle || webpage.title,
      description: metaDescription,
      keywords: metaKeywords ? metaKeywords.split(',') : null,
+     alternates: getMetadataAlternates({ path: webpage.path, locale }),
    };
  }
```

### Step 6: Public wishlist page

Update `core/app/[locale]/(default)/wishlist/[token]/page.tsx`:

```diff
+ import { getMetadataAlternates } from '~/lib/seo/canonical';
  ...
  export async function generateMetadata({ params, searchParams }: Props): Promise<Metadata> {
    const { locale, token } = await params;
    ...
    return {
      title: wishlist?.name ?? t('title'),
+     alternates: getMetadataAlternates({ path: `/wishlist/${token}`, locale }),
    };
  }
```

### Step 7: Compare page

Update `core/app/[locale]/(default)/compare/page.tsx`:

```diff
+ import { getMetadataAlternates } from '~/lib/seo/canonical';
  ...
  export async function generateMetadata({ params }: Props): Promise<Metadata> {
    const { locale } = await params;
    const t = await getTranslations({ locale, namespace: 'Compare' });

    return {
      title: t('title'),
+     alternates: getMetadataAlternates({ path: '/compare', locale }),
    };
  }
```