### PR TITLE
refactor(core): use dynamic imports in client for next.js 16 compat

### DIFF
--- a/.changeset/dynamic-imports-client.md
+++ b/.changeset/dynamic-imports-client.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Use dynamic imports for next/headers, next/navigation, and next-intl/server in the client module to avoid AsyncLocalStorage poisoning during next.config.ts resolution

--- a/core/client/index.ts
+++ b/core/client/index.ts
@@ -1,22 +1,30 @@
 import { BigCommerceAuthError, createClient } from '@bigcommerce/catalyst-client';
-import { headers } from 'next/headers';
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import { redirect } from 'next/navigation';
-import { getLocale as getServerLocale } from 'next-intl/server';
 
 import { getChannelIdFromLocale } from '../channels.config';
 import { backendUserAgent } from '../user-agent';
 
+// next/headers, next/navigation, and next-intl/server are imported dynamically
+// (via `import()`) rather than statically. Static imports cause these modules to
+// be evaluated during module graph resolution when next.config.ts imports this
+// file, which poisons the process-wide AsyncLocalStorage context (pnpm symlinks
+// create two separate singleton instances of next/headers). Dynamic imports
+// defer module loading to call time, after Next.js has fully initialized.
+//
+// During config resolution, the dynamic import of next-intl/server succeeds but
+// getLocale() throws ("not supported in Client Components") — the try/catch
+// below absorbs this gracefully, and getChannelId falls back to defaultChannelId.
+
 const getLocale = async () => {
   try {
-    const locale = await getServerLocale();
+    const { getLocale: getServerLocale } = await import('next-intl/server');
 
-    return locale;
+    return await getServerLocale();
   } catch {
     /**
      * Next-intl `getLocale` only works on the server, and when middleware has run.
      *
      * Instances when `getLocale` will not work:
+     * - Requests during next.config.ts resolution
      * - Requests in middlewares
      * - Requests in `generateStaticParams`
      * - Request in api routes
@@ -45,6 +53,7 @@ export const client = createClient({
     const locale = await getLocale();
 
     if (fetchOptions?.cache && ['no-store', 'no-cache'].includes(fetchOptions.cache)) {
+      const { headers } = await import('next/headers');
       const ipAddress = (await headers()).get('X-Forwarded-For');
 
       if (ipAddress) {
@@ -61,8 +70,10 @@ export const client = createClient({
       headers: requestHeaders,
     };
   },
-  onError: (error, queryType) => {
+  onError: async (error, queryType) => {
     if (error instanceof BigCommerceAuthError && queryType === 'query') {
+      const { redirect } = await import('next/navigation');
+
       redirect('/api/auth/signout');
     }
   },


### PR DESCRIPTION
## What/Why?

In Next.js 16 with pnpm, statically importing `next/headers`, `next/navigation`, or `next-intl/server` at the top of `core/client/index.ts` causes AsyncLocalStorage poisoning. When `next.config.ts` imports the client module, static imports trigger the full module graph (`next-intl/server` → `getConfig.js` → `RequestLocale.js` → `next/headers`) to be evaluated during module resolution. With pnpm symlinks, this creates two separate singleton instances of the `next/headers` AsyncLocalStorage, breaking request-scoped context for subsequent runtime calls.

The Next.js team identified this as a bug and opened [vercel/next.js#90711](https://github.com/vercel/next.js/pull/90711) to fix it upstream. However, regardless of that fix, the client module shouldn't eagerly import framework-specific APIs like `next/headers` or `next/navigation` at the module level — these are runtime concerns that belong inside the hooks that use them. This refactor improves separation of concerns and makes the client resilient to module evaluation order, independent of any upstream fix.

### Solution

Replace all three static imports with dynamic `import()` calls inside the hooks that use them:

- **`next-intl/server`** — dynamically imported in `getLocale()`. During config resolution, the import succeeds but `getLocale()` throws ("not supported in Client Components"), which the existing try/catch absorbs gracefully. At request time, it works normally.
- **`next/headers`** — dynamically imported inside the `fetchOptions.cache` guard in `beforeRequest`. Config-time calls pass no `fetchOptions`, so this never executes during config resolution.
- **`next/navigation`** — dynamically imported inside the `BigCommerceAuthError` check in `onError`. Config-time settings queries don't produce auth errors.

Dynamic imports defer module loading to call time (after Next.js has fully initialized), avoiding the module-graph-level poisoning that static imports cause.

### Scope

Only `core/client/index.ts` changes. `next.config.ts` and all 30+ consumer files remain untouched.

## Testing

We added temporary instrumentation (`console.log` with `NEXT_RUNTIME` value and call stack) to `getLocale()`, `next.config.ts`, and `middlewares/with-routes.ts`, then tested across all runtime contexts on Next.js 16.1.6 (Turbopack) by cherry-picking the Next.js 16 upgrade commits onto this branch.

### `NEXT_RUNTIME` behavior (key finding)

We initially guarded `getLocale()` with a `process.env.NEXT_RUNTIME` check, expecting it to be `undefined` during config resolution. **Testing revealed `NEXT_RUNTIME="nodejs"` in every context, including config resolution.** The guard was dead code and was removed. The actual protection comes from:

1. **Dynamic `import()` vs static `import`** — defers module loading past the initialization window where poisoning occurs
2. **The existing try/catch** — absorbs `getLocale()` failures in contexts where next-intl isn't available

### Runtime context matrix

| Context | `NEXT_RUNTIME` | `getLocale` outcome | Status |
|---|---|---|---|
| Config resolution (`next.config.ts` startup) | `"nodejs"` | Throws "not supported in Client Components" → caught by try/catch, falls back to `defaultChannelId` | **Pass** |
| Middleware (module load) | `"edge"` | N/A | **Pass** |
| Middleware (request handling) | `"edge"` | Throws `NEXT_HTTP_ERROR_FALLBACK;404` for non-matching routes → caught | **Pass** |
| RSC — homepage (`GET /`) | `"nodejs"` | Succeeds, locale resolved | **Pass** |
| Server action — search (`POST /`) | `"nodejs"` | Succeeds, locale resolved | **Pass** |
| RSC — search results (`GET /search?term=spray`) | `"nodejs"` | Succeeds, locale resolved | **Pass** |
| RSC — product page (`GET /spray-bottle`) | `"nodejs"` | Succeeds, locale resolved | **Pass** |
| RSC — locale switch (`GET /es-MX/spray-bottle`) | `"nodejs"` | Succeeds, correct locale resolved | **Pass** |
| Build (`next build`) | `"nodejs"` | Succeeds for all pages | **Pass** |

### Manual verification

- Homepage renders with correct channel data and locale-aware content
- Search bar triggers server action, returns results with correct locale
- Product pages render with full data (metadata, pricing, inventory, reviews)
- Locale switching serves correct localized content
- No AsyncLocalStorage errors in any context
- No regressions in existing functionality
- Build completes successfully with all pages generated

## Migration

No migration needed. Only `core/client/index.ts` was modified. All consumer imports remain unchanged.