### PR TITLE
CATALYST-1744 - Remove default loading of environment variable files

### DIFF
--- a/.changeset/curvy-pandas-stop.md
+++ b/.changeset/curvy-pandas-stop.md
@@ -1,0 +1,9 @@
+---
+"@bigcommerce/catalyst": patch
+---
+
+Remove the reading of default environment variable files.
+
+## Migration
+
+Ensure that environment variables are passed explicitly using flags if they are not already included in the `project.json` config file.

--- a/packages/catalyst/src/cli/program.ts
+++ b/packages/catalyst/src/cli/program.ts
@@ -1,7 +1,5 @@
 import { Command } from 'commander';
 import { colorize } from 'consola/utils';
-import { config } from 'dotenv';
-import { resolve } from 'node:path';
 
 import PACKAGE_INFO from '../../package.json';
 
@@ -16,16 +14,6 @@ import { telemetryPostHook, telemetryPreHook } from './hooks/telemetry';
 import { consola } from './lib/logger';
 
 export const program = new Command();
-
-config({
-  path: [
-    resolve(process.cwd(), '.env'),
-    resolve(process.cwd(), '.env.local'),
-    // Assumes the parent directory is the monorepo root:
-    resolve(process.cwd(), '..', '.env'),
-    resolve(process.cwd(), '..', '.env.local'),
-  ],
-});
 
 consola.log(colorize('cyanBright', `◢ ${PACKAGE_INFO.name} v${PACKAGE_INFO.version}\n`));
 


### PR DESCRIPTION
## What/Why?
Remove the reading of default environment variable files. 

## Testing
`pnpm build --filter @bigcommerce/catalyst` compiles without errors
`pnpm --filter @bigcommerce/catalyst test` — all tests pass

TO manually test. First, delete an existing `.bigcommerce/project.json` file if it exists. Then, show that running `catalyst project create` will not work if you don't pass variables in explicit flags.

## Migration
Pass environment variable files explicitly using flags in the command or include them in your project.json
