### PR TITLE
feat(ci): enable unlighthouse performance audits for vercel

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -38,6 +38,6 @@ jobs:
         if: failure() || success()
         uses: actions/upload-artifact@v4
         with:
-          name: unlighthouse-${{ matrix.device }}-report
+          name: unlighthouse-vercel-${{ matrix.device }}-report
           path: './.unlighthouse/'
           include-hidden-files: 'true'

--- a/unlighthouse.config.ts
+++ b/unlighthouse.config.ts
@@ -15,6 +15,28 @@ export default {
     // Run each page multiple times and use the median to absorb cold start
     // outliers across all discovered pages.
     samples: 3,
+    // Only audit one representative URL per unique page template. PLP/PDP and
+    // other dynamic routes share the same layout, so scanning more instances of
+    // the same template yields redundant data.
+    include: [
+      "/",
+      "/fog-linen-chambray-towel-beige-stripe", // PDP
+      "/bath", // PLP categories
+      "/brands/ofs", // PLP brands
+      "/search",
+      "/cart",
+      "/login",
+      "/login/forgot-password",
+      "/register",
+      "/blog",
+      "/your-first-blog-post", // Blog post
+      "/compare",
+      "/gift-certificates", // Gift certificates page
+      "/gift-certificates/balance", // Gift certificates balance page
+      "/gift-certificates/purchase", // Gift certificates purchase page
+      "/contact-us",
+      "/shipping-returns",
+    ],
   },
   lighthouseOptions: {
     onlyCategories: ["best-practices", "accessibility", "seo", "performance"],

--- a/unlighthouse.config.ts
+++ b/unlighthouse.config.ts
@@ -31,9 +31,8 @@ export default {
       "/smith-journal-13/|/dustpan-brush/|/utility-caddy/|/canvas-laundry-cart/|/laundry-detergent/|/tiered-wire-basket/|/oak-cheese-grater/|/1-l-le-parfait-jar/|/chemex-coffeemaker-3-cup/|/sample-able-brewing-system/|/orbit-terrarium-small/|/orbit-terrarium-large/|/fog-linen-chambray-towel-beige-stripe/|/zz-plant/":
         { name: "PDP" },
       "/shop-all/|/bath/|/garden/|/kitchen/|/publications/|/early-access/": {
-        name: "Categories PLP",
+        name: "PLP",
       },
-      "/brands.*": { name: "Brands PLP" },
     },
     // Disable throttling to avoid issues with cold start and cold cache.
     throttle: false,

--- a/unlighthouse.config.ts
+++ b/unlighthouse.config.ts
@@ -11,37 +11,10 @@ export default {
       // performance: 80,
     },
   },
-  puppeteerClusterOptions: {
-    // Limit to one concurrent Lighthouse instance to mitigate hardware-throttling
-    // false positives that previously caused us to disable the performance category.
-    maxConcurrency: 1,
-  },
   scanner: {
     // Run each page multiple times and use the median to absorb cold start
-    // outliers across all discovered pages (no explicit warm-up step needed).
+    // outliers across all discovered pages.
     samples: 3,
-    // Only audit one representative URL per unique page template. PLP/PDP and
-    // other dynamic routes share the same layout, so scanning more instances of
-    // the same template yields redundant data.
-    include: [
-      "/",
-      "/fog-linen-chambray-towel-beige-stripe", // PDP
-      "/bath", // PLP categories
-      "/brands/ofs", // PLP brands
-      "/search",
-      "/cart",
-      "/login",
-      "/login/forgot-password",
-      "/register",
-      "/blog",
-      "/your-first-blog-post", // Blog post
-      "/compare",
-      "/gift-certificates", // Gift certificates page
-      "/gift-certificates/balance", // Gift certificates balance page
-      "/gift-certificates/purchase", // Gift certificates purchase page
-      "/contact-us",
-      "/shipping-returns",
-    ],
   },
   lighthouseOptions: {
     onlyCategories: ["best-practices", "accessibility", "seo", "performance"],

--- a/unlighthouse.config.ts
+++ b/unlighthouse.config.ts
@@ -28,8 +28,10 @@ export default {
     customSampling: {
       "/smith-journal-13/|/dustpan-brush/|/utility-caddy/|/canvas-laundry-cart/|/laundry-detergent/|/tiered-wire-basket/|/oak-cheese-grater/|/1-l-le-parfait-jar/|/chemex-coffeemaker-3-cup/|/sample-able-brewing-system/|/orbit-terrarium-small/|/orbit-terrarium-large/|/fog-linen-chambray-towel-beige-stripe/|/zz-plant/":
         { name: "PDP" },
-      "/shop-all/|/bath/|/garden/|/kitchen/|/publications/|/early-access/|/brands.*|":
-        { name: "PLP" },
+      "/shop-all/|/bath/|/garden/|/kitchen/|/publications/|/early-access/": {
+        name: "Categories PLP",
+      },
+      "/brands.*": { name: "Brands PLP" },
     },
   },
   lighthouseOptions: {

--- a/unlighthouse.config.ts
+++ b/unlighthouse.config.ts
@@ -17,8 +17,8 @@ export default {
     samples: 3,
     dynamicSampling: 5,
     exclude: [
-      "/bundleb2b.*",
-      "/invoices.*",
+      "/bundleb2b/",
+      "/invoices/",
       "/bath/*/*",
       "/garden/*/*",
       "/kitchen/*/*",

--- a/unlighthouse.config.ts
+++ b/unlighthouse.config.ts
@@ -17,8 +17,8 @@ export default {
     samples: 3,
     dynamicSampling: 5,
     exclude: [
-      "/bundleb2b*",
-      "/invoices*",
+      "/bundleb2b.*",
+      "/invoices.*",
       "/bath/*/*",
       "/garden/*/*",
       "/kitchen/*/*",

--- a/unlighthouse.config.ts
+++ b/unlighthouse.config.ts
@@ -4,17 +4,27 @@ import type { UserConfig } from 'unlighthouse';
 export default {
   ci: {
     buildStatic: true,
-    // Disabling the budget so we can audit and fix the issues first
     budget: {
       // "best-practices": 100,
       // "accessibility": 100,
       // "seo": 100,
+      performance: 80,
     },
-  }, 
+  },
+  scanner: {
+    // Run each page multiple times and use the median to absorb cold start
+    // outliers across all discovered pages (no explicit warm-up step needed).
+    samples: 5,
+  },
+  puppeteerClusterOptions: {
+    // Limit to one concurrent Lighthouse instance to mitigate hardware-throttling
+    // false positives that previously caused us to disable the performance category.
+    maxConcurrency: 1,
+  },
   lighthouseOptions: {
-    // Disabling performance tests because lighthouse utilizes hardware throttling. This affects concurrently running tests which might lead to false positives.
-    // The best way to truly measure performance is to use real user metrics – Vercel's Speed Insights is a great tool for that.
-    onlyCategories: ['best-practices', 'accessibility', 'seo'],
+    // Performance re-enabled — hardware throttling concerns are mitigated by
+    // maxConcurrency: 1 (no concurrent runs) and samples: 3 (median smoothing).
+    onlyCategories: ['best-practices', 'accessibility', 'seo', 'performance'],
     skipAudits: [
       // Disabling `is-crawlable` as it's more relevant for production sites.
       'is-crawlable',
@@ -22,6 +32,6 @@ export default {
       'third-party-cookies',
       // Disabling inspector issues as it's only providing third-party cookie issues, which are not relevant for our audits.
       'inspector-issues',
-    ]
-  }
+    ],
+  },
 } satisfies UserConfig;

--- a/unlighthouse.config.ts
+++ b/unlighthouse.config.ts
@@ -15,14 +15,7 @@ export default {
     // outliers across all discovered pages (no explicit warm-up step needed).
     samples: 3,
   },
-  puppeteerClusterOptions: {
-    // Limit to one concurrent Lighthouse instance to mitigate hardware-throttling
-    // false positives that previously caused us to disable the performance category.
-    maxConcurrency: 1,
-  },
   lighthouseOptions: {
-    // Performance re-enabled — hardware throttling concerns are mitigated by
-    // maxConcurrency: 1 (no concurrent runs) and samples: 3 (median smoothing).
     onlyCategories: ["best-practices", "accessibility", "seo", "performance"],
     skipAudits: [
       // Disabling `is-crawlable` as it's more relevant for production sites.

--- a/unlighthouse.config.ts
+++ b/unlighthouse.config.ts
@@ -3,6 +3,7 @@ import type { UserConfig } from "unlighthouse";
 export default {
   ci: {
     buildStatic: true,
+    reporter: "jsonExpanded",
     budget: {
       // "best-practices": 100,
       // "accessibility": 100,

--- a/unlighthouse.config.ts
+++ b/unlighthouse.config.ts
@@ -11,33 +11,6 @@ export default {
       // performance: 80,
     },
   },
-  scanner: {
-    // Run each page multiple times and use the median to absorb cold start
-    // outliers across all discovered pages.
-    samples: 3,
-    // Only audit one representative URL per unique page template. PLP/PDP and
-    // other dynamic routes share the same layout, so scanning more instances of
-    // the same template yields redundant data.
-    include: [
-      "/",
-      "/fog-linen-chambray-towel-beige-stripe", // PDP
-      "/bath", // PLP categories
-      "/brands/ofs", // PLP brands
-      "/search",
-      "/cart",
-      "/login",
-      "/login/forgot-password",
-      "/register",
-      "/blog",
-      "/your-first-blog-post", // Blog post
-      "/compare",
-      "/gift-certificates", // Gift certificates page
-      "/gift-certificates/balance", // Gift certificates balance page
-      "/gift-certificates/purchase", // Gift certificates purchase page
-      "/contact-us",
-      "/shipping-returns",
-    ],
-  },
   lighthouseOptions: {
     onlyCategories: ["best-practices", "accessibility", "seo", "performance"],
     skipAudits: [

--- a/unlighthouse.config.ts
+++ b/unlighthouse.config.ts
@@ -11,6 +11,11 @@ export default {
       // performance: 80,
     },
   },
+  puppeteerClusterOptions: {
+    // Limit to one concurrent Lighthouse instance to mitigate hardware-throttling
+    // false positives that previously caused us to disable the performance category.
+    maxConcurrency: 1,
+  },
   scanner: {
     // Run each page multiple times and use the median to absorb cold start
     // outliers across all discovered pages.

--- a/unlighthouse.config.ts
+++ b/unlighthouse.config.ts
@@ -1,5 +1,4 @@
-
-import type { UserConfig } from 'unlighthouse';
+import type { UserConfig } from "unlighthouse";
 
 export default {
   ci: {
@@ -14,7 +13,7 @@ export default {
   scanner: {
     // Run each page multiple times and use the median to absorb cold start
     // outliers across all discovered pages (no explicit warm-up step needed).
-    samples: 5,
+    samples: 3,
   },
   puppeteerClusterOptions: {
     // Limit to one concurrent Lighthouse instance to mitigate hardware-throttling
@@ -24,14 +23,14 @@ export default {
   lighthouseOptions: {
     // Performance re-enabled — hardware throttling concerns are mitigated by
     // maxConcurrency: 1 (no concurrent runs) and samples: 3 (median smoothing).
-    onlyCategories: ['best-practices', 'accessibility', 'seo', 'performance'],
+    onlyCategories: ["best-practices", "accessibility", "seo", "performance"],
     skipAudits: [
       // Disabling `is-crawlable` as it's more relevant for production sites.
-      'is-crawlable',
+      "is-crawlable",
       // Disabling third-party cookies because the only third-party cookies we have is provided through Cloudflare for our CDN, which is not relevant for our audits.
-      'third-party-cookies',
+      "third-party-cookies",
       // Disabling inspector issues as it's only providing third-party cookie issues, which are not relevant for our audits.
-      'inspector-issues',
+      "inspector-issues",
     ],
   },
 } satisfies UserConfig;

--- a/unlighthouse.config.ts
+++ b/unlighthouse.config.ts
@@ -11,11 +11,6 @@ export default {
       // performance: 80,
     },
   },
-  puppeteerClusterOptions: {
-    // Limit to one concurrent Lighthouse instance to mitigate hardware-throttling
-    // false positives that previously caused us to disable the performance category.
-    maxConcurrency: 1,
-  },
   scanner: {
     // Run each page multiple times and use the median to absorb cold start
     // outliers across all discovered pages.

--- a/unlighthouse.config.ts
+++ b/unlighthouse.config.ts
@@ -7,13 +7,39 @@ export default {
       // "best-practices": 100,
       // "accessibility": 100,
       // "seo": 100,
-      performance: 80,
+      // performance: 80,
     },
+  },
+  puppeteerClusterOptions: {
+    // Limit to one concurrent Lighthouse instance to mitigate hardware-throttling
+    // false positives that previously caused us to disable the performance category.
+    maxConcurrency: 1,
   },
   scanner: {
     // Run each page multiple times and use the median to absorb cold start
     // outliers across all discovered pages (no explicit warm-up step needed).
     samples: 3,
+    // Only audit one representative URL per unique page template. PLP/PDP and
+    // other dynamic routes share the same layout, so scanning more instances of
+    // the same template yields redundant data.
+    include: [
+      "/",
+      "/fog-linen-chambray-towel-beige-stripe", // PDP
+      "/shop-all", // PLP categories
+      "/brands/ofs", // PLP brands
+      "/search",
+      "/cart",
+      "/login",
+      "/register",
+      "/blog",
+      "/your-first-blog-post", // Blog post
+      "/compare",
+      "/gift-certificates", // Gift certificates page
+      "/gift-certificates/balance", // Gift certificates balance page
+      "/gift-certificates/purchase", // Gift certificates purchase page
+      "/contact-us",
+      "/shipping-returns",
+    ],
   },
   lighthouseOptions: {
     onlyCategories: ["best-practices", "accessibility", "seo", "performance"],

--- a/unlighthouse.config.ts
+++ b/unlighthouse.config.ts
@@ -25,11 +25,12 @@ export default {
     include: [
       "/",
       "/fog-linen-chambray-towel-beige-stripe", // PDP
-      "/shop-all", // PLP categories
+      "/bath", // PLP categories
       "/brands/ofs", // PLP brands
       "/search",
       "/cart",
       "/login",
+      "/login/forgot-password",
       "/register",
       "/blog",
       "/your-first-blog-post", // Blog post

--- a/unlighthouse.config.ts
+++ b/unlighthouse.config.ts
@@ -15,7 +15,7 @@ export default {
     // Run each page multiple times and use the median to absorb cold start
     // outliers across all discovered pages.
     samples: 3,
-    dynamicSampling: 6,
+    dynamicSampling: 5,
     exclude: [
       "/bundleb2b/",
       "/invoices/",

--- a/unlighthouse.config.ts
+++ b/unlighthouse.config.ts
@@ -11,6 +11,11 @@ export default {
       // performance: 80,
     },
   },
+  scanner: {
+    // Run each page multiple times and use the median to absorb cold start
+    // outliers across all discovered pages.
+    samples: 3,
+  },
   lighthouseOptions: {
     onlyCategories: ["best-practices", "accessibility", "seo", "performance"],
     skipAudits: [

--- a/unlighthouse.config.ts
+++ b/unlighthouse.config.ts
@@ -35,6 +35,8 @@ export default {
       },
       "/brands.*": { name: "Brands PLP" },
     },
+    // Disable throttling to avoid issues with cold start and cold cache.
+    throttle: false,
   },
   lighthouseOptions: {
     onlyCategories: ["best-practices", "accessibility", "seo", "performance"],

--- a/unlighthouse.config.ts
+++ b/unlighthouse.config.ts
@@ -15,7 +15,7 @@ export default {
     // Run each page multiple times and use the median to absorb cold start
     // outliers across all discovered pages.
     samples: 3,
-    dynamicSampling: 5,
+    dynamicSampling: 6,
     exclude: [
       "/bundleb2b/",
       "/invoices/",
@@ -24,6 +24,8 @@ export default {
       "/kitchen/*/*",
       "/publications/*/*",
       "/early-access/*/*",
+      "/digital-test-product/",
+      "/blog/\\?tag=*",
     ],
     customSampling: {
       "/smith-journal-13/|/dustpan-brush/|/utility-caddy/|/canvas-laundry-cart/|/laundry-detergent/|/tiered-wire-basket/|/oak-cheese-grater/|/1-l-le-parfait-jar/|/chemex-coffeemaker-3-cup/|/sample-able-brewing-system/|/orbit-terrarium-small/|/orbit-terrarium-large/|/fog-linen-chambray-towel-beige-stripe/|/zz-plant/":

--- a/unlighthouse.config.ts
+++ b/unlighthouse.config.ts
@@ -15,6 +15,22 @@ export default {
     // Run each page multiple times and use the median to absorb cold start
     // outliers across all discovered pages.
     samples: 3,
+    dynamicSampling: 5,
+    exclude: [
+      "/bundleb2b*",
+      "/invoices*",
+      "/bath/*/*",
+      "/garden/*/*",
+      "/kitchen/*/*",
+      "/publications/*/*",
+      "/early-access/*/*",
+    ],
+    customSampling: {
+      "/smith-journal-13/|/dustpan-brush/|/utility-caddy/|/canvas-laundry-cart/|/laundry-detergent/|/tiered-wire-basket/|/oak-cheese-grater/|/1-l-le-parfait-jar/|/chemex-coffeemaker-3-cup/|/sample-able-brewing-system/|/orbit-terrarium-small/|/orbit-terrarium-large/|/fog-linen-chambray-towel-beige-stripe/|/zz-plant/":
+        { name: "PDP" },
+      "/shop-all/|/bath/|/garden/|/kitchen/|/publications/|/early-access/|/brands.*|":
+        { name: "PLP" },
+    },
   },
   lighthouseOptions: {
     onlyCategories: ["best-practices", "accessibility", "seo", "performance"],


### PR DESCRIPTION
## What/Why?
Re-enable the performance category in Unlighthouse with mitigations for hardware throttling: maxConcurrency=1 and samples=3 for stable medians. Limit testing to known paths to remove redundant testing (PDP and PLP). Rename artifacts with a "vercel" label for future cross-platform comparison.

## Testing
Unlighthouse mobile and desktop reports below

## Migration
N/A
