### PR TITLE
feat(cli): add --prebuilt flag to deploy command

### DIFF
--- a/packages/catalyst/src/cli/commands/deploy.spec.ts
+++ b/packages/catalyst/src/cli/commands/deploy.spec.ts
@@ -1,7 +1,7 @@
 import AdmZip from 'adm-zip';
 import { Command } from 'commander';
 import { http, HttpResponse } from 'msw';
-import { mkdir, realpath, stat, writeFile } from 'node:fs/promises';
+import { mkdir, realpath, rm, stat, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import {
   afterAll,
@@ -21,6 +21,7 @@ import { consola } from '../lib/logger';
 import { mkTempDir } from '../lib/mk-temp-dir';
 import { program } from '../program';
 
+import { buildCatalystProject } from './build';
 import {
   createDeployment,
   deploy,
@@ -102,6 +103,7 @@ test('properly configured Command instance', () => {
       expect.objectContaining({ flags: '--project-uuid <uuid>' }),
       expect.objectContaining({ flags: '--secret <secrets...>' }),
       expect.objectContaining({ flags: '--dry-run' }),
+      expect.objectContaining({ flags: '--prebuilt' }),
     ]),
   );
 });
@@ -332,4 +334,97 @@ test('reads from env options', () => {
   expect(() => parseEnvironmentVariables(['foo_bar'])).toThrow(
     'Invalid secret format: foo_bar. Expected format: KEY=VALUE',
   );
+});
+
+describe('--prebuilt flag', () => {
+  test('skips build step when --prebuilt is passed', async () => {
+    await program.parseAsync([
+      'node',
+      'catalyst',
+      'deploy',
+      '--store-hash',
+      storeHash,
+      '--access-token',
+      accessToken,
+      '--api-host',
+      apiHost,
+      '--project-uuid',
+      projectUuid,
+      '--prebuilt',
+      '--dry-run',
+    ]);
+
+    expect(buildCatalystProject).not.toHaveBeenCalled();
+    expect(consola.info).toHaveBeenCalledWith('Using existing build output (--prebuilt).');
+    expect(consola.info).toHaveBeenCalledWith('Generating bundle...');
+  });
+
+  test('fails when dist directory is missing', async () => {
+    const [missingDistDir, missingDistCleanup] = await mkTempDir();
+    const resolvedDir = await realpath(missingDistDir);
+
+    process.chdir(resolvedDir);
+
+    await program.parseAsync([
+      'node',
+      'catalyst',
+      'deploy',
+      '--store-hash',
+      storeHash,
+      '--access-token',
+      accessToken,
+      '--api-host',
+      apiHost,
+      '--project-uuid',
+      projectUuid,
+      '--prebuilt',
+    ]);
+
+    expect(consola.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message:
+          'No build output found at .bigcommerce/dist/. Run `catalyst build` first or remove `--prebuilt` to build automatically.',
+      }),
+    );
+    expect(exitMock).toHaveBeenCalledWith(1);
+
+    process.chdir(tmpDir);
+    await missingDistCleanup();
+  });
+
+  test('fails when dist directory is empty', async () => {
+    const [emptyDistDir, emptyDistCleanup] = await mkTempDir();
+    const resolvedDir = await realpath(emptyDistDir);
+
+    await mkdir(join(resolvedDir, '.bigcommerce', 'dist'), { recursive: true });
+
+    process.chdir(resolvedDir);
+
+    await program.parseAsync([
+      'node',
+      'catalyst',
+      'deploy',
+      '--store-hash',
+      storeHash,
+      '--access-token',
+      accessToken,
+      '--api-host',
+      apiHost,
+      '--project-uuid',
+      projectUuid,
+      '--prebuilt',
+    ]);
+
+    expect(consola.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message:
+          'No build output found at .bigcommerce/dist/. Run `catalyst build` first or remove `--prebuilt` to build automatically.',
+      }),
+    );
+    expect(exitMock).toHaveBeenCalledWith(1);
+
+    process.chdir(tmpDir);
+    await rm(join(resolvedDir, '.bigcommerce'), { recursive: true });
+    await emptyDistCleanup();
+  });
 });

--- a/packages/catalyst/src/cli/commands/deploy.ts
+++ b/packages/catalyst/src/cli/commands/deploy.ts
@@ -364,7 +364,10 @@ export const deploy = new Command('deploy')
     ),
   )
   .option('--dry-run', 'Run the command to generate the bundle without uploading or deploying.')
-
+  .option(
+    '--prebuilt',
+    'Skip the build step. Requires .bigcommerce/dist/ to already contain build output.',
+  )
   .action(async (options) => {
     try {
       const config = getProjectConfig();
@@ -379,7 +382,30 @@ export const deploy = new Command('deploy')
         );
       }
 
-      await buildCatalystProject(projectUuid);
+      if (options.prebuilt) {
+        const distDir = join(process.cwd(), '.bigcommerce', 'dist');
+
+        try {
+          await access(distDir);
+        } catch {
+          throw new Error(
+            'No build output found at .bigcommerce/dist/. Run `catalyst build` first or remove `--prebuilt` to build automatically.',
+          );
+        }
+
+        const contents = await readdir(distDir);
+
+        if (contents.length === 0) {
+          throw new Error(
+            'No build output found at .bigcommerce/dist/. Run `catalyst build` first or remove `--prebuilt` to build automatically.',
+          );
+        }
+
+        consola.info('Using existing build output (--prebuilt).');
+      } else {
+        await buildCatalystProject(projectUuid);
+      }
+
       await generateBundleZip();
 
       if (options.dryRun) {


### PR DESCRIPTION
## What/Why?

Adds a `--prebuilt` flag to `catalyst deploy` so users who have already run `catalyst build` separately can skip the automatic build step. When `--prebuilt` is passed but `.bigcommerce/dist/` is missing or empty, the CLI fails with an actionable error message directing the user to either run `catalyst build` first or remove the flag.

**Jira:** [CATALYST-1753](https://bigcommercecloud.atlassian.net/browse/CATALYST-1753)

### Changes
- Add `--prebuilt` option to the deploy command definition
- Replace unconditional `buildCatalystProject()` call with conditional logic that validates existing build output when `--prebuilt` is set
- Add tests: command instance check, build skip verification, missing dist failure, empty dist failure

## Testing

```bash
pnpm --filter @bigcommerce/catalyst run test   # 47 tests pass
pnpm --filter @bigcommerce/catalyst run lint    # 0 warnings
```

## Migration

N/A — additive change, no breaking behavior.

[CATALYST-1753]: https://bigcommercecloud.atlassian.net/browse/CATALYST-1753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ