### PR TITLE
fix(core): allow disabling canonical SEO via env variable

### DIFF
--- a/.changeset/quick-lies-lie.md
+++ b/.changeset/quick-lies-lie.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Add `NEXT_DISABLE_METADATA_BASE` environment variable to disable canonical URL and hreflang alternate tags. When set to `'true'`, `metadataBase`, canonical URLs, and hreflang alternates are omitted from all pages. This is useful for preview deployments (Vercel, Cloudflare, etc.) where the vanity URL from BigCommerce points to production and causes SEO mismatch warnings. Default behavior (canonical tags enabled) is unchanged.

--- a/core/app/[locale]/layout.tsx
+++ b/core/app/[locale]/layout.tsx
@@ -74,7 +74,10 @@ export async function generateMetadata(): Promise<Metadata> {
   const vanityUrl = data.site.settings?.url.vanityUrl;
 
   return {
-    metadataBase: vanityUrl ? new URL(vanityUrl) : undefined,
+    metadataBase:
+      process.env.NEXT_DISABLE_METADATA_BASE !== 'true' && vanityUrl
+        ? new URL(vanityUrl)
+        : undefined,
     title: {
       template: `%s - ${storeName}`,
       default: pageTitle || storeName,

--- a/core/lib/seo/canonical.ts
+++ b/core/lib/seo/canonical.ts
@@ -61,6 +61,10 @@ const getVanityUrl = cache(async () => {
 });
 
 export async function getMetadataAlternates(options: CanonicalUrlOptions) {
+  if (process.env.NEXT_DISABLE_METADATA_BASE === 'true') {
+    return undefined;
+  }
+
   const { path, locale, includeAlternates = true } = options;
 
   const baseUrl = await getVanityUrl();


### PR DESCRIPTION
## What/Why?
Add `NEXT_DISABLE_METADATA_BASE` environment variable to disable canonical URL and hreflang alternate tags. When set to `'true'`, `metadataBase`, canonical URLs, and hreflang alternates are omitted from all pages. This is useful for preview deployments (Vercel, Cloudflare, etc.) where the vanity URL from BigCommerce points to production and causes SEO mismatch warnings. Default behavior (canonical tags enabled) is unchanged.

## Testing
Preview url, canonical and alternates not set.

## Migration
N/A
