### PR TITLE
refactor(core): split client into base config and extended client

### DIFF
--- a/core/client/base.ts
+++ b/core/client/base.ts
@@ -1,0 +1,31 @@
+/**
+ * Base client configuration and instance for BigCommerce API access.
+ *
+ * This module intentionally avoids importing any Next.js runtime APIs
+ * (`next/headers`, `next/navigation`) or `next-intl/server`. In Next.js 16,
+ * importing those modules during config resolution (i.e., from `next.config.ts`)
+ * poisons the process-wide AsyncLocalStorage context and causes
+ * "workUnitAsyncStorage" invariant errors at runtime.
+ *
+ * - `baseClientConfig` — shared configuration object (env vars + logger).
+ *   Re-used by `./index.ts` to build the full client with request hooks.
+ * - `baseClient` — a ready-to-use client instance without hooks.
+ *   Safe to import from `next.config.ts` and other non-request contexts.
+ */
+import { createClient } from '@bigcommerce/catalyst-client';
+
+import { backendUserAgent } from '../user-agent';
+
+type ClientConfig = Parameters<typeof createClient>[0];
+
+export const baseClientConfig = {
+  storefrontToken: process.env.BIGCOMMERCE_STOREFRONT_TOKEN ?? '',
+  storeHash: process.env.BIGCOMMERCE_STORE_HASH ?? '',
+  channelId: process.env.BIGCOMMERCE_CHANNEL_ID,
+  backendUserAgentExtensions: backendUserAgent,
+  logger:
+    (process.env.NODE_ENV !== 'production' && process.env.CLIENT_LOGGER !== 'false') ||
+    process.env.CLIENT_LOGGER === 'true',
+} satisfies Partial<ClientConfig>;
+
+export const baseClient = createClient(baseClientConfig);

--- a/core/client/index.ts
+++ b/core/client/index.ts
@@ -5,7 +5,8 @@ import { redirect } from 'next/navigation';
 import { getLocale as getServerLocale } from 'next-intl/server';
 
 import { getChannelIdFromLocale } from '../channels.config';
-import { backendUserAgent } from '../user-agent';
+
+import { baseClientConfig } from './base';
 
 const getLocale = async () => {
   try {
@@ -26,13 +27,7 @@ const getLocale = async () => {
 };
 
 export const client = createClient({
-  storefrontToken: process.env.BIGCOMMERCE_STOREFRONT_TOKEN ?? '',
-  storeHash: process.env.BIGCOMMERCE_STORE_HASH ?? '',
-  channelId: process.env.BIGCOMMERCE_CHANNEL_ID,
-  backendUserAgentExtensions: backendUserAgent,
-  logger:
-    (process.env.NODE_ENV !== 'production' && process.env.CLIENT_LOGGER !== 'false') ||
-    process.env.CLIENT_LOGGER === 'true',
+  ...baseClientConfig,
   getChannelId: async (defaultChannelId: string) => {
     const locale = await getLocale();
 

--- a/core/next.config.ts
+++ b/core/next.config.ts
@@ -3,7 +3,7 @@ import type { NextConfig } from 'next';
 import createNextIntlPlugin from 'next-intl/plugin';
 
 import { writeBuildConfig } from './build-config/writer';
-import { client } from './client';
+import { baseClient } from './client/base';
 import { graphql } from './client/graphql';
 import { cspHeader } from './lib/content-security-policy';
 
@@ -32,7 +32,7 @@ const SettingsQuery = graphql(`
 `);
 
 async function writeSettingsToBuildConfig() {
-  const { data } = await client.fetch({ document: SettingsQuery });
+  const { data } = await baseClient.fetch({ document: SettingsQuery });
 
   const cdnEnvHostnames = process.env.NEXT_PUBLIC_BIGCOMMERCE_CDN_HOSTNAME;
 


### PR DESCRIPTION
## Summary

- Extracts shared BigCommerce client configuration into a new framework-agnostic `core/client/base.ts` module
- Updates `core/next.config.ts` to import `baseClient` from `./client/base` instead of `client` from the barrel `./client`
- Updates `core/client/index.ts` to spread `baseClientConfig` instead of duplicating config fields

## Motivation

In Next.js 16, `core/client/index.ts` statically imports `next/headers`, `next/navigation`, and `next-intl/server`. When `next.config.ts` imports this module, those imports poison the process-wide AsyncLocalStorage context, causing "workUnitAsyncStorage" invariant errors at runtime.

This is **Approach B** from [CATALYST-1808](https://bigcommercecloud.atlassian.net/browse/CATALYST-1808). Compared to the dynamic-imports approach in PR #2905 (Approach A), this approach:

- Avoids runtime overhead of dynamic `import()` on every request
- Keeps all Next.js-dependent hooks in `index.ts` exactly as-is
- Is a smaller, more surgical change (new file + two edits)

## Test plan

- [ ] `pnpm tsc --noEmit` in `core/` — no new type errors
- [ ] `pnpm build` — Next.js config resolution works without AsyncLocalStorage errors
- [ ] Grep confirms `next.config.ts` no longer imports from `./client` barrel
- [ ] All 30+ consumer files importing from `~/client` continue working unchanged

[CATALYST-1808]: https://bigcommercecloud.atlassian.net/browse/CATALYST-1808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ