### PR TITLE
fix(core): conditionally include optional SEO metadata

### DIFF
--- a/.changeset/quiet-tags-spread.md
+++ b/.changeset/quiet-tags-spread.md
@@ -1,0 +1,77 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Conditionally include optional SEO metadata fields in `generateMetadata` across page files. Fields `description`, `keywords`, `alternates`, and `openGraph` are now only included in the returned metadata object when they have a value, using spread syntax (`...(value && { key: value })`). Previously, these fields were always set — potentially assigning `null` or an empty string — which could cause Next.js to render empty `<meta>` tags.
+
+## Migration steps
+
+Update `generateMetadata` in the following pages to use conditional spread syntax for optional metadata fields:
+
+### brand, category, webpages (contact + normal)
+
+```diff
+  return {
+    title: pageTitle || entity.name,
+-   description: metaDescription,
+-   keywords: metaKeywords ? metaKeywords.split(',') : null,
++   ...(metaDescription && { description: metaDescription }),
++   ...(metaKeywords && { keywords: metaKeywords.split(',') }),
+  };
+```
+
+For `brand/[slug]/page.tsx`, also guard the `alternates` field:
+
+```diff
+-   alternates: await getMetadataAlternates({ path: brand.path, locale }),
++   ...(brand.path && { alternates: await getMetadataAlternates({ path: brand.path, locale }) }),
+```
+
+### blog/[blogId]/page.tsx
+
+```diff
+  return {
+    title: pageTitle || blogPost.name,
+-   description: metaDescription,
+-   keywords: metaKeywords ? metaKeywords.split(',') : null,
++   ...(metaDescription && { description: metaDescription }),
++   ...(metaKeywords && { keywords: metaKeywords.split(',') }),
+    ...(blogPost.path && {
+      alternates: await getMetadataAlternates({ path: blogPost.path, locale }),
+    }),
+  };
+```
+
+### product/[slug]/page.tsx
+
+```diff
+- keywords: metaKeywords ? metaKeywords.split(',') : null,
++ ...(metaKeywords && { keywords: metaKeywords.split(',') }),
+- openGraph: url
+-   ? {
+-       images: [{ url, alt }],
+-     }
+-   : null,
++ ...(url && { openGraph: { images: [{ url, alt }] } }),
+```
+
+### blog/page.tsx
+
+Extract the description to a variable and spread conditionally:
+
+```diff
++ const description =
++   blog?.description && blog.description.length > 150
++     ? `${blog.description.substring(0, 150)}...`
++     : blog?.description;
++
+  return {
+    title: blog?.name ?? t('title'),
+-   description:
+-     blog?.description && blog.description.length > 150
+-       ? `${blog.description.substring(0, 150)}...`
+-       : blog?.description,
++   ...(description && { description }),
+    ...(blog?.path && { alternates: await getMetadataAlternates({ path: blog.path, locale }) }),
+  };
+```

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
@@ -83,9 +83,9 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 
   return {
     title: pageTitle || brand.name,
-    description: metaDescription,
-    keywords: metaKeywords ? metaKeywords.split(',') : null,
-    alternates: await getMetadataAlternates({ path: brand.path, locale }),
+    ...(metaDescription && { description: metaDescription }),
+    ...(metaKeywords && { keywords: metaKeywords.split(',') }),
+    ...(brand.path && { alternates: await getMetadataAlternates({ path: brand.path, locale }) }),
   };
 }
 

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -88,8 +88,8 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 
   return {
     title: pageTitle || category.name,
-    description: metaDescription,
-    keywords: metaKeywords ? metaKeywords.split(',') : null,
+    ...(metaDescription && { description: metaDescription }),
+    ...(metaKeywords && { keywords: metaKeywords.split(',') }),
     ...(categoryPath && {
       alternates: await getMetadataAlternates({ path: categoryPath, locale }),
     }),

--- a/core/app/[locale]/(default)/blog/[blogId]/page.tsx
+++ b/core/app/[locale]/(default)/blog/[blogId]/page.tsx
@@ -34,8 +34,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   return {
     title: pageTitle || blogPost.name,
-    description: metaDescription,
-    keywords: metaKeywords ? metaKeywords.split(',') : null,
+    ...(metaDescription && { description: metaDescription }),
+    ...(metaKeywords && { keywords: metaKeywords.split(',') }),
     ...(blogPost.path && {
       alternates: await getMetadataAlternates({ path: blogPost.path, locale }),
     }),

--- a/core/app/[locale]/(default)/blog/page.tsx
+++ b/core/app/[locale]/(default)/blog/page.tsx
@@ -31,12 +31,14 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const t = await getTranslations({ locale, namespace: 'Blog' });
   const blog = await getBlog();
 
+  const description =
+    blog?.description && blog.description.length > 150
+      ? `${blog.description.substring(0, 150)}...`
+      : blog?.description;
+
   return {
     title: blog?.name ?? t('title'),
-    description:
-      blog?.description && blog.description.length > 150
-        ? `${blog.description.substring(0, 150)}...`
-        : blog?.description,
+    ...(description && { description }),
     ...(blog?.path && { alternates: await getMetadataAlternates({ path: blog.path, locale }) }),
   };
 }

--- a/core/app/[locale]/(default)/product/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/page.tsx
@@ -56,18 +56,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return {
     title: pageTitle || product.name,
     description: metaDescription || `${product.plainTextDescription.slice(0, 150)}...`,
-    keywords: metaKeywords ? metaKeywords.split(',') : null,
+    ...(metaKeywords && { keywords: metaKeywords.split(',') }),
     alternates: await getMetadataAlternates({ path: product.path, locale }),
-    openGraph: url
-      ? {
-          images: [
-            {
-              url,
-              alt,
-            },
-          ],
-        }
-      : null,
+    ...(url && { openGraph: { images: [{ url, alt }] } }),
   };
 }
 

--- a/core/app/[locale]/(default)/product/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/page.tsx
@@ -55,7 +55,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   return {
     title: pageTitle || product.name,
-    description: metaDescription || `${product.plainTextDescription.slice(0, 150)}...`,
+    description:
+      metaDescription ||
+      `${product.plainTextDescription.replaceAll(/\s+/g, ' ').trim().slice(0, 150)}...`,
     ...(metaKeywords && { keywords: metaKeywords.split(',') }),
     alternates: await getMetadataAlternates({ path: product.path, locale }),
     ...(url && { openGraph: { images: [{ url, alt }] } }),

--- a/core/app/[locale]/(default)/webpages/[id]/contact/page.tsx
+++ b/core/app/[locale]/(default)/webpages/[id]/contact/page.tsx
@@ -160,9 +160,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   return {
     title: pageTitle || webpage.title,
-    description: metaDescription,
-    keywords: metaKeywords ? metaKeywords.split(',') : null,
-    alternates: await getMetadataAlternates({ path: webpage.path, locale }),
+    ...(metaDescription && { description: metaDescription }),
+    ...(metaKeywords && { keywords: metaKeywords.split(',') }),
+    ...(webpage.path && {
+      alternates: await getMetadataAlternates({ path: webpage.path, locale }),
+    }),
   };
 }
 

--- a/core/app/[locale]/(default)/webpages/[id]/normal/page.tsx
+++ b/core/app/[locale]/(default)/webpages/[id]/normal/page.tsx
@@ -67,8 +67,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   return {
     title: pageTitle || webpage.title,
-    description: metaDescription,
-    keywords: metaKeywords ? metaKeywords.split(',') : null,
+    ...(metaDescription && { description: metaDescription }),
+    ...(metaKeywords && { keywords: metaKeywords.split(',') }),
     ...(pagePath && { alternates: await getMetadataAlternates({ path: pagePath, locale }) }),
   };
 }


### PR DESCRIPTION
## What/Why?
Conditionally include optional SEO metadata fields in `generateMetadata` across page files. Fields `description`, `keywords`, and `alternates` are now only included in the returned metadata object when they have a value, using spread syntax (`...(value && { key: value })`). Previously, these fields were always set — potentially assigning `null` or an empty string — which could cause Next.js to render empty `<meta>` tags.

## Testing
Unlighthouse report
<img width="228" height="37" alt="Screenshot 2026-02-24 at 5 22 47 PM" src="https://github.com/user-attachments/assets/eec4f1fc-a4b1-4817-a9d3-d0df26141565" />

## Migration steps

Update `generateMetadata` in the following pages to use conditional spread syntax for optional metadata fields:

### brand, category, webpages (contact + normal)

```diff
  return {
    title: pageTitle || entity.name,
-   description: metaDescription,
-   keywords: metaKeywords ? metaKeywords.split(',') : null,
+   ...(metaDescription && { description: metaDescription }),
+   ...(metaKeywords && { keywords: metaKeywords.split(',') }),
  };
```

For `brand/[slug]/page.tsx`, also guard the `alternates` field:

```diff
-   alternates: await getMetadataAlternates({ path: brand.path, locale }),
+   ...(brand.path && { alternates: await getMetadataAlternates({ path: brand.path, locale }) }),
```

### blog/[blogId]/page.tsx

```diff
  return {
    title: pageTitle || blogPost.name,
-   description: metaDescription,
-   keywords: metaKeywords ? metaKeywords.split(',') : null,
+   ...(metaDescription && { description: metaDescription }),
+   ...(metaKeywords && { keywords: metaKeywords.split(',') }),
    ...(blogPost.path && {
      alternates: await getMetadataAlternates({ path: blogPost.path, locale }),
    }),
  };
```

### blog/page.tsx

Extract the description to a variable and spread conditionally:

```diff
+ const description =
+   blog?.description && blog.description.length > 150
+     ? `${blog.description.substring(0, 150)}...`
+     : blog?.description;
+
  return {
    title: blog?.name ?? t('title'),
-   description:
-     blog?.description && blog.description.length > 150
-       ? `${blog.description.substring(0, 150)}...`
-       : blog?.description,
+   ...(description && { description }),
    ...(blog?.path && { alternates: await getMetadataAlternates({ path: blog.path, locale }) }),
  };
```
