### PR TITLE
feat(cli): add whoami command

### DIFF
--- a/.changeset/brave-maps-arrive.md
+++ b/.changeset/brave-maps-arrive.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst": minor
+---
+
+Add `catalyst whoami` command to verify stored credentials and display store/project info.

--- a/packages/catalyst/src/cli/commands/auth.ts
+++ b/packages/catalyst/src/cli/commands/auth.ts
@@ -1,0 +1,106 @@
+import { Command, Option } from 'commander';
+import { z } from 'zod';
+
+import { consola } from '../lib/logger';
+import { fetchProjects } from '../lib/project';
+import { getProjectConfig } from '../lib/project-config';
+
+const StoreProfileSchema = z.object({
+  data: z.object({
+    store_name: z.string(),
+  }),
+});
+
+async function fetchStoreProfile(storeHash: string, accessToken: string, apiHost: string) {
+  const response = await fetch(`https://${apiHost}/stores/${storeHash}/v3/settings/store/profile`, {
+    method: 'GET',
+    headers: {
+      'X-Auth-Token': accessToken,
+      Accept: 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`);
+  }
+
+  const res: unknown = await response.json();
+  const { data } = StoreProfileSchema.parse(res);
+
+  return data;
+}
+
+const whoami = new Command('whoami')
+  .description('Verify stored credentials and display store/project info.')
+  .addOption(
+    new Option(
+      '--store-hash <hash>',
+      'BigCommerce store hash. Can be found in the URL of your store Control Panel.',
+    ).env('CATALYST_STORE_HASH'),
+  )
+  .addOption(
+    new Option(
+      '--access-token <token>',
+      'BigCommerce access token. Can be found after creating a store-level API account.',
+    ).env('CATALYST_ACCESS_TOKEN'),
+  )
+  .addOption(
+    new Option('--api-host <host>', 'BigCommerce API host. The default is api.bigcommerce.com.')
+      .env('BIGCOMMERCE_API_HOST')
+      .default('api.bigcommerce.com'),
+  )
+  .action(async (options) => {
+    try {
+      const config = getProjectConfig();
+
+      const storeHash = options.storeHash ?? config.get('storeHash');
+      const accessToken = options.accessToken ?? config.get('accessToken');
+
+      if (!storeHash || !accessToken) {
+        consola.info('Not logged in: no credentials found.');
+        consola.info(
+          'Provide --store-hash and --access-token flags, set CATALYST_STORE_HASH and CATALYST_ACCESS_TOKEN environment variables, or run `catalyst project create` / `catalyst project link` with credentials.',
+        );
+        process.exit(1);
+
+        return;
+      }
+
+      const store = await fetchStoreProfile(storeHash, accessToken, options.apiHost);
+
+      const projectUuid = config.get('projectUuid');
+
+      if (projectUuid) {
+        const projects = await fetchProjects(storeHash, accessToken, options.apiHost);
+        const linkedProject = projects.find((p) => p.uuid === projectUuid);
+
+        if (linkedProject) {
+          consola.info(
+            `Logged in to ${store.store_name} (${storeHash}), connected to project ${linkedProject.name} (${projectUuid})`,
+          );
+        } else {
+          consola.info(
+            `Logged in to ${store.store_name} (${storeHash}), project ${projectUuid} not found`,
+          );
+        }
+      } else {
+        consola.info(`Logged in to ${store.store_name} (${storeHash})`);
+      }
+
+      process.exit(0);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+
+      if (message.includes('401') || message.includes('403')) {
+        consola.error(`Not logged in: invalid credentials (${message})`);
+      } else {
+        consola.error(`Failed to verify credentials: ${message}`);
+      }
+
+      process.exit(1);
+    }
+  });
+
+export const auth = new Command('auth')
+  .description('Manage authentication for the BigCommerce CLI.')
+  .addCommand(whoami);

--- a/packages/catalyst/src/cli/program.ts
+++ b/packages/catalyst/src/cli/program.ts
@@ -3,6 +3,7 @@ import { colorize } from 'consola/utils';
 
 import PACKAGE_INFO from '../../package.json';
 
+import { auth } from './commands/auth';
 import { build } from './commands/build';
 import { deploy } from './commands/deploy';
 import { dev } from './commands/dev';
@@ -27,6 +28,7 @@ program
   .addCommand(build)
   .addCommand(deploy)
   .addCommand(project)
+  .addCommand(auth)
   .addCommand(telemetry)
   .hook('preAction', telemetryPreHook)
   .hook('postAction', telemetryPostHook);

--- a/packages/catalyst/tests/mocks/handlers.ts
+++ b/packages/catalyst/tests/mocks/handlers.ts
@@ -74,6 +74,15 @@ export const handlers = [
     },
   ),
 
+  // Handler for fetchStoreProfile (auth whoami)
+  http.get('https://:apiHost/stores/:storeHash/v3/settings/store/profile', () =>
+    HttpResponse.json({
+      data: {
+        store_name: 'Test Store',
+      },
+    }),
+  ),
+
   // Handle for createProjects
   http.post('https://:apiHost/stores/:storeHash/v3/infrastructure/projects', () =>
     HttpResponse.json({


### PR DESCRIPTION
## What/Why?

CATALYST-1759: Adds a `catalyst whoami` command that verifies stored credentials and displays store/project info.

Credential resolution follows the same priority as other CLI commands: CLI flags → env vars (`CATALYST_STORE_HASH`, `CATALYST_ACCESS_TOKEN`) → `.bigcommerce/project.json` config. Calls the V2 Store Information API to verify the token and fetch the store name, and optionally looks up the linked project name if `projectUuid` is set in config.

**Dependency on #2876 (CATALYST-1744):** This branch adds `storeHash`/`accessToken` to `ProjectConfigSchema` so it works standalone. The rebase onto `alpha` after #2876 merges will be a trivial conflict.

### Changes
- **`packages/catalyst/src/cli/commands/whoami.ts`** — new `whoami` command
- **`packages/catalyst/src/cli/lib/project-config.ts`** — add `storeHash`/`accessToken` to schema (matches #2876)
- **`packages/catalyst/src/cli/program.ts`** — register `whoami` command
- **`packages/catalyst/tests/mocks/handlers.ts`** — add MSW handler for `GET /v2/store`

## Testing

```bash
# no credentials — helpful message
catalyst whoami

# with flags — displays store info
catalyst whoami --store-hash <hash> --access-token <token>

# invalid token — reports auth error
catalyst whoami --store-hash <hash> --access-token bad-token

# via env vars
CATALYST_STORE_HASH=xxx CATALYST_ACCESS_TOKEN=yyy catalyst whoami
```

Build, lint, and all 47 existing tests pass.

## Migration

None.