### PR TITLE
feat(core): add X-Correlation-ID header, cache guest queries separately

### DIFF
--- a/.changeset/curly-hats-greet.md
+++ b/.changeset/curly-hats-greet.md
@@ -1,0 +1,112 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+All GraphQL requests now include an `X-Correlation-ID` header containing a UUID that is stable for the duration of a single page render (via `React.cache`), making it easier to trace and correlate all requests made during a single render in server logs.
+
+Guest (unauthenticated) queries are now cached using `unstable_cache` with the configured revalidation interval, while authenticated requests continue to use `cache: 'no-store'`. This separates cacheable public data from session-specific data, improving performance for unauthenticated visitors. The `X-Forwarded-For` and `True-Client-IP` headers are only forwarded on uncached (`no-store`) requests since they are unavailable inside `unstable_cache`.
+
+## Migration
+
+### Step 1: Add the correlation ID helper
+
+Create `core/client/correlation-id.ts`:
+
+```ts
+import { cache } from 'react';
+
+/**
+ * Returns a stable correlation ID for the current request.
+ * React.cache ensures the same UUID is returned for all fetches within a
+ * single page render, while being unique across renders/requests.
+ */
+export const getCorrelationId = cache((): string => crypto.randomUUID());
+```
+
+### Step 2: Update `core/client/index.ts`
+
+Update the `beforeRequest` hook to add the `X-Correlation-ID` header to all requests and to only forward `X-Forwarded-For` / `True-Client-IP` on uncached requests:
+
+```diff
++ import { getCorrelationId } from './correlation-id';
+
+  export const client = createClient({
+    ...
+    beforeRequest: async (fetchOptions) => {
+      const requestHeaders: Record<string, string> = {};
+
+-     try {
+-       const ipAddress = (await headers()).get('X-Forwarded-For');
+-       if (ipAddress) {
+-         requestHeaders['X-Forwarded-For'] = ipAddress;
+-         requestHeaders['True-Client-IP'] = ipAddress;
+-       }
+-     } catch {
+-       // Not in a request context
+-     }
++     if (fetchOptions?.cache && ['no-store', 'no-cache'].includes(fetchOptions.cache)) {
++       try {
++         // headers() is a dynamic API unavailable inside unstable_cache; skip IP forwarding in that context
++         const ipAddress = (await headers()).get('X-Forwarded-For');
++         if (ipAddress) {
++           requestHeaders['X-Forwarded-For'] = ipAddress;
++           requestHeaders['True-Client-IP'] = ipAddress;
++         }
++       } catch {
++         // Not in a request context (e.g. inside unstable_cache); IP forwarding not available
++       }
++     }
++
++     requestHeaders['X-Correlation-ID'] = getCorrelationId();
+
+      return { headers: requestHeaders };
+    },
+  });
+```
+
+### Step 3: Wrap guest queries with `unstable_cache`
+
+For each page data file, wrap the guest (unauthenticated) fetch in `unstable_cache` and branch on whether a `customerAccessToken` is present. Example pattern:
+
+```diff
++ import { unstable_cache } from 'next/cache';
+  import { cache } from 'react';
++ import { revalidate } from '~/client/revalidate-target';
+
++ const getCachedPageData = unstable_cache(
++   async (locale: string, ...args) => {
++     const { data } = await client.fetch({
++       document: PageQuery,
++       variables: { ... },
++       locale,
++       fetchOptions: { cache: 'no-store' },
++     });
++     return data;
++   },
++   ['cache-key'],
++   { revalidate },
++ );
+
+  export const getPageData = cache(
+-   async (locale: string, customerAccessToken?: string) => {
+-     const { data } = await client.fetch({
+-       document: PageQuery,
+-       locale,
+-       fetchOptions: { cache: 'no-store' },
+-     });
+-     return data;
+-   },
++   async (locale: string, customerAccessToken?: string) => {
++     if (customerAccessToken) {
++       const { data } = await client.fetch({
++         document: PageQuery,
++         customerAccessToken,
++         locale,
++         fetchOptions: { cache: 'no-store' },
++       });
++       return data;
++     }
++     return getCachedPageData(locale);
++   },
+  );
+```

--- a/.changeset/plain-results-happen.md
+++ b/.changeset/plain-results-happen.md
@@ -1,0 +1,40 @@
+---
+"@bigcommerce/catalyst-client": minor
+---
+
+`locale` is now a parameter on `client.fetch()` and is required for all queries. It is passed through to channel ID resolution so the `getChannelId` callback can return a locale-specific channel, and it is used to set the `Accept-Language` request header on each GraphQL call.
+
+The `getChannelId` config callback signature now accepts `locale` as an optional second argument:
+
+```diff
+- getChannelId?: (defaultChannelId: string) => Promise<string> | string;
++ getChannelId?: (defaultChannelId: string, locale?: string) => Promise<string> | string;
+```
+
+## Migration
+
+### Step 1: Update all `client.fetch()` calls
+
+Pass `locale` as a parameter to every `client.fetch()` call across your page data files:
+
+```diff
+  const { data } = await client.fetch({
+    document: PageQuery,
+    variables: { ... },
++   locale,
+    fetchOptions: { cache: 'no-store' },
+  });
+```
+
+### Step 2: Update the `getChannelId` callback in `core/client/index.ts`
+
+Update the callback to accept and forward the `locale` parameter:
+
+```diff
+- getChannelId: (defaultChannelId: string) => {
+-   return getChannelIdFromLocale() ?? defaultChannelId;
+- },
++ getChannelId: (defaultChannelId: string, locale?: string) => {
++   return getChannelIdFromLocale(locale) ?? defaultChannelId;
++ },
+```

--- a/core/app/[locale]/(default)/(auth)/change-password/page-data.ts
+++ b/core/app/[locale]/(default)/(auth)/change-password/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -24,16 +25,24 @@ const ChangePasswordQuery = graphql(`
   }
 `);
 
-export const getChangePasswordQuery = cache(async () => {
-  const response = await client.fetch({
-    document: ChangePasswordQuery,
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedChangePasswordQuery = unstable_cache(
+  async (locale: string) => {
+    const response = await client.fetch({
+      document: ChangePasswordQuery,
+      locale,
+    });
 
-  const passwordComplexitySettings =
-    response.data.site.settings?.customers?.passwordComplexitySettings;
+    const passwordComplexitySettings =
+      response.data.site.settings?.customers?.passwordComplexitySettings;
 
-  return {
-    passwordComplexitySettings,
-  };
+    return {
+      passwordComplexitySettings,
+    };
+  },
+  ['get-change-password-query'],
+  { revalidate },
+);
+
+export const getChangePasswordQuery = cache(async (locale: string) => {
+  return getCachedChangePasswordQuery(locale);
 });

--- a/core/app/[locale]/(default)/(auth)/change-password/page.tsx
+++ b/core/app/[locale]/(default)/(auth)/change-password/page.tsx
@@ -38,7 +38,7 @@ export default async function ChangePassword({ params, searchParams }: Props) {
     return redirect({ href: '/login', locale });
   }
 
-  const { passwordComplexitySettings } = await getChangePasswordQuery();
+  const { passwordComplexitySettings } = await getChangePasswordQuery(locale);
 
   return (
     <ResetPasswordSection

--- a/core/app/[locale]/(default)/(auth)/register/page-data.ts
+++ b/core/app/[locale]/(default)/(auth)/register/page-data.ts
@@ -1,8 +1,9 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
-import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
 import { graphql, VariablesOf } from '~/client/graphql';
+import { revalidate } from '~/client/revalidate-target';
 import { FormFieldsFragment } from '~/data-transformers/form-field-transformer/fragment';
 
 const RegisterCustomerQuery = graphql(
@@ -61,35 +62,41 @@ interface Props {
   };
 }
 
-export const getRegisterCustomerQuery = cache(async ({ address, customer }: Props) => {
-  const customerAccessToken = await getSessionCustomerAccessToken();
+const getCachedRegisterCustomerQuery = unstable_cache(
+  async (locale: string, { address, customer }: Props) => {
+    const response = await client.fetch({
+      document: RegisterCustomerQuery,
+      variables: {
+        addressFilters: address?.filters,
+        addressSortBy: address?.sortBy,
+        customerFilters: customer?.filters,
+        customerSortBy: customer?.sortBy,
+      },
+      fetchOptions: { cache: 'no-store' },
+      locale,
+    });
 
-  const response = await client.fetch({
-    document: RegisterCustomerQuery,
-    variables: {
-      addressFilters: address?.filters,
-      addressSortBy: address?.sortBy,
-      customerFilters: customer?.filters,
-      customerSortBy: customer?.sortBy,
-    },
-    fetchOptions: { cache: 'no-store' },
-    customerAccessToken,
-  });
+    const addressFields = response.data.site.settings?.formFields.shippingAddress;
+    const customerFields = response.data.site.settings?.formFields.customer;
+    const countries = response.data.geography.countries;
+    const passwordComplexitySettings =
+      response.data.site.settings?.customers?.passwordComplexitySettings;
 
-  const addressFields = response.data.site.settings?.formFields.shippingAddress;
-  const customerFields = response.data.site.settings?.formFields.customer;
-  const countries = response.data.geography.countries;
-  const passwordComplexitySettings =
-    response.data.site.settings?.customers?.passwordComplexitySettings;
+    if (!addressFields || !customerFields) {
+      return null;
+    }
 
-  if (!addressFields || !customerFields) {
-    return null;
-  }
+    return {
+      addressFields,
+      customerFields,
+      countries,
+      passwordComplexitySettings,
+    };
+  },
+  ['get-register-customer-query'],
+  { revalidate },
+);
 
-  return {
-    addressFields,
-    customerFields,
-    countries,
-    passwordComplexitySettings,
-  };
+export const getRegisterCustomerQuery = cache(async (locale: string, props: Props) => {
+  return getCachedRegisterCustomerQuery(locale, props);
 });

--- a/core/app/[locale]/(default)/(auth)/register/page.tsx
+++ b/core/app/[locale]/(default)/(auth)/register/page.tsx
@@ -52,7 +52,7 @@ export default async function Register({ params }: Props) {
 
   const t = await getTranslations('Auth.Register');
 
-  const registerCustomerData = await getRegisterCustomerQuery({
+  const registerCustomerData = await getRegisterCustomerQuery(locale, {
     address: { sortBy: 'SORT_ORDER' },
     customer: { sortBy: 'SORT_ORDER' },
   });

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -38,13 +39,35 @@ const BrandPageQuery = graphql(`
   }
 `);
 
-export const getBrandPageData = cache(async (entityId: number, customerAccessToken?: string) => {
-  const response = await client.fetch({
-    document: BrandPageQuery,
-    variables: { entityId },
-    customerAccessToken,
-    fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
-  });
+const getCachedBrandPageData = unstable_cache(
+  async (locale: string, entityId: number) => {
+    const response = await client.fetch({
+      document: BrandPageQuery,
+      variables: { entityId },
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return response.data.site;
-});
+    return response.data.site;
+  },
+  ['get-brand-page-data'],
+  { revalidate },
+);
+
+export const getBrandPageData = cache(
+  async (locale: string, entityId: number, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const response = await client.fetch({
+        document: BrandPageQuery,
+        variables: { entityId },
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return response.data.site;
+    }
+
+    return getCachedBrandPageData(locale, entityId);
+  },
+);

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
@@ -30,9 +30,14 @@ const getCachedBrand = cache((brandId: string) => {
 const compareLoader = createCompareLoader();
 
 const createBrandSearchParamsLoader = cache(
-  async (brandId: string, customerAccessToken?: string) => {
+  async (locale: string, brandId: string, customerAccessToken?: string) => {
     const cachedBrand = getCachedBrand(brandId);
-    const brandSearch = await fetchFacetedSearch(cachedBrand, undefined, customerAccessToken);
+    const brandSearch = await fetchFacetedSearch(
+      locale,
+      cachedBrand,
+      undefined,
+      customerAccessToken,
+    );
     const brandFacets = brandSearch.facets.items.filter(
       (facet) => facet.__typename !== 'BrandSearchFilter',
     );
@@ -68,12 +73,14 @@ interface Props {
 }
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
-  const { slug, locale } = await props.params;
-  const customerAccessToken = await getSessionCustomerAccessToken();
+  const [{ slug, locale }, customerAccessToken] = await Promise.all([
+    props.params,
+    getSessionCustomerAccessToken(),
+  ]);
 
   const brandId = Number(slug);
 
-  const { brand } = await getBrandPageData(brandId, customerAccessToken);
+  const { brand } = await getBrandPageData(locale, brandId, customerAccessToken);
 
   if (!brand) {
     return notFound();
@@ -90,16 +97,17 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 }
 
 export default async function Brand(props: Props) {
-  const { locale, slug } = await props.params;
-  const customerAccessToken = await getSessionCustomerAccessToken();
+  const [{ locale, slug }, customerAccessToken, t] = await Promise.all([
+    props.params,
+    getSessionCustomerAccessToken(),
+    getTranslations('Faceted'),
+  ]);
 
   setRequestLocale(locale);
 
-  const t = await getTranslations('Faceted');
-
   const brandId = Number(slug);
 
-  const { brand, settings } = await getBrandPageData(brandId, customerAccessToken);
+  const { brand, settings } = await getBrandPageData(locale, brandId, customerAccessToken);
 
   if (!brand) {
     return notFound();
@@ -114,10 +122,11 @@ export default async function Brand(props: Props) {
     const searchParams = await props.searchParams;
     const currencyCode = await getPreferredCurrencyCode();
 
-    const loadSearchParams = await createBrandSearchParamsLoader(slug, customerAccessToken);
+    const loadSearchParams = await createBrandSearchParamsLoader(locale, slug, customerAccessToken);
     const parsedSearchParams = loadSearchParams?.(searchParams) ?? {};
 
     const search = await fetchFacetedSearch(
+      locale,
       {
         ...searchParams,
         ...parsedSearchParams,
@@ -162,10 +171,15 @@ export default async function Brand(props: Props) {
 
   const streamableFilters = Streamable.from(async () => {
     const searchParams = await props.searchParams;
-    const loadSearchParams = await createBrandSearchParamsLoader(slug, customerAccessToken);
+    const loadSearchParams = await createBrandSearchParamsLoader(locale, slug, customerAccessToken);
     const parsedSearchParams = loadSearchParams?.(searchParams) ?? {};
     const cachedBrand = getCachedBrand(slug);
-    const categorySearch = await fetchFacetedSearch(cachedBrand, undefined, customerAccessToken);
+    const categorySearch = await fetchFacetedSearch(
+      locale,
+      cachedBrand,
+      undefined,
+      customerAccessToken,
+    );
     const refinedSearch = await streamableFacetedSearch;
 
     const allFacets = categorySearch.facets.items.filter(
@@ -195,7 +209,7 @@ export default async function Brand(props: Props) {
 
     const compareIds = { entityIds: compare ? compare.map((id: string) => Number(id)) : [] };
 
-    const products = await getCompareProductsData(compareIds, customerAccessToken);
+    const products = await getCompareProductsData(locale, compareIds, customerAccessToken);
 
     return products.map((product) => ({
       id: product.entityId.toString(),

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -58,13 +59,35 @@ const CategoryPageQuery = graphql(
   [BreadcrumbsCategoryFragment],
 );
 
-export const getCategoryPageData = cache(async (entityId: number, customerAccessToken?: string) => {
-  const response = await client.fetch({
-    document: CategoryPageQuery,
-    variables: { entityId },
-    customerAccessToken,
-    fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
-  });
+const getCachedCategoryPageData = unstable_cache(
+  async (locale: string, entityId: number) => {
+    const response = await client.fetch({
+      document: CategoryPageQuery,
+      variables: { entityId },
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return response.data.site;
-});
+    return response.data.site;
+  },
+  ['get-category-page-data'],
+  { revalidate },
+);
+
+export const getCategoryPageData = cache(
+  async (locale: string, entityId: number, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const response = await client.fetch({
+        document: CategoryPageQuery,
+        variables: { entityId },
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return response.data.site;
+    }
+
+    return getCachedCategoryPageData(locale, entityId);
+  },
+);

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -32,9 +32,14 @@ const getCachedCategory = cache((categoryId: number) => {
 const compareLoader = createCompareLoader();
 
 const createCategorySearchParamsLoader = cache(
-  async (categoryId: number, customerAccessToken?: string) => {
+  async (locale: string, categoryId: number, customerAccessToken?: string) => {
     const cachedCategory = getCachedCategory(categoryId);
-    const categorySearch = await fetchFacetedSearch(cachedCategory, undefined, customerAccessToken);
+    const categorySearch = await fetchFacetedSearch(
+      locale,
+      cachedCategory,
+      undefined,
+      customerAccessToken,
+    );
     const categoryFacets = categorySearch.facets.items.filter(
       (facet) => facet.__typename !== 'CategorySearchFilter',
     );
@@ -70,12 +75,14 @@ interface Props {
 }
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
-  const { slug, locale } = await props.params;
-  const customerAccessToken = await getSessionCustomerAccessToken();
+  const [{ slug, locale }, customerAccessToken] = await Promise.all([
+    props.params,
+    getSessionCustomerAccessToken(),
+  ]);
 
   const categoryId = Number(slug);
 
-  const { category } = await getCategoryPageData(categoryId, customerAccessToken);
+  const { category } = await getCategoryPageData(locale, categoryId, customerAccessToken);
 
   if (!category) {
     return notFound();
@@ -97,16 +104,18 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 }
 
 export default async function Category(props: Props) {
-  const { slug, locale } = await props.params;
-  const customerAccessToken = await getSessionCustomerAccessToken();
+  const [{ slug, locale }, customerAccessToken, t] = await Promise.all([
+    props.params,
+    getSessionCustomerAccessToken(),
+    getTranslations('Faceted'),
+  ]);
 
   setRequestLocale(locale);
-
-  const t = await getTranslations('Faceted');
 
   const categoryId = Number(slug);
 
   const { category, settings, categoryTree } = await getCategoryPageData(
+    locale,
     categoryId,
     customerAccessToken,
   );
@@ -130,12 +139,14 @@ export default async function Category(props: Props) {
     const currencyCode = await getPreferredCurrencyCode();
 
     const loadSearchParams = await createCategorySearchParamsLoader(
+      locale,
       categoryId,
       customerAccessToken,
     );
     const parsedSearchParams = loadSearchParams?.(searchParams) ?? {};
 
     const search = await fetchFacetedSearch(
+      locale,
       {
         ...searchParams,
         ...parsedSearchParams,
@@ -182,12 +193,18 @@ export default async function Category(props: Props) {
     const searchParams = await props.searchParams;
 
     const loadSearchParams = await createCategorySearchParamsLoader(
+      locale,
       categoryId,
       customerAccessToken,
     );
     const parsedSearchParams = loadSearchParams?.(searchParams) ?? {};
     const cachedCategory = getCachedCategory(categoryId);
-    const categorySearch = await fetchFacetedSearch(cachedCategory, undefined, customerAccessToken);
+    const categorySearch = await fetchFacetedSearch(
+      locale,
+      cachedCategory,
+      undefined,
+      customerAccessToken,
+    );
     const refinedSearch = await streamableFacetedSearch;
 
     const allFacets = categorySearch.facets.items.filter(
@@ -234,7 +251,7 @@ export default async function Category(props: Props) {
 
     const compareIds = { entityIds: compare ? compare.map((id: string) => Number(id)) : [] };
 
-    const products = await getCompareProducts(compareIds, customerAccessToken);
+    const products = await getCompareProducts(locale, compareIds, customerAccessToken);
 
     return products.map((product) => ({
       id: product.entityId.toString(),

--- a/core/app/[locale]/(default)/(faceted)/fetch-compare-products.ts
+++ b/core/app/[locale]/(default)/(faceted)/fetch-compare-products.ts
@@ -1,5 +1,6 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
 import { VariablesOf } from 'gql.tada';
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 import { z } from 'zod';
 
@@ -42,8 +43,8 @@ const CompareProductsQuery = graphql(`
 
 type Variables = VariablesOf<typeof CompareProductsQuery>;
 
-export const getCompareProducts = cache(
-  async (variables: Variables, customerAccessToken?: string) => {
+const getCachedCompareProducts = unstable_cache(
+  async (locale: string, variables: Variables) => {
     const parsedVariables = CompareProductsSchema.parse(variables);
 
     if (parsedVariables.entityIds.length === 0) {
@@ -53,10 +54,36 @@ export const getCompareProducts = cache(
     const response = await client.fetch({
       document: CompareProductsQuery,
       variables: { ...parsedVariables, first: MAX_COMPARE_LIMIT },
-      customerAccessToken,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
+      locale,
+      fetchOptions: { cache: 'no-store' },
     });
 
     return removeEdgesAndNodes(response.data.site.products);
+  },
+  ['get-compare-products'],
+  { revalidate },
+);
+
+export const getCompareProducts = cache(
+  async (locale: string, variables: Variables, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const parsedVariables = CompareProductsSchema.parse(variables);
+
+      if (parsedVariables.entityIds.length === 0) {
+        return [];
+      }
+
+      const response = await client.fetch({
+        document: CompareProductsQuery,
+        variables: { ...parsedVariables, first: MAX_COMPARE_LIMIT },
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return removeEdgesAndNodes(response.data.site.products);
+    }
+
+    return getCachedCompareProducts(locale, variables);
   },
 );

--- a/core/app/[locale]/(default)/(faceted)/fetch-faceted-search.ts
+++ b/core/app/[locale]/(default)/(faceted)/fetch-faceted-search.ts
@@ -1,4 +1,5 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 import { z } from 'zod';
 
@@ -178,11 +179,11 @@ interface ProductSearch {
   filters: SearchProductsFiltersInput;
 }
 
-const getProductSearchResults = cache(
+const getCachedProductSearchResults = unstable_cache(
   async (
+    locale: string,
     { limit = 9, after, before, sort, filters }: ProductSearch,
     currencyCode?: CurrencyCode,
-    customerAccessToken?: string,
   ) => {
     const filterArgs = { filters, sort };
     const paginationArgs = before ? { last: limit, before } : { first: limit, after };
@@ -190,12 +191,11 @@ const getProductSearchResults = cache(
     const response = await client.fetch({
       document: GetProductSearchResultsQuery,
       variables: { ...filterArgs, ...paginationArgs, currencyCode },
-      customerAccessToken,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate: 300 } },
+      locale,
+      fetchOptions: { cache: 'no-store' },
     });
 
     const { site } = response.data;
-
     const searchResults = site.search.searchProducts;
 
     const items = removeEdgesAndNodes(searchResults.products).map((product) => ({
@@ -241,6 +241,84 @@ const getProductSearchResults = cache(
         items,
       },
     };
+  },
+  ['get-product-search-results'],
+  { revalidate: 300 },
+);
+
+const getProductSearchResults = cache(
+  // We need to make sure the reference passed into this function is the same if we want it to be memoized.
+  async (
+    locale: string,
+    { limit = 9, after, before, sort, filters }: ProductSearch,
+    currencyCode?: CurrencyCode,
+    customerAccessToken?: string,
+  ) => {
+    if (customerAccessToken) {
+      const filterArgs = { filters, sort };
+      const paginationArgs = before ? { last: limit, before } : { first: limit, after };
+
+      const response = await client.fetch({
+        document: GetProductSearchResultsQuery,
+        variables: { ...filterArgs, ...paginationArgs, currencyCode },
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      const { site } = response.data;
+      const searchResults = site.search.searchProducts;
+
+      const items = removeEdgesAndNodes(searchResults.products).map((product) => ({
+        ...product,
+      }));
+
+      return {
+        facets: {
+          items: removeEdgesAndNodes(searchResults.filters).map((node) => {
+            switch (node.__typename) {
+              case 'BrandSearchFilter':
+                return {
+                  ...node,
+                  brands: removeEdgesAndNodes(node.brands),
+                };
+
+              case 'CategorySearchFilter':
+                return {
+                  ...node,
+                  categories: removeEdgesAndNodes(node.categories),
+                };
+
+              case 'ProductAttributeSearchFilter':
+                return {
+                  ...node,
+                  attributes: removeEdgesAndNodes(node.attributes),
+                };
+
+              case 'RatingSearchFilter':
+                return {
+                  ...node,
+                  ratings: removeEdgesAndNodes(node.ratings),
+                };
+
+              default:
+                return node;
+            }
+          }),
+        },
+        products: {
+          collectionInfo: searchResults.products.collectionInfo,
+          pageInfo: searchResults.products.pageInfo,
+          items,
+        },
+      };
+    }
+
+    return getCachedProductSearchResults(
+      locale,
+      { limit, after, before, sort, filters },
+      currencyCode,
+    );
   },
 );
 
@@ -406,6 +484,7 @@ export const PublicToPrivateParams = PublicSearchParamsSchema.catchall(SearchPar
 export const fetchFacetedSearch = cache(
   // We need to make sure the reference passed into this function is the same if we want it to be memoized.
   async (
+    locale: string,
     params: z.input<typeof PublicSearchParamsSchema>,
     currencyCode?: CurrencyCode,
     customerAccessToken?: string,
@@ -413,6 +492,7 @@ export const fetchFacetedSearch = cache(
     const { after, before, limit = 9, sort, filters } = PublicToPrivateParams.parse(params);
 
     return getProductSearchResults(
+      locale,
       {
         after,
         before,

--- a/core/app/[locale]/(default)/(faceted)/search/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/search/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -29,11 +30,20 @@ const SearchPageQuery = graphql(`
   }
 `);
 
-export const getSearchPageData = cache(async () => {
-  const response = await client.fetch({
-    document: SearchPageQuery,
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedSearchPageData = unstable_cache(
+  async (locale: string) => {
+    const response = await client.fetch({
+      document: SearchPageQuery,
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return response.data.site;
+    return response.data.site;
+  },
+  ['get-search-page-data'],
+  { revalidate },
+);
+
+export const getSearchPageData = cache(async (locale: string) => {
+  return getCachedSearchPageData(locale);
 });

--- a/core/app/[locale]/(default)/(faceted)/search/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/search/page.tsx
@@ -22,14 +22,14 @@ import { getSearchPageData } from './page-data';
 const compareLoader = createCompareLoader();
 
 const createSearchSearchParamsLoader = cache(
-  async (searchParams: SearchParams, customerAccessToken?: string) => {
+  async (locale: string, searchParams: SearchParams, customerAccessToken?: string) => {
     const searchTerm = typeof searchParams.term === 'string' ? searchParams.term : '';
 
     if (!searchTerm) {
       return null;
     }
 
-    const search = await fetchFacetedSearch(searchParams, undefined, customerAccessToken);
+    const search = await fetchFacetedSearch(locale, searchParams, undefined, customerAccessToken);
     const searchFacets = search.facets.items;
     const transformedSearchFacets = await facetsTransformer({
       refinedFacets: searchFacets,
@@ -76,7 +76,7 @@ export default async function Search(props: Props) {
 
   const t = await getTranslations('Faceted');
 
-  const { settings } = await getSearchPageData();
+  const { settings } = await getSearchPageData(locale);
 
   const showRating = Boolean(settings?.reviews.enabled && settings.display.showProductRating);
 
@@ -89,12 +89,14 @@ export default async function Search(props: Props) {
     const currencyCode = await getPreferredCurrencyCode();
 
     const loadSearchParams = await createSearchSearchParamsLoader(
+      locale,
       searchParams,
       customerAccessToken,
     );
     const parsedSearchParams = loadSearchParams?.(searchParams) ?? {};
 
     const search = await fetchFacetedSearch(
+      locale,
       {
         ...searchParams,
         ...parsedSearchParams,
@@ -186,11 +188,12 @@ export default async function Search(props: Props) {
     }
 
     const loadSearchParams = await createSearchSearchParamsLoader(
+      locale,
       searchParams,
       customerAccessToken,
     );
     const parsedSearchParams = loadSearchParams?.(searchParams) ?? {};
-    const categorySearch = await fetchFacetedSearch({}, undefined, customerAccessToken);
+    const categorySearch = await fetchFacetedSearch(locale, {}, undefined, customerAccessToken);
     const refinedSearch = await streamableFacetedSearch;
 
     const allFacets = categorySearch.facets.items.filter(
@@ -221,7 +224,7 @@ export default async function Search(props: Props) {
 
     const compareIds = { entityIds: compare ? compare.map((id: string) => Number(id)) : [] };
 
-    const products = await getCompareProductsData(compareIds, customerAccessToken);
+    const products = await getCompareProductsData(locale, compareIds, customerAccessToken);
 
     return products.map((product) => ({
       id: product.entityId.toString(),

--- a/core/app/[locale]/(default)/account/addresses/page-data.ts
+++ b/core/app/[locale]/(default)/account/addresses/page-data.ts
@@ -1,7 +1,6 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
 import { cache } from 'react';
 
-import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
 import { PaginationFragment } from '~/client/fragments/pagination';
 import { graphql } from '~/client/graphql';
@@ -70,13 +69,17 @@ interface Pagination {
 }
 
 export const getCustomerAddresses = cache(
-  async ({ before = '', after = '', limit = 10 }: Pagination) => {
-    const customerAccessToken = await getSessionCustomerAccessToken();
+  async (
+    locale: string,
+    { before = '', after = '', limit = 10 }: Pagination,
+    customerAccessToken?: string,
+  ) => {
     const paginationArgs = before ? { last: limit, before } : { first: limit, after };
 
     const response = await client.fetch({
       document: GetCustomerAddressesQuery,
       variables: { ...paginationArgs },
+      locale,
       customerAccessToken,
       fetchOptions: { cache: 'no-store', next: { tags: [TAGS.customer] } },
     });

--- a/core/app/[locale]/(default)/account/addresses/page.tsx
+++ b/core/app/[locale]/(default)/account/addresses/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { Address, AddressListSection } from '@/vibes/soul/sections/address-list-section';
+import { getSessionCustomerAccessToken } from '~/auth';
 import {
   formFieldTransformer,
   injectCountryCodeOptions,
@@ -41,13 +42,20 @@ export default async function Addresses({ params, searchParams }: Props) {
 
   setRequestLocale(locale);
 
-  const t = await getTranslations('Account.Addresses');
-  const { before, after } = await searchParams;
+  const [customerAccessToken, t, { before, after }] = await Promise.all([
+    getSessionCustomerAccessToken(),
+    getTranslations('Account.Addresses'),
+    searchParams,
+  ]);
 
-  const data = await getCustomerAddresses({
-    ...(after && { after }),
-    ...(before && { before }),
-  });
+  const data = await getCustomerAddresses(
+    locale,
+    {
+      ...(after && { after }),
+      ...(before && { before }),
+    },
+    customerAccessToken,
+  );
 
   if (!data) {
     notFound();

--- a/core/app/[locale]/(default)/account/orders/[id]/page-data.tsx
+++ b/core/app/[locale]/(default)/account/orders/[id]/page-data.tsx
@@ -1,7 +1,6 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
 import { cache } from 'react';
 
-import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
 import { TAGS } from '~/client/tags';
@@ -155,9 +154,7 @@ const CustomerOrderDetails = graphql(
   [OrderItemFragment, OrderGiftCertificateItemFragment],
 );
 
-export const getCustomerOrderDetails = cache(async (id: number) => {
-  const customerAccessToken = await getSessionCustomerAccessToken();
-
+export const getCustomerOrderDetails = cache(async (id: number, customerAccessToken?: string) => {
   const response = await client.fetch({
     document: CustomerOrderDetails,
     variables: {

--- a/core/app/[locale]/(default)/account/orders/[id]/page.tsx
+++ b/core/app/[locale]/(default)/account/orders/[id]/page.tsx
@@ -3,6 +3,7 @@ import { getFormatter, getTranslations, setRequestLocale } from 'next-intl/serve
 
 import { Streamable } from '@/vibes/soul/lib/streamable';
 import { OrderDetailsSection } from '@/vibes/soul/sections/order-details-section';
+import { getSessionCustomerAccessToken } from '~/auth';
 import { orderDetailsTransformer } from '~/data-transformers/order-details-transformer';
 
 import { getCustomerOrderDetails } from './page-data';
@@ -23,7 +24,8 @@ export default async function OrderDetails(props: Props) {
   const format = await getFormatter();
 
   const streamableOrder = Streamable.from(async () => {
-    const order = await getCustomerOrderDetails(Number(id));
+    const customerAccessToken = await getSessionCustomerAccessToken();
+    const order = await getCustomerOrderDetails(Number(id), customerAccessToken);
 
     if (!order) {
       notFound();

--- a/core/app/[locale]/(default)/account/orders/page-data.ts
+++ b/core/app/[locale]/(default)/account/orders/page-data.ts
@@ -1,7 +1,6 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
 import { cache } from 'react';
 
-import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
 import { PaginationFragment } from '~/client/fragments/pagination';
 import { graphql, VariablesOf } from '~/client/graphql';
@@ -89,14 +88,11 @@ interface CustomerOrdersArgs {
 }
 
 export const getCustomerOrders = cache(
-  async ({
-    before = '',
-    after = '',
-    filterByStatus,
-    filterByDateRange,
-    limit = 5,
-  }: CustomerOrdersArgs) => {
-    const customerAccessToken = await getSessionCustomerAccessToken();
+  async (
+    locale: string,
+    { before = '', after = '', filterByStatus, filterByDateRange, limit = 5 }: CustomerOrdersArgs,
+    customerAccessToken?: string,
+  ) => {
     const paginationArgs = before ? { last: limit, before } : { first: limit, after };
     const filtersArgs = {
       filters: {
@@ -107,6 +103,7 @@ export const getCustomerOrders = cache(
     const response = await client.fetch({
       document: CustomerAllOrders,
       variables: { ...paginationArgs, ...filtersArgs },
+      locale,
       customerAccessToken,
       fetchOptions: { cache: 'no-store', next: { tags: [TAGS.customer] } },
       errorPolicy: 'auth',

--- a/core/app/[locale]/(default)/account/orders/page.tsx
+++ b/core/app/[locale]/(default)/account/orders/page.tsx
@@ -1,6 +1,7 @@
 import { getFormatter, getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { Order, OrderList } from '@/vibes/soul/sections/order-list';
+import { getSessionCustomerAccessToken } from '~/auth';
 import { ordersTransformer } from '~/data-transformers/orders-transformer';
 import { defaultPageInfo, pageInfoTransformer } from '~/data-transformers/page-info-transformer';
 
@@ -15,12 +16,21 @@ interface Props {
   }>;
 }
 
-async function getOrders(after?: string, before?: string): Promise<Order[]> {
+async function getOrders(
+  locale: string,
+  after?: string,
+  before?: string,
+  customerAccessToken?: string,
+): Promise<Order[]> {
   const format = await getFormatter();
-  const customerOrdersDetails = await getCustomerOrders({
-    ...(after && { after }),
-    ...(before && { before }),
-  });
+  const customerOrdersDetails = await getCustomerOrders(
+    locale,
+    {
+      ...(after && { after }),
+      ...(before && { before }),
+    },
+    customerAccessToken,
+  );
 
   if (!customerOrdersDetails) {
     return [];
@@ -31,11 +41,20 @@ async function getOrders(after?: string, before?: string): Promise<Order[]> {
   return ordersTransformer(orders, format);
 }
 
-async function getPaginationInfo(after?: string, before?: string) {
-  const customerOrdersDetails = await getCustomerOrders({
-    ...(after && { after }),
-    ...(before && { before }),
-  });
+async function getPaginationInfo(
+  locale: string,
+  after?: string,
+  before?: string,
+  customerAccessToken?: string,
+) {
+  const customerOrdersDetails = await getCustomerOrders(
+    locale,
+    {
+      ...(after && { after }),
+      ...(before && { before }),
+    },
+    customerAccessToken,
+  );
 
   return pageInfoTransformer(customerOrdersDetails?.pageInfo ?? defaultPageInfo);
 }
@@ -45,16 +64,19 @@ export default async function Orders({ params, searchParams }: Props) {
 
   setRequestLocale(locale);
 
-  const { before, after } = await searchParams;
-  const t = await getTranslations('Account.Orders');
+  const [{ before, after }, t, customerAccessToken] = await Promise.all([
+    searchParams,
+    getTranslations('Account.Orders'),
+    getSessionCustomerAccessToken(),
+  ]);
 
   return (
     <OrderList
       emptyStateActionLabel={t('EmptyState.cta')}
       emptyStateTitle={t('EmptyState.title')}
       orderNumberLabel={t('orderNumber')}
-      orders={getOrders(after, before)}
-      paginationInfo={getPaginationInfo(after, before)}
+      orders={getOrders(locale, after, before, customerAccessToken)}
+      paginationInfo={getPaginationInfo(locale, after, before, customerAccessToken)}
       title={t('title')}
       totalLabel={t('totalPrice')}
       viewDetailsLabel={t('viewDetails')}

--- a/core/app/[locale]/(default)/account/settings/page-data.tsx
+++ b/core/app/[locale]/(default)/account/settings/page-data.tsx
@@ -1,6 +1,5 @@
 import { cache } from 'react';
 
-import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
 import { graphql, VariablesOf } from '~/client/graphql';
 import { TAGS } from '~/client/tags';
@@ -67,37 +66,37 @@ interface Props {
   };
 }
 
-export const getAccountSettingsQuery = cache(async ({ address, customer }: Props = {}) => {
-  const customerAccessToken = await getSessionCustomerAccessToken();
+export const getAccountSettingsQuery = cache(
+  async ({ address, customer }: Props = {}, customerAccessToken?: string) => {
+    const response = await client.fetch({
+      document: AccountSettingsQuery,
+      variables: {
+        addressFilters: address?.filters,
+        addressSortBy: address?.sortBy,
+        customerFilters: customer?.filters,
+        customerSortBy: customer?.sortBy,
+      },
+      fetchOptions: { cache: 'no-store', next: { tags: [TAGS.customer] } },
+      customerAccessToken,
+    });
 
-  const response = await client.fetch({
-    document: AccountSettingsQuery,
-    variables: {
-      addressFilters: address?.filters,
-      addressSortBy: address?.sortBy,
-      customerFilters: customer?.filters,
-      customerSortBy: customer?.sortBy,
-    },
-    fetchOptions: { cache: 'no-store', next: { tags: [TAGS.customer] } },
-    customerAccessToken,
-  });
+    const addressFields = response.data.site.settings?.formFields.shippingAddress;
+    const customerFields = response.data.site.settings?.formFields.customer;
+    const customerInfo = response.data.customer;
+    const newsletterSettings = response.data.site.settings?.newsletter;
+    const passwordComplexitySettings =
+      response.data.site.settings?.customers?.passwordComplexitySettings;
 
-  const addressFields = response.data.site.settings?.formFields.shippingAddress;
-  const customerFields = response.data.site.settings?.formFields.customer;
-  const customerInfo = response.data.customer;
-  const newsletterSettings = response.data.site.settings?.newsletter;
-  const passwordComplexitySettings =
-    response.data.site.settings?.customers?.passwordComplexitySettings;
+    if (!addressFields || !customerFields || !customerInfo) {
+      return null;
+    }
 
-  if (!addressFields || !customerFields || !customerInfo) {
-    return null;
-  }
-
-  return {
-    addressFields,
-    customerFields,
-    customerInfo,
-    newsletterSettings,
-    passwordComplexitySettings,
-  };
-});
+    return {
+      addressFields,
+      customerFields,
+      customerInfo,
+      newsletterSettings,
+      passwordComplexitySettings,
+    };
+  },
+);

--- a/core/app/[locale]/(default)/account/settings/page.tsx
+++ b/core/app/[locale]/(default)/account/settings/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { AccountSettingsSection } from '@/vibes/soul/sections/account-settings';
+import { getSessionCustomerAccessToken } from '~/auth';
 
 import { changePassword } from './_actions/change-password';
 import { updateCustomer } from './_actions/update-customer';
@@ -30,8 +31,9 @@ export default async function Settings({ params }: Props) {
   setRequestLocale(locale);
 
   const t = await getTranslations('Account.Settings');
+  const customerAccessToken = await getSessionCustomerAccessToken();
 
-  const accountSettings = await getAccountSettingsQuery();
+  const accountSettings = await getAccountSettingsQuery({}, customerAccessToken);
 
   if (!accountSettings) {
     notFound();

--- a/core/app/[locale]/(default)/account/wishlists/[id]/page-data.ts
+++ b/core/app/[locale]/(default)/account/wishlists/[id]/page-data.ts
@@ -1,11 +1,10 @@
 import { cache } from 'react';
 
-import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
 import { TAGS } from '~/client/tags';
+import type { CurrencyCode } from '~/components/header/fragment';
 import { WishlistPaginatedItemsFragment } from '~/components/wishlist/fragment';
-import { getPreferredCurrencyCode } from '~/lib/currency';
 
 const WishlistDetailsQuery = graphql(
   `
@@ -37,23 +36,30 @@ interface Pagination {
   after: string | null;
 }
 
-export const getCustomerWishlist = cache(async (entityId: number, pagination: Pagination) => {
-  const { before, after, limit = 9 } = pagination;
-  const customerAccessToken = await getSessionCustomerAccessToken();
-  const currencyCode = await getPreferredCurrencyCode();
-  const paginationArgs = before ? { last: limit, before } : { first: limit, after };
-  const response = await client.fetch({
-    document: WishlistDetailsQuery,
-    variables: { ...paginationArgs, currencyCode, entityId },
-    customerAccessToken,
-    fetchOptions: { cache: 'no-store', next: { tags: [TAGS.customer] } },
-  });
+export const getCustomerWishlist = cache(
+  async (
+    locale: string,
+    entityId: number,
+    pagination: Pagination,
+    customerAccessToken?: string,
+    currencyCode?: CurrencyCode,
+  ) => {
+    const { before, after, limit = 9 } = pagination;
+    const paginationArgs = before ? { last: limit, before } : { first: limit, after };
+    const response = await client.fetch({
+      document: WishlistDetailsQuery,
+      variables: { ...paginationArgs, currencyCode, entityId },
+      locale,
+      customerAccessToken,
+      fetchOptions: { cache: 'no-store', next: { tags: [TAGS.customer] } },
+    });
 
-  const wishlist = response.data.customer?.wishlists.edges?.[0]?.node;
+    const wishlist = response.data.customer?.wishlists.edges?.[0]?.node;
 
-  if (!wishlist) {
-    return null;
-  }
+    if (!wishlist) {
+      return null;
+    }
 
-  return wishlist;
-});
+    return wishlist;
+  },
+);

--- a/core/app/[locale]/(default)/account/wishlists/[id]/page.tsx
+++ b/core/app/[locale]/(default)/account/wishlists/[id]/page.tsx
@@ -6,10 +6,13 @@ import { createSearchParamsCache, parseAsInteger, parseAsString } from 'nuqs/ser
 import { Streamable } from '@/vibes/soul/lib/streamable';
 import { CursorPaginationInfo } from '@/vibes/soul/primitives/cursor-pagination';
 import { Wishlist, WishlistDetails } from '@/vibes/soul/sections/wishlist-details';
+import { getSessionCustomerAccessToken } from '~/auth';
 import { ExistingResultType } from '~/client/util';
+import type { CurrencyCode } from '~/components/header/fragment';
 import { defaultPageInfo, pageInfoTransformer } from '~/data-transformers/page-info-transformer';
 import { wishlistDetailsTransformer } from '~/data-transformers/wishlists-transformer';
 import { redirect } from '~/i18n/routing';
+import { getPreferredCurrencyCode } from '~/lib/currency';
 import { isMobileUser } from '~/lib/user-agent';
 
 import { removeWishlistItem } from '../_actions/remove-wishlist-item';
@@ -39,11 +42,19 @@ async function getWishlist(
   pt: ExistingResultType<typeof getTranslations<'Product.ProductDetails'>>,
   searchParamsPromise: Promise<SearchParams>,
   locale: string,
+  customerAccessToken?: string,
+  currencyCode?: CurrencyCode,
 ): Promise<Wishlist> {
   const entityId = Number(id);
   const searchParamsParsed = searchParamsCache.parse(await searchParamsPromise);
   const formatter = await getFormatter();
-  const wishlist = await getCustomerWishlist(entityId, searchParamsParsed);
+  const wishlist = await getCustomerWishlist(
+    locale,
+    entityId,
+    searchParamsParsed,
+    customerAccessToken,
+    currencyCode,
+  );
 
   if (!wishlist) {
     return redirect({ href: '/account/wishlists/', locale });
@@ -52,10 +63,22 @@ async function getWishlist(
   return wishlistDetailsTransformer(wishlist, t, pt, formatter);
 }
 
-const getAnalyticsData = async (id: string, searchParamsPromise: Promise<SearchParams>) => {
+const getAnalyticsData = async (
+  locale: string,
+  id: string,
+  searchParamsPromise: Promise<SearchParams>,
+  customerAccessToken?: string,
+  currencyCode?: CurrencyCode,
+) => {
   const entityId = Number(id);
   const searchParamsParsed = searchParamsCache.parse(await searchParamsPromise);
-  const wishlist = await getCustomerWishlist(entityId, searchParamsParsed);
+  const wishlist = await getCustomerWishlist(
+    locale,
+    entityId,
+    searchParamsParsed,
+    customerAccessToken,
+    currencyCode,
+  );
 
   if (!wishlist) {
     return [];
@@ -77,12 +100,21 @@ const getAnalyticsData = async (id: string, searchParamsPromise: Promise<SearchP
 };
 
 async function getPaginationInfo(
+  locale: string,
   id: string,
   searchParamsPromise: Promise<SearchParams>,
+  customerAccessToken?: string,
+  currencyCode?: CurrencyCode,
 ): Promise<CursorPaginationInfo> {
   const entityId = Number(id);
   const searchParamsParsed = searchParamsCache.parse(await searchParamsPromise);
-  const wishlist = await getCustomerWishlist(entityId, searchParamsParsed);
+  const wishlist = await getCustomerWishlist(
+    locale,
+    entityId,
+    searchParamsParsed,
+    customerAccessToken,
+    currencyCode,
+  );
 
   return pageInfoTransformer(wishlist?.items.pageInfo ?? defaultPageInfo);
 }
@@ -92,8 +124,12 @@ export default async function WishlistPage({ params, searchParams }: Props) {
 
   setRequestLocale(locale);
 
-  const t = await getTranslations('Wishlist');
-  const pt = await getTranslations('Product.ProductDetails');
+  const [t, pt, customerAccessToken, currencyCode] = await Promise.all([
+    getTranslations('Wishlist'),
+    getTranslations('Product.ProductDetails'),
+    getSessionCustomerAccessToken(),
+    getPreferredCurrencyCode(),
+  ]);
   const wishlistActions = (wishlist?: Wishlist) => {
     if (!wishlist) {
       return <WishlistActionsSkeleton />;
@@ -127,16 +163,24 @@ export default async function WishlistPage({ params, searchParams }: Props) {
   };
 
   return (
-    <WishlistAnalyticsProvider data={Streamable.from(() => getAnalyticsData(id, searchParams))}>
+    <WishlistAnalyticsProvider
+      data={Streamable.from(() =>
+        getAnalyticsData(locale, id, searchParams, customerAccessToken, currencyCode),
+      )}
+    >
       <WishlistDetails
         action={addWishlistItemToCart}
         emptyStateText={t('emptyWishlist')}
         headerActions={wishlistActions}
-        paginationInfo={Streamable.from(() => getPaginationInfo(id, searchParams))}
+        paginationInfo={Streamable.from(() =>
+          getPaginationInfo(locale, id, searchParams, customerAccessToken, currencyCode),
+        )}
         prevHref="/account/wishlists"
         removeAction={removeWishlistItem}
         removeButtonTitle={t('removeButtonTitle')}
-        wishlist={Streamable.from(() => getWishlist(id, t, pt, searchParams, locale))}
+        wishlist={Streamable.from(() =>
+          getWishlist(id, t, pt, searchParams, locale, customerAccessToken, currencyCode),
+        )}
       />
     </WishlistAnalyticsProvider>
   );

--- a/core/app/[locale]/(default)/account/wishlists/page-data.ts
+++ b/core/app/[locale]/(default)/account/wishlists/page-data.ts
@@ -1,11 +1,10 @@
 import { cache } from 'react';
 
-import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
 import { TAGS } from '~/client/tags';
+import type { CurrencyCode } from '~/components/header/fragment';
 import { WishlistsFragment } from '~/components/wishlist/fragment';
-import { getPreferredCurrencyCode } from '~/lib/currency';
 
 const WishlistsPageQuery = graphql(
   `
@@ -33,22 +32,28 @@ interface Pagination {
   after: string | null;
 }
 
-export const getCustomerWishlists = cache(async ({ limit = 9, before, after }: Pagination) => {
-  const customerAccessToken = await getSessionCustomerAccessToken();
-  const currencyCode = await getPreferredCurrencyCode();
-  const paginationArgs = before ? { last: limit, before } : { first: limit, after };
-  const response = await client.fetch({
-    document: WishlistsPageQuery,
-    variables: { ...paginationArgs, currencyCode },
-    customerAccessToken,
-    fetchOptions: { cache: 'no-store', next: { tags: [TAGS.customer] } },
-  });
+export const getCustomerWishlists = cache(
+  async (
+    locale: string,
+    { limit = 9, before, after }: Pagination,
+    customerAccessToken?: string,
+    currencyCode?: CurrencyCode,
+  ) => {
+    const paginationArgs = before ? { last: limit, before } : { first: limit, after };
+    const response = await client.fetch({
+      document: WishlistsPageQuery,
+      variables: { ...paginationArgs, currencyCode },
+      locale,
+      customerAccessToken,
+      fetchOptions: { cache: 'no-store', next: { tags: [TAGS.customer] } },
+    });
 
-  const wishlists = response.data.customer?.wishlists;
+    const wishlists = response.data.customer?.wishlists;
 
-  if (!wishlists) {
-    return null;
-  }
+    if (!wishlists) {
+      return null;
+    }
 
-  return wishlists;
-});
+    return wishlists;
+  },
+);

--- a/core/app/[locale]/(default)/account/wishlists/page.tsx
+++ b/core/app/[locale]/(default)/account/wishlists/page.tsx
@@ -7,9 +7,12 @@ import { CursorPaginationInfo } from '@/vibes/soul/primitives/cursor-pagination'
 import * as Skeleton from '@/vibes/soul/primitives/skeleton';
 import { Wishlist } from '@/vibes/soul/sections/wishlist-details';
 import { WishlistsSection } from '@/vibes/soul/sections/wishlists-section';
+import { getSessionCustomerAccessToken } from '~/auth';
 import { ExistingResultType } from '~/client/util';
+import type { CurrencyCode } from '~/components/header/fragment';
 import { defaultPageInfo, pageInfoTransformer } from '~/data-transformers/page-info-transformer';
 import { wishlistsTransformer } from '~/data-transformers/wishlists-transformer';
+import { getPreferredCurrencyCode } from '~/lib/currency';
 import { isMobileUser } from '~/lib/user-agent';
 
 import { NewWishlistButton } from './_components/new-wishlist-button';
@@ -36,12 +39,20 @@ const searchParamsCache = createSearchParamsCache({
 });
 
 async function listWishlists(
+  locale: string,
   searchParamsPromise: Promise<SearchParams>,
   t: ExistingResultType<typeof getTranslations<'Wishlist'>>,
+  customerAccessToken?: string,
+  currencyCode?: CurrencyCode,
 ): Promise<Wishlist[]> {
   const searchParamsParsed = searchParamsCache.parse(await searchParamsPromise);
   const formatter = await getFormatter();
-  const wishlists = await getCustomerWishlists(searchParamsParsed);
+  const wishlists = await getCustomerWishlists(
+    locale,
+    searchParamsParsed,
+    customerAccessToken,
+    currencyCode,
+  );
 
   if (!wishlists) {
     return [];
@@ -51,10 +62,18 @@ async function listWishlists(
 }
 
 async function getPaginationInfo(
+  locale: string,
   searchParamsPromise: Promise<SearchParams>,
+  customerAccessToken?: string,
+  currencyCode?: CurrencyCode,
 ): Promise<CursorPaginationInfo> {
   const searchParamsParsed = searchParamsCache.parse(await searchParamsPromise);
-  const wishlists = await getCustomerWishlists(searchParamsParsed);
+  const wishlists = await getCustomerWishlists(
+    locale,
+    searchParamsParsed,
+    customerAccessToken,
+    currencyCode,
+  );
 
   return pageInfoTransformer(wishlists?.pageInfo ?? defaultPageInfo);
 }
@@ -64,8 +83,12 @@ export default async function Wishlists({ params, searchParams }: Props) {
 
   setRequestLocale(locale);
 
-  const t = await getTranslations('Wishlist');
-  const isMobile = await isMobileUser();
+  const [t, isMobile, customerAccessToken, currencyCode] = await Promise.all([
+    getTranslations('Wishlist'),
+    isMobileUser(),
+    getSessionCustomerAccessToken(),
+    getPreferredCurrencyCode(),
+  ]);
   const newWishlistModal = getNewWishlistModal(t);
 
   return (
@@ -121,10 +144,14 @@ export default async function Wishlists({ params, searchParams }: Props) {
           );
         },
       }}
-      paginationInfo={Streamable.from(() => getPaginationInfo(searchParams))}
+      paginationInfo={Streamable.from(() =>
+        getPaginationInfo(locale, searchParams, customerAccessToken, currencyCode),
+      )}
       title={t('title')}
       viewWishlistLabel={t('viewWishlist')}
-      wishlists={Streamable.from(() => listWishlists(searchParams, t))}
+      wishlists={Streamable.from(() =>
+        listWishlists(locale, searchParams, t, customerAccessToken, currencyCode),
+      )}
     />
   );
 }

--- a/core/app/[locale]/(default)/blog/[blogId]/page-data.ts
+++ b/core/app/[locale]/(default)/blog/[blogId]/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -38,18 +39,27 @@ const BlogPageQuery = graphql(`
 
 type Variables = VariablesOf<typeof BlogPageQuery>;
 
-export const getBlogPageData = cache(async (variables: Variables) => {
-  const response = await client.fetch({
-    document: BlogPageQuery,
-    variables,
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedBlogPageData = unstable_cache(
+  async (locale: string, variables: Variables) => {
+    const response = await client.fetch({
+      document: BlogPageQuery,
+      variables,
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  const { blog } = response.data.site.content;
+    const { blog } = response.data.site.content;
 
-  if (!blog?.post) {
-    return null;
-  }
+    if (!blog?.post) {
+      return null;
+    }
 
-  return blog;
+    return blog;
+  },
+  ['get-blog-page-data'],
+  { revalidate },
+);
+
+export const getBlogPageData = cache(async (locale: string, variables: Variables) => {
+  return getCachedBlogPageData(locale, variables);
 });

--- a/core/app/[locale]/(default)/blog/[blogId]/page.tsx
+++ b/core/app/[locale]/(default)/blog/[blogId]/page.tsx
@@ -23,7 +23,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   const variables = cachedBlogPageDataVariables(blogId);
 
-  const blog = await getBlogPageData(variables);
+  const blog = await getBlogPageData(locale, variables);
   const blogPost = blog?.post;
 
   if (!blogPost) {
@@ -43,13 +43,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 }
 
 async function getBlogPost(props: Props): Promise<BlogPostContentBlogPost> {
-  const format = await getFormatter();
-
-  const { blogId } = await props.params;
+  const [format, { blogId, locale }] = await Promise.all([getFormatter(), props.params]);
 
   const variables = cachedBlogPageDataVariables(blogId);
 
-  const blog = await getBlogPageData(variables);
+  const blog = await getBlogPageData(locale, variables);
   const blogPost = blog?.post;
 
   if (!blog || !blogPost) {
@@ -74,13 +72,11 @@ async function getBlogPost(props: Props): Promise<BlogPostContentBlogPost> {
 }
 
 async function getBlogPostBreadcrumbs(props: Props): Promise<Breadcrumb[]> {
-  const t = await getTranslations('Blog');
-
-  const { blogId } = await props.params;
+  const [t, { blogId, locale }] = await Promise.all([getTranslations('Blog'), props.params]);
 
   const variables = cachedBlogPageDataVariables(blogId);
 
-  const blog = await getBlogPageData(variables);
+  const blog = await getBlogPageData(locale, variables);
   const blogPost = blog?.post;
 
   if (!blog || !blogPost) {

--- a/core/app/[locale]/(default)/blog/page-data.ts
+++ b/core/app/[locale]/(default)/blog/page-data.ts
@@ -1,4 +1,5 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
+import { unstable_cache } from 'next/cache';
 import { getFormatter } from 'next-intl/server';
 import { cache } from 'react';
 
@@ -72,24 +73,34 @@ interface Pagination {
   after: string | null;
 }
 
-export const getBlog = cache(async () => {
-  const response = await client.fetch({
-    document: BlogQuery,
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedBlog = unstable_cache(
+  async (locale: string) => {
+    const response = await client.fetch({
+      document: BlogQuery,
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return response.data.site.content.blog;
+    return response.data.site.content.blog;
+  },
+  ['get-blog'],
+  { revalidate },
+);
+
+export const getBlog = cache(async (locale: string) => {
+  return getCachedBlog(locale);
 });
 
-export const getBlogPosts = cache(
-  async ({ tag, limit = 9, before, after }: BlogPostsFiltersInput & Pagination) => {
+const getCachedBlogPosts = unstable_cache(
+  async (locale: string, { tag, limit = 9, before, after }: BlogPostsFiltersInput & Pagination) => {
     const filterArgs = tag ? { filters: { tags: [tag] } } : {};
     const paginationArgs = before ? { last: limit, before } : { first: limit, after };
 
     const response = await client.fetch({
       document: BlogPostsPageQuery,
       variables: { ...filterArgs, ...paginationArgs },
-      fetchOptions: { next: { revalidate } },
+      locale,
+      fetchOptions: { cache: 'no-store' },
     });
 
     const { blog } = response.data.site.content;
@@ -98,15 +109,13 @@ export const getBlogPosts = cache(
       return null;
     }
 
-    const format = await getFormatter();
-
     return {
       pageInfo: blog.posts.pageInfo,
       posts: removeEdgesAndNodes(blog.posts).map((post) => ({
         id: String(post.entityId),
         author: post.author,
         content: post.plainTextSummary,
-        date: format.dateTime(new Date(post.publishedDate.utc)),
+        dateUtc: post.publishedDate.utc,
         image: post.thumbnailImage
           ? {
               src: post.thumbnailImage.url,
@@ -115,6 +124,28 @@ export const getBlogPosts = cache(
           : undefined,
         href: post.path,
         title: post.name,
+      })),
+    };
+  },
+  ['get-blog-posts'],
+  { revalidate },
+);
+
+export const getBlogPosts = cache(
+  async (locale: string, { tag, limit = 9, before, after }: BlogPostsFiltersInput & Pagination) => {
+    const raw = await getCachedBlogPosts(locale, { tag, limit, before, after });
+
+    if (!raw) {
+      return null;
+    }
+
+    const format = await getFormatter();
+
+    return {
+      pageInfo: raw.pageInfo,
+      posts: raw.posts.map(({ dateUtc, ...post }) => ({
+        ...post,
+        date: format.dateTime(new Date(dateUtc)),
       })),
     };
   },

--- a/core/app/[locale]/(default)/blog/page.tsx
+++ b/core/app/[locale]/(default)/blog/page.tsx
@@ -29,7 +29,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale } = await params;
 
   const t = await getTranslations({ locale, namespace: 'Blog' });
-  const blog = await getBlog();
+  const blog = await getBlog(locale);
 
   const description =
     blog?.description && blog.description.length > 150
@@ -43,9 +43,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-async function listBlogPosts(searchParamsPromise: Promise<SearchParams>) {
+async function listBlogPosts(locale: string, searchParamsPromise: Promise<SearchParams>) {
   const searchParamsParsed = searchParamsCache.parse(await searchParamsPromise);
-  const blogPosts = await getBlogPosts(searchParamsParsed);
+  const blogPosts = await getBlogPosts(locale, searchParamsParsed);
   const posts = blogPosts?.posts ?? [];
 
   return posts;
@@ -63,9 +63,9 @@ async function getEmptyStateSubtitle(): Promise<string | null> {
   return t('subtitle');
 }
 
-async function getPaginationInfo(searchParamsPromise: Promise<SearchParams>) {
+async function getPaginationInfo(locale: string, searchParamsPromise: Promise<SearchParams>) {
   const searchParamsParsed = searchParamsCache.parse(await searchParamsPromise);
-  const blogPosts = await getBlogPosts(searchParamsParsed);
+  const blogPosts = await getBlogPosts(locale, searchParamsParsed);
 
   return pageInfoTransformer(blogPosts?.pageInfo ?? defaultPageInfo);
 }
@@ -79,7 +79,7 @@ export default async function Blog(props: Props) {
 
   const searchParamsParsed = searchParamsCache.parse(await props.searchParams);
   const { tag } = searchParamsParsed;
-  const blog = await getBlog();
+  const blog = await getBlog(locale);
 
   if (!blog) {
     return notFound();
@@ -103,9 +103,9 @@ export default async function Blog(props: Props) {
       description={blog.description}
       emptyStateSubtitle={Streamable.from(getEmptyStateSubtitle)}
       emptyStateTitle={Streamable.from(getEmptyStateTitle)}
-      paginationInfo={Streamable.from(() => getPaginationInfo(props.searchParams))}
+      paginationInfo={Streamable.from(() => getPaginationInfo(locale, props.searchParams))}
       placeholderCount={6}
-      posts={Streamable.from(() => listBlogPosts(props.searchParams))}
+      posts={Streamable.from(() => listBlogPosts(locale, props.searchParams))}
       title={blog.name}
     />
   );

--- a/core/app/[locale]/(default)/cart/_actions/update-coupon-code.ts
+++ b/core/app/[locale]/(default)/cart/_actions/update-coupon-code.ts
@@ -3,9 +3,10 @@
 import { BigCommerceGQLError } from '@bigcommerce/catalyst-client';
 import { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
-import { getTranslations } from 'next-intl/server';
+import { getLocale, getTranslations } from 'next-intl/server';
 
 import { couponCodeActionFormDataSchema } from '@/vibes/soul/sections/cart/schema';
+import { getSessionCustomerAccessToken } from '~/auth';
 import { getCartId } from '~/lib/cart';
 
 import { getCart } from '../page-data';
@@ -34,7 +35,11 @@ export const updateCouponCode = async (
     return { ...prevState, lastResult: submission.reply({ formErrors: [t('cartNotFound')] }) };
   }
 
-  const cart = await getCart({ cartId });
+  const [locale, customerAccessToken] = await Promise.all([
+    getLocale(),
+    getSessionCustomerAccessToken(),
+  ]);
+  const cart = await getCart(locale, { cartId }, customerAccessToken);
   const checkout = cart.site.checkout;
 
   if (!checkout) {

--- a/core/app/[locale]/(default)/cart/_actions/update-gift-certificate.ts
+++ b/core/app/[locale]/(default)/cart/_actions/update-gift-certificate.ts
@@ -3,9 +3,10 @@
 import { BigCommerceGQLError } from '@bigcommerce/catalyst-client';
 import { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
-import { getTranslations } from 'next-intl/server';
+import { getLocale, getTranslations } from 'next-intl/server';
 
 import { giftCertificateCodeActionFormDataSchema } from '@/vibes/soul/sections/cart/schema';
+import { getSessionCustomerAccessToken } from '~/auth';
 import { getCartId } from '~/lib/cart';
 
 import { getCart } from '../page-data';
@@ -36,7 +37,11 @@ export const updateGiftCertificate = async (
     return { ...prevState, lastResult: submission.reply({ formErrors: [t('cartNotFound')] }) };
   }
 
-  const cart = await getCart({ cartId });
+  const [locale, customerAccessToken] = await Promise.all([
+    getLocale(),
+    getSessionCustomerAccessToken(),
+  ]);
+  const cart = await getCart(locale, { cartId }, customerAccessToken);
   const checkout = cart.site.checkout;
 
   if (!checkout) {

--- a/core/app/[locale]/(default)/cart/_actions/update-shipping-info.ts
+++ b/core/app/[locale]/(default)/cart/_actions/update-shipping-info.ts
@@ -2,10 +2,11 @@
 
 import { BigCommerceGQLError } from '@bigcommerce/catalyst-client';
 import { parseWithZod } from '@conform-to/zod';
-import { getTranslations } from 'next-intl/server';
+import { getLocale, getTranslations } from 'next-intl/server';
 
 import { shippingActionFormDataSchema } from '@/vibes/soul/sections/cart/schema';
 import { ShippingFormState } from '@/vibes/soul/sections/cart/shipping-form';
+import { getSessionCustomerAccessToken } from '~/auth';
 import { getCartId } from '~/lib/cart';
 
 import { getCart } from '../page-data';
@@ -32,7 +33,11 @@ export const updateShippingInfo = async (
     return { ...prevState, lastResult: submission.reply({ formErrors: [t('cartNotFound')] }) };
   }
 
-  const cart = await getCart({ cartId });
+  const [locale, customerAccessToken] = await Promise.all([
+    getLocale(),
+    getSessionCustomerAccessToken(),
+  ]);
+  const cart = await getCart(locale, { cartId }, customerAccessToken);
   const checkout = cart.site.checkout;
 
   if (!checkout || !cart.site.cart) {

--- a/core/app/[locale]/(default)/cart/page-data.ts
+++ b/core/app/[locale]/(default)/cart/page-data.ts
@@ -1,6 +1,6 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
-import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
 import { graphql, VariablesOf } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
@@ -295,12 +295,15 @@ const CartPageQuery = graphql(
 
 type Variables = VariablesOf<typeof CartPageQuery>;
 
-export const getCart = async (variables: Variables) => {
-  const customerAccessToken = await getSessionCustomerAccessToken();
-
+export const getCart = async (
+  locale: string,
+  variables: Variables,
+  customerAccessToken?: string,
+) => {
   const { data } = await client.fetch({
     document: CartPageQuery,
     variables,
+    locale,
     customerAccessToken,
     fetchOptions: {
       cache: 'no-store',
@@ -336,11 +339,20 @@ const SupportedShippingDestinationsQuery = graphql(`
   }
 `);
 
-export const getShippingCountries = cache(async () => {
-  const { data } = await client.fetch({
-    document: SupportedShippingDestinationsQuery,
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedShippingCountries = unstable_cache(
+  async (locale: string) => {
+    const { data } = await client.fetch({
+      document: SupportedShippingDestinationsQuery,
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return data.site.settings?.shipping?.supportedShippingDestinations.countries ?? [];
+    return data.site.settings?.shipping?.supportedShippingDestinations.countries ?? [];
+  },
+  ['get-shipping-countries'],
+  { revalidate },
+);
+
+export const getShippingCountries = cache(async (locale: string) => {
+  return getCachedShippingCountries(locale);
 });

--- a/core/app/[locale]/(default)/cart/page.tsx
+++ b/core/app/[locale]/(default)/cart/page.tsx
@@ -4,6 +4,7 @@ import { getFormatter, getTranslations, setRequestLocale } from 'next-intl/serve
 import { Streamable } from '@/vibes/soul/lib/streamable';
 import { Cart as CartComponent, CartEmptyState } from '@/vibes/soul/sections/cart';
 import { CartAnalyticsProvider } from '~/app/[locale]/(default)/cart/_components/cart-analytics-provider';
+import { getSessionCustomerAccessToken } from '~/auth';
 import { getCartId } from '~/lib/cart';
 import { getPreferredCurrencyCode } from '~/lib/currency';
 import { exists } from '~/lib/utils';
@@ -32,8 +33,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-const getAnalyticsData = async (cartId: string) => {
-  const data = await getCart({ cartId });
+const getAnalyticsData = async (locale: string, cartId: string, customerAccessToken?: string) => {
+  const data = await getCart(locale, { cartId }, customerAccessToken);
 
   const cart = data.site.cart;
 
@@ -65,10 +66,7 @@ export default async function Cart({ params }: Props) {
 
   setRequestLocale(locale);
 
-  const t = await getTranslations('Cart');
-  const tGiftCertificates = await getTranslations('GiftCertificates');
-  const format = await getFormatter();
-  const cartId = await getCartId();
+  const [t, cartId] = await Promise.all([getTranslations('Cart'), getCartId()]);
 
   if (!cartId) {
     return (
@@ -80,8 +78,13 @@ export default async function Cart({ params }: Props) {
     );
   }
 
-  const currencyCode = await getPreferredCurrencyCode();
-  const data = await getCart({ cartId, currencyCode });
+  const [tGiftCertificates, format, currencyCode, customerAccessToken] = await Promise.all([
+    getTranslations('GiftCertificates'),
+    getFormatter(),
+    getPreferredCurrencyCode(),
+    getSessionCustomerAccessToken(),
+  ]);
+  const data = await getCart(locale, { cartId, currencyCode }, customerAccessToken);
 
   const cart = data.site.cart;
   const checkout = data.site.checkout;
@@ -227,7 +230,7 @@ export default async function Cart({ params }: Props) {
     checkout?.shippingConsignments?.find((consignment) => consignment.selectedShippingOption) ||
     checkout?.shippingConsignments?.[0];
 
-  const shippingCountries = await getShippingCountries();
+  const shippingCountries = await getShippingCountries(locale);
 
   const countries = shippingCountries.map((country) => ({
     value: country.code,
@@ -260,7 +263,9 @@ export default async function Cart({ params }: Props) {
 
   return (
     <>
-      <CartAnalyticsProvider data={Streamable.from(() => getAnalyticsData(cartId))}>
+      <CartAnalyticsProvider
+        data={Streamable.from(() => getAnalyticsData(locale, cartId, customerAccessToken))}
+      >
         {checkoutUrl ? <CheckoutPreconnect url={checkoutUrl} /> : null}
         <CartComponent
           cart={{

--- a/core/app/[locale]/(default)/compare/page-data.ts
+++ b/core/app/[locale]/(default)/compare/page-data.ts
@@ -1,4 +1,5 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -55,8 +56,8 @@ const ComparedProductsQuery = graphql(
   [ProductCardFragment],
 );
 
-export const getComparedProducts = cache(
-  async (productIds: number[] = [], currencyCode?: CurrencyCode, customerAccessToken?: string) => {
+const getCachedComparedProducts = unstable_cache(
+  async (locale: string, productIds: number[], currencyCode?: CurrencyCode) => {
     if (productIds.length === 0) {
       return [];
     }
@@ -68,10 +69,43 @@ export const getComparedProducts = cache(
         first: productIds.length ? MAX_COMPARE_LIMIT : 0,
         currencyCode,
       },
-      customerAccessToken,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
+      locale,
+      fetchOptions: { cache: 'no-store' },
     });
 
     return removeEdgesAndNodes(data.site.products);
+  },
+  ['get-compared-products'],
+  { revalidate },
+);
+
+export const getComparedProducts = cache(
+  async (
+    locale: string,
+    productIds: number[] = [],
+    currencyCode?: CurrencyCode,
+    customerAccessToken?: string,
+  ) => {
+    if (customerAccessToken) {
+      if (productIds.length === 0) {
+        return [];
+      }
+
+      const { data } = await client.fetch({
+        document: ComparedProductsQuery,
+        variables: {
+          entityIds: productIds,
+          first: productIds.length ? MAX_COMPARE_LIMIT : 0,
+          currencyCode,
+        },
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return removeEdgesAndNodes(data.site.products);
+    }
+
+    return getCachedComparedProducts(locale, productIds, currencyCode);
   },
 );

--- a/core/app/[locale]/(default)/compare/page.tsx
+++ b/core/app/[locale]/(default)/compare/page.tsx
@@ -57,15 +57,21 @@ export default async function Compare(props: Props) {
   const t = await getTranslations('Compare');
 
   const streamableProducts = Streamable.from(async () => {
-    const customerAccessToken = await getSessionCustomerAccessToken();
-    const currencyCode = await getPreferredCurrencyCode();
-
-    const searchParams = await props.searchParams;
+    const [customerAccessToken, currencyCode, searchParams, format] = await Promise.all([
+      getSessionCustomerAccessToken(),
+      getPreferredCurrencyCode(),
+      props.searchParams,
+      getFormatter(),
+    ]);
     const parsed = CompareParamsSchema.parse(searchParams);
     const productIds = parsed.ids?.filter((id) => !Number.isNaN(id));
 
-    const products = await getComparedProducts(productIds, currencyCode, customerAccessToken);
-    const format = await getFormatter();
+    const products = await getComparedProducts(
+      locale,
+      productIds,
+      currencyCode,
+      customerAccessToken,
+    );
 
     return products.map((product) => ({
       id: product.entityId.toString(),
@@ -90,14 +96,20 @@ export default async function Compare(props: Props) {
   });
 
   const streamableAnalyticsData = Streamable.from(async () => {
-    const customerAccessToken = await getSessionCustomerAccessToken();
-    const currencyCode = await getPreferredCurrencyCode();
-
-    const searchParams = await props.searchParams;
+    const [customerAccessToken, currencyCode, searchParams] = await Promise.all([
+      getSessionCustomerAccessToken(),
+      getPreferredCurrencyCode(),
+      props.searchParams,
+    ]);
     const parsed = CompareParamsSchema.parse(searchParams);
     const productIds = parsed.ids?.filter((id) => !Number.isNaN(id));
 
-    const products = await getComparedProducts(productIds, currencyCode, customerAccessToken);
+    const products = await getComparedProducts(
+      locale,
+      productIds,
+      currencyCode,
+      customerAccessToken,
+    );
 
     return products.map((product) => {
       return {

--- a/core/app/[locale]/(default)/gift-certificates/balance/page.tsx
+++ b/core/app/[locale]/(default)/gift-certificates/balance/page.tsx
@@ -32,7 +32,7 @@ export default async function GiftCertificates(props: Props) {
 
   const t = await getTranslations('GiftCertificates');
   const currencyCode = await getPreferredCurrencyCode();
-  const data = await getGiftCertificatesData(currencyCode);
+  const data = await getGiftCertificatesData(locale, currencyCode);
 
   if (!data.giftCertificatesEnabled) {
     return redirect({ href: '/', locale });

--- a/core/app/[locale]/(default)/gift-certificates/page-data.ts
+++ b/core/app/[locale]/(default)/gift-certificates/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -26,16 +27,27 @@ const GiftCertificatesRootQuery = graphql(
   [StoreLogoFragment],
 );
 
-export const getGiftCertificatesData = cache(async (currencyCode?: CurrencyCode) => {
-  const response = await client.fetch({
-    document: GiftCertificatesRootQuery,
-    variables: { currencyCode },
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedGiftCertificatesData = unstable_cache(
+  async (locale: string, currencyCode?: CurrencyCode) => {
+    const response = await client.fetch({
+      document: GiftCertificatesRootQuery,
+      variables: { currencyCode },
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return {
-    giftCertificatesEnabled: response.data.site.settings?.giftCertificates?.isEnabled ?? false,
-    defaultCurrency: response.data.site.settings?.currency.defaultCurrency ?? undefined,
-    logo: response.data.site.settings ? logoTransformer(response.data.site.settings) : '',
-  };
-});
+    return {
+      giftCertificatesEnabled: response.data.site.settings?.giftCertificates?.isEnabled ?? false,
+      defaultCurrency: response.data.site.settings?.currency.defaultCurrency ?? undefined,
+      logo: response.data.site.settings ? logoTransformer(response.data.site.settings) : '',
+    };
+  },
+  ['get-gift-certificates-data'],
+  { revalidate },
+);
+
+export const getGiftCertificatesData = cache(
+  async (locale: string, currencyCode?: CurrencyCode) => {
+    return getCachedGiftCertificatesData(locale, currencyCode);
+  },
+);

--- a/core/app/[locale]/(default)/gift-certificates/page.tsx
+++ b/core/app/[locale]/(default)/gift-certificates/page.tsx
@@ -31,7 +31,7 @@ export default async function GiftCertificates(props: Props) {
   const t = await getTranslations('GiftCertificates');
   const format = await getFormatter();
   const currencyCode = await getPreferredCurrencyCode();
-  const data = await getGiftCertificatesData(currencyCode);
+  const data = await getGiftCertificatesData(locale, currencyCode);
 
   if (!data.giftCertificatesEnabled) {
     return redirect({ href: '/', locale });

--- a/core/app/[locale]/(default)/gift-certificates/purchase/page-data.ts
+++ b/core/app/[locale]/(default)/gift-certificates/purchase/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -29,17 +30,28 @@ const GiftCertificatePurchaseSettingsQuery = graphql(
   [GiftCertificateSettingsFragment, StoreLogoFragment],
 );
 
-export const getGiftCertificatePurchaseData = cache(async (currencyCode?: CurrencyCode) => {
-  const response = await client.fetch({
-    document: GiftCertificatePurchaseSettingsQuery,
-    variables: { currencyCode },
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedGiftCertificatePurchaseData = unstable_cache(
+  async (locale: string, currencyCode?: CurrencyCode) => {
+    const response = await client.fetch({
+      document: GiftCertificatePurchaseSettingsQuery,
+      variables: { currencyCode },
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return {
-    giftCertificateSettings: response.data.site.settings?.giftCertificates ?? null,
-    logo: response.data.site.settings ? logoTransformer(response.data.site.settings) : '',
-    storeName: response.data.site.settings?.storeName ?? undefined,
-    defaultCurrency: response.data.site.settings?.currency.defaultCurrency ?? undefined,
-  };
-});
+    return {
+      giftCertificateSettings: response.data.site.settings?.giftCertificates ?? null,
+      logo: response.data.site.settings ? logoTransformer(response.data.site.settings) : '',
+      storeName: response.data.site.settings?.storeName ?? undefined,
+      defaultCurrency: response.data.site.settings?.currency.defaultCurrency ?? undefined,
+    };
+  },
+  ['get-gift-certificate-purchase-data'],
+  { revalidate },
+);
+
+export const getGiftCertificatePurchaseData = cache(
+  async (locale: string, currencyCode?: CurrencyCode) => {
+    return getCachedGiftCertificatePurchaseData(locale, currencyCode);
+  },
+);

--- a/core/app/[locale]/(default)/gift-certificates/purchase/page.tsx
+++ b/core/app/[locale]/(default)/gift-certificates/purchase/page.tsx
@@ -150,10 +150,12 @@ function getExpiryDate(
 export default async function GiftCertificatePurchasePage({ params }: Props) {
   const { locale } = await params;
 
-  const t = await getTranslations({ locale, namespace: 'GiftCertificates' });
-  const format = await getFormatter();
-  const currencyCode = await getPreferredCurrencyCode();
-  const data = await getGiftCertificatePurchaseData(currencyCode);
+  const [t, format, currencyCode] = await Promise.all([
+    getTranslations({ locale, namespace: 'GiftCertificates' }),
+    getFormatter(),
+    getPreferredCurrencyCode(),
+  ]);
+  const data = await getGiftCertificatePurchaseData(locale, currencyCode);
 
   if (!data.giftCertificateSettings?.isEnabled) {
     return redirect({ href: '/', locale });

--- a/core/app/[locale]/(default)/page-data.ts
+++ b/core/app/[locale]/(default)/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -77,15 +78,35 @@ const HomePageQuery = graphql(
   [FeaturedProductsCarouselFragment, FeaturedProductsListFragment],
 );
 
-export const getPageData = cache(
-  async (currencyCode?: CurrencyCode, customerAccessToken?: string) => {
+const getCachedPageData = unstable_cache(
+  async (locale: string, currencyCode?: CurrencyCode) => {
     const { data } = await client.fetch({
       document: HomePageQuery,
-      customerAccessToken,
       variables: { currencyCode },
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
+      locale,
+      fetchOptions: { cache: 'no-store' },
     });
 
     return data;
+  },
+  ['get-page-data'],
+  { revalidate },
+);
+
+export const getPageData = cache(
+  async (locale: string, currencyCode?: CurrencyCode, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const { data } = await client.fetch({
+        document: HomePageQuery,
+        customerAccessToken,
+        variables: { currencyCode },
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return data;
+    }
+
+    return getCachedPageData(locale, currencyCode);
   },
 );

--- a/core/app/[locale]/(default)/page.tsx
+++ b/core/app/[locale]/(default)/page.tsx
@@ -38,7 +38,7 @@ export default async function Home({ params }: Props) {
     const customerAccessToken = await getSessionCustomerAccessToken();
     const currencyCode = await getPreferredCurrencyCode();
 
-    return getPageData(currencyCode, customerAccessToken);
+    return getPageData(locale, currencyCode, customerAccessToken);
   });
 
   const streamableFeaturedProducts = Streamable.from(async () => {

--- a/core/app/[locale]/(default)/product/[slug]/_components/reviews.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/_components/reviews.tsx
@@ -1,4 +1,5 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
+import { unstable_cache } from 'next/cache';
 import { getFormatter, getTranslations } from 'next-intl/server';
 import { createLoader, parseAsString, SearchParams } from 'nuqs/server';
 import { cache } from 'react';
@@ -64,18 +65,48 @@ const ReviewsQuery = graphql(
   [ProductReviewSchemaFragment, PaginationFragment],
 );
 
-const getReviews = cache(async (productId: number, paginationArgs: object) => {
-  const { data } = await client.fetch({
-    document: ReviewsQuery,
-    variables: { ...paginationArgs, entityId: productId },
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedReviews = unstable_cache(
+  async (locale: string, productId: number, paginationArgs: object) => {
+    const { data } = await client.fetch({
+      document: ReviewsQuery,
+      variables: { ...paginationArgs, entityId: productId },
+      locale,
+      fetchOptions: { next: { revalidate } },
+    });
 
-  return data.site.product;
-});
+    return data.site.product;
+  },
+  ['get-reviews'],
+  { revalidate },
+);
+
+const getReviews = cache(
+  async (
+    locale: string,
+    productId: number,
+    paginationArgs: object,
+    customerAccessToken?: string,
+  ) => {
+    if (customerAccessToken) {
+      const { data } = await client.fetch({
+        document: ReviewsQuery,
+        variables: { ...paginationArgs, entityId: productId },
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return data.site.product;
+    }
+
+    return getCachedReviews(locale, productId, paginationArgs);
+  },
+);
 
 interface Props {
   productId: number;
+  locale: string;
+  customerAccessToken?: string;
   searchParams: Promise<SearchParams>;
   streamableImages: Streamable<{
     images: Array<{ src: string; alt: string }>;
@@ -87,6 +118,8 @@ interface Props {
 
 export const Reviews = async ({
   productId,
+  locale,
+  customerAccessToken,
   searchParams,
   streamableProduct,
   streamableImages,
@@ -103,7 +136,7 @@ export const Reviews = async ({
     } = paginationSearchParams;
     const paginationArgs = before == null ? { first: 5, after } : { last: 5, before };
 
-    return getReviews(productId, paginationArgs);
+    return getReviews(locale, productId, paginationArgs, customerAccessToken);
   });
 
   const streamableReviews = Streamable.from(async () => {

--- a/core/app/[locale]/(default)/product/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/product/[slug]/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -154,16 +155,36 @@ const ProductPageMetadataQuery = graphql(`
   }
 `);
 
-export const getProductPageMetadata = cache(
-  async (entityId: number, customerAccessToken?: string) => {
+const getCachedProductPageMetadata = unstable_cache(
+  async (locale: string, entityId: number) => {
     const { data } = await client.fetch({
       document: ProductPageMetadataQuery,
       variables: { entityId },
-      customerAccessToken,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
+      locale,
+      fetchOptions: { cache: 'no-store' },
     });
 
     return data.site.product;
+  },
+  ['get-product-page-metadata'],
+  { revalidate },
+);
+
+export const getProductPageMetadata = cache(
+  async (locale: string, entityId: number, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const { data } = await client.fetch({
+        document: ProductPageMetadataQuery,
+        variables: { entityId },
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return data.site.product;
+    }
+
+    return getCachedProductPageMetadata(locale, entityId);
   },
 );
 
@@ -200,16 +221,38 @@ const ProductQuery = graphql(
   [ProductOptionsFragment],
 );
 
-export const getProduct = cache(async (entityId: number, customerAccessToken?: string) => {
-  const { data } = await client.fetch({
-    document: ProductQuery,
-    variables: { entityId },
-    customerAccessToken,
-    fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
-  });
+const getCachedProduct = unstable_cache(
+  async (locale: string, entityId: number) => {
+    const { data } = await client.fetch({
+      document: ProductQuery,
+      variables: { entityId },
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return data.site;
-});
+    return data.site;
+  },
+  ['get-product'],
+  { revalidate },
+);
+
+export const getProduct = cache(
+  async (locale: string, entityId: number, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const { data } = await client.fetch({
+        document: ProductQuery,
+        variables: { entityId },
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return data.site;
+    }
+
+    return getCachedProduct(locale, entityId);
+  },
+);
 
 const StreamableProductVariantInventoryBySkuQuery = graphql(`
   query ProductVariantBySkuQuery($productId: Int!, $sku: String!) {
@@ -249,16 +292,36 @@ const StreamableProductVariantInventoryBySkuQuery = graphql(`
 
 type VariantInventoryVariables = VariablesOf<typeof StreamableProductVariantInventoryBySkuQuery>;
 
-export const getStreamableProductVariantInventory = cache(
-  async (variables: VariantInventoryVariables, customerAccessToken?: string) => {
+const getCachedStreamableProductVariantInventory = unstable_cache(
+  async (locale: string, variables: VariantInventoryVariables) => {
     const { data } = await client.fetch({
       document: StreamableProductVariantInventoryBySkuQuery,
       variables,
-      customerAccessToken,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate: 60 } },
+      locale,
+      fetchOptions: { cache: 'no-store' },
     });
 
     return data.site.product?.variants;
+  },
+  ['get-streamable-product-variant-inventory'],
+  { revalidate: 60 },
+);
+
+export const getStreamableProductVariantInventory = cache(
+  async (locale: string, variables: VariantInventoryVariables, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const { data } = await client.fetch({
+        document: StreamableProductVariantInventoryBySkuQuery,
+        variables,
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return data.site.product?.variants;
+    }
+
+    return getCachedStreamableProductVariantInventory(locale, variables);
   },
 );
 
@@ -322,16 +385,36 @@ const StreamableProductQuery = graphql(
 
 type Variables = VariablesOf<typeof StreamableProductQuery>;
 
-export const getStreamableProduct = cache(
-  async (variables: Variables, customerAccessToken?: string) => {
+const getCachedStreamableProduct = unstable_cache(
+  async (locale: string, variables: Variables) => {
     const { data } = await client.fetch({
       document: StreamableProductQuery,
       variables,
-      customerAccessToken,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
+      locale,
+      fetchOptions: { cache: 'no-store' },
     });
 
     return data.site.product;
+  },
+  ['get-streamable-product'],
+  { revalidate },
+);
+
+export const getStreamableProduct = cache(
+  async (locale: string, variables: Variables, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const { data } = await client.fetch({
+        document: StreamableProductQuery,
+        variables,
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return data.site.product;
+    }
+
+    return getCachedStreamableProduct(locale, variables);
   },
 );
 
@@ -365,16 +448,36 @@ const StreamableProductInventoryQuery = graphql(
 
 type ProductInventoryVariables = VariablesOf<typeof StreamableProductQuery>;
 
-export const getStreamableProductInventory = cache(
-  async (variables: ProductInventoryVariables, customerAccessToken?: string) => {
+const getCachedStreamableProductInventory = unstable_cache(
+  async (locale: string, variables: ProductInventoryVariables) => {
     const { data } = await client.fetch({
       document: StreamableProductInventoryQuery,
       variables,
-      customerAccessToken,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate: 60 } },
+      locale,
+      fetchOptions: { cache: 'no-store' },
     });
 
     return data.site.product;
+  },
+  ['get-streamable-product-inventory'],
+  { revalidate: 60 },
+);
+
+export const getStreamableProductInventory = cache(
+  async (locale: string, variables: ProductInventoryVariables, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const { data } = await client.fetch({
+        document: StreamableProductInventoryQuery,
+        variables,
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return data.site.product;
+    }
+
+    return getCachedStreamableProductInventory(locale, variables);
   },
 );
 
@@ -409,16 +512,36 @@ const ProductPricingAndRelatedProductsQuery = graphql(
   [PricingFragment, FeaturedProductsCarouselFragment],
 );
 
-export const getProductPricingAndRelatedProducts = cache(
-  async (variables: Variables, customerAccessToken?: string) => {
+const getCachedProductPricingAndRelatedProducts = unstable_cache(
+  async (locale: string, variables: Variables) => {
     const { data } = await client.fetch({
       document: ProductPricingAndRelatedProductsQuery,
       variables,
-      customerAccessToken,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
+      locale,
+      fetchOptions: { cache: 'no-store' },
     });
 
     return data.site.product;
+  },
+  ['get-product-pricing-and-related-products'],
+  { revalidate },
+);
+
+export const getProductPricingAndRelatedProducts = cache(
+  async (locale: string, variables: Variables, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const { data } = await client.fetch({
+        document: ProductPricingAndRelatedProductsQuery,
+        variables,
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return data.site.product;
+    }
+
+    return getCachedProductPricingAndRelatedProducts(locale, variables);
   },
 );
 
@@ -440,12 +563,33 @@ const InventorySettingsQuery = graphql(`
   }
 `);
 
-export const getStreamableInventorySettingsQuery = cache(async (customerAccessToken?: string) => {
-  const { data } = await client.fetch({
-    document: InventorySettingsQuery,
-    customerAccessToken,
-    fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
-  });
+const getCachedStreamableInventorySettingsQuery = unstable_cache(
+  async (locale: string) => {
+    const { data } = await client.fetch({
+      document: InventorySettingsQuery,
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return data.site.settings?.inventory;
-});
+    return data.site.settings?.inventory;
+  },
+  ['get-streamable-inventory-settings'],
+  { revalidate },
+);
+
+export const getStreamableInventorySettingsQuery = cache(
+  async (locale: string, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const { data } = await client.fetch({
+        document: InventorySettingsQuery,
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return data.site.settings?.inventory;
+    }
+
+    return getCachedStreamableInventorySettingsQuery(locale);
+  },
+);

--- a/core/app/[locale]/(default)/product/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/page.tsx
@@ -613,6 +613,8 @@ export default async function Product({ params, searchParams }: Props) {
       {showRating && (
         <div id="reviews">
           <Reviews
+            customerAccessToken={customerAccessToken}
+            locale={locale}
             productId={productId}
             recaptchaSiteKey={recaptchaSiteKey}
             searchParams={searchParams}

--- a/core/app/[locale]/(default)/product/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/page.tsx
@@ -40,12 +40,14 @@ interface Props {
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { slug, locale } = await params;
-  const customerAccessToken = await getSessionCustomerAccessToken();
+  const [{ slug, locale }, customerAccessToken] = await Promise.all([
+    params,
+    getSessionCustomerAccessToken(),
+  ]);
 
   const productId = Number(slug);
 
-  const product = await getProductPageMetadata(productId, customerAccessToken);
+  const product = await getProductPageMetadata(locale, productId, customerAccessToken);
 
   if (!product) {
     return notFound();
@@ -66,19 +68,20 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 }
 
 export default async function Product({ params, searchParams }: Props) {
-  const { locale, slug } = await params;
-  const customerAccessToken = await getSessionCustomerAccessToken();
+  const [{ locale, slug }, customerAccessToken, t, format] = await Promise.all([
+    params,
+    getSessionCustomerAccessToken(),
+    getTranslations('Product'),
+    getFormatter(),
+  ]);
   const detachedWishlistFormId = 'product-add-to-wishlist-form';
 
   setRequestLocale(locale);
 
-  const t = await getTranslations('Product');
-  const format = await getFormatter();
-
   const productId = Number(slug);
 
   const [{ product: baseProduct, settings }, recaptchaSiteKey] = await Promise.all([
-    getProduct(productId, customerAccessToken),
+    getProduct(locale, productId, customerAccessToken),
     getRecaptchaSiteKey(),
   ]);
 
@@ -107,7 +110,7 @@ export default async function Product({ params, searchParams }: Props) {
       useDefaultOptionSelections: true,
     };
 
-    const product = await getStreamableProduct(variables, customerAccessToken);
+    const product = await getStreamableProduct(locale, variables, customerAccessToken);
 
     if (!product) {
       return notFound();
@@ -123,7 +126,7 @@ export default async function Product({ params, searchParams }: Props) {
       entityId: Number(productId),
     };
 
-    const product = await getStreamableProductInventory(variables, customerAccessToken);
+    const product = await getStreamableProductInventory(locale, variables, customerAccessToken);
 
     if (!product) {
       return notFound();
@@ -144,7 +147,11 @@ export default async function Product({ params, searchParams }: Props) {
       sku: product.sku,
     };
 
-    const variants = await getStreamableProductVariantInventory(variables, customerAccessToken);
+    const variants = await getStreamableProductVariantInventory(
+      locale,
+      variables,
+      customerAccessToken,
+    );
 
     if (!variants) {
       return undefined;
@@ -174,7 +181,7 @@ export default async function Product({ params, searchParams }: Props) {
       currencyCode,
     };
 
-    return await getProductPricingAndRelatedProducts(variables, customerAccessToken);
+    return await getProductPricingAndRelatedProducts(locale, variables, customerAccessToken);
   });
 
   const streamablePrices = Streamable.from(async () => {
@@ -242,7 +249,7 @@ export default async function Product({ params, searchParams }: Props) {
   });
 
   const streamableInventorySettings = Streamable.from(async () => {
-    return await getStreamableInventorySettingsQuery(customerAccessToken);
+    return await getStreamableInventorySettingsQuery(locale, customerAccessToken);
   });
 
   const getBackorderAvailabilityPrompt = ({

--- a/core/app/[locale]/(default)/webpages/[id]/contact/page-data.ts
+++ b/core/app/[locale]/(default)/webpages/[id]/contact/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -31,12 +32,21 @@ const ContactPageQuery = graphql(
 
 type Variables = VariablesOf<typeof ContactPageQuery>;
 
-export const getWebpageData = cache(async (variables: Variables) => {
-  const { data } = await client.fetch({
-    document: ContactPageQuery,
-    variables,
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedWebpageData = unstable_cache(
+  async (locale: string, variables: Variables) => {
+    const { data } = await client.fetch({
+      document: ContactPageQuery,
+      variables,
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return data;
+    return data;
+  },
+  ['get-contact-webpage-data'],
+  { revalidate },
+);
+
+export const getWebpageData = cache(async (locale: string, variables: Variables) => {
+  return getCachedWebpageData(locale, variables);
 });

--- a/core/app/[locale]/(default)/webpages/[id]/contact/page.tsx
+++ b/core/app/[locale]/(default)/webpages/[id]/contact/page.tsx
@@ -41,8 +41,8 @@ const fieldMapping = {
 
 type ContactField = keyof typeof fieldMapping;
 
-const getWebPage = cache(async (id: string): Promise<ContactPage> => {
-  const data = await getWebpageData({ id: decodeURIComponent(id) });
+const getWebPage = cache(async (locale: string, id: string): Promise<ContactPage> => {
+  const data = await getWebpageData(locale, { id: decodeURIComponent(id) });
   const webpage = data.node?.__typename === 'ContactPage' ? data.node : null;
 
   if (!webpage) {
@@ -62,10 +62,10 @@ const getWebPage = cache(async (id: string): Promise<ContactPage> => {
   };
 });
 
-async function getWebPageBreadcrumbs(id: string): Promise<Breadcrumb[]> {
+async function getWebPageBreadcrumbs(locale: string, id: string): Promise<Breadcrumb[]> {
   const t = await getTranslations('WebPages.ContactUs');
 
-  const webpage = await getWebPage(id);
+  const webpage = await getWebPage(locale, id);
   const [, ...rest] = webpage.breadcrumbs.reverse();
   const breadcrumbs = [
     {
@@ -82,8 +82,8 @@ async function getWebPageBreadcrumbs(id: string): Promise<Breadcrumb[]> {
   return truncateBreadcrumbs(breadcrumbs, 5);
 }
 
-async function getWebPageWithSuccessContent(id: string, message: string) {
-  const webpage = await getWebPage(id);
+async function getWebPageWithSuccessContent(locale: string, id: string, message: string) {
+  const webpage = await getWebPage(locale, id);
 
   return {
     ...webpage,
@@ -91,9 +91,9 @@ async function getWebPageWithSuccessContent(id: string, message: string) {
   };
 }
 
-async function getContactFields(id: string) {
+async function getContactFields(locale: string, id: string) {
   const t = await getTranslations('WebPages.ContactUs.Form');
-  const { entityId, path, contactFields } = await getWebPage(id);
+  const { entityId, path, contactFields } = await getWebPage(locale, id);
   const toGroupsOfTwo = (fields: Field[]) =>
     fields.reduce<Array<FieldGroup<Field>>>((acc, _, i) => {
       if (i % 2 === 0) {
@@ -156,7 +156,7 @@ async function getContactFields(id: string) {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id, locale } = await params;
-  const webpage = await getWebPage(id);
+  const webpage = await getWebPage(locale, id);
   const { pageTitle, metaDescription, metaKeywords } = webpage.seo;
 
   return {
@@ -180,8 +180,8 @@ export default async function ContactPage({ params, searchParams }: Props) {
   if (success === 'true') {
     return (
       <WebPageContent
-        breadcrumbs={Streamable.from(() => getWebPageBreadcrumbs(id))}
-        webPage={Streamable.from(() => getWebPageWithSuccessContent(id, t('success')))}
+        breadcrumbs={Streamable.from(() => getWebPageBreadcrumbs(locale, id))}
+        webPage={Streamable.from(() => getWebPageWithSuccessContent(locale, id, t('success')))}
       >
         <ButtonLink
           className="mt-8 @2xl:mt-12 @4xl:mt-16"
@@ -200,13 +200,13 @@ export default async function ContactPage({ params, searchParams }: Props) {
 
   return (
     <WebPageContent
-      breadcrumbs={Streamable.from(() => getWebPageBreadcrumbs(id))}
-      webPage={Streamable.from(() => getWebPage(id))}
+      breadcrumbs={Streamable.from(() => getWebPageBreadcrumbs(locale, id))}
+      webPage={Streamable.from(() => getWebPage(locale, id))}
     >
       <div className="mt-8 @2xl:mt-12 @4xl:mt-16">
         <DynamicForm
           action={submitContactForm}
-          fields={await getContactFields(id)}
+          fields={await getContactFields(locale, id)}
           recaptchaSiteKey={recaptchaSiteKey}
           submitLabel={t('cta')}
         />

--- a/core/app/[locale]/(default)/webpages/[id]/layout.tsx
+++ b/core/app/[locale]/(default)/webpages/[id]/layout.tsx
@@ -1,4 +1,5 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
+import { unstable_cache } from 'next/cache';
 import { setRequestLocale } from 'next-intl/server';
 import { cache } from 'react';
 
@@ -45,34 +46,43 @@ interface PageLink {
   href: string;
 }
 
-const getWebPageChildren = cache(async (id: string): Promise<PageLink[]> => {
-  const { data } = await client.fetch({
-    document: WebPageChildrenQuery,
-    variables: { id: decodeURIComponent(id) },
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedWebPageChildren = unstable_cache(
+  async (locale: string, id: string): Promise<PageLink[]> => {
+    const { data } = await client.fetch({
+      document: WebPageChildrenQuery,
+      variables: { id: decodeURIComponent(id) },
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  if (!data.node) {
-    return [];
-  }
-
-  if (!('children' in data.node)) {
-    return [];
-  }
-
-  const { children } = data.node;
-
-  return removeEdgesAndNodes(children).reduce((acc: PageLink[], child) => {
-    if ('path' in child) {
-      return [...acc, { label: child.name, href: child.path }];
+    if (!data.node) {
+      return [];
     }
 
-    if ('link' in child) {
-      return [...acc, { label: child.name, href: child.link }];
+    if (!('children' in data.node)) {
+      return [];
     }
 
-    return acc;
-  }, []);
+    const { children } = data.node;
+
+    return removeEdgesAndNodes(children).reduce((acc: PageLink[], child) => {
+      if ('path' in child) {
+        return [...acc, { label: child.name, href: child.path }];
+      }
+
+      if ('link' in child) {
+        return [...acc, { label: child.name, href: child.link }];
+      }
+
+      return acc;
+    }, []);
+  },
+  ['get-webpage-children'],
+  { revalidate },
+);
+
+const getWebPageChildren = cache(async (locale: string, id: string): Promise<PageLink[]> => {
+  return getCachedWebPageChildren(locale, id);
 });
 
 export default async function WebPageLayout({ params, children }: Props) {
@@ -82,7 +92,7 @@ export default async function WebPageLayout({ params, children }: Props) {
 
   return (
     <StickySidebarLayout
-      sidebar={<SidebarMenu links={getWebPageChildren(id)} />}
+      sidebar={<SidebarMenu links={getWebPageChildren(locale, id)} />}
       sidebarSize="small"
     >
       {children}

--- a/core/app/[locale]/(default)/webpages/[id]/normal/page-data.ts
+++ b/core/app/[locale]/(default)/webpages/[id]/normal/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -29,12 +30,21 @@ const NormalPageQuery = graphql(
 
 type Variables = VariablesOf<typeof NormalPageQuery>;
 
-export const getWebpageData = cache(async (variables: Variables) => {
-  const { data } = await client.fetch({
-    document: NormalPageQuery,
-    variables,
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedWebpageData = unstable_cache(
+  async (locale: string, variables: Variables) => {
+    const { data } = await client.fetch({
+      document: NormalPageQuery,
+      variables,
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return data;
+    return data;
+  },
+  ['get-normal-webpage-data'],
+  { revalidate },
+);
+
+export const getWebpageData = cache(async (locale: string, variables: Variables) => {
+  return getCachedWebpageData(locale, variables);
 });

--- a/core/app/[locale]/(default)/webpages/[id]/normal/page.tsx
+++ b/core/app/[locale]/(default)/webpages/[id]/normal/page.tsx
@@ -19,8 +19,8 @@ interface Props {
   params: Promise<{ locale: string; id: string }>;
 }
 
-const getWebPage = cache(async (id: string): Promise<WebPageData> => {
-  const data = await getWebpageData({ id: decodeURIComponent(id) });
+const getWebPage = cache(async (locale: string, id: string): Promise<WebPageData> => {
+  const data = await getWebpageData(locale, { id: decodeURIComponent(id) });
   const webpage = data.node?.__typename === 'NormalPage' ? data.node : null;
 
   if (!webpage) {
@@ -37,10 +37,10 @@ const getWebPage = cache(async (id: string): Promise<WebPageData> => {
   };
 });
 
-async function getWebPageBreadcrumbs(id: string): Promise<Breadcrumb[]> {
+async function getWebPageBreadcrumbs(locale: string, id: string): Promise<Breadcrumb[]> {
   const t = await getTranslations('WebPages.Normal');
 
-  const webpage = await getWebPage(id);
+  const webpage = await getWebPage(locale, id);
   const [, ...rest] = webpage.breadcrumbs.reverse();
   const breadcrumbs = [
     {
@@ -59,7 +59,7 @@ async function getWebPageBreadcrumbs(id: string): Promise<Breadcrumb[]> {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id, locale } = await params;
-  const webpage = await getWebPage(id);
+  const webpage = await getWebPage(locale, id);
   const { pageTitle, metaDescription, metaKeywords } = webpage.seo;
 
   // Get the path from the last breadcrumb
@@ -80,8 +80,8 @@ export default async function WebPage({ params }: Props) {
 
   return (
     <WebPageContent
-      breadcrumbs={Streamable.from(() => getWebPageBreadcrumbs(id))}
-      webPage={Streamable.from(() => getWebPage(id))}
+      breadcrumbs={Streamable.from(() => getWebPageBreadcrumbs(locale, id))}
+      webPage={Streamable.from(() => getWebPage(locale, id))}
     />
   );
 }

--- a/core/app/[locale]/(default)/wishlist/[token]/page-data.ts
+++ b/core/app/[locale]/(default)/wishlist/[token]/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -5,9 +6,9 @@ import { PaginationFragment } from '~/client/fragments/pagination';
 import { graphql } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
 import { TAGS } from '~/client/tags';
+import type { CurrencyCode } from '~/components/header/fragment';
 import { ProductCardFragment } from '~/components/product-card/fragment';
 import { WishlistItemFragment } from '~/components/wishlist/fragment';
-import { getPreferredCurrencyCode } from '~/lib/currency';
 
 const PublicWishlistQuery = graphql(
   `
@@ -50,22 +51,27 @@ interface Pagination {
   after?: string | null;
 }
 
-export const getPublicWishlist = cache(async (token: string, pagination: Pagination) => {
-  const { before, after, limit = 9 } = pagination;
-  const currencyCode = await getPreferredCurrencyCode();
-  const paginationArgs = before ? { last: limit, before } : { first: limit, after };
-  const response = await client.fetch({
-    document: PublicWishlistQuery,
-    variables: { ...paginationArgs, currencyCode, token },
-    // Since the wishlist is public, it's okay that we cache this request
-    fetchOptions: { next: { revalidate, tags: [TAGS.customer] } },
-  });
+const getCachedPublicWishlist = unstable_cache(
+  async (locale: string, token: string, pagination: Pagination, currencyCode?: CurrencyCode) => {
+    const { before, after, limit = 9 } = pagination;
+    const paginationArgs = before ? { last: limit, before } : { first: limit, after };
+    const response = await client.fetch({
+      document: PublicWishlistQuery,
+      variables: { ...paginationArgs, currencyCode, token },
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  const wishlist = response.data.site.publicWishlist;
+    const wishlist = response.data.site.publicWishlist;
 
-  if (!wishlist) {
-    return null;
-  }
+    return wishlist;
+  },
+  ['get-public-wishlist'],
+  { revalidate, tags: [TAGS.customer] },
+);
 
-  return wishlist;
-});
+export const getPublicWishlist = cache(
+  async (locale: string, token: string, pagination: Pagination, currencyCode?: CurrencyCode) => {
+    return getCachedPublicWishlist(locale, token, pagination, currencyCode);
+  },
+);

--- a/core/app/[locale]/(default)/wishlist/[token]/page.tsx
+++ b/core/app/[locale]/(default)/wishlist/[token]/page.tsx
@@ -13,12 +13,14 @@ import { Wishlist, WishlistDetails } from '@/vibes/soul/sections/wishlist-detail
 import { addWishlistItemToCart } from '~/app/[locale]/(default)/account/wishlists/[id]/_actions/add-to-cart';
 import { WishlistAnalyticsProvider } from '~/app/[locale]/(default)/account/wishlists/[id]/_components/wishlist-analytics-provider';
 import { ExistingResultType } from '~/client/util';
+import type { CurrencyCode } from '~/components/header/fragment';
 import {
   WishlistShareButton,
   WishlistShareButtonSkeleton,
 } from '~/components/wishlist/share-button';
 import { defaultPageInfo, pageInfoTransformer } from '~/data-transformers/page-info-transformer';
 import { publicWishlistDetailsTransformer } from '~/data-transformers/wishlists-transformer';
+import { getPreferredCurrencyCode } from '~/lib/currency';
 import { getMetadataAlternates } from '~/lib/seo/canonical';
 import { isMobileUser } from '~/lib/user-agent';
 
@@ -38,14 +40,16 @@ const searchParamsCache = createSearchParamsCache({
 });
 
 async function getWishlist(
+  locale: string,
   token: string,
   t: ExistingResultType<typeof getTranslations<'Wishlist'>>,
   pt: ExistingResultType<typeof getTranslations<'Product.ProductDetails'>>,
   searchParams: Promise<SearchParams>,
+  currencyCode?: CurrencyCode,
 ): Promise<Wishlist> {
   const searchParamsParsed = searchParamsCache.parse(await searchParams);
   const formatter = await getFormatter();
-  const wishlist = await getPublicWishlist(token, searchParamsParsed);
+  const wishlist = await getPublicWishlist(locale, token, searchParamsParsed, currencyCode);
 
   if (!wishlist) {
     return notFound();
@@ -55,11 +59,13 @@ async function getWishlist(
 }
 
 async function getPaginationInfo(
+  locale: string,
   token: string,
   searchParams: Promise<SearchParams>,
+  currencyCode?: CurrencyCode,
 ): Promise<CursorPaginationInfo> {
   const searchParamsParsed = searchParamsCache.parse(await searchParams);
-  const wishlist = await getPublicWishlist(token, searchParamsParsed);
+  const wishlist = await getPublicWishlist(locale, token, searchParamsParsed, currencyCode);
 
   return pageInfoTransformer(wishlist?.items.pageInfo ?? defaultPageInfo);
 }
@@ -70,7 +76,8 @@ export async function generateMetadata({ params, searchParams }: Props): Promise
   // to make sure we aren't bypassing an existing cache just for the metadata generation.
   const searchParamsParsed = searchParamsCache.parse(await searchParams);
   const t = await getTranslations({ locale, namespace: 'PublicWishlist' });
-  const wishlist = await getPublicWishlist(token, searchParamsParsed);
+  const currencyCode = await getPreferredCurrencyCode();
+  const wishlist = await getPublicWishlist(locale, token, searchParamsParsed, currencyCode);
 
   return {
     title: wishlist?.name ?? t('title'),
@@ -78,9 +85,14 @@ export async function generateMetadata({ params, searchParams }: Props): Promise
   };
 }
 
-const getAnalyticsData = async (token: string, searchParamsPromise: Promise<SearchParams>) => {
+const getAnalyticsData = async (
+  locale: string,
+  token: string,
+  searchParamsPromise: Promise<SearchParams>,
+  currencyCode?: CurrencyCode,
+) => {
   const searchParamsParsed = searchParamsCache.parse(await searchParamsPromise);
-  const wishlist = await getPublicWishlist(token, searchParamsParsed);
+  const wishlist = await getPublicWishlist(locale, token, searchParamsParsed, currencyCode);
 
   if (!wishlist) {
     return [];
@@ -102,12 +114,14 @@ const getAnalyticsData = async (token: string, searchParamsPromise: Promise<Sear
 };
 
 async function getBreadcrumbs(
+  locale: string,
   token: string,
   searchParams: Promise<SearchParams>,
+  currencyCode?: CurrencyCode,
 ): Promise<Breadcrumb[]> {
   const t = await getTranslations('PublicWishlist');
   const searchParamsParsed = searchParamsCache.parse(await searchParams);
-  const wishlist = await getPublicWishlist(token, searchParamsParsed);
+  const wishlist = await getPublicWishlist(locale, token, searchParamsParsed, currencyCode);
 
   return [
     { href: '/', label: 'Home' },
@@ -120,6 +134,7 @@ export default async function PublicWishlist({ params, searchParams }: Props) {
 
   setRequestLocale(locale);
 
+  const currencyCode = await getPreferredCurrencyCode();
   const t = await getTranslations('Wishlist');
   const pwt = await getTranslations('PublicWishlist');
   const pt = await getTranslations('Product.ProductDetails');
@@ -159,17 +174,27 @@ export default async function PublicWishlist({ params, searchParams }: Props) {
   };
 
   return (
-    <WishlistAnalyticsProvider data={Streamable.from(() => getAnalyticsData(token, searchParams))}>
+    <WishlistAnalyticsProvider
+      data={Streamable.from(() => getAnalyticsData(locale, token, searchParams, currencyCode))}
+    >
       <SectionLayout>
-        <Breadcrumbs breadcrumbs={Streamable.from(() => getBreadcrumbs(token, searchParams))} />
+        <Breadcrumbs
+          breadcrumbs={Streamable.from(() =>
+            getBreadcrumbs(locale, token, searchParams, currencyCode),
+          )}
+        />
 
         <WishlistDetails
           action={addWishlistItemToCart}
           className="mt-8"
           emptyStateText={pwt('emptyWishlist')}
           headerActions={wishlistActions}
-          paginationInfo={Streamable.from(() => getPaginationInfo(token, searchParams))}
-          wishlist={Streamable.from(() => getWishlist(token, t, pt, searchParams))}
+          paginationInfo={Streamable.from(() =>
+            getPaginationInfo(locale, token, searchParams, currencyCode),
+          )}
+          wishlist={Streamable.from(() =>
+            getWishlist(locale, token, t, pt, searchParams, currencyCode),
+          )}
         />
       </SectionLayout>
     </WishlistAnalyticsProvider>

--- a/core/app/[locale]/layout.tsx
+++ b/core/app/[locale]/layout.tsx
@@ -1,6 +1,7 @@
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import type { Metadata } from 'next';
+import { unstable_cache } from 'next/cache';
 import { notFound } from 'next/navigation';
 import { NextIntlClientProvider } from 'next-intl';
 import { setRequestLocale } from 'next-intl/server';
@@ -53,12 +54,18 @@ const RootLayoutMetadataQuery = graphql(
   [WebAnalyticsFragment, ScriptsFragment],
 );
 
-const fetchRootLayoutMetadata = cache(async () => {
-  return await client.fetch({
-    document: RootLayoutMetadataQuery,
-    fetchOptions: { next: { revalidate } },
-  });
-});
+const getCachedRootLayoutMetadata = unstable_cache(
+  async () => {
+    return await client.fetch({
+      document: RootLayoutMetadataQuery,
+      fetchOptions: { cache: 'no-store' },
+    });
+  },
+  ['root-layout-metadata'],
+  { revalidate },
+);
+
+const fetchRootLayoutMetadata = cache(async () => getCachedRootLayoutMetadata());
 
 export async function generateMetadata(): Promise<Metadata> {
   const { data } = await fetchRootLayoutMetadata();

--- a/core/client/correlation-id.ts
+++ b/core/client/correlation-id.ts
@@ -1,0 +1,8 @@
+import { cache } from 'react';
+
+/**
+ * Returns a stable correlation ID for the current request.
+ * React.cache ensures the same UUID is returned for all fetches within a
+ * single page render, while being unique across renders/requests.
+ */
+export const getCorrelationId = cache((): string => crypto.randomUUID());

--- a/core/client/index.ts
+++ b/core/client/index.ts
@@ -3,35 +3,7 @@ import { BigCommerceAuthError, createClient } from '@bigcommerce/catalyst-client
 import { getChannelIdFromLocale } from '../channels.config';
 import { backendUserAgent } from '../user-agent';
 
-// next/headers, next/navigation, and next-intl/server are imported dynamically
-// (via `import()`) rather than statically. Static imports cause these modules to
-// be evaluated during module graph resolution when next.config.ts imports this
-// file, which poisons the process-wide AsyncLocalStorage context (pnpm symlinks
-// create two separate singleton instances of next/headers). Dynamic imports
-// defer module loading to call time, after Next.js has fully initialized.
-//
-// During config resolution, the dynamic import of next-intl/server succeeds but
-// getLocale() throws ("not supported in Client Components") — the try/catch
-// below absorbs this gracefully, and getChannelId falls back to defaultChannelId.
-
-const getLocale = async () => {
-  try {
-    const { getLocale: getServerLocale } = await import('next-intl/server');
-
-    return await getServerLocale();
-  } catch {
-    /**
-     * Next-intl `getLocale` only works on the server, and when the proxy has run.
-     *
-     * Instances when `getLocale` will not work:
-     * - Requests during next.config.ts resolution
-     * - Requests in proxies
-     * - Requests in `generateStaticParams`
-     * - Request in api routes
-     * - Requests in static sites without `setRequestLocale`
-     */
-  }
-};
+import { getCorrelationId } from './correlation-id';
 
 export const client = createClient({
   storefrontToken: process.env.BIGCOMMERCE_STOREFRONT_TOKEN ?? '',
@@ -41,30 +13,30 @@ export const client = createClient({
   logger:
     (process.env.NODE_ENV !== 'production' && process.env.CLIENT_LOGGER !== 'false') ||
     process.env.CLIENT_LOGGER === 'true',
-  getChannelId: async (defaultChannelId: string) => {
-    const locale = await getLocale();
-
-    // We use the default channelId as a fallback, but it is not ideal in some scenarios.
+  getChannelId: (defaultChannelId: string, locale?: string) => {
     return getChannelIdFromLocale(locale) ?? defaultChannelId;
   },
   beforeRequest: async (fetchOptions) => {
     // We can't serialize a `Headers` object within this method so we have to opt into using a plain object
     const requestHeaders: Record<string, string> = {};
-    const locale = await getLocale();
 
     if (fetchOptions?.cache && ['no-store', 'no-cache'].includes(fetchOptions.cache)) {
-      const { headers } = await import('next/headers');
-      const ipAddress = (await headers()).get('X-Forwarded-For');
+      try {
+        // headers() is a dynamic API unavailable inside unstable_cache; skip IP forwarding in that context
+        const { headers } = await import('next/headers');
 
-      if (ipAddress) {
-        requestHeaders['X-Forwarded-For'] = ipAddress;
-        requestHeaders['True-Client-IP'] = ipAddress;
+        const ipAddress = (await headers()).get('X-Forwarded-For');
+
+        if (ipAddress) {
+          requestHeaders['X-Forwarded-For'] = ipAddress;
+          requestHeaders['True-Client-IP'] = ipAddress;
+        }
+      } catch {
+        // Not in a request context (e.g. inside unstable_cache); IP forwarding not available
       }
     }
 
-    if (locale) {
-      requestHeaders['Accept-Language'] = locale;
-    }
+    requestHeaders['X-Correlation-ID'] = getCorrelationId();
 
     return {
       headers: requestHeaders,

--- a/core/components/footer/index.tsx
+++ b/core/components/footer/index.tsx
@@ -6,6 +6,7 @@ import {
   SiX,
   SiYoutube,
 } from '@icons-pack/react-simple-icons';
+import { unstable_cache } from 'next/cache';
 import { getTranslations } from 'next-intl/server';
 import { cache, JSX } from 'react';
 
@@ -46,30 +47,55 @@ const socialIcons: Record<string, { icon: JSX.Element }> = {
   YouTube: { icon: <SiYoutube title="YouTube" /> },
 };
 
-const getFooterSections = cache(
-  async (customerAccessToken?: string, currencyCode?: CurrencyCode) => {
+const getCachedFooterSections = unstable_cache(
+  async (currencyCode?: CurrencyCode) => {
     const { data: response } = await client.fetch({
       document: GetLinksAndSectionsQuery,
-      customerAccessToken,
       variables: { currencyCode },
       // Since this query is needed on every page, it's a good idea not to validate the customer access token.
       // The 'cache' function also caches errors, so we might get caught in a redirect loop if the cache saves an invalid token error response.
       validateCustomerAccessToken: false,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
+      fetchOptions: { cache: 'no-store' },
     });
 
     return readFragment(FooterSectionsFragment, response).site;
   },
+  ['get-footer-sections'],
+  { revalidate },
 );
 
-const getFooterData = cache(async () => {
-  const { data: response } = await client.fetch({
-    document: LayoutQuery,
-    fetchOptions: { next: { revalidate } },
-  });
+const getFooterSections = cache(
+  async (customerAccessToken?: string, currencyCode?: CurrencyCode) => {
+    if (customerAccessToken) {
+      const { data: response } = await client.fetch({
+        document: GetLinksAndSectionsQuery,
+        customerAccessToken,
+        variables: { currencyCode },
+        validateCustomerAccessToken: false,
+        fetchOptions: { cache: 'no-store' },
+      });
 
-  return readFragment(FooterFragment, response).site;
-});
+      return readFragment(FooterSectionsFragment, response).site;
+    }
+
+    return getCachedFooterSections(currencyCode);
+  },
+);
+
+const getCachedFooterData = unstable_cache(
+  async () => {
+    const { data: response } = await client.fetch({
+      document: LayoutQuery,
+      fetchOptions: { cache: 'no-store' },
+    });
+
+    return readFragment(FooterFragment, response).site;
+  },
+  ['get-footer-data'],
+  { revalidate },
+);
+
+const getFooterData = cache(async () => getCachedFooterData());
 
 export const Footer = async () => {
   const t = await getTranslations('Components.Footer');

--- a/core/components/header/index.tsx
+++ b/core/components/header/index.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { getLocale, getTranslations } from 'next-intl/server';
 import { cache } from 'react';
 
@@ -47,28 +48,53 @@ const getCartCount = cache(async (cartId: string, customerAccessToken?: string) 
   return response.data.site.cart?.lineItems.totalQuantity ?? null;
 });
 
+const getCachedHeaderLinks = unstable_cache(
+  async (currencyCode?: CurrencyCode) => {
+    const { data: response } = await client.fetch({
+      document: GetLinksAndSectionsQuery,
+      variables: { currencyCode },
+      // Since this query is needed on every page, it's a good idea not to validate the customer access token.
+      // The 'cache' function also caches errors, so we might get caught in a redirect loop if the cache saves an invalid token error response.
+      validateCustomerAccessToken: false,
+      fetchOptions: { cache: 'no-store' },
+    });
+
+    return readFragment(HeaderLinksFragment, response).site;
+  },
+  ['get-header-links'],
+  { revalidate },
+);
+
 const getHeaderLinks = cache(async (customerAccessToken?: string, currencyCode?: CurrencyCode) => {
-  const { data: response } = await client.fetch({
-    document: GetLinksAndSectionsQuery,
-    customerAccessToken,
-    variables: { currencyCode },
-    // Since this query is needed on every page, it's a good idea not to validate the customer access token.
-    // The 'cache' function also caches errors, so we might get caught in a redirect loop if the cache saves an invalid token error response.
-    validateCustomerAccessToken: false,
-    fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
-  });
+  if (customerAccessToken) {
+    const { data: response } = await client.fetch({
+      document: GetLinksAndSectionsQuery,
+      customerAccessToken,
+      variables: { currencyCode },
+      validateCustomerAccessToken: false,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return readFragment(HeaderLinksFragment, response).site;
+    return readFragment(HeaderLinksFragment, response).site;
+  }
+
+  return getCachedHeaderLinks(currencyCode);
 });
 
-const getHeaderData = cache(async () => {
-  const { data: response } = await client.fetch({
-    document: LayoutQuery,
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedHeaderData = unstable_cache(
+  async () => {
+    const { data: response } = await client.fetch({
+      document: LayoutQuery,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return readFragment(HeaderFragment, response).site;
-});
+    return readFragment(HeaderFragment, response).site;
+  },
+  ['get-header-data'],
+  { revalidate },
+);
+
+const getHeaderData = cache(async () => getCachedHeaderData());
 
 export const Header = async () => {
   const t = await getTranslations('Components.Header');

--- a/core/lib/seo/canonical.ts
+++ b/core/lib/seo/canonical.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -45,20 +46,26 @@ const VanityUrlQuery = graphql(`
   }
 `);
 
-const getVanityUrl = cache(async () => {
-  const { data } = await client.fetch({
-    document: VanityUrlQuery,
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedVanityUrl = unstable_cache(
+  async () => {
+    const { data } = await client.fetch({
+      document: VanityUrlQuery,
+      fetchOptions: { next: { revalidate } },
+    });
 
-  const vanityUrl = data.site.settings?.url.vanityUrl;
+    const vanityUrl = data.site.settings?.url.vanityUrl;
 
-  if (!vanityUrl) {
-    throw new Error('Vanity URL not found in site settings');
-  }
+    if (!vanityUrl) {
+      throw new Error('Vanity URL not found in site settings');
+    }
 
-  return vanityUrl;
-});
+    return vanityUrl;
+  },
+  ['get-vanity-url'],
+  { revalidate },
+);
+
+const getVanityUrl = cache(getCachedVanityUrl);
 
 export async function getMetadataAlternates(options: CanonicalUrlOptions) {
   const { path, locale, includeAlternates = true } = options;

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -20,7 +20,7 @@ interface Config<FetcherRequestInit extends RequestInit = RequestInit> {
   platform?: string;
   backendUserAgentExtensions?: string;
   logger?: boolean;
-  getChannelId?: (defaultChannelId: string) => Promise<string> | string;
+  getChannelId?: (defaultChannelId: string, locale?: string) => Promise<string> | string;
   beforeRequest?: (
     fetchOptions?: FetcherRequestInit,
   ) => Promise<Partial<FetcherRequestInit> | undefined> | Partial<FetcherRequestInit> | undefined;
@@ -49,7 +49,7 @@ type GraphQLErrorPolicy = 'none' | 'all' | 'auth' | 'ignore';
 class Client<FetcherRequestInit extends RequestInit = RequestInit> {
   private backendUserAgent: string;
   private readonly defaultChannelId: string;
-  private getChannelId: (defaultChannelId: string) => Promise<string> | string;
+  private getChannelId: (defaultChannelId: string, locale?: string) => Promise<string> | string;
   private beforeRequest?: (
     fetchOptions?: FetcherRequestInit,
   ) => Promise<Partial<FetcherRequestInit> | undefined> | Partial<FetcherRequestInit> | undefined;
@@ -85,6 +85,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     customerAccessToken?: string;
     fetchOptions?: FetcherRequestInit;
     channelId?: string;
+    locale?: string;
     errorPolicy?: GraphQLErrorPolicy;
     validateCustomerAccessToken?: boolean;
   }): Promise<BigCommerceResponse<TResult>>;
@@ -96,6 +97,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     customerAccessToken?: string;
     fetchOptions?: FetcherRequestInit;
     channelId?: string;
+    locale?: string;
     errorPolicy?: GraphQLErrorPolicy;
     validateCustomerAccessToken?: boolean;
   }): Promise<BigCommerceResponse<TResult>>;
@@ -106,6 +108,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     customerAccessToken,
     fetchOptions = {} as FetcherRequestInit,
     channelId,
+    locale,
     errorPolicy = 'none',
     validateCustomerAccessToken = true,
   }: {
@@ -114,6 +117,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     customerAccessToken?: string;
     fetchOptions?: FetcherRequestInit;
     channelId?: string;
+    locale?: string;
     errorPolicy?: GraphQLErrorPolicy;
     validateCustomerAccessToken?: boolean;
   }): Promise<BigCommerceResponse<TResult>> {
@@ -126,6 +130,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
       channelId,
       operationInfo.name,
       operationInfo.type,
+      locale,
     );
     const { headers: additionalFetchHeaders = {}, ...additionalFetchOptions } =
       (await this.beforeRequest?.(fetchOptions)) ?? {};
@@ -136,6 +141,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${this.config.storefrontToken}`,
         'User-Agent': this.backendUserAgent,
+        ...(locale && { 'Accept-Language': locale }),
         ...(customerAccessToken && { 'X-Bc-Customer-Access-Token': customerAccessToken }),
         ...(validateCustomerAccessToken && {
           'X-Bc-Error-On-Invalid-Customer-Access-Token': 'true',
@@ -210,8 +216,8 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     return response.text();
   }
 
-  private async getCanonicalUrl(channelId?: string) {
-    const resolvedChannelId = channelId ?? (await this.getChannelId(this.defaultChannelId));
+  private async getCanonicalUrl(channelId?: string, locale?: string) {
+    const resolvedChannelId = channelId ?? (await this.getChannelId(this.defaultChannelId, locale));
 
     return `https://store-${this.config.storeHash}-${resolvedChannelId}.${graphqlApiDomain}`;
   }
@@ -220,8 +226,9 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     channelId?: string,
     operationName?: string,
     operationType?: string,
+    locale?: string,
   ) {
-    const baseUrl = new URL(`${await this.getCanonicalUrl(channelId)}/graphql`);
+    const baseUrl = new URL(`${await this.getCanonicalUrl(channelId, locale)}/graphql`);
 
     if (operationName) {
       baseUrl.searchParams.set('operation', operationName);


### PR DESCRIPTION
## What/Why?
All GraphQL requests now include an `X-Correlation-ID` header containing a UUID that is stable for the duration of a single page render (via `React.cache`), making it easier to trace and correlate all requests made during a single render in server logs.

Guest (unauthenticated) queries are now cached using `unstable_cache` with the configured revalidation interval, while authenticated requests continue to use `cache: 'no-store'`. This separates cacheable public data from session-specific data, improving performance for unauthenticated visitors. The `X-Forwarded-For` and `True-Client-IP` headers are only forwarded on uncached (`no-store`) requests since they are unavailable inside `unstable_cache`.

## Testing
Locally + E2E

<img width="1285" height="763" alt="Screenshot 2026-03-09 at 12 31 31 PM" src="https://github.com/user-attachments/assets/25d0acc5-8a37-4e98-be72-c16245dac722" />

## Migration
### Step 1: Add the correlation ID helper

Create `core/client/correlation-id.ts`:

```ts
import { cache } from 'react';

/**
 * Returns a stable correlation ID for the current request.
 * React.cache ensures the same UUID is returned for all fetches within a
 * single page render, while being unique across renders/requests.
 */
export const getCorrelationId = cache((): string => crypto.randomUUID());
```

### Step 2: Update `core/client/index.ts`

Update the `beforeRequest` hook to add the `X-Correlation-ID` header to all requests and to only forward `X-Forwarded-For` / `True-Client-IP` on uncached requests:

```diff
+ import { getCorrelationId } from './correlation-id';

  export const client = createClient({
    ...
    beforeRequest: async (fetchOptions) => {
      const requestHeaders: Record<string, string> = {};

-     try {
-       const ipAddress = (await headers()).get('X-Forwarded-For');
-       if (ipAddress) {
-         requestHeaders['X-Forwarded-For'] = ipAddress;
-         requestHeaders['True-Client-IP'] = ipAddress;
-       }
-     } catch {
-       // Not in a request context
-     }
+     if (fetchOptions?.cache && ['no-store', 'no-cache'].includes(fetchOptions.cache)) {
+       try {
+         // headers() is a dynamic API unavailable inside unstable_cache; skip IP forwarding in that context
+         const ipAddress = (await headers()).get('X-Forwarded-For');
+         if (ipAddress) {
+           requestHeaders['X-Forwarded-For'] = ipAddress;
+           requestHeaders['True-Client-IP'] = ipAddress;
+         }
+       } catch {
+         // Not in a request context (e.g. inside unstable_cache); IP forwarding not available
+       }
+     }
+
+     requestHeaders['X-Correlation-ID'] = getCorrelationId();

      return { headers: requestHeaders };
    },
  });
```

### Step 3: Wrap guest queries with `unstable_cache`

For each page data file, wrap the guest (unauthenticated) fetch in `unstable_cache` and branch on whether a `customerAccessToken` is present. Example pattern:

```diff
+ import { unstable_cache } from 'next/cache';
  import { cache } from 'react';
+ import { revalidate } from '~/client/revalidate-target';

+ const getCachedPageData = unstable_cache(
+   async (locale: string, ...args) => {
+     const { data } = await client.fetch({
+       document: PageQuery,
+       variables: { ... },
+       locale,
+       fetchOptions: { cache: 'no-store' },
+     });
+     return data;
+   },
+   ['cache-key'],
+   { revalidate },
+ );

  export const getPageData = cache(
-   async (locale: string, customerAccessToken?: string) => {
-     const { data } = await client.fetch({
-       document: PageQuery,
-       locale,
-       fetchOptions: { cache: 'no-store' },
-     });
-     return data;
-   },
+   async (locale: string, customerAccessToken?: string) => {
+     if (customerAccessToken) {
+       const { data } = await client.fetch({
+         document: PageQuery,
+         customerAccessToken,
+         locale,
+         fetchOptions: { cache: 'no-store' },
+       });
+       return data;
+     }
+     return getCachedPageData(locale);
+   },
  );
```

## Future path with Next 16
We will eventually migrate to use `cacheComponents`, so this migration to `unstable_cache` will provide as the foundation of caching request functions in Catalyst going forward. In a future scenario, it will be as simple as replacing `unstable_cache` for the `use cache` directive.

```diff
-const getCachedPageData = unstable_cache(
-  async (locale: string, currencyCode?: CurrencyCode) => {
-    const { data } = await client.fetch({
-      document: HomePageQuery,
-      variables: { currencyCode },
-      locale,
-      fetchOptions: { cache: 'no-store' },
-    });
-
-    return data;
-  },
-  ['get-page-data'],
-  { revalidate },
-);
-
-export const getPageData = cache(
-  async (locale: string, currencyCode?: CurrencyCode, customerAccessToken?: string) => {
-    if (customerAccessToken) {
-      const { data } = await client.fetch({
-        document: HomePageQuery,
-        customerAccessToken,
-        variables: { currencyCode },
-        locale,
-        fetchOptions: { cache: 'no-store' },
-      });
-
-      return data;
-    }
-
-    return getCachedPageData(locale, currencyCode);
-  },
-);
+async function getCachedPageData(locale: string, currencyCode?: CurrencyCode) {
+  'use cache';
+  cacheLife({revalidate});
+  cacheTag('page-data');
+
+  const { data } = await client.fetch({
+    document: HomePageQuery,
+    variables: { currencyCode },
+    locale,
+    fetchOptions: { cache: 'no-store' },
+  });
+
+  return data;
+}
+
+export async function getPageData(
+  locale: string,
+  currencyCode?: CurrencyCode,
+  customerAccessToken?: string,
+) {
+  if (customerAccessToken) {
+    const { data } = await client.fetch({
+      document: HomePageQuery,
+      customerAccessToken,
+      variables: { currencyCode },
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
+
+    return data;
+  }
+
+  return getCachedPageData(locale, currencyCode);
+}
```
