### PR TITLE
PR 2825 sequence diagram

### DIFF
--- a/core/pr-2825-graphql-proxy-sequence-diagram.md
+++ b/core/pr-2825-graphql-proxy-sequence-diagram.md
@@ -1,0 +1,83 @@
+# PR #2825 Analysis: GraphQL Proxy Middleware
+
+This document analyzes [bigcommerce/catalyst#2825](https://github.com/bigcommerce/catalyst/pull/2825) and models the request flow introduced by `withGraphqlProxy`.
+
+## Summary of behavior changes
+
+- Adds a new middleware: `withGraphqlProxy` (`core/middlewares/with-graphql-proxy.ts`).
+- Inserts it in `core/middleware.ts` after `withChannelId` and before `withRoutes`.
+- Intercepts only requests to `/graphql` with an allowed requester header.
+- Proxies valid GraphQL POST payloads through the existing Catalyst GraphQL client.
+- Preserves browser cookie context and passes optional customer auth token to Storefront API requests.
+- Falls through to `withRoutes` when request path or requester header does not match proxy criteria.
+
+## Middleware order after PR #2825
+
+1. `withAuth`
+2. `withIntl`
+3. `withAnalyticsCookies`
+4. `withChannelId`
+5. `withGraphqlProxy` (new)
+6. `withRoutes`
+
+## Sequence diagram
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Client as Browser / checkout-sdk-js
+    participant AuthMW as withAuth
+    participant IntlMW as withIntl
+    participant AnalyticsMW as withAnalyticsCookies
+    participant ChannelMW as withChannelId
+    participant ProxyMW as withGraphqlProxy
+    participant RoutesMW as withRoutes
+    participant AuthWrap as auth(...) in withGraphqlProxy
+    participant GqlClient as client.fetch(...)
+    participant Storefront as BigCommerce Storefront GraphQL API
+
+    Client->>AuthMW: Incoming request
+    AuthMW->>IntlMW: next(request, event)
+    IntlMW->>AnalyticsMW: set x-bc-locale, continue
+    AnalyticsMW->>ChannelMW: set visitor/visit cookies, continue
+    ChannelMW->>ProxyMW: set x-bc-channel-id, continue
+
+    alt Request path is not /graphql
+        ProxyMW->>RoutesMW: next(request, event)
+        RoutesMW-->>Client: rewrite/redirect/response
+    else Request path is /graphql
+        ProxyMW->>ProxyMW: Read x-catalyst-graphql-proxy-requester
+        alt Missing or disallowed requester
+            ProxyMW->>RoutesMW: next(request, event)
+            RoutesMW-->>Client: route handling response
+        else Allowed requester
+            alt HTTP method is not POST
+                ProxyMW-->>Client: 405 Method not allowed
+            else HTTP method is POST
+                ProxyMW->>AuthWrap: auth(handler)(request, event)
+                AuthWrap-->>ProxyMW: req.auth?.user?.customerAccessToken
+                ProxyMW->>ProxyMW: Parse JSON body with zod
+                alt query is missing
+                    ProxyMW-->>Client: 400 { error: "Missing query" }
+                else query present
+                    ProxyMW->>GqlClient: client.fetch({document, variables, customerAccessToken, Cookie, revalidate: 0})
+                    GqlClient->>Storefront: GraphQL request (channel resolved by client)
+                    Storefront-->>GqlClient: GraphQL payload/errors
+                    GqlClient-->>ProxyMW: response object
+                    ProxyMW-->>Client: 200 JSON(response)
+                end
+                opt Any parse/fetch/runtime error
+                    ProxyMW-->>Client: 500 JSON(error)
+                end
+            end
+        end
+    end
+```
+
+## Key implementation notes
+
+- **Guard rails:** proxying is constrained by both route (`/graphql`) and requester allowlist (`x-catalyst-graphql-proxy-requester`).
+- **Auth context:** middleware wraps proxy handling in `auth(...)` to obtain `customerAccessToken` when available.
+- **Channel + locale continuity:** placing proxy middleware after `withChannelId` ensures channel context is resolved before API calls.
+- **Cookie forwarding:** original request cookies are forwarded to emulate browser-originated Storefront API behavior.
+- **No-cache fetch option:** `next: { revalidate: 0 }` is used for proxy requests to avoid stale responses.


### PR DESCRIPTION
## What/Why?
This PR adds a new documentation artifact, `core/pr-2825-graphql-proxy-sequence-diagram.md`, which provides an analysis and a Mermaid sequence diagram for the `withGraphqlProxy` middleware introduced in [bigcommerce/catalyst#2825](https://github.com/bigcommerce/catalyst/pull/2825).

The purpose is to clearly illustrate the request flow, middleware ordering, and key behaviors of the GraphQL proxy, including pass-through scenarios, validation, and successful proxying to the Storefront GraphQL API. This helps in understanding the middleware's integration and functionality.

## Testing
This PR introduces a new documentation file. Testing involves reviewing the content of `core/pr-2825-graphql-proxy-sequence-diagram.md` for accuracy, clarity, and correct representation of the `withGraphqlProxy` middleware's behavior as implemented in PR #2825.

## Migration
No files were moved, and no breaking changes were introduced. This PR adds a new documentation file.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-54988749-dfc4-46e9-a047-2e4f8450d78a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-54988749-dfc4-46e9-a047-2e4f8450d78a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

