### PR TITLE
[Catalyst-1744] Ignore `.bigcommerce` directory in `core`

### DIFF
--- a/.changeset/kind-hairs-study.md
+++ b/.changeset/kind-hairs-study.md
@@ -1,5 +1,0 @@
----
-"@bigcommerce/catalyst": patch
----
-
-Ignore .bigcommerce folder in the core directory since the project.json file can contain sensitive variables

--- a/.changeset/kind-hairs-study.md
+++ b/.changeset/kind-hairs-study.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst": patch
+---
+
+Ignore .bigcommerce folder in the core directory since the project.json file can contain sensitive variables

--- a/core/.gitignore
+++ b/core/.gitignore
@@ -54,3 +54,5 @@ build-config.json
 # OpenNext
 .open-next
 .wrangler
+
+.bigcommerce

--- a/core/.gitignore
+++ b/core/.gitignore
@@ -55,4 +55,5 @@ build-config.json
 .open-next
 .wrangler
 
+# Catalyst CLI config
 .bigcommerce


### PR DESCRIPTION
## What/Why?
Ignore the `.bigcommerce` directory inside of the `core` directory since the `project.json` file might contain private variables.

## Testing
Ensure `core/.bigcommerce` directory is not checked into source control.

## Migration
Ensure `core/.bigcommerce` directory is not checked into source control.