### PR TITLE
CATALYST-1744 Rename Env Variable Names

### DIFF
--- a/packages/catalyst/src/cli/commands/build.ts
+++ b/packages/catalyst/src/cli/commands/build.ts
@@ -22,7 +22,7 @@ export const build = new Command('build')
     new Option(
       '--project-uuid <uuid>',
       'Project UUID to be included in the deployment configuration.',
-    ).env('BIGCOMMERCE_PROJECT_UUID'),
+    ).env('CATALYST_PROJECT_UUID'),
   )
   .addOption(
     new Option('--framework <framework>', 'The framework to use for the build.').choices([

--- a/packages/catalyst/src/cli/commands/deploy.ts
+++ b/packages/catalyst/src/cli/commands/deploy.ts
@@ -284,7 +284,7 @@ export const deploy = new Command('deploy')
       '--store-hash <hash>',
       'BigCommerce store hash. Can be found in the URL of your store Control Panel.',
     )
-      .env('BIGCOMMERCE_STORE_HASH')
+      .env('CATALYST_STORE_HASH')
       .makeOptionMandatory(),
   )
   .addOption(
@@ -292,7 +292,7 @@ export const deploy = new Command('deploy')
       '--access-token <token>',
       'BigCommerce access token. Can be found after creating a store-level API account.',
     )
-      .env('BIGCOMMERCE_ACCESS_TOKEN')
+      .env('CATALYST_ACCESS_TOKEN')
       .makeOptionMandatory(),
   )
   .addOption(
@@ -304,7 +304,7 @@ export const deploy = new Command('deploy')
     new Option(
       '--project-uuid <uuid>',
       'BigCommerce intrastructure project UUID. Can be found via the BigCommerce API (GET /v3/infrastructure/projects).',
-    ).env('BIGCOMMERCE_PROJECT_UUID'),
+    ).env('CATALYST_PROJECT_UUID'),
   )
   .addOption(
     new Option(

--- a/packages/catalyst/src/cli/commands/project.spec.ts
+++ b/packages/catalyst/src/cli/commands/project.spec.ts
@@ -127,21 +127,21 @@ describe('project create', () => {
   });
 
   test('with insufficient credentials exits with error', async () => {
-    // Unset env so Commander doesn't pick up BIGCOMMERCE_* and trigger the create flow (which would prompt for name)
-    const savedStoreHash = process.env.BIGCOMMERCE_STORE_HASH;
-    const savedAccessToken = process.env.BIGCOMMERCE_ACCESS_TOKEN;
+    // Unset env so Commander doesn't pick up CATALYST_* and trigger the create flow (which would prompt for name)
+    const savedStoreHash = process.env.CATALYST_STORE_HASH;
+    const savedAccessToken = process.env.CATALYST_ACCESS_TOKEN;
 
-    delete process.env.BIGCOMMERCE_STORE_HASH;
-    delete process.env.BIGCOMMERCE_ACCESS_TOKEN;
+    delete process.env.CATALYST_STORE_HASH;
+    delete process.env.CATALYST_ACCESS_TOKEN;
 
     await program.parseAsync(['node', 'catalyst', 'project', 'create', '--root-dir', tmpDir]);
 
-    if (savedStoreHash !== undefined) process.env.BIGCOMMERCE_STORE_HASH = savedStoreHash;
-    if (savedAccessToken !== undefined) process.env.BIGCOMMERCE_ACCESS_TOKEN = savedAccessToken;
+    if (savedStoreHash !== undefined) process.env.CATALYST_STORE_HASH = savedStoreHash;
+    if (savedAccessToken !== undefined) process.env.CATALYST_ACCESS_TOKEN = savedAccessToken;
 
     expect(consola.error).toHaveBeenCalledWith('Insufficient information to create a project.');
     expect(consola.info).toHaveBeenCalledWith(
-      'Provide both --store-hash and --access-token (or set BIGCOMMERCE_STORE_HASH and BIGCOMMERCE_ACCESS_TOKEN).',
+      'Provide both --store-hash and --access-token (or set CATALYST_STORE_HASH and CATALYST_ACCESS_TOKEN).',
     );
     expect(exitMock).toHaveBeenCalledWith(1);
   });
@@ -199,20 +199,20 @@ describe('project list', () => {
   });
 
   test('with insufficient credentials exits with error', async () => {
-    const savedStoreHash = process.env.BIGCOMMERCE_STORE_HASH;
-    const savedAccessToken = process.env.BIGCOMMERCE_ACCESS_TOKEN;
+    const savedStoreHash = process.env.CATALYST_STORE_HASH;
+    const savedAccessToken = process.env.CATALYST_ACCESS_TOKEN;
 
-    delete process.env.BIGCOMMERCE_STORE_HASH;
-    delete process.env.BIGCOMMERCE_ACCESS_TOKEN;
+    delete process.env.CATALYST_STORE_HASH;
+    delete process.env.CATALYST_ACCESS_TOKEN;
 
     await program.parseAsync(['node', 'catalyst', 'project', 'list']);
 
-    if (savedStoreHash !== undefined) process.env.BIGCOMMERCE_STORE_HASH = savedStoreHash;
-    if (savedAccessToken !== undefined) process.env.BIGCOMMERCE_ACCESS_TOKEN = savedAccessToken;
+    if (savedStoreHash !== undefined) process.env.CATALYST_STORE_HASH = savedStoreHash;
+    if (savedAccessToken !== undefined) process.env.CATALYST_ACCESS_TOKEN = savedAccessToken;
 
     expect(consola.error).toHaveBeenCalledWith('Insufficient information to list projects.');
     expect(consola.info).toHaveBeenCalledWith(
-      'Provide both --store-hash and --access-token (or set BIGCOMMERCE_STORE_HASH and BIGCOMMERCE_ACCESS_TOKEN).',
+      'Provide both --store-hash and --access-token (or set CATALYST_STORE_HASH and CATALYST_ACCESS_TOKEN).',
     );
     expect(exitMock).toHaveBeenCalledWith(1);
   });

--- a/packages/catalyst/src/cli/commands/project.ts
+++ b/packages/catalyst/src/cli/commands/project.ts
@@ -13,13 +13,13 @@ const list = new Command('list')
     new Option(
       '--store-hash <hash>',
       'BigCommerce store hash. Can be found in the URL of your store Control Panel.',
-    ).env('BIGCOMMERCE_STORE_HASH'),
+    ).env('CATALYST_STORE_HASH'),
   )
   .addOption(
     new Option(
       '--access-token <token>',
       'BigCommerce access token. Can be found after creating a store-level API account.',
-    ).env('BIGCOMMERCE_ACCESS_TOKEN'),
+    ).env('CATALYST_ACCESS_TOKEN'),
   )
   .addOption(
     new Option('--api-host <host>', 'BigCommerce API host. The default is api.bigcommerce.com.')
@@ -31,7 +31,7 @@ const list = new Command('list')
       if (!options.storeHash || !options.accessToken) {
         consola.error('Insufficient information to list projects.');
         consola.info(
-          'Provide both --store-hash and --access-token (or set BIGCOMMERCE_STORE_HASH and BIGCOMMERCE_ACCESS_TOKEN).',
+          'Provide both --store-hash and --access-token (or set CATALYST_STORE_HASH and CATALYST_ACCESS_TOKEN).',
         );
         process.exit(1);
 
@@ -72,13 +72,13 @@ const create = new Command('create')
     new Option(
       '--store-hash <hash>',
       'BigCommerce store hash. Can be found in the URL of your store Control Panel.',
-    ).env('BIGCOMMERCE_STORE_HASH'),
+    ).env('CATALYST_STORE_HASH'),
   )
   .addOption(
     new Option(
       '--access-token <token>',
       'BigCommerce access token. Can be found after creating a store-level API account.',
-    ).env('BIGCOMMERCE_ACCESS_TOKEN'),
+    ).env('CATALYST_ACCESS_TOKEN'),
   )
   .addOption(
     new Option('--api-host <host>', 'BigCommerce API host. The default is api.bigcommerce.com.')
@@ -95,7 +95,7 @@ const create = new Command('create')
       if (!options.storeHash || !options.accessToken) {
         consola.error('Insufficient information to create a project.');
         consola.info(
-          'Provide both --store-hash and --access-token (or set BIGCOMMERCE_STORE_HASH and BIGCOMMERCE_ACCESS_TOKEN).',
+          'Provide both --store-hash and --access-token (or set CATALYST_STORE_HASH and CATALYST_ACCESS_TOKEN).',
         );
         process.exit(1);
 
@@ -139,13 +139,13 @@ export const link = new Command('link')
     new Option(
       '--store-hash <hash>',
       'BigCommerce store hash. Can be found in the URL of your store Control Panel.',
-    ).env('BIGCOMMERCE_STORE_HASH'),
+    ).env('CATALYST_STORE_HASH'),
   )
   .addOption(
     new Option(
       '--access-token <token>',
       'BigCommerce access token. Can be found after creating a store-level API account.',
-    ).env('BIGCOMMERCE_ACCESS_TOKEN'),
+    ).env('CATALYST_ACCESS_TOKEN'),
   )
   .addOption(
     new Option('--api-host <host>', 'BigCommerce API host. The default is api.bigcommerce.com.')


### PR DESCRIPTION
## What/Why?
To avoid confusion between variables needed for the CLI commands and runtime variables for running Catalyst, we are renaming the prefix of `BIGCOMMERCE_` to `CATALYST_` for variables used in Catalyst CLI commands.

BIGCOMMERCE_STORE_HASH -> CATALYST_STORE_HASH
BIGCOMMERCE_PROJECT_UUID -> CATALYST_PROJECT_UUID
BIGCOMMERCE_FRAMEWORK -> CATALYST_FRAMEWORK
BIGCOMMERCE_ACCESS_TOKEN - > CATALYST_ACCESS_TOKEN

## Testing
- Rename environment variables in local `.env.*` files to use the `CATALYST_` prefix.
- `pnpm build --filter @bigcommerce/catalyst` compiles without errors`
- `pnpm --filter @bigcommerce/catalyst test` — all tests pass

## Migration
Rename environment variables used in Catalyst CLI commands to the `CATALYST_` prefix
