### PR TITLE
feat(cli): run build automatically when deploying

### DIFF
--- a/.changeset/ripe-beers-switch.md
+++ b/.changeset/ripe-beers-switch.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst": minor
+---
+
+Build now runs automatically when deploying. You can pass `--prebuilt` if you don't need to run build before deploying.

--- a/packages/catalyst/src/cli/commands/build.ts
+++ b/packages/catalyst/src/cli/commands/build.ts
@@ -11,6 +11,71 @@ import { getWranglerConfig } from '../lib/wrangler-config';
 
 const WRANGLER_VERSION = '4.24.3';
 
+export async function buildCatalystProject(projectUuid: string): Promise<void> {
+  const coreDir = process.cwd();
+  const openNextOutDir = join(coreDir, '.open-next');
+  const bigcommerceDistDir = join(coreDir, '.bigcommerce', 'dist');
+
+  const wranglerConfig = getWranglerConfig(projectUuid);
+
+  consola.start('Copying templates...');
+
+  await copyFile(
+    join(getModuleCliPath(), 'templates', 'open-next.config.ts'),
+    join(coreDir, '.bigcommerce', 'open-next.config.ts'),
+  );
+  await writeFile(
+    join(coreDir, '.bigcommerce', 'wrangler.jsonc'),
+    JSON.stringify(wranglerConfig, null, 2),
+  );
+
+  consola.success('Templates copied');
+
+  consola.start('Building project...');
+
+  await execa(
+    'pnpm',
+    [
+      'exec',
+      'opennextjs-cloudflare',
+      'build',
+      '--skipWranglerConfigCheck',
+      '--openNextConfigPath',
+      join(coreDir, '.bigcommerce', 'open-next.config.ts'),
+    ],
+    {
+      stdout: ['pipe', 'inherit'],
+      cwd: coreDir,
+    },
+  );
+
+  await execa(
+    'pnpm',
+    [
+      'dlx',
+      `wrangler@${WRANGLER_VERSION}`,
+      'deploy',
+      '--config',
+      join(coreDir, '.bigcommerce', 'wrangler.jsonc'),
+      '--keep-vars',
+      '--outdir',
+      bigcommerceDistDir,
+      '--dry-run',
+    ],
+    {
+      stdout: ['pipe', 'inherit'],
+      cwd: coreDir,
+    },
+  );
+
+  consola.success('Project built');
+
+  await cp(join(openNextOutDir, 'assets'), join(bigcommerceDistDir, 'assets'), {
+    recursive: true,
+    force: true,
+  });
+}
+
 export const build = new Command('build')
   .allowUnknownOption()
   // The unknown options end up in program.args, not in program.opts(). Commander does not take a guess at how to interpret the unknown options.
@@ -53,9 +118,6 @@ export const build = new Command('build')
       }
 
       if (framework === 'catalyst') {
-        const openNextOutDir = join(coreDir, '.open-next');
-        const bigcommerceDistDir = join(coreDir, '.bigcommerce', 'dist');
-
         const projectUuid = options.projectUuid ?? config.get('projectUuid');
 
         if (!projectUuid) {
@@ -64,69 +126,7 @@ export const build = new Command('build')
           );
         }
 
-        const wranglerConfig = getWranglerConfig(projectUuid);
-
-        consola.start('Copying templates...');
-
-        await copyFile(
-          join(getModuleCliPath(), 'templates', 'open-next.config.ts'),
-          join(coreDir, '.bigcommerce', 'open-next.config.ts'),
-        );
-        await writeFile(
-          join(coreDir, '.bigcommerce', 'wrangler.jsonc'),
-          JSON.stringify(wranglerConfig, null, 2),
-        );
-
-        consola.success('Templates copied');
-
-        consola.start('Building project...');
-
-        await execa(
-          'pnpm',
-          [
-            'exec',
-            'opennextjs-cloudflare',
-            'build',
-            '--skipWranglerConfigCheck',
-            '--openNextConfigPath',
-            join(coreDir, '.bigcommerce', 'open-next.config.ts'),
-          ],
-          {
-            stdout: ['pipe', 'inherit'],
-            cwd: coreDir,
-          },
-        );
-
-        await execa(
-          'pnpm',
-          [
-            'dlx',
-            `wrangler@${WRANGLER_VERSION}`,
-            'deploy',
-            '--config',
-            join(coreDir, '.bigcommerce', 'wrangler.jsonc'),
-            '--keep-vars',
-            '--outdir',
-            bigcommerceDistDir,
-            '--dry-run',
-          ],
-          {
-            stdout: ['pipe', 'inherit'],
-            cwd: coreDir,
-          },
-        );
-
-        consola.success('Project built');
-
-        await cp(join(openNextOutDir, 'assets'), join(bigcommerceDistDir, 'assets'), {
-          recursive: true,
-          force: true,
-        });
-
-        await copyFile(
-          join(getModuleCliPath(), 'templates', 'public_headers'),
-          join(coreDir, '.bigcommerce', 'dist', 'assets', '_headers'),
-        );
+        await buildCatalystProject(projectUuid);
       }
     } catch (error) {
       consola.error(error);

--- a/packages/catalyst/src/cli/commands/deploy.spec.ts
+++ b/packages/catalyst/src/cli/commands/deploy.spec.ts
@@ -1,7 +1,7 @@
 import AdmZip from 'adm-zip';
 import { Command } from 'commander';
 import { http, HttpResponse } from 'msw';
-import { mkdir, realpath, stat, writeFile } from 'node:fs/promises';
+import { mkdir, realpath, rm, stat, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import {
   afterAll,
@@ -21,6 +21,7 @@ import { consola } from '../lib/logger';
 import { mkTempDir } from '../lib/mk-temp-dir';
 import { program } from '../program';
 
+import { buildCatalystProject } from './build';
 import {
   createDeployment,
   deploy,
@@ -102,6 +103,7 @@ test('properly configured Command instance', () => {
       expect.objectContaining({ flags: '--project-uuid <uuid>' }),
       expect.objectContaining({ flags: '--secret <secrets...>' }),
       expect.objectContaining({ flags: '--dry-run' }),
+      expect.objectContaining({ flags: '--prebuilt' }),
     ]),
   );
 });
@@ -332,4 +334,97 @@ test('reads from env options', () => {
   expect(() => parseEnvironmentVariables(['foo_bar'])).toThrow(
     'Invalid secret format: foo_bar. Expected format: KEY=VALUE',
   );
+});
+
+describe('--prebuilt flag', () => {
+  test('skips build step when --prebuilt is passed', async () => {
+    await program.parseAsync([
+      'node',
+      'catalyst',
+      'deploy',
+      '--store-hash',
+      storeHash,
+      '--access-token',
+      accessToken,
+      '--api-host',
+      apiHost,
+      '--project-uuid',
+      projectUuid,
+      '--prebuilt',
+      '--dry-run',
+    ]);
+
+    expect(buildCatalystProject).not.toHaveBeenCalled();
+    expect(consola.info).toHaveBeenCalledWith('Using existing build output (--prebuilt).');
+    expect(consola.info).toHaveBeenCalledWith('Generating bundle...');
+  });
+
+  test('fails when dist directory is missing', async () => {
+    const [missingDistDir, missingDistCleanup] = await mkTempDir();
+    const resolvedDir = await realpath(missingDistDir);
+
+    process.chdir(resolvedDir);
+
+    await program.parseAsync([
+      'node',
+      'catalyst',
+      'deploy',
+      '--store-hash',
+      storeHash,
+      '--access-token',
+      accessToken,
+      '--api-host',
+      apiHost,
+      '--project-uuid',
+      projectUuid,
+      '--prebuilt',
+    ]);
+
+    expect(consola.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message:
+          'No build output found at .bigcommerce/dist/. Run `catalyst build` first or remove `--prebuilt` to build automatically.',
+      }),
+    );
+    expect(exitMock).toHaveBeenCalledWith(1);
+
+    process.chdir(tmpDir);
+    await missingDistCleanup();
+  });
+
+  test('fails when dist directory is empty', async () => {
+    const [emptyDistDir, emptyDistCleanup] = await mkTempDir();
+    const resolvedDir = await realpath(emptyDistDir);
+
+    await mkdir(join(resolvedDir, '.bigcommerce', 'dist'), { recursive: true });
+
+    process.chdir(resolvedDir);
+
+    await program.parseAsync([
+      'node',
+      'catalyst',
+      'deploy',
+      '--store-hash',
+      storeHash,
+      '--access-token',
+      accessToken,
+      '--api-host',
+      apiHost,
+      '--project-uuid',
+      projectUuid,
+      '--prebuilt',
+    ]);
+
+    expect(consola.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message:
+          'No build output found at .bigcommerce/dist/. Run `catalyst build` first or remove `--prebuilt` to build automatically.',
+      }),
+    );
+    expect(exitMock).toHaveBeenCalledWith(1);
+
+    process.chdir(tmpDir);
+    await rm(join(resolvedDir, '.bigcommerce'), { recursive: true });
+    await emptyDistCleanup();
+  });
 });

--- a/packages/catalyst/src/cli/commands/deploy.spec.ts
+++ b/packages/catalyst/src/cli/commands/deploy.spec.ts
@@ -33,6 +33,11 @@ import {
 
 // eslint-disable-next-line import/dynamic-import-chunkname
 vi.mock('yocto-spinner', () => import('../../../tests/mocks/spinner'));
+vi.mock('./build', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./build')>();
+
+  return { ...actual, buildCatalystProject: vi.fn() };
+});
 
 let exitMock: MockInstance;
 

--- a/packages/catalyst/src/cli/commands/deploy.ts
+++ b/packages/catalyst/src/cli/commands/deploy.ts
@@ -9,6 +9,8 @@ import { consola } from '../lib/logger';
 import { getProjectConfig } from '../lib/project-config';
 import { Telemetry } from '../lib/telemetry';
 
+import { buildCatalystProject } from './build';
+
 const telemetry = new Telemetry();
 
 const stepsEnum = z.enum([
@@ -377,24 +379,7 @@ export const deploy = new Command('deploy')
         );
       }
 
-      const project = await fetchProject(
-        projectUuid,
-        options.storeHash,
-        options.accessToken,
-        options.apiHost,
-      );
-
-      if (!project) {
-        throw new Error(`Project with UUID ${projectUuid} not found.`);
-      }
-
-      if (process.env.CI !== 'true') {
-        await consola.prompt(`Are you sure you want to deploy to the project: ${project.name}?`, {
-          type: 'confirm',
-          cancel: 'reject',
-        });
-      }
-
+      await buildCatalystProject(projectUuid);
       await generateBundleZip();
 
       if (options.dryRun) {

--- a/packages/catalyst/src/cli/commands/deploy.ts
+++ b/packages/catalyst/src/cli/commands/deploy.ts
@@ -364,7 +364,10 @@ export const deploy = new Command('deploy')
     ),
   )
   .option('--dry-run', 'Run the command to generate the bundle without uploading or deploying.')
-
+  .option(
+    '--prebuilt',
+    'Skip the build step. Requires .bigcommerce/dist/ to already contain build output.',
+  )
   .action(async (options) => {
     try {
       const config = getProjectConfig();
@@ -379,7 +382,30 @@ export const deploy = new Command('deploy')
         );
       }
 
-      await buildCatalystProject(projectUuid);
+      if (options.prebuilt) {
+        const distDir = join(process.cwd(), '.bigcommerce', 'dist');
+
+        try {
+          await access(distDir);
+        } catch {
+          throw new Error(
+            'No build output found at .bigcommerce/dist/. Run `catalyst build` first or remove `--prebuilt` to build automatically.',
+          );
+        }
+
+        const contents = await readdir(distDir);
+
+        if (contents.length === 0) {
+          throw new Error(
+            'No build output found at .bigcommerce/dist/. Run `catalyst build` first or remove `--prebuilt` to build automatically.',
+          );
+        }
+
+        consola.info('Using existing build output (--prebuilt).');
+      } else {
+        await buildCatalystProject(projectUuid);
+      }
+
       await generateBundleZip();
 
       if (options.dryRun) {


### PR DESCRIPTION
## What/Why?

Currently, `catalyst deploy` expects `.bigcommerce/dist/` to already exist (produced by a prior `catalyst build`). Users must manually run two commands: `catalyst build && catalyst deploy`.

This PR changes `deploy` to automatically run the build pipeline before bundling:

- Extracts `buildCatalystProject()` from the `build` command into a reusable exported function
- Calls `buildCatalystProject()` in the `deploy` command before `generateBundleZip()`
- Updates the deploy dry-run test to mock `buildCatalystProject`

Resolves: CATALYST-1756

## Testing

- `pnpm build --filter @bigcommerce/catalyst` compiles without errors
- `pnpm --filter @bigcommerce/catalyst test` — all 44 tests pass
- Manual: run `catalyst deploy` on a project and verify it builds before bundling