### PR TITLE
[Catalyst-1744] Write additional variables to project config

### DIFF
--- a/.changeset/honest-nights-knock.md
+++ b/.changeset/honest-nights-knock.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst": patch
+---
+
+Write additional config variables to the project.json file so that we have a centralized place for all required variables.

--- a/packages/catalyst/src/cli/commands/deploy.spec.ts
+++ b/packages/catalyst/src/cli/commands/deploy.spec.ts
@@ -336,13 +336,9 @@ test('errors when store hash is missing and not in .bigcommerce/project.json', a
   config.set('accessToken', accessToken);
   config.delete('storeHash');
 
-  const savedStoreHash = process.env.CATALYST_STORE_HASH;
-
-  delete process.env.CATALYST_STORE_HASH;
+  vi.stubEnv('CATALYST_STORE_HASH', undefined);
 
   await program.parseAsync(['node', 'catalyst', 'deploy']);
-
-  if (savedStoreHash !== undefined) process.env.CATALYST_STORE_HASH = savedStoreHash;
 
   expect(consola.error).toHaveBeenCalledWith(
     expect.objectContaining({
@@ -351,6 +347,8 @@ test('errors when store hash is missing and not in .bigcommerce/project.json', a
     }),
   );
   expect(exitMock).toHaveBeenCalledWith(1);
+
+  vi.unstubAllEnvs();
 });
 
 test('errors when access token is missing and not in .bigcommerce/project.json', async () => {
@@ -360,13 +358,9 @@ test('errors when access token is missing and not in .bigcommerce/project.json',
   config.set('storeHash', storeHash);
   config.delete('accessToken');
 
-  const savedAccessToken = process.env.CATALYST_ACCESS_TOKEN;
-
-  delete process.env.CATALYST_ACCESS_TOKEN;
+  vi.stubEnv('CATALYST_ACCESS_TOKEN', undefined);
 
   await program.parseAsync(['node', 'catalyst', 'deploy']);
-
-  if (savedAccessToken !== undefined) process.env.CATALYST_ACCESS_TOKEN = savedAccessToken;
 
   expect(consola.error).toHaveBeenCalledWith(
     expect.objectContaining({
@@ -375,6 +369,8 @@ test('errors when access token is missing and not in .bigcommerce/project.json',
     }),
   );
   expect(exitMock).toHaveBeenCalledWith(1);
+
+  vi.unstubAllEnvs();
 });
 
 test('reads from env options', () => {

--- a/packages/catalyst/src/cli/commands/deploy.spec.ts
+++ b/packages/catalyst/src/cli/commands/deploy.spec.ts
@@ -19,6 +19,7 @@ import { server } from '../../../tests/mocks/node';
 import { textHistory } from '../../../tests/mocks/spinner';
 import { consola } from '../lib/logger';
 import { mkTempDir } from '../lib/mk-temp-dir';
+import { getProjectConfig } from '../lib/project-config';
 import { program } from '../program';
 
 import { buildCatalystProject } from './build';
@@ -312,6 +313,66 @@ test('--dry-run skips upload and deployment', async () => {
   expect(consola.info).toHaveBeenCalledWith('- Upload bundle.zip');
   expect(consola.info).toHaveBeenCalledWith('- Create deployment');
   expect(exitMock).toHaveBeenCalledWith(0);
+});
+
+test('--dry-run uses storeHash and accessToken from .bigcommerce/project.json when not provided', async () => {
+  const config = getProjectConfig();
+  config.set('projectUuid', projectUuid);
+  config.set('storeHash', storeHash);
+  config.set('accessToken', accessToken);
+
+  await program.parseAsync([
+    'node',
+    'catalyst',
+    'deploy',
+    '--dry-run',
+  ]);
+
+  expect(consola.info).toHaveBeenCalledWith('Generating bundle...');
+  expect(consola.success).toHaveBeenCalledWith(`Bundle created at: ${outputZip}`);
+  expect(exitMock).toHaveBeenCalledWith(0);
+});
+
+test('errors when store hash is missing and not in .bigcommerce/project.json', async () => {
+  const config = getProjectConfig();
+  config.set('projectUuid', projectUuid);
+  config.set('accessToken', accessToken);
+  config.delete('storeHash');
+
+  const savedStoreHash = process.env.CATALYST_STORE_HASH;
+  delete process.env.CATALYST_STORE_HASH;
+
+  await program.parseAsync(['node', 'catalyst', 'deploy']);
+
+  if (savedStoreHash !== undefined) process.env.CATALYST_STORE_HASH = savedStoreHash;
+
+  expect(consola.error).toHaveBeenCalledWith(
+    expect.objectContaining({
+      message: expect.stringContaining('Store hash is required'),
+    }),
+  );
+  expect(exitMock).toHaveBeenCalledWith(1);
+});
+
+test('errors when access token is missing and not in .bigcommerce/project.json', async () => {
+  const config = getProjectConfig();
+  config.set('projectUuid', projectUuid);
+  config.set('storeHash', storeHash);
+  config.delete('accessToken');
+
+  const savedAccessToken = process.env.CATALYST_ACCESS_TOKEN;
+  delete process.env.CATALYST_ACCESS_TOKEN;
+
+  await program.parseAsync(['node', 'catalyst', 'deploy']);
+
+  if (savedAccessToken !== undefined) process.env.CATALYST_ACCESS_TOKEN = savedAccessToken;
+
+  expect(consola.error).toHaveBeenCalledWith(
+    expect.objectContaining({
+      message: expect.stringContaining('Access token is required'),
+    }),
+  );
+  expect(exitMock).toHaveBeenCalledWith(1);
 });
 
 test('reads from env options', () => {

--- a/packages/catalyst/src/cli/commands/deploy.spec.ts
+++ b/packages/catalyst/src/cli/commands/deploy.spec.ts
@@ -317,16 +317,12 @@ test('--dry-run skips upload and deployment', async () => {
 
 test('--dry-run uses storeHash and accessToken from .bigcommerce/project.json when not provided', async () => {
   const config = getProjectConfig();
+
   config.set('projectUuid', projectUuid);
   config.set('storeHash', storeHash);
   config.set('accessToken', accessToken);
 
-  await program.parseAsync([
-    'node',
-    'catalyst',
-    'deploy',
-    '--dry-run',
-  ]);
+  await program.parseAsync(['node', 'catalyst', 'deploy', '--dry-run']);
 
   expect(consola.info).toHaveBeenCalledWith('Generating bundle...');
   expect(consola.success).toHaveBeenCalledWith(`Bundle created at: ${outputZip}`);
@@ -335,11 +331,13 @@ test('--dry-run uses storeHash and accessToken from .bigcommerce/project.json wh
 
 test('errors when store hash is missing and not in .bigcommerce/project.json', async () => {
   const config = getProjectConfig();
+
   config.set('projectUuid', projectUuid);
   config.set('accessToken', accessToken);
   config.delete('storeHash');
 
   const savedStoreHash = process.env.CATALYST_STORE_HASH;
+
   delete process.env.CATALYST_STORE_HASH;
 
   await program.parseAsync(['node', 'catalyst', 'deploy']);
@@ -356,11 +354,13 @@ test('errors when store hash is missing and not in .bigcommerce/project.json', a
 
 test('errors when access token is missing and not in .bigcommerce/project.json', async () => {
   const config = getProjectConfig();
+
   config.set('projectUuid', projectUuid);
   config.set('storeHash', storeHash);
   config.delete('accessToken');
 
   const savedAccessToken = process.env.CATALYST_ACCESS_TOKEN;
+
   delete process.env.CATALYST_ACCESS_TOKEN;
 
   await program.parseAsync(['node', 'catalyst', 'deploy']);

--- a/packages/catalyst/src/cli/commands/deploy.spec.ts
+++ b/packages/catalyst/src/cli/commands/deploy.spec.ts
@@ -346,6 +346,7 @@ test('errors when store hash is missing and not in .bigcommerce/project.json', a
 
   expect(consola.error).toHaveBeenCalledWith(
     expect.objectContaining({
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Vitest matcher return type is any
       message: expect.stringContaining('Store hash is required'),
     }),
   );
@@ -369,6 +370,7 @@ test('errors when access token is missing and not in .bigcommerce/project.json',
 
   expect(consola.error).toHaveBeenCalledWith(
     expect.objectContaining({
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Vitest matcher return type is any
       message: expect.stringContaining('Access token is required'),
     }),
   );

--- a/packages/catalyst/src/cli/commands/deploy.ts
+++ b/packages/catalyst/src/cli/commands/deploy.ts
@@ -374,9 +374,6 @@ export const deploy = new Command('deploy')
       const config = getProjectConfig();
       const storeHash = options.storeHash ?? config.get('storeHash');
       const accessToken = options.accessToken ?? config.get('accessToken');
-
-      await telemetry.identify(storeHash);
-
       const projectUuid = options.projectUuid ?? config.get('projectUuid');
 
       if (!projectUuid) {
@@ -384,6 +381,20 @@ export const deploy = new Command('deploy')
           'Project UUID is required. Please run either `catalyst project link` or `catalyst project create` or this command again with --project-uuid <uuid>.',
         );
       }
+
+      if (!storeHash) {
+        throw new Error(
+          'Store hash is required. Provide --store-hash (or set CATALYST_STORE_HASH), or run `catalyst project create` or `catalyst project link` with credentials to save it to .bigcommerce/project.json.',
+        );
+      }
+
+      if (!accessToken) {
+        throw new Error(
+          'Access token is required. Provide --access-token (or set CATALYST_ACCESS_TOKEN), or run `catalyst project create` or `catalyst project link` with credentials to save it to .bigcommerce/project.json.',
+        );
+      }
+
+      await telemetry.identify(storeHash);
 
       if (options.prebuilt) {
         const distDir = join(process.cwd(), '.bigcommerce', 'dist');
@@ -419,18 +430,6 @@ export const deploy = new Command('deploy')
         consola.info('- Create deployment');
 
         process.exit(0);
-      }
-
-      if (!storeHash) {
-        throw new Error(
-          'Store hash is required. Provide --store-hash (or set CATALYST_STORE_HASH), or run `catalyst project create` or `catalyst project link` with credentials to save it to .bigcommerce/project.json.',
-        );
-      }
-
-      if (!accessToken) {
-        throw new Error(
-          'Access token is required. Provide --access-token (or set CATALYST_ACCESS_TOKEN), or run `catalyst project create` or `catalyst project link` with credentials to save it to .bigcommerce/project.json.',
-        );
       }
 
       const uploadSignature = await generateUploadSignature(

--- a/packages/catalyst/src/cli/commands/deploy.ts
+++ b/packages/catalyst/src/cli/commands/deploy.ts
@@ -336,18 +336,14 @@ export const deploy = new Command('deploy')
   .addOption(
     new Option(
       '--store-hash <hash>',
-      'BigCommerce store hash. Can be found in the URL of your store Control Panel.',
-    )
-      .env('CATALYST_STORE_HASH')
-      .makeOptionMandatory(),
+      'BigCommerce store hash. Can be found in the URL of your store Control Panel. Read from .bigcommerce/project.json when not provided.',
+    ).env('CATALYST_STORE_HASH'),
   )
   .addOption(
     new Option(
       '--access-token <token>',
-      'BigCommerce access token. Can be found after creating a store-level API account.',
-    )
-      .env('CATALYST_ACCESS_TOKEN')
-      .makeOptionMandatory(),
+      'BigCommerce access token. Can be found after creating a store-level API account. Read from .bigcommerce/project.json when not provided.',
+    ).env('CATALYST_ACCESS_TOKEN'),
   )
   .addOption(
     new Option('--api-host <host>', 'BigCommerce API host. The default is api.bigcommerce.com.')
@@ -376,8 +372,10 @@ export const deploy = new Command('deploy')
   .action(async (options) => {
     try {
       const config = getProjectConfig();
+      const storeHash = options.storeHash ?? config.get('storeHash');
+      const accessToken = options.accessToken ?? config.get('accessToken');
 
-      await telemetry.identify(options.storeHash);
+      await telemetry.identify(storeHash);
 
       const projectUuid = options.projectUuid ?? config.get('projectUuid');
 
@@ -423,9 +421,21 @@ export const deploy = new Command('deploy')
         process.exit(0);
       }
 
+      if (!storeHash) {
+        throw new Error(
+          'Store hash is required. Provide --store-hash (or set CATALYST_STORE_HASH), or run `catalyst project create` or `catalyst project link` with credentials to save it to .bigcommerce/project.json.',
+        );
+      }
+
+      if (!accessToken) {
+        throw new Error(
+          'Access token is required. Provide --access-token (or set CATALYST_ACCESS_TOKEN), or run `catalyst project create` or `catalyst project link` with credentials to save it to .bigcommerce/project.json.',
+        );
+      }
+
       const uploadSignature = await generateUploadSignature(
-        options.storeHash,
-        options.accessToken,
+        storeHash,
+        accessToken,
         options.apiHost,
       );
 
@@ -436,16 +446,16 @@ export const deploy = new Command('deploy')
       const { deployment_uuid: deploymentUuid } = await createDeployment(
         projectUuid,
         uploadSignature.upload_uuid,
-        options.storeHash,
-        options.accessToken,
+        storeHash,
+        accessToken,
         options.apiHost,
         environmentVariables,
       );
 
       await getDeploymentStatus(
         deploymentUuid,
-        options.storeHash,
-        options.accessToken,
+        storeHash,
+        accessToken,
         options.apiHost,
       );
     } catch (error) {

--- a/packages/catalyst/src/cli/commands/deploy.ts
+++ b/packages/catalyst/src/cli/commands/deploy.ts
@@ -452,12 +452,7 @@ export const deploy = new Command('deploy')
         environmentVariables,
       );
 
-      await getDeploymentStatus(
-        deploymentUuid,
-        storeHash,
-        accessToken,
-        options.apiHost,
-      );
+      await getDeploymentStatus(deploymentUuid, storeHash, accessToken, options.apiHost);
     } catch (error) {
       consola.error(error);
       process.exit(1);

--- a/packages/catalyst/src/cli/commands/project.spec.ts
+++ b/packages/catalyst/src/cli/commands/project.spec.ts
@@ -122,6 +122,8 @@ describe('project create', () => {
 
     expect(config.get('projectUuid')).toBe('c23f5785-fd99-4a94-9fb3-945551623925');
     expect(config.get('framework')).toBe('catalyst');
+    expect(config.get('storeHash')).toBe(storeHash);
+    expect(config.get('accessToken')).toBe(accessToken);
 
     consolaPromptMock.mockRestore();
   });
@@ -212,7 +214,7 @@ describe('project list', () => {
 
     expect(consola.error).toHaveBeenCalledWith('Insufficient information to list projects.');
     expect(consola.info).toHaveBeenCalledWith(
-      'Provide both --store-hash and --access-token (or set CATALYST_STORE_HASH and CATALYST_ACCESS_TOKEN).',
+      'Provide both --store-hash and --access-token (or set CATALYST_STORE_HASH and CATALYST_ACCESS_TOKEN), or run from a project that has been linked with credentials.',
     );
     expect(exitMock).toHaveBeenCalledWith(1);
   });
@@ -313,6 +315,8 @@ describe('project link', () => {
 
     expect(config.get('projectUuid')).toBe(projectUuid2);
     expect(config.get('framework')).toBe('catalyst');
+    expect(config.get('storeHash')).toBe(storeHash);
+    expect(config.get('accessToken')).toBe(accessToken);
 
     consolaPromptMock.mockRestore();
   });
@@ -368,6 +372,8 @@ describe('project link', () => {
 
     expect(config.get('projectUuid')).toBe(projectUuid3);
     expect(config.get('framework')).toBe('catalyst');
+    expect(config.get('storeHash')).toBe(storeHash);
+    expect(config.get('accessToken')).toBe(accessToken);
 
     consolaPromptMock.mockRestore();
   });

--- a/packages/catalyst/src/cli/commands/project.ts
+++ b/packages/catalyst/src/cli/commands/project.ts
@@ -28,21 +28,25 @@ const list = new Command('list')
   )
   .action(async (options) => {
     try {
-      if (!options.storeHash || !options.accessToken) {
+      const config = getProjectConfig();
+      const storeHash = options.storeHash ?? config.get('storeHash');
+      const accessToken = options.accessToken ?? config.get('accessToken');
+
+      if (!storeHash || !accessToken) {
         consola.error('Insufficient information to list projects.');
         consola.info(
-          'Provide both --store-hash and --access-token (or set CATALYST_STORE_HASH and CATALYST_ACCESS_TOKEN).',
+          'Provide both --store-hash and --access-token (or set CATALYST_STORE_HASH and CATALYST_ACCESS_TOKEN), or run from a project that has been linked with credentials.',
         );
         process.exit(1);
 
         return;
       }
 
-      await telemetry.identify(options.storeHash);
+      await telemetry.identify(storeHash);
 
       consola.start('Fetching projects...');
 
-      const projects = await fetchProjects(options.storeHash, options.accessToken, options.apiHost);
+      const projects = await fetchProjects(storeHash, accessToken, options.apiHost);
 
       consola.success('Projects fetched.');
 
@@ -122,6 +126,8 @@ const create = new Command('create')
       consola.start('Writing project UUID to .bigcommerce/project.json...');
       config.set('projectUuid', data.uuid);
       config.set('framework', 'catalyst');
+      config.set('storeHash', options.storeHash);
+      config.set('accessToken', options.accessToken);
       consola.success('Project UUID written to .bigcommerce/project.json.');
 
       process.exit(0);
@@ -165,10 +171,17 @@ export const link = new Command('link')
     try {
       const config = getProjectConfig(options.rootDir);
 
-      const writeProjectConfig = (uuid: string) => {
+      const writeProjectConfig = (
+        uuid: string,
+        credentials?: { storeHash: string; accessToken: string },
+      ) => {
         consola.start('Writing project UUID to .bigcommerce/project.json...');
         config.set('projectUuid', uuid);
         config.set('framework', 'catalyst');
+        if (credentials) {
+          config.set('storeHash', credentials.storeHash);
+          config.set('accessToken', credentials.accessToken);
+        }
         consola.success('Project UUID written to .bigcommerce/project.json.');
       };
 
@@ -230,7 +243,10 @@ export const link = new Command('link')
           consola.success(`Project "${data.name}" created successfully.`);
         }
 
-        writeProjectConfig(projectUuid);
+        writeProjectConfig(projectUuid, {
+          storeHash: options.storeHash,
+          accessToken: options.accessToken,
+        });
 
         process.exit(0);
       }

--- a/packages/catalyst/src/cli/commands/project.ts
+++ b/packages/catalyst/src/cli/commands/project.ts
@@ -178,10 +178,12 @@ export const link = new Command('link')
         consola.start('Writing project UUID to .bigcommerce/project.json...');
         config.set('projectUuid', uuid);
         config.set('framework', 'catalyst');
+
         if (credentials) {
           config.set('storeHash', credentials.storeHash);
           config.set('accessToken', credentials.accessToken);
         }
+
         consola.success('Project UUID written to .bigcommerce/project.json.');
       };
 

--- a/packages/catalyst/src/cli/lib/project-config.spec.ts
+++ b/packages/catalyst/src/cli/lib/project-config.spec.ts
@@ -40,10 +40,12 @@ test('writes and reads field from .bigcommerce/project.json', async () => {
   await writeFile(projectJsonPath, JSON.stringify({}));
 
   config.set('projectUuid', projectUuid);
+  config.set('storeHash', 'abc123');
+  config.set('accessToken', 'secret-token');
 
-  const modifiedProjectUuid = config.get('projectUuid');
-
-  expect(modifiedProjectUuid).toBe(projectUuid);
+  expect(config.get('projectUuid')).toBe(projectUuid);
+  expect(config.get('storeHash')).toBe('abc123');
+  expect(config.get('accessToken')).toBe('secret-token');
 });
 
 test('sets default framework to nextjs', async () => {

--- a/packages/catalyst/src/cli/lib/project-config.ts
+++ b/packages/catalyst/src/cli/lib/project-config.ts
@@ -4,6 +4,8 @@ import { join } from 'path';
 export interface ProjectConfigSchema {
   projectUuid: string;
   framework: 'catalyst' | 'nextjs';
+  storeHash?: string;
+  accessToken?: string;
   telemetry: {
     enabled: boolean;
     anonymousId: string;
@@ -22,6 +24,8 @@ export function getProjectConfig(rootDir = process.cwd()) {
         enum: ['catalyst', 'nextjs'],
         default: 'nextjs',
       },
+      storeHash: { type: 'string' },
+      accessToken: { type: 'string' },
       telemetry: {
         type: 'object',
         properties: {


### PR DESCRIPTION
## What/Why?
Write additional config variables to project.json file so that we have a centralized place for all required variables.

`projectUuid`
`framework`
`storeHash`
`accessToken`

## Testing
`pnpm build --filter @bigcommerce/catalyst` compiles without errors
`pnpm --filter @bigcommerce/catalyst test` — all 44 tests pass

Manually, you can run a `project create` command and verify that the 4 properties above are written to the `project.json` file.

