### PR TITLE
feat(cli): remove framework config and simplify build command

### DIFF
--- a/.changeset/remove-framework-config.md
+++ b/.changeset/remove-framework-config.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst": minor
+---
+
+Remove `framework` configuration and simplify `catalyst build` to only run the Catalyst build path.

--- a/packages/catalyst/src/cli/commands/build.spec.ts
+++ b/packages/catalyst/src/cli/commands/build.spec.ts
@@ -1,43 +1,15 @@
 import { Command } from 'commander';
-import { execa } from 'execa';
 import { expect, test, vi } from 'vitest';
-
-import { program } from '../program';
 
 import { build } from './build';
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 vi.spyOn(process, 'exit').mockImplementation(() => null as never);
 
-vi.mock('node:fs', () => ({
-  existsSync: vi.fn(() => true),
-}));
-
-vi.mock('execa', () => ({
-  execa: vi.fn(() => Promise.resolve({ stdout: '' })),
-  __esModule: true,
-}));
-
 test('properly configured Command instance', () => {
   expect(build).toBeInstanceOf(Command);
   expect(build.name()).toBe('build');
   expect(build.options).toEqual(
-    expect.arrayContaining([
-      expect.objectContaining({ long: '--framework' }),
-      expect.objectContaining({ long: '--project-uuid' }),
-    ]),
-  );
-});
-
-test('calls execa with Next.js build if framework is nextjs', async () => {
-  await program.parseAsync(['node', 'catalyst', 'build', '--framework', 'nextjs', '--debug']);
-
-  expect(execa).toHaveBeenCalledWith(
-    'node_modules/.bin/next',
-    ['build', '--debug'],
-    expect.objectContaining({
-      stdio: 'inherit',
-      cwd: process.cwd(),
-    }),
+    expect.arrayContaining([expect.objectContaining({ long: '--project-uuid' })]),
   );
 });

--- a/packages/catalyst/src/cli/commands/build.ts
+++ b/packages/catalyst/src/cli/commands/build.ts
@@ -1,6 +1,5 @@
 import { Command, Option } from 'commander';
 import { execa } from 'execa';
-import { existsSync } from 'node:fs';
 import { copyFile, cp, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
@@ -77,53 +76,21 @@ export async function buildCatalystProject(projectUuid: string): Promise<void> {
 }
 
 export const build = new Command('build')
-  .allowUnknownOption()
-  // The unknown options end up in program.args, not in program.opts(). Commander does not take a guess at how to interpret the unknown options.
-  .argument(
-    '[next-build-options...]',
-    'Next.js `build` options (see: https://nextjs.org/docs/app/api-reference/cli/next#next-build-options)',
-  )
   .addOption(
     new Option(
       '--project-uuid <uuid>',
       'Project UUID to be included in the deployment configuration.',
     ).env('CATALYST_PROJECT_UUID'),
   )
-  .addOption(
-    new Option('--framework <framework>', 'The framework to use for the build.').choices([
-      'nextjs',
-      'catalyst',
-    ]),
-  )
-  .action(async (nextBuildOptions, options) => {
-    const coreDir = process.cwd();
+  .action(async (options) => {
     const config = getProjectConfig();
-    const framework = options.framework ?? config.get('framework');
+    const projectUuid = options.projectUuid ?? config.get('projectUuid');
 
-    if (framework === 'nextjs') {
-      const nextBin = join('node_modules', '.bin', 'next');
-
-      if (!existsSync(nextBin)) {
-        throw new Error(
-          `Next.js is not installed in ${coreDir}. Are you in a valid Next.js project?`,
-        );
-      }
-
-      await execa(nextBin, ['build', ...nextBuildOptions], {
-        stdio: 'inherit',
-        cwd: coreDir,
-      });
+    if (!projectUuid) {
+      throw new Error(
+        'Project UUID is required. Please run `catalyst project create` or `catalyst project link` or this command again with --project-uuid <uuid>.',
+      );
     }
 
-    if (framework === 'catalyst') {
-      const projectUuid = options.projectUuid ?? config.get('projectUuid');
-
-      if (!projectUuid) {
-        throw new Error(
-          'Project UUID is required. Please run `catalyst project create` or `catalyst project link` or this command again with --project-uuid <uuid>.',
-        );
-      }
-
-      await buildCatalystProject(projectUuid);
-    }
+    await buildCatalystProject(projectUuid);
   });

--- a/packages/catalyst/src/cli/commands/project.spec.ts
+++ b/packages/catalyst/src/cli/commands/project.spec.ts
@@ -129,7 +129,6 @@ describe('project create', () => {
     expect(exitMock).toHaveBeenCalledWith(0);
 
     expect(config.get('projectUuid')).toBe('c23f5785-fd99-4a94-9fb3-945551623925');
-    expect(config.get('framework')).toBe('catalyst');
     expect(config.get('storeHash')).toBe(storeHash);
     expect(config.get('accessToken')).toBe(accessToken);
 
@@ -265,7 +264,6 @@ describe('project link', () => {
     );
     expect(exitMock).toHaveBeenCalledWith(0);
     expect(config.get('projectUuid')).toBe(projectUuid1);
-    expect(config.get('framework')).toBe('catalyst');
   });
 
   test('fetches projects and prompts user to select one', async () => {
@@ -316,7 +314,6 @@ describe('project link', () => {
     expect(exitMock).toHaveBeenCalledWith(0);
 
     expect(config.get('projectUuid')).toBe(projectUuid2);
-    expect(config.get('framework')).toBe('catalyst');
     expect(config.get('storeHash')).toBe(storeHash);
     expect(config.get('accessToken')).toBe(accessToken);
 
@@ -371,7 +368,6 @@ describe('project link', () => {
     expect(exitMock).toHaveBeenCalledWith(0);
 
     expect(config.get('projectUuid')).toBe(projectUuid3);
-    expect(config.get('framework')).toBe('catalyst');
     expect(config.get('storeHash')).toBe(storeHash);
     expect(config.get('accessToken')).toBe(accessToken);
 

--- a/packages/catalyst/src/cli/commands/project.ts
+++ b/packages/catalyst/src/cli/commands/project.ts
@@ -88,7 +88,6 @@ const create = new Command('create')
 
     consola.start('Writing project UUID to .bigcommerce/project.json...');
     config.set('projectUuid', data.uuid);
-    config.set('framework', 'catalyst');
     config.set('storeHash', storeHash);
     config.set('accessToken', accessToken);
     consola.success('Project UUID written to .bigcommerce/project.json.');
@@ -130,7 +129,6 @@ export const link = new Command('link')
     ) => {
       consola.start('Writing project UUID to .bigcommerce/project.json...');
       config.set('projectUuid', uuid);
-      config.set('framework', 'catalyst');
 
       if (credentials) {
         config.set('storeHash', credentials.storeHash);

--- a/packages/catalyst/src/cli/lib/project-config.spec.ts
+++ b/packages/catalyst/src/cli/lib/project-config.spec.ts
@@ -50,12 +50,3 @@ test('writes and reads field from .bigcommerce/project.json', async () => {
   expect(config.get('storeHash')).toBe('abc123');
   expect(config.get('accessToken')).toBe('secret-token');
 });
-
-test('sets default framework to nextjs', async () => {
-  const projectJsonPath = join(tmpDir, '.bigcommerce/project.json');
-
-  await mkdir(dirname(projectJsonPath), { recursive: true });
-  await writeFile(projectJsonPath, JSON.stringify({}));
-
-  expect(config.get('framework')).toBe('nextjs');
-});

--- a/packages/catalyst/src/cli/lib/project-config.ts
+++ b/packages/catalyst/src/cli/lib/project-config.ts
@@ -3,7 +3,8 @@ import { join } from 'path';
 
 export interface ProjectConfigSchema {
   projectUuid: string;
-  framework: 'catalyst' | 'nextjs';
+  // Reserved for future use
+  framework: 'catalyst';
   storeHash?: string;
   accessToken?: string;
   telemetry: {
@@ -21,8 +22,8 @@ export function getProjectConfig() {
       projectUuid: { type: 'string', format: 'uuid' },
       framework: {
         type: 'string',
-        enum: ['catalyst', 'nextjs'],
-        default: 'nextjs',
+        enum: ['catalyst'],
+        default: 'catalyst',
       },
       storeHash: { type: 'string' },
       accessToken: { type: 'string' },


### PR DESCRIPTION
## What/Why?

The `framework` configuration concept (`catalyst` | `nextjs`) is no longer needed. The CLI will only be installed when using native hosting, so the `nextjs` framework path is a dead code path. This PR removes it entirely and simplifies the build command to always call `buildCatalystProject()` directly.

### Changes

- **`project-config.ts`** — Remove `framework` from `ProjectConfigSchema` and its Conf schema definition
- **`build.ts`** — Remove `.allowUnknownOption()`, `[next-build-options...]` argument, `--framework` option, and the nextjs branch in the action handler; remove unused `existsSync` import
- **`project.ts`** — Remove `config.set('framework', 'catalyst')` from `create` and `link` actions
- **Tests** — Remove all framework-related assertions, mocks, and test cases across `build.spec.ts`, `project.spec.ts`, and `project-config.spec.ts`

## Testing

- `vitest run` — all tests pass (2 pre-existing failures in `index.spec.ts` and `version.spec.ts` are unrelated)
- `eslint .` — clean
- `tsc --noEmit` — clean

## Migration

The `framework` key in `.bigcommerce/project.json` is no longer read or written. Existing config files with this key will be silently ignored by `conf`.