### PR TITLE
fix(core): render branded page for /404 instead of Vercel default

### DIFF
--- a/.changeset/fix-root-not-found.md
+++ b/.changeset/fix-root-not-found.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Add root-level not-found page so /404 renders a branded page instead of the default Vercel error screen

--- a/core/app/[locale]/layout.tsx
+++ b/core/app/[locale]/layout.tsx
@@ -1,6 +1,5 @@
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
-import { clsx } from 'clsx';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { NextIntlClientProvider } from 'next-intl';
@@ -8,9 +7,6 @@ import { setRequestLocale } from 'next-intl/server';
 import { NuqsAdapter } from 'nuqs/adapters/next/app';
 import { cache, PropsWithChildren } from 'react';
 
-import '../../globals.css';
-
-import { fonts } from '~/app/fonts';
 import { CookieNotifications } from '~/app/notifications';
 import { Providers } from '~/app/providers';
 import { client } from '~/client';
@@ -140,34 +136,32 @@ export default async function RootLayout({ params, children }: Props) {
   const privacyPolicyUrl = rootData.data.site.settings?.privacy?.privacyPolicyUrl;
 
   return (
-    <html className={clsx(fonts.map((f) => f.variable))} lang={locale}>
-      <body className="flex min-h-screen flex-col">
-        <NextIntlClientProvider>
-          <ConsentManager
-            isCookieConsentEnabled={isCookieConsentEnabled}
-            privacyPolicyUrl={privacyPolicyUrl}
-            scripts={scripts}
-          >
-            <NuqsAdapter>
-              <AnalyticsProvider
-                channelId={rootData.data.channel.entityId}
-                isCookieConsentEnabled={isCookieConsentEnabled}
-                settings={rootData.data.site.settings}
-              >
-                <Providers>
-                  {toastNotificationCookieData && (
-                    <CookieNotifications {...toastNotificationCookieData} />
-                  )}
-                  {children}
-                </Providers>
-              </AnalyticsProvider>
-            </NuqsAdapter>
-          </ConsentManager>
-        </NextIntlClientProvider>
-        <VercelComponents />
-        <ContainerQueryPolyfill />
-      </body>
-    </html>
+    <>
+      <NextIntlClientProvider>
+        <ConsentManager
+          isCookieConsentEnabled={isCookieConsentEnabled}
+          privacyPolicyUrl={privacyPolicyUrl}
+          scripts={scripts}
+        >
+          <NuqsAdapter>
+            <AnalyticsProvider
+              channelId={rootData.data.channel.entityId}
+              isCookieConsentEnabled={isCookieConsentEnabled}
+              settings={rootData.data.site.settings}
+            >
+              <Providers>
+                {toastNotificationCookieData && (
+                  <CookieNotifications {...toastNotificationCookieData} />
+                )}
+                {children}
+              </Providers>
+            </AnalyticsProvider>
+          </NuqsAdapter>
+        </ConsentManager>
+      </NextIntlClientProvider>
+      <VercelComponents />
+      <ContainerQueryPolyfill />
+    </>
   );
 }
 

--- a/core/app/layout.tsx
+++ b/core/app/layout.tsx
@@ -1,0 +1,14 @@
+import { clsx } from 'clsx';
+import { PropsWithChildren } from 'react';
+
+import '../globals.css';
+
+import { fonts } from '~/app/fonts';
+
+export default function RootLayout({ children }: PropsWithChildren) {
+  return (
+    <html className={clsx(fonts.map((f) => f.variable))} lang="en">
+      <body className="flex min-h-screen flex-col">{children}</body>
+    </html>
+  );
+}

--- a/core/app/not-found.tsx
+++ b/core/app/not-found.tsx
@@ -1,0 +1,16 @@
+export default function RootNotFound() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-[hsl(var(--background))] text-[hsl(var(--foreground))]">
+      <h1 className="font-heading text-4xl font-medium">Page not found</h1>
+      <p className="mt-4 text-lg text-[hsl(var(--contrast-400))]">
+        The page you are looking for could not be found.
+      </p>
+      <a
+        className="mt-6 inline-flex items-center text-[hsl(var(--foreground))] underline underline-offset-4 hover:no-underline"
+        href="/"
+      >
+        Go to homepage
+      </a>
+    </div>
+  );
+}


### PR DESCRIPTION
Visiting /404 directly shows the default Vercel black screen because
Next.js special-cases this path with a pre-rendered static 404.html,
bypassing the [locale] segment entirely.

Fix by splitting the layout into a true root layout (app/layout.tsx)
owning <html>, <body>, fonts, and globals.css, and converting the
locale layout into a nested layout. A new root not-found.tsx renders
a minimal branded 404 page for this edge case.