### PR TITLE
feat(cli): remove --root-dir flag from project create and link commands

### DIFF
--- a/.changeset/remove-root-dir-opt.md
+++ b/.changeset/remove-root-dir-opt.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst": minor
+---
+
+Remove `--root-dir` flag from `project create` and `project link` commands. Use `process.cwd()` as a hardcoded default for usage simplicity.

--- a/packages/catalyst/src/cli/commands/project.spec.ts
+++ b/packages/catalyst/src/cli/commands/project.spec.ts
@@ -55,7 +55,9 @@ beforeAll(async () => {
 
   [tmpDir, cleanup] = await mkTempDir();
 
-  config = getProjectConfig(tmpDir);
+  vi.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+
+  config = getProjectConfig();
 });
 
 afterEach(() => {
@@ -110,8 +112,6 @@ describe('project create', () => {
       storeHash,
       '--access-token',
       accessToken,
-      '--root-dir',
-      tmpDir,
     ]);
 
     expect(mockIdentify).toHaveBeenCalledWith(storeHash);
@@ -144,9 +144,9 @@ describe('project create', () => {
     delete process.env.CATALYST_STORE_HASH;
     delete process.env.CATALYST_ACCESS_TOKEN;
 
-    await expect(
-      program.parseAsync(['node', 'catalyst', 'project', 'create', '--root-dir', tmpDir]),
-    ).rejects.toThrow('Missing credentials');
+    await expect(program.parseAsync(['node', 'catalyst', 'project', 'create'])).rejects.toThrow(
+      'Missing credentials',
+    );
 
     if (savedStoreHash !== undefined) process.env.CATALYST_STORE_HASH = savedStoreHash;
     if (savedAccessToken !== undefined) process.env.CATALYST_ACCESS_TOKEN = savedAccessToken;
@@ -177,8 +177,6 @@ describe('project create', () => {
         storeHash,
         '--access-token',
         accessToken,
-        '--root-dir',
-        tmpDir,
       ]),
     ).rejects.toThrow('Failed to create project, is the name already in use?');
 
@@ -245,7 +243,6 @@ describe('project link', () => {
           defaultValue: 'api.bigcommerce.com',
         }),
         expect.objectContaining({ flags: '--project-uuid <uuid>' }),
-        expect.objectContaining({ flags: '--root-dir <path>', defaultValue: process.cwd() }),
       ]),
     );
   });
@@ -258,8 +255,6 @@ describe('project link', () => {
       'link',
       '--project-uuid',
       projectUuid1,
-      '--root-dir',
-      tmpDir,
     ]);
 
     expect(consola.start).toHaveBeenCalledWith(
@@ -304,8 +299,6 @@ describe('project link', () => {
       storeHash,
       '--access-token',
       accessToken,
-      '--root-dir',
-      tmpDir,
     ]);
 
     expect(mockIdentify).toHaveBeenCalledWith(storeHash);
@@ -366,8 +359,6 @@ describe('project link', () => {
       storeHash,
       '--access-token',
       accessToken,
-      '--root-dir',
-      tmpDir,
     ]);
 
     expect(mockIdentify).toHaveBeenCalledWith(storeHash);
@@ -430,8 +421,6 @@ describe('project link', () => {
         storeHash,
         '--access-token',
         accessToken,
-        '--root-dir',
-        tmpDir,
       ]),
     ).rejects.toThrow('Failed to create project, is the name already in use?');
 
@@ -460,8 +449,6 @@ describe('project link', () => {
         storeHash,
         '--access-token',
         accessToken,
-        '--root-dir',
-        tmpDir,
       ]),
     ).rejects.toThrow(
       'Infrastructure Projects API not enabled. If you are part of the alpha, contact support@bigcommerce.com to enable it.',
@@ -473,9 +460,9 @@ describe('project link', () => {
   });
 
   test('errors when no projectUuid, storeHash, or accessToken are provided', async () => {
-    await expect(
-      program.parseAsync(['node', 'catalyst', 'project', 'link', '--root-dir', tmpDir]),
-    ).rejects.toThrow('Missing credentials');
+    await expect(program.parseAsync(['node', 'catalyst', 'project', 'link'])).rejects.toThrow(
+      'Missing credentials',
+    );
 
     expect(consola.start).not.toHaveBeenCalled();
     expect(consola.success).not.toHaveBeenCalled();

--- a/packages/catalyst/src/cli/commands/project.ts
+++ b/packages/catalyst/src/cli/commands/project.ts
@@ -72,13 +72,8 @@ const create = new Command('create')
       .env('BIGCOMMERCE_API_HOST')
       .default('api.bigcommerce.com'),
   )
-  .option(
-    '--root-dir <path>',
-    'Path to the root directory of your Catalyst project (default: current working directory).',
-    process.cwd(),
-  )
   .action(async (options) => {
-    const config = getProjectConfig(options.rootDir);
+    const config = getProjectConfig();
     const { storeHash, accessToken } = resolveCredentials(options, config);
 
     await getTelemetry().identify(storeHash);
@@ -126,13 +121,8 @@ export const link = new Command('link')
     '--project-uuid <uuid>',
     'BigCommerce infrastructure project UUID. Can be found via the BigCommerce API (GET /v3/infrastructure/projects). Use this to link directly without fetching projects.',
   )
-  .option(
-    '--root-dir <path>',
-    'Path to the root directory of your Catalyst project (default: current working directory).',
-    process.cwd(),
-  )
   .action(async (options) => {
-    const config = getProjectConfig(options.rootDir);
+    const config = getProjectConfig();
 
     const writeProjectConfig = (
       uuid: string,

--- a/packages/catalyst/src/cli/lib/project-config.spec.ts
+++ b/packages/catalyst/src/cli/lib/project-config.spec.ts
@@ -1,7 +1,7 @@
 import Conf from 'conf';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
-import { afterAll, beforeAll, expect, test } from 'vitest';
+import { afterAll, beforeAll, expect, test, vi } from 'vitest';
 
 import { mkTempDir } from './mk-temp-dir';
 import { getProjectConfig, ProjectConfigSchema } from './project-config';
@@ -15,10 +15,13 @@ const projectUuid = 'a23f5785-fd99-4a94-9fb3-945551623923';
 beforeAll(async () => {
   [tmpDir, cleanup] = await mkTempDir();
 
-  config = getProjectConfig(tmpDir);
+  vi.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+
+  config = getProjectConfig();
 });
 
 afterAll(async () => {
+  vi.restoreAllMocks();
   await cleanup();
 });
 

--- a/packages/catalyst/src/cli/lib/project-config.ts
+++ b/packages/catalyst/src/cli/lib/project-config.ts
@@ -12,9 +12,9 @@ export interface ProjectConfigSchema {
   };
 }
 
-export function getProjectConfig(rootDir = process.cwd()) {
+export function getProjectConfig() {
   return new Conf<ProjectConfigSchema>({
-    cwd: join(rootDir, '.bigcommerce'),
+    cwd: join(process.cwd(), '.bigcommerce'),
     projectSuffix: '',
     configName: 'project',
     schema: {

--- a/packages/catalyst/src/cli/lib/resolve-credentials.spec.ts
+++ b/packages/catalyst/src/cli/lib/resolve-credentials.spec.ts
@@ -17,7 +17,8 @@ beforeAll(async () => {
   exitMock = vi.spyOn(process, 'exit').mockImplementation(() => null as never);
 
   [tmpDir, cleanup] = await mkTempDir();
-  config = getProjectConfig(tmpDir);
+  vi.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+  config = getProjectConfig();
 });
 
 afterEach(() => {


### PR DESCRIPTION
## What/Why?

The `--root-dir` flag on `project create` and `project link` is a footgun — if a user passes it once but forgets it on subsequent commands (e.g. `catalyst deploy`), they get confusing errors.

This removes the `--root-dir` option from both commands and hardcodes `process.cwd()` in `getProjectConfig()`, simplifying the CLI surface and eliminating a class of user mistakes.

**Changes:**
- Remove `rootDir` parameter from `getProjectConfig()` — always use `process.cwd()`
- Remove `--root-dir` option from `project create` and `project link` commands
- Update tests to mock `process.cwd()` instead of passing `--root-dir`

## Testing

- `vitest run src/cli/commands/project.spec.ts` — 13 tests pass
- `vitest run src/cli/lib/project-config.spec.ts` — 3 tests pass

## Migration

The `--root-dir` flag has been removed. `process.cwd()` is now used as the hardcoded default. Run CLI commands from your project directory instead of passing `--root-dir`.