### PR TITLE
CATALYST-1532: Fix analytics visit count inflation

### DIFF
--- a/.changeset/fix-analytics-visit-inflation.md
+++ b/.changeset/fix-analytics-visit-inflation.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Fix analytics visit count inflation by implementing a sliding window for the visit cookie TTL, guarding against prefetch/RSC requests creating spurious visits, and reordering middleware so analytics cookies survive locale redirects.

--- a/core/middleware.ts
+++ b/core/middleware.ts
@@ -7,8 +7,8 @@ import { withRoutes } from './middlewares/with-routes';
 
 export const middleware = composeMiddlewares(
   withAuth,
-  withIntl,
   withAnalyticsCookies,
+  withIntl,
   withChannelId,
   withRoutes,
 );

--- a/core/middlewares/with-analytics-cookies.ts
+++ b/core/middlewares/with-analytics-cookies.ts
@@ -12,22 +12,30 @@ import { MiddlewareFactory } from './compose-middlewares';
 
 export const withAnalyticsCookies: MiddlewareFactory = (next) => {
   return async (request, event) => {
-    let visitorId = await getVisitorIdCookie();
-    let visitId = await getVisitIdCookie();
+    const existingVisitorId = await getVisitorIdCookie();
+    const existingVisitId = await getVisitIdCookie();
 
-    if (!visitorId || !isUuid(visitorId)) {
-      visitorId = uuidv4();
-    }
+    const isPrefetch = request.headers.get('Next-Router-Prefetch') === '1';
+    const isRSC = request.headers.get('RSC') === '1';
 
-    // Update the visitorId cookie every time
+    const visitorId = existingVisitorId && isUuid(existingVisitorId) ? existingVisitorId : uuidv4();
+
     await setVisitorIdCookie(visitorId);
 
-    if (!visitId || !isUuid(visitId)) {
-      visitId = uuidv4();
-      await setVisitIdCookie(visitId);
+    const hasValidVisit = existingVisitId != null && isUuid(existingVisitId);
 
+    if (hasValidVisit) {
+      // Sliding window: refresh the TTL on every request
+      await setVisitIdCookie(existingVisitId);
+    } else if (!isPrefetch && !isRSC) {
+      // New visit on a real navigation: create cookie and fire event
+      const visitId = uuidv4();
+
+      await setVisitIdCookie(visitId);
       event.waitUntil(recordNewVisit(request, visitorId, visitId));
     }
+    // Prefetch/RSC with no valid visit: skip entirely so the
+    // subsequent real navigation properly detects a new visit.
 
     return next(request, event);
   };

--- a/core/middlewares/with-routes.ts
+++ b/core/middlewares/with-routes.ts
@@ -369,7 +369,12 @@ export const withRoutes: MiddlewareFactory = () => {
       case 'Product': {
         url = `/${locale}/product/${node.entityId}`;
 
-        event.waitUntil(recordProductVisit(request, node.entityId));
+        const isPrefetch = request.headers.get('Next-Router-Prefetch') === '1';
+        const isRSC = request.headers.get('RSC') === '1';
+
+        if (!isPrefetch && !isRSC) {
+          event.waitUntil(recordProductVisit(request, node.entityId));
+        }
 
         break;
       }


### PR DESCRIPTION
Jira: [CATALYST-1532](https://bigcommercecloud.atlassian.net/browse/CATALYST-1532)

## What/Why?

Enterprise merchant (Marucci Sports) reported significantly inflated visitor counts after migrating from Stencil to Catalyst. Three root causes:

1. **No sliding window on visit cookie** — the 30-minute `visitId` cookie TTL was set once and never refreshed, so sessions >30 minutes silently created new visits.
2. **Prefetch/RSC requests create visits** — Next.js client-side navigation fires `RSC` and `Next-Router-Prefetch` requests through middleware. With an expired cookie, each triggered a separate `VisitStarted` mutation.
3. **Locale redirects bypass analytics** — `withIntl` ran before `withAnalyticsCookies` and returned early on redirects, so the visit cookie was never refreshed on those requests.

Notable edge case: when a prefetch/RSC request arrives with an expired cookie, we intentionally skip setting a new `visitId` cookie so the subsequent real navigation properly detects a new visit and fires the event. The same prefetch guard is applied to `recordProductVisit` in `with-routes.ts`.

Fixes CATALYST-1532

## Rollout/Rollback

Standard code rollout. No feature flags, database migrations, or experiments. Rollback is a simple revert.

## Testing

1. **Sliding window**: Browse the storefront for >30 minutes. Confirm in dev tools that `catalyst.visitId` cookie expiry resets on each navigation.
2. **Prefetch guard**: In the network tab, observe RSC/prefetch requests (`RSC: 1` or `Next-Router-Prefetch: 1` headers). Confirm these do not trigger `VisitStarted` mutations in GraphQL client logs.
3. **Middleware reorder**: Navigate to a URL that triggers a locale redirect. Confirm `Set-Cookie` for `catalyst.visitId` is present on the redirect response.
4. **Regression check**: `cd core && npx playwright test`

[CATALYST-1532]: https://bigcommercecloud.atlassian.net/browse/CATALYST-1532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ