### PR TITLE
fix(cart): Show backorder details for cart digital items

### DIFF
--- a/.changeset/rotten-vans-train.md
+++ b/.changeset/rotten-vans-train.md
@@ -1,0 +1,10 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Show backorder details for digital items on cart page
+
+## Migration
+For existing Catalyst stores, to this fix, simply rebase the existing code with the new release code. The files to be rebased for this change to be applied are:
+- core/app/[locale]/(default)/cart/page-data.ts
+- core/app/[locale]/(default)/cart/page.tsx

--- a/core/app/[locale]/(default)/cart/page-data.ts
+++ b/core/app/[locale]/(default)/cart/page-data.ts
@@ -115,6 +115,12 @@ export const DigitalItemFragment = graphql(`
       }
     }
     url
+    stockPosition {
+      backorderMessage
+      quantityOnHand
+      quantityBackordered
+      quantityOutOfStock
+    }
   }
 `);
 

--- a/core/app/[locale]/(default)/cart/page.tsx
+++ b/core/app/[locale]/(default)/cart/page.tsx
@@ -127,43 +127,40 @@ export default async function Cart({ params }: Props) {
 
     let inventoryMessages;
 
-    if (item.__typename === 'CartPhysicalItem') {
-      if (item.stockPosition?.quantityOutOfStock === item.quantity) {
-        inventoryMessages = {
-          outOfStockMessage: data.site.settings?.inventory?.showOutOfStockMessage
-            ? data.site.settings.inventory.defaultOutOfStockMessage
+    if (item.stockPosition?.quantityOutOfStock === item.quantity) {
+      inventoryMessages = {
+        outOfStockMessage: data.site.settings?.inventory?.showOutOfStockMessage
+          ? data.site.settings.inventory.defaultOutOfStockMessage
+          : undefined,
+      };
+    } else {
+      inventoryMessages = {
+        quantityReadyToShipMessage:
+          data.site.settings?.inventory?.showQuantityOnHand && !!item.stockPosition?.quantityOnHand
+            ? t('quantityReadyToShip', {
+                quantity: Number(item.stockPosition.quantityOnHand),
+              })
             : undefined,
-        };
-      } else {
-        inventoryMessages = {
-          quantityReadyToShipMessage:
-            data.site.settings?.inventory?.showQuantityOnHand &&
-            !!item.stockPosition?.quantityOnHand
-              ? t('quantityReadyToShip', {
-                  quantity: Number(item.stockPosition.quantityOnHand),
-                })
-              : undefined,
-          quantityBackorderedMessage:
-            data.site.settings?.inventory?.showQuantityOnBackorder &&
-            !!item.stockPosition?.quantityBackordered
-              ? t('quantityOnBackorder', {
-                  quantity: Number(item.stockPosition.quantityBackordered),
-                })
-              : undefined,
-          quantityOutOfStockMessage:
-            data.site.settings?.inventory?.showOutOfStockMessage &&
-            !!item.stockPosition?.quantityOutOfStock
-              ? t('partiallyAvailable', {
-                  quantity: item.quantity - Number(item.stockPosition.quantityOutOfStock),
-                })
-              : undefined,
-          backorderMessage:
-            data.site.settings?.inventory?.showBackorderMessage &&
-            !!item.stockPosition?.quantityBackordered
-              ? (item.stockPosition.backorderMessage ?? undefined)
-              : undefined,
-        };
-      }
+        quantityBackorderedMessage:
+          data.site.settings?.inventory?.showQuantityOnBackorder &&
+          !!item.stockPosition?.quantityBackordered
+            ? t('quantityOnBackorder', {
+                quantity: Number(item.stockPosition.quantityBackordered),
+              })
+            : undefined,
+        quantityOutOfStockMessage:
+          data.site.settings?.inventory?.showOutOfStockMessage &&
+          !!item.stockPosition?.quantityOutOfStock
+            ? t('partiallyAvailable', {
+                quantity: item.quantity - Number(item.stockPosition.quantityOutOfStock),
+              })
+            : undefined,
+        backorderMessage:
+          data.site.settings?.inventory?.showBackorderMessage &&
+          !!item.stockPosition?.quantityBackordered
+            ? (item.stockPosition.backorderMessage ?? undefined)
+            : undefined,
+      };
     }
 
     return {


### PR DESCRIPTION
## What/Why?
Show backorders details for digital cart items as well.

## Testing
Screenshots
**Before**
<img width="1129" height="715" alt="Screenshot 2026-02-27 at 7 16 12 am" src="https://github.com/user-attachments/assets/5320b2c7-5189-4ca5-af66-2334f20b749a" />

**After**
<img width="1128" height="723" alt="Screenshot 2026-02-27 at 6 56 25 am" src="https://github.com/user-attachments/assets/1915c71e-e9e9-43b3-a8e6-711e7239d0ef" />

## Migration
Rebase
