### PR TITLE
feat(cli): remove next start proxy from start command

### DIFF
--- a/.changeset/simplify-start-command.md
+++ b/.changeset/simplify-start-command.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst": minor
+---
+
+Remove `next start` proxy from `catalyst start` command. The command now only runs the OpenNext Cloudflare local preview.

--- a/packages/catalyst/src/cli/commands/start.spec.ts
+++ b/packages/catalyst/src/cli/commands/start.spec.ts
@@ -7,25 +7,9 @@ import { program } from '../program';
 
 import { start } from './start';
 
-vi.mock('node:fs', () => ({
-  existsSync: vi.fn(() => true),
-}));
-
 vi.mock('execa', () => ({
   execa: vi.fn(() => Promise.resolve({})),
   __esModule: true,
-}));
-
-vi.mock('../../src/lib/project-config', () => ({
-  getProjectConfig: vi.fn(() => ({
-    get: vi.fn((key) => {
-      if (key === 'framework') {
-        return 'catalyst';
-      }
-
-      return undefined;
-    }),
-  })),
 }));
 
 beforeAll(() => {
@@ -43,60 +27,17 @@ afterEach(() => {
 test('properly configured Command instance', () => {
   expect(start).toBeInstanceOf(Command);
   expect(start.name()).toBe('start');
-  expect(start.description()).toBe('Start your Catalyst storefront in optimized production mode.');
-  expect(start.options).toEqual(
-    expect.arrayContaining([
-      expect.objectContaining({
-        flags: '--framework <framework>',
-        argChoices: ['catalyst', 'nextjs'],
-      }),
-    ]),
-  );
-});
-
-test('calls execa with Next.js production optimized server', async () => {
-  await program.parseAsync([
-    'node',
-    'catalyst',
-    'start',
-    '--port',
-    '3001',
-    '--framework',
-    'nextjs',
-  ]);
-
-  expect(execa).toHaveBeenCalledWith(
-    'node_modules/.bin/next',
-    ['start', '--port', '3001'],
-    expect.objectContaining({
-      stdio: 'inherit',
-      cwd: process.cwd(),
-    }),
+  expect(start.description()).toBe(
+    'Start a local preview of your Catalyst storefront using the OpenNext Cloudflare adapter.',
   );
 });
 
 test('calls execa with OpenNext production optimized server', async () => {
-  await program.parseAsync([
-    'node',
-    'catalyst',
-    'start',
-    '--port',
-    '3001',
-    '--framework',
-    'catalyst',
-  ]);
+  await program.parseAsync(['node', 'catalyst', 'start']);
 
   expect(execa).toHaveBeenCalledWith(
     'pnpm',
-    [
-      'exec',
-      'opennextjs-cloudflare',
-      'preview',
-      '--config',
-      '.bigcommerce/wrangler.jsonc',
-      '--port',
-      '3001',
-    ],
+    ['exec', 'opennextjs-cloudflare', 'preview', '--config', '.bigcommerce/wrangler.jsonc'],
     expect.objectContaining({
       stdio: 'inherit',
       cwd: process.cwd(),

--- a/packages/catalyst/src/cli/commands/start.ts
+++ b/packages/catalyst/src/cli/commands/start.ts
@@ -1,43 +1,12 @@
-import { Command, Option } from 'commander';
+import { Command } from 'commander';
 import { execa } from 'execa';
-import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { getProjectConfig } from '../lib/project-config';
-
 export const start = new Command('start')
-  .description('Start your Catalyst storefront in optimized production mode.')
-  .allowUnknownOption(true)
-  // The unknown options end up in program.args, not in program.opts(). Commander does not take a guess at how to interpret the unknown options.
-  .argument(
-    '[start-options...]',
-    'Pass additional options to the start command. If framework is Next.js, see https://nextjs.org/docs/api-reference/cli#start for available options.',
+  .description(
+    'Start a local preview of your Catalyst storefront using the OpenNext Cloudflare adapter.',
   )
-  .addOption(
-    new Option('--framework <framework>', 'The framework to use for the preview').choices([
-      'catalyst',
-      'nextjs',
-    ]),
-  )
-  .action(async (startOptions, options) => {
-    const config = getProjectConfig();
-    const framework = options.framework ?? config.get('framework');
-
-    if (framework === 'nextjs') {
-      const nextBin = join('node_modules', '.bin', 'next');
-
-      if (!existsSync(nextBin)) {
-        throw new Error(
-          `Next.js is not installed in ${process.cwd()}. Are you in a valid Next.js project?`,
-        );
-      }
-
-      await execa(nextBin, ['start', ...startOptions], {
-        stdio: 'inherit',
-        cwd: process.cwd(),
-      });
-    }
-
+  .action(async () => {
     await execa(
       'pnpm',
       [
@@ -46,7 +15,6 @@ export const start = new Command('start')
         'preview',
         '--config',
         join('.bigcommerce', 'wrangler.jsonc'),
-        ...startOptions,
       ],
       {
         stdio: 'inherit',


### PR DESCRIPTION
## What/Why?

The `catalyst start` command currently supports two modes via a `--framework` option: proxying `next start` (for vanilla Next.js users) or running `opennextjs-cloudflare preview` (for native hosting users). The CLI is moving away from proxying Next.js commands — users who don't use native hosting should simply run `next start` directly.

This simplifies `start` to only run `opennextjs-cloudflare preview`, removing:
- The `--framework` option and conditional code path
- The `.allowUnknownOption(true)` passthrough hack and `[start-options...]` argument
- The `existsSync` / `getProjectConfig` dependencies
- The Next.js binary resolution logic

Net result: **-108 lines** across implementation and tests.

## Testing

- `pnpm --filter @bigcommerce/catalyst test` — all 87 tests pass (15 files)
- Verified no other files depend on the removed `--framework` option or `next start` path

## Migration

Users who previously ran `catalyst start --framework nextjs` should use `next start` (or `npx next start`) directly instead.