### PR TITLE
fix(cli): change --secret from variadic to repeatable

### DIFF
--- a/packages/catalyst/src/cli/commands/deploy.spec.ts
+++ b/packages/catalyst/src/cli/commands/deploy.spec.ts
@@ -95,7 +95,7 @@ test('properly configured Command instance', () => {
       expect.objectContaining({ flags: '--access-token <token>' }),
       expect.objectContaining({ flags: '--api-host <host>', defaultValue: 'api.bigcommerce.com' }),
       expect.objectContaining({ flags: '--project-uuid <uuid>' }),
-      expect.objectContaining({ flags: '--secret <secrets...>' }),
+      expect.objectContaining({ flags: '--secret <value>' }),
       expect.objectContaining({ flags: '--dry-run' }),
     ]),
   );

--- a/packages/catalyst/src/cli/commands/deploy.ts
+++ b/packages/catalyst/src/cli/commands/deploy.ts
@@ -357,9 +357,11 @@ export const deploy = new Command('deploy')
   )
   .addOption(
     new Option(
-      '--secret <secrets...>',
-      'Secrets to set for the deployment. Format: SECRET_1=FOO SECRET_2=BAR',
-    ),
+      '--secret <value>',
+      'Secret to set for the deployment (repeatable). Format: --secret KEY=VALUE',
+    ).argParser((value: string, previous: string[] = []) => {
+      return previous.concat([value]);
+    }),
   )
   .option('--dry-run', 'Run the command to generate the bundle without uploading or deploying.')
 


### PR DESCRIPTION
## What/Why?

The `--secret` flag on the `deploy` command used Commander.js variadic syntax (`--secret <secrets...>`), which accepts space-separated values. This is problematic because secret values themselves could contain spaces.

This changes `--secret` to a repeatable option (`--secret KEY=VALUE --secret KEY2=VALUE2`) using Commander's custom argument parser, making each secret explicit and unambiguous. The parsed result is still a `string[]`, so no changes were needed to `parseEnvironmentVariables` or `createDeployment`.

## Testing

Existing tests pass — `parseEnvironmentVariables` already expects a `string[]` input. Updated the command options test to match the new flag format.

## Migration

**Before:** `catalyst deploy --secret SECRET_1=FOO SECRET_2=BAR`
**After:** `catalyst deploy --secret SECRET_1=FOO --secret SECRET_2=BAR`