### PR TITLE
feat(cli): integrate stored auth into existing commands

### DIFF
--- a/packages/catalyst/src/cli/commands/auth.spec.ts
+++ b/packages/catalyst/src/cli/commands/auth.spec.ts
@@ -91,6 +91,9 @@ describe('whoami', () => {
     await program.parseAsync(['node', 'catalyst', 'auth', 'whoami']);
 
     expect(consola.info).toHaveBeenCalledWith('Not logged in: no credentials found.');
+    expect(consola.info).toHaveBeenCalledWith(
+      'Run `catalyst auth login`, or provide --store-hash and --access-token flags (or set CATALYST_STORE_HASH and CATALYST_ACCESS_TOKEN environment variables).',
+    );
     expect(exitMock).toHaveBeenCalledWith(1);
   });
 

--- a/packages/catalyst/src/cli/commands/auth.ts
+++ b/packages/catalyst/src/cli/commands/auth.ts
@@ -67,7 +67,7 @@ const whoami = new Command('whoami')
       if (!storeHash || !accessToken) {
         consola.info('Not logged in: no credentials found.');
         consola.info(
-          'Provide --store-hash and --access-token flags, set CATALYST_STORE_HASH and CATALYST_ACCESS_TOKEN environment variables, or run `catalyst project create` / `catalyst project link` with credentials.',
+          'Run `catalyst auth login`, or provide --store-hash and --access-token flags (or set CATALYST_STORE_HASH and CATALYST_ACCESS_TOKEN environment variables).',
         );
         process.exit(1);
 

--- a/packages/catalyst/src/cli/commands/deploy.spec.ts
+++ b/packages/catalyst/src/cli/commands/deploy.spec.ts
@@ -339,8 +339,11 @@ test('errors when store hash is missing and not in .bigcommerce/project.json', a
   vi.stubEnv('CATALYST_STORE_HASH', undefined);
 
   await expect(program.parseAsync(['node', 'catalyst', 'deploy'])).rejects.toThrow(
-    'Store hash is required',
+    'Missing credentials',
   );
+
+  expect(consola.error).toHaveBeenCalledWith('Missing credentials.');
+  expect(exitMock).toHaveBeenCalledWith(1);
 
   vi.unstubAllEnvs();
 });
@@ -355,8 +358,11 @@ test('errors when access token is missing and not in .bigcommerce/project.json',
   vi.stubEnv('CATALYST_ACCESS_TOKEN', undefined);
 
   await expect(program.parseAsync(['node', 'catalyst', 'deploy'])).rejects.toThrow(
-    'Access token is required',
+    'Missing credentials',
   );
+
+  expect(consola.error).toHaveBeenCalledWith('Missing credentials.');
+  expect(exitMock).toHaveBeenCalledWith(1);
 
   vi.unstubAllEnvs();
 });

--- a/packages/catalyst/src/cli/commands/deploy.ts
+++ b/packages/catalyst/src/cli/commands/deploy.ts
@@ -8,6 +8,7 @@ import { z } from 'zod';
 import { getDeploymentErrorMessage } from '../lib/deployment-errors';
 import { consola } from '../lib/logger';
 import { getProjectConfig } from '../lib/project-config';
+import { resolveCredentials } from '../lib/resolve-credentials';
 import { getTelemetry } from '../lib/telemetry';
 
 import { buildCatalystProject } from './build';
@@ -373,26 +374,13 @@ export const deploy = new Command('deploy')
   )
   .action(async (options) => {
     const config = getProjectConfig();
-    const storeHash = options.storeHash ?? config.get('storeHash');
-    const accessToken = options.accessToken ?? config.get('accessToken');
+    const { storeHash, accessToken } = resolveCredentials(options, config);
     const telemetry = getTelemetry();
     const projectUuid = options.projectUuid ?? config.get('projectUuid');
 
     if (!projectUuid) {
       throw new Error(
         'Project UUID is required. Please run either `catalyst project link` or `catalyst project create` or this command again with --project-uuid <uuid>.',
-      );
-    }
-
-    if (!storeHash) {
-      throw new Error(
-        'Store hash is required. Provide --store-hash (or set CATALYST_STORE_HASH), or run `catalyst project create` or `catalyst project link` with credentials to save it to .bigcommerce/project.json.',
-      );
-    }
-
-    if (!accessToken) {
-      throw new Error(
-        'Access token is required. Provide --access-token (or set CATALYST_ACCESS_TOKEN), or run `catalyst project create` or `catalyst project link` with credentials to save it to .bigcommerce/project.json.',
       );
     }
 

--- a/packages/catalyst/src/cli/commands/project.spec.ts
+++ b/packages/catalyst/src/cli/commands/project.spec.ts
@@ -60,6 +60,9 @@ beforeAll(async () => {
 
 afterEach(() => {
   vi.clearAllMocks();
+  config.delete('storeHash');
+  config.delete('accessToken');
+  config.delete('projectUuid');
 });
 
 afterAll(async () => {
@@ -141,14 +144,16 @@ describe('project create', () => {
     delete process.env.CATALYST_STORE_HASH;
     delete process.env.CATALYST_ACCESS_TOKEN;
 
-    await program.parseAsync(['node', 'catalyst', 'project', 'create', '--root-dir', tmpDir]);
+    await expect(
+      program.parseAsync(['node', 'catalyst', 'project', 'create', '--root-dir', tmpDir]),
+    ).rejects.toThrow('Missing credentials');
 
     if (savedStoreHash !== undefined) process.env.CATALYST_STORE_HASH = savedStoreHash;
     if (savedAccessToken !== undefined) process.env.CATALYST_ACCESS_TOKEN = savedAccessToken;
 
-    expect(consola.error).toHaveBeenCalledWith('Insufficient information to create a project.');
+    expect(consola.error).toHaveBeenCalledWith('Missing credentials.');
     expect(consola.info).toHaveBeenCalledWith(
-      'Provide both --store-hash and --access-token (or set CATALYST_STORE_HASH and CATALYST_ACCESS_TOKEN).',
+      'Run `catalyst auth login`, or provide --store-hash and --access-token flags (or set CATALYST_STORE_HASH and CATALYST_ACCESS_TOKEN environment variables).',
     );
     expect(exitMock).toHaveBeenCalledWith(1);
   });
@@ -209,14 +214,16 @@ describe('project list', () => {
     delete process.env.CATALYST_STORE_HASH;
     delete process.env.CATALYST_ACCESS_TOKEN;
 
-    await program.parseAsync(['node', 'catalyst', 'project', 'list']);
+    await expect(program.parseAsync(['node', 'catalyst', 'project', 'list'])).rejects.toThrow(
+      'Missing credentials',
+    );
 
     if (savedStoreHash !== undefined) process.env.CATALYST_STORE_HASH = savedStoreHash;
     if (savedAccessToken !== undefined) process.env.CATALYST_ACCESS_TOKEN = savedAccessToken;
 
-    expect(consola.error).toHaveBeenCalledWith('Insufficient information to list projects.');
+    expect(consola.error).toHaveBeenCalledWith('Missing credentials.');
     expect(consola.info).toHaveBeenCalledWith(
-      'Provide both --store-hash and --access-token (or set CATALYST_STORE_HASH and CATALYST_ACCESS_TOKEN), or run from a project that has been linked with credentials.',
+      'Run `catalyst auth login`, or provide --store-hash and --access-token flags (or set CATALYST_STORE_HASH and CATALYST_ACCESS_TOKEN environment variables).',
     );
     expect(exitMock).toHaveBeenCalledWith(1);
   });
@@ -466,14 +473,15 @@ describe('project link', () => {
   });
 
   test('errors when no projectUuid, storeHash, or accessToken are provided', async () => {
-    await program.parseAsync(['node', 'catalyst', 'project', 'link', '--root-dir', tmpDir]);
+    await expect(
+      program.parseAsync(['node', 'catalyst', 'project', 'link', '--root-dir', tmpDir]),
+    ).rejects.toThrow('Missing credentials');
 
     expect(consola.start).not.toHaveBeenCalled();
     expect(consola.success).not.toHaveBeenCalled();
-    expect(consola.error).toHaveBeenCalledWith('Insufficient information to link a project.');
-    expect(consola.info).toHaveBeenCalledWith('Provide a project UUID with --project-uuid, or');
+    expect(consola.error).toHaveBeenCalledWith('Missing credentials.');
     expect(consola.info).toHaveBeenCalledWith(
-      'Provide both --store-hash and --access-token to fetch and select a project.',
+      'Run `catalyst auth login`, or provide --store-hash and --access-token flags (or set CATALYST_STORE_HASH and CATALYST_ACCESS_TOKEN environment variables).',
     );
 
     expect(exitMock).toHaveBeenCalledWith(1);

--- a/packages/catalyst/src/cli/commands/project.ts
+++ b/packages/catalyst/src/cli/commands/project.ts
@@ -3,6 +3,7 @@ import { Command, Option } from 'commander';
 import { consola } from '../lib/logger';
 import { createProject, fetchProjects } from '../lib/project';
 import { getProjectConfig } from '../lib/project-config';
+import { resolveCredentials } from '../lib/resolve-credentials';
 import { getTelemetry } from '../lib/telemetry';
 
 const list = new Command('list')
@@ -26,18 +27,7 @@ const list = new Command('list')
   )
   .action(async (options) => {
     const config = getProjectConfig();
-    const storeHash = options.storeHash ?? config.get('storeHash');
-    const accessToken = options.accessToken ?? config.get('accessToken');
-
-    if (!storeHash || !accessToken) {
-      consola.error('Insufficient information to list projects.');
-      consola.info(
-        'Provide both --store-hash and --access-token (or set CATALYST_STORE_HASH and CATALYST_ACCESS_TOKEN), or run from a project that has been linked with credentials.',
-      );
-      process.exit(1);
-
-      return;
-    }
+    const { storeHash, accessToken } = resolveCredentials(options, config);
 
     await getTelemetry().identify(storeHash);
 
@@ -88,38 +78,24 @@ const create = new Command('create')
     process.cwd(),
   )
   .action(async (options) => {
-    if (!options.storeHash || !options.accessToken) {
-      consola.error('Insufficient information to create a project.');
-      consola.info(
-        'Provide both --store-hash and --access-token (or set CATALYST_STORE_HASH and CATALYST_ACCESS_TOKEN).',
-      );
-      process.exit(1);
+    const config = getProjectConfig(options.rootDir);
+    const { storeHash, accessToken } = resolveCredentials(options, config);
 
-      return;
-    }
-
-    await getTelemetry().identify(options.storeHash);
+    await getTelemetry().identify(storeHash);
 
     const newProjectName = await consola.prompt('Enter a name for the new project:', {
       type: 'text',
     });
 
-    const data = await createProject(
-      newProjectName,
-      options.storeHash,
-      options.accessToken,
-      options.apiHost,
-    );
+    const data = await createProject(newProjectName, storeHash, accessToken, options.apiHost);
 
     consola.success(`Project "${data.name}" created successfully.`);
-
-    const config = getProjectConfig(options.rootDir);
 
     consola.start('Writing project UUID to .bigcommerce/project.json...');
     config.set('projectUuid', data.uuid);
     config.set('framework', 'catalyst');
-    config.set('storeHash', options.storeHash);
-    config.set('accessToken', options.accessToken);
+    config.set('storeHash', storeHash);
+    config.set('accessToken', accessToken);
     consola.success('Project UUID written to .bigcommerce/project.json.');
 
     process.exit(0);
@@ -178,68 +154,57 @@ export const link = new Command('link')
       writeProjectConfig(options.projectUuid);
 
       process.exit(0);
+
+      return;
     }
 
-    if (options.storeHash && options.accessToken) {
-      await getTelemetry().identify(options.storeHash);
+    const { storeHash, accessToken } = resolveCredentials(options, config);
 
-      consola.start('Fetching projects...');
+    await getTelemetry().identify(storeHash);
 
-      const projects = await fetchProjects(options.storeHash, options.accessToken, options.apiHost);
+    consola.start('Fetching projects...');
 
-      consola.success('Projects fetched.');
+    const projects = await fetchProjects(storeHash, accessToken, options.apiHost);
 
-      const promptOptions = [
-        ...projects.map((proj) => ({
-          label: proj.name,
-          value: proj.uuid,
-          hint: proj.uuid,
-        })),
-        {
-          label: 'Create a new project',
-          value: 'create',
-          hint: 'Create a new infrastructure project for this BigCommerce store.',
-        },
-      ];
+    consola.success('Projects fetched.');
 
-      let projectUuid = await consola.prompt(
-        'Select a project or create a new project (Press <enter> to select).',
-        {
-          type: 'select',
-          options: promptOptions,
-          cancel: 'reject',
-        },
-      );
+    const promptOptions = [
+      ...projects.map((proj) => ({
+        label: proj.name,
+        value: proj.uuid,
+        hint: proj.uuid,
+      })),
+      {
+        label: 'Create a new project',
+        value: 'create',
+        hint: 'Create a new infrastructure project for this BigCommerce store.',
+      },
+    ];
 
-      if (projectUuid === 'create') {
-        const newProjectName = await consola.prompt('Enter a name for the new project:', {
-          type: 'text',
-        });
+    let projectUuid = await consola.prompt(
+      'Select a project or create a new project (Press <enter> to select).',
+      {
+        type: 'select',
+        options: promptOptions,
+        cancel: 'reject',
+      },
+    );
 
-        const data = await createProject(
-          newProjectName,
-          options.storeHash,
-          options.accessToken,
-          options.apiHost,
-        );
-
-        projectUuid = data.uuid;
-
-        consola.success(`Project "${data.name}" created successfully.`);
-      }
-
-      writeProjectConfig(projectUuid, {
-        storeHash: options.storeHash,
-        accessToken: options.accessToken,
+    if (projectUuid === 'create') {
+      const newProjectName = await consola.prompt('Enter a name for the new project:', {
+        type: 'text',
       });
 
-      process.exit(0);
+      const data = await createProject(newProjectName, storeHash, accessToken, options.apiHost);
+
+      projectUuid = data.uuid;
+
+      consola.success(`Project "${data.name}" created successfully.`);
     }
 
-    consola.error('Insufficient information to link a project.');
-    consola.info('Provide a project UUID with --project-uuid, or');
-    consola.info('Provide both --store-hash and --access-token to fetch and select a project.');
-    process.exit(1);
+    writeProjectConfig(projectUuid, { storeHash, accessToken });
+
+    process.exit(0);
   });
 
 export const project = new Command('project')

--- a/packages/catalyst/src/cli/lib/resolve-credentials.spec.ts
+++ b/packages/catalyst/src/cli/lib/resolve-credentials.spec.ts
@@ -1,0 +1,80 @@
+import Conf from 'conf';
+import { afterAll, afterEach, beforeAll, expect, MockInstance, test, vi } from 'vitest';
+
+import { consola } from './logger';
+import { mkTempDir } from './mk-temp-dir';
+import { getProjectConfig, ProjectConfigSchema } from './project-config';
+import { resolveCredentials } from './resolve-credentials';
+
+let exitMock: MockInstance;
+let tmpDir: string;
+let cleanup: () => Promise<void>;
+let config: Conf<ProjectConfigSchema>;
+
+beforeAll(async () => {
+  consola.mockTypes(() => vi.fn());
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  exitMock = vi.spyOn(process, 'exit').mockImplementation(() => null as never);
+
+  [tmpDir, cleanup] = await mkTempDir();
+  config = getProjectConfig(tmpDir);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  config.delete('storeHash');
+  config.delete('accessToken');
+});
+
+afterAll(async () => {
+  vi.restoreAllMocks();
+  exitMock.mockRestore();
+  await cleanup();
+});
+
+test('returns credentials from options when both provided', () => {
+  const result = resolveCredentials({ storeHash: 'opt-hash', accessToken: 'opt-token' }, config);
+
+  expect(result).toEqual({ storeHash: 'opt-hash', accessToken: 'opt-token' });
+  expect(exitMock).not.toHaveBeenCalled();
+});
+
+test('falls back to config when options missing', () => {
+  config.set('storeHash', 'cfg-hash');
+  config.set('accessToken', 'cfg-token');
+
+  const result = resolveCredentials({}, config);
+
+  expect(result).toEqual({ storeHash: 'cfg-hash', accessToken: 'cfg-token' });
+  expect(exitMock).not.toHaveBeenCalled();
+});
+
+test('options take precedence over config', () => {
+  config.set('storeHash', 'cfg-hash');
+  config.set('accessToken', 'cfg-token');
+
+  const result = resolveCredentials({ storeHash: 'opt-hash', accessToken: 'opt-token' }, config);
+
+  expect(result).toEqual({ storeHash: 'opt-hash', accessToken: 'opt-token' });
+});
+
+test('mixed resolution: option storeHash + config accessToken', () => {
+  config.set('accessToken', 'cfg-token');
+
+  const result = resolveCredentials({ storeHash: 'opt-hash' }, config);
+
+  expect(result).toEqual({ storeHash: 'opt-hash', accessToken: 'cfg-token' });
+});
+
+test('exits with error when no credentials found anywhere', () => {
+  expect(() => resolveCredentials({}, config)).toThrow('Missing credentials');
+
+  expect(consola.error).toHaveBeenCalledWith('Missing credentials.');
+  expect(exitMock).toHaveBeenCalledWith(1);
+});
+
+test('error message mentions catalyst auth login', () => {
+  expect(() => resolveCredentials({}, config)).toThrow();
+
+  expect(consola.info).toHaveBeenCalledWith(expect.stringContaining('catalyst auth login'));
+});

--- a/packages/catalyst/src/cli/lib/resolve-credentials.ts
+++ b/packages/catalyst/src/cli/lib/resolve-credentials.ts
@@ -1,0 +1,25 @@
+import Conf from 'conf';
+
+import { consola } from './logger';
+import { ProjectConfigSchema } from './project-config';
+
+export function resolveCredentials(
+  options: { storeHash?: string; accessToken?: string },
+  config: Conf<ProjectConfigSchema>,
+): { storeHash: string; accessToken: string } {
+  const storeHash = options.storeHash ?? config.get('storeHash');
+  const accessToken = options.accessToken ?? config.get('accessToken');
+
+  if (!storeHash || !accessToken) {
+    consola.error('Missing credentials.');
+    consola.info(
+      'Run `catalyst auth login`, or provide --store-hash and --access-token flags (or set CATALYST_STORE_HASH and CATALYST_ACCESS_TOKEN environment variables).',
+    );
+    process.exit(1);
+
+    // Unreachable in production; prevents continuation when process.exit is mocked in tests.
+    throw new Error('Missing credentials');
+  }
+
+  return { storeHash, accessToken };
+}


### PR DESCRIPTION
> [!WARNING]
> This PR depends on #2887

## What/Why?

The CLI now has `auth login`/`logout`/`whoami` commands that store credentials in `.bigcommerce/project.json`, but existing authenticated commands (`project create`, `project list`, `project link`, `deploy`) handle credential resolution inconsistently — some fall back to stored config, some don't, and error messages don't mention `catalyst auth login`.

This PR creates a centralized `resolveCredentials()` utility and applies it to all authenticated commands, making `--store-hash`/`--access-token` flags optional everywhere when credentials are stored via `catalyst auth login`.

**Changes:**

- **New `resolveCredentials()` utility** (`packages/catalyst/src/cli/lib/resolve-credentials.ts`) — resolves credentials from options (flags/env vars) with config fallback, exits with unified error mentioning `catalyst auth login`
- **Updated `project create`** — now falls back to stored config (previously required flags)
- **Updated `project list`** — replaced inline fallback + error with `resolveCredentials`
- **Updated `project link`** — replaced guard + error block with `resolveCredentials`
- **Updated `deploy`** — replaced three separate validation blocks with single `resolveCredentials` call
- **Updated `auth whoami`** — error message now mentions `catalyst auth login` first
- **New tests** for `resolveCredentials` (6 test cases)
- **Updated existing tests** for new error messages and behavior

## Testing

- All 88 tests pass across 15 test files (`pnpm --filter @bigcommerce/catalyst test`)
- Lint and typecheck pass
- CI compatibility preserved: flags/env vars still take precedence, config is only consulted as fallback

## Demo

### Before

https://github.com/user-attachments/assets/8ebe22fe-211f-4116-9d0a-860b792950d7

### After

https://github.com/user-attachments/assets/cc797cc3-6fa1-4e1f-8e83-56e1f15e8ca3

## Migration

No breaking changes. Commands that previously required `--store-hash`/`--access-token` flags now optionally fall back to credentials stored via `catalyst auth login`. Error messages have been updated to mention `catalyst auth login` as the primary resolution path.