### PR TITLE
fix(core): preview deployments now use correct metadataBase

### DIFF
--- a/.changeset/new-onions-flash.md
+++ b/.changeset/new-onions-flash.md
@@ -15,13 +15,14 @@ Update `core/app/[locale]/layout.tsx`:
 ```diff
 + const vanityUrl = data.site.settings?.url.vanityUrl;
 +
-+ const isPreview = process.env.VERCEL_ENV === 'preview';
-+ const baseUrl =
-+   isPreview && process.env.VERCEL_URL
-+     ? new URL(`https://${process.env.VERCEL_URL}`)
-+     : vanityUrl
-+       ? new URL(vanityUrl)
-+       : undefined;
++ // Use preview deployment URL so metadataBase (canonical, og:url) points at the preview, not production.
++ let baseUrl: URL | undefined;
++
++ if (process.env.VERCEL_ENV === 'preview' && process.env.VERCEL_URL) {
++   baseUrl = new URL(`https://${process.env.VERCEL_URL}`);
++ } else if (vanityUrl) {
++   baseUrl = new URL(vanityUrl);
++ }
 +
   return {
 +   metadataBase: baseUrl,

--- a/.changeset/new-onions-flash.md
+++ b/.changeset/new-onions-flash.md
@@ -8,7 +8,7 @@ Add canonical URLs and hreflang alternates for SEO. Pages now set `alternates.ca
 
 ### Step 1: Root layout metadata base
 
-The root locale layout now sets `metadataBase` from the vanity URL fetched via GraphQL. On Vercel preview deployments, `VERCEL_URL` is used instead so preview environments don't point to production.
+The root locale layout now sets `metadataBase` from the vanity URL fetched via GraphQL. On Vercel preview deployments, `VERCEL_URL` is used instead so preview environments don't point to production. `URL.canParse` guards against malformed URLs.
 
 Update `core/app/[locale]/layout.tsx`:
 
@@ -17,10 +17,12 @@ Update `core/app/[locale]/layout.tsx`:
 +
 + // Use preview deployment URL so metadataBase (canonical, og:url) points at the preview, not production.
 + let baseUrl: URL | undefined;
++ const previewUrl =
++   process.env.VERCEL_ENV === 'preview' ? `https://${process.env.VERCEL_URL}` : undefined;
 +
-+ if (process.env.VERCEL_ENV === 'preview' && process.env.VERCEL_URL) {
-+   baseUrl = new URL(`https://${process.env.VERCEL_URL}`);
-+ } else if (vanityUrl) {
++ if (previewUrl && URL.canParse(previewUrl)) {
++   baseUrl = new URL(previewUrl);
++ } else if (vanityUrl && URL.canParse(vanityUrl)) {
 +   baseUrl = new URL(vanityUrl);
 + }
 +
@@ -31,19 +33,19 @@ Update `core/app/[locale]/layout.tsx`:
 
 ### Step 2: Canonical/hreflang base URL for preview environments
 
-The `getVanityUrl` helper in `core/lib/seo/canonical.ts` now returns `VERCEL_URL` on preview deployments, skipping the GraphQL query.
+The `getMetadataAlternates` function in `core/lib/seo/canonical.ts` now checks for a Vercel preview URL before falling back to the GraphQL vanity URL. `URL.canParse` guards against malformed URLs.
 
 Update `core/lib/seo/canonical.ts`:
 
 ```diff
- const getVanityUrl = cache(async () => {
-+  const isPreview = process.env.VERCEL_ENV === 'preview';
-+
-+  if (isPreview && process.env.VERCEL_URL) {
-+    return `https://${process.env.VERCEL_URL}`;
-+  }
-+
-   const { data } = await client.fetch({
+ export async function getMetadataAlternates(options: CanonicalUrlOptions) {
+   const { path, locale, includeAlternates = true } = options;
+
+-  const baseUrl = await getVanityUrl();
++  // Use preview deployment URL so canonical/hreflang URLs point at the preview, not production.
++  const previewUrl =
++    process.env.VERCEL_ENV === 'preview' ? `https://${process.env.VERCEL_URL}` : undefined;
++  const baseUrl = previewUrl && URL.canParse(previewUrl) ? previewUrl : await getVanityUrl();
 ```
 
 ### Step 3: GraphQL fragment updates

--- a/.changeset/new-onions-flash.md
+++ b/.changeset/new-onions-flash.md
@@ -2,25 +2,50 @@
 "@bigcommerce/catalyst-core": patch
 ---
 
-Add canonical URLs and hreflang alternates for SEO. Pages now set `alternates.canonical` and `alternates.languages` in `generateMetadata` via the new `getMetadataAlternates` helper in `core/lib/seo/canonical.ts`. The helper fetches the vanity URL via GraphQL (`site.settings.url.vanityUrl`) and is cached per request. The default locale uses no path prefix; other locales use `/{locale}/path`. The root locale layout sets `metadataBase` to the configured vanity URL so canonical URLs resolve correctly.
+Add canonical URLs and hreflang alternates for SEO. Pages now set `alternates.canonical` and `alternates.languages` in `generateMetadata` via the new `getMetadataAlternates` helper in `core/lib/seo/canonical.ts`. The helper fetches the vanity URL via GraphQL (`site.settings.url.vanityUrl`) and is cached per request. The default locale uses no path prefix; other locales use `/{locale}/path`. The root locale layout sets `metadataBase` to the configured vanity URL so canonical URLs resolve correctly. On Vercel preview deployments (`VERCEL_ENV=preview`), `metadataBase` and canonical/hreflang URLs use `VERCEL_URL` instead of the production vanity URL to prevent preview environments from generating SEO metadata pointing to production.
 
 ## Migration steps
 
 ### Step 1: Root layout metadata base
 
-The root locale layout now sets `metadataBase` from the vanity URL fetched via GraphQL. This is already included in the `RootLayoutMetadataQuery`.
+The root locale layout now sets `metadataBase` from the vanity URL fetched via GraphQL. On Vercel preview deployments, `VERCEL_URL` is used instead so preview environments don't point to production.
 
 Update `core/app/[locale]/layout.tsx`:
 
 ```diff
 + const vanityUrl = data.site.settings?.url.vanityUrl;
 +
++ const isPreview = process.env.VERCEL_ENV === 'preview';
++ const baseUrl =
++   isPreview && process.env.VERCEL_URL
++     ? new URL(`https://${process.env.VERCEL_URL}`)
++     : vanityUrl
++       ? new URL(vanityUrl)
++       : undefined;
++
   return {
-+   metadataBase: vanityUrl ? new URL(vanityUrl) : undefined,
++   metadataBase: baseUrl,
     title: {
 ```
 
-### Step 2: GraphQL fragment updates
+### Step 2: Canonical/hreflang base URL for preview environments
+
+The `getVanityUrl` helper in `core/lib/seo/canonical.ts` now returns `VERCEL_URL` on preview deployments, skipping the GraphQL query.
+
+Update `core/lib/seo/canonical.ts`:
+
+```diff
+ const getVanityUrl = cache(async () => {
++  const isPreview = process.env.VERCEL_ENV === 'preview';
++
++  if (isPreview && process.env.VERCEL_URL) {
++    return `https://${process.env.VERCEL_URL}`;
++  }
++
+   const { data } = await client.fetch({
+```
+
+### Step 3: GraphQL fragment updates
 
 Add the `path` field to brand, blog post, and product queries so metadata can build canonical URLs.
 
@@ -54,7 +79,7 @@ Update `core/app/[locale]/(default)/product/[slug]/page-data.ts` (in the metadat
       defaultImage {
 ```
 
-### Step 3: Page metadata alternates
+### Step 4: Page metadata alternates
 
 Add the `getMetadataAlternates` import and set `alternates` in `generateMetadata` for each page. The function is async and must be awaited. Ensure `core/lib/seo/canonical.ts` exists (it is included in this release).
 
@@ -94,7 +119,7 @@ For entity pages (product, category, brand, blog, blog post, webpage), add the i
   }
 ```
 
-### Step 4: Gift certificates pages
+### Step 5: Gift certificates pages
 
 Update `core/app/[locale]/(default)/gift-certificates/page.tsx`:
 
@@ -142,7 +167,7 @@ Add `generateMetadata` to `core/app/[locale]/(default)/gift-certificates/purchas
 + }
 ```
 
-### Step 5: Contact page
+### Step 6: Contact page
 
 Update `core/app/[locale]/(default)/webpages/[id]/contact/page.tsx`:
 
@@ -164,7 +189,7 @@ Update `core/app/[locale]/(default)/webpages/[id]/contact/page.tsx`:
   }
 ```
 
-### Step 6: Public wishlist page
+### Step 7: Public wishlist page
 
 Update `core/app/[locale]/(default)/wishlist/[token]/page.tsx`:
 
@@ -181,7 +206,7 @@ Update `core/app/[locale]/(default)/wishlist/[token]/page.tsx`:
   }
 ```
 
-### Step 7: Compare page
+### Step 8: Compare page
 
 Update `core/app/[locale]/(default)/compare/page.tsx`:
 

--- a/core/app/[locale]/layout.tsx
+++ b/core/app/[locale]/layout.tsx
@@ -73,8 +73,16 @@ export async function generateMetadata(): Promise<Metadata> {
 
   const vanityUrl = data.site.settings?.url.vanityUrl;
 
+  const isPreview = process.env.VERCEL_ENV === 'preview';
+  const baseUrl =
+    isPreview && process.env.VERCEL_URL
+      ? new URL(`https://${process.env.VERCEL_URL}`)
+      : vanityUrl
+        ? new URL(vanityUrl)
+        : undefined;
+
   return {
-    metadataBase: vanityUrl ? new URL(vanityUrl) : undefined,
+    metadataBase: baseUrl,
     title: {
       template: `%s - ${storeName}`,
       default: pageTitle || storeName,

--- a/core/app/[locale]/layout.tsx
+++ b/core/app/[locale]/layout.tsx
@@ -73,13 +73,14 @@ export async function generateMetadata(): Promise<Metadata> {
 
   const vanityUrl = data.site.settings?.url.vanityUrl;
 
-  const isPreview = process.env.VERCEL_ENV === 'preview';
-  const baseUrl =
-    isPreview && process.env.VERCEL_URL
-      ? new URL(`https://${process.env.VERCEL_URL}`)
-      : vanityUrl
-        ? new URL(vanityUrl)
-        : undefined;
+  // Use preview deployment URL so metadataBase (canonical, og:url) points at the preview, not production.
+  let baseUrl: URL | undefined;
+
+  if (process.env.VERCEL_ENV === 'preview' && process.env.VERCEL_URL) {
+    baseUrl = new URL(`https://${process.env.VERCEL_URL}`);
+  } else if (vanityUrl) {
+    baseUrl = new URL(vanityUrl);
+  }
 
   return {
     metadataBase: baseUrl,

--- a/core/app/[locale]/layout.tsx
+++ b/core/app/[locale]/layout.tsx
@@ -75,10 +75,12 @@ export async function generateMetadata(): Promise<Metadata> {
 
   // Use preview deployment URL so metadataBase (canonical, og:url) points at the preview, not production.
   let baseUrl: URL | undefined;
+  const previewUrl =
+    process.env.VERCEL_ENV === 'preview' ? `https://${process.env.VERCEL_URL}` : undefined;
 
-  if (process.env.VERCEL_ENV === 'preview' && process.env.VERCEL_URL) {
-    baseUrl = new URL(`https://${process.env.VERCEL_URL}`);
-  } else if (vanityUrl) {
+  if (previewUrl && URL.canParse(previewUrl)) {
+    baseUrl = new URL(previewUrl);
+  } else if (vanityUrl && URL.canParse(vanityUrl)) {
     baseUrl = new URL(vanityUrl);
   }
 

--- a/core/lib/seo/canonical.ts
+++ b/core/lib/seo/canonical.ts
@@ -46,12 +46,6 @@ const VanityUrlQuery = graphql(`
 `);
 
 const getVanityUrl = cache(async () => {
-  const isPreview = process.env.VERCEL_ENV === 'preview';
-
-  if (isPreview && process.env.VERCEL_URL) {
-    return `https://${process.env.VERCEL_URL}`;
-  }
-
   const { data } = await client.fetch({
     document: VanityUrlQuery,
     fetchOptions: { next: { revalidate } },
@@ -69,7 +63,10 @@ const getVanityUrl = cache(async () => {
 export async function getMetadataAlternates(options: CanonicalUrlOptions) {
   const { path, locale, includeAlternates = true } = options;
 
-  const baseUrl = await getVanityUrl();
+  // Use preview deployment URL so canonical/hreflang URLs point at the preview, not production.
+  const previewUrl =
+    process.env.VERCEL_ENV === 'preview' ? `https://${process.env.VERCEL_URL}` : undefined;
+  const baseUrl = previewUrl && URL.canParse(previewUrl) ? previewUrl : await getVanityUrl();
 
   const canonical = buildLocalizedUrl(baseUrl, path, locale);
 

--- a/core/lib/seo/canonical.ts
+++ b/core/lib/seo/canonical.ts
@@ -46,6 +46,12 @@ const VanityUrlQuery = graphql(`
 `);
 
 const getVanityUrl = cache(async () => {
+  const isPreview = process.env.VERCEL_ENV === 'preview';
+
+  if (isPreview && process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
+  }
+
   const { data } = await client.fetch({
     document: VanityUrlQuery,
     fetchOptions: { next: { revalidate } },


### PR DESCRIPTION
## What/Why?
On Vercel preview deployments (`VERCEL_ENV=preview`), `metadataBase` and canonical/hreflang URLs use `VERCEL_URL` instead of the production vanity URL to prevent preview environments from generating SEO metadata pointing to production.

## Testing
Preview deployment/unlighthouse score

## Migration
N/A
