### PR TITLE
fix(core): update gift certificate amount handler to include amount_display

### DIFF
--- a/.changeset/kind-gifts-update.md
+++ b/.changeset/kind-gifts-update.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Fix GiftCertificateCard not updating when selecting a new amount on the gift certificate purchase form

--- a/core/vibes/soul/sections/gift-certificate-purchase-section/index.tsx
+++ b/core/vibes/soul/sections/gift-certificate-purchase-section/index.tsx
@@ -93,7 +93,7 @@ export function GiftCertificatePurchaseSection({
       return;
     }
 
-    if (e.target.name !== 'amount') {
+    if (e.target.name !== 'amount' && e.target.name !== 'amount_display') {
       return;
     }
 


### PR DESCRIPTION
## What/Why?

The `GiftCertificateCard` preview component was not updating when selecting a predefined amount from the dropdown on the gift certificate purchase form.

The `handleFormChange` handler only checked for inputs with `name === 'amount'`, but the select element for predefined gift certificate amounts uses the name `amount_display`. This meant selecting a new amount from the dropdown was silently ignored, and the card preview never reflected the selected value.

The fix adds `amount_display` to the name check so both the custom amount input and the predefined amount select trigger the card preview update.

## Rollout/Rollback

No special rollout needed. Simple code change with no migrations or feature flags. Rollback is a standard revert.

## Testing

1. Navigate to the gift certificate purchase page
2. Select a predefined amount from the dropdown — verify the `GiftCertificateCard` preview updates to show the formatted amount
3. Enter a custom amount — verify the preview still updates correctly
4. Clear the amount — verify the preview resets

### Before fix
<img width="723" height="389" alt="image" src="https://github.com/user-attachments/assets/6796e304-1ff1-49aa-9adc-20aa6f5f158a" />

### After fix
<img width="839" height="439" alt="image" src="https://github.com/user-attachments/assets/85c91f47-aaf4-4aac-9392-034aa0941b38" />
