### PR TITLE
fix(core): fix layout shift on makeswift page navigation

### DIFF
--- a/.changeset/fix-layout-shift.md
+++ b/.changeset/fix-layout-shift.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-makeswift": patch
+---
+
+Upgrade `@makeswift/runtime` to `0.26.3`, which uses the `<Activity>` API instead of `<Suspense>`. This fixes layout shift both when loading a Makeswift page directly and when client-side navigating from a non-Makeswift page to a Makeswift page after a hard refresh.

--- a/core/package.json
+++ b/core/package.json
@@ -22,7 +22,7 @@
     "@conform-to/react": "^1.6.1",
     "@conform-to/zod": "^1.6.1",
     "@icons-pack/react-simple-icons": "^11.2.0",
-    "@makeswift/runtime": "^0.26.0",
+    "@makeswift/runtime": "^0.26.3",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/api-logs": "^0.208.0",
     "@opentelemetry/instrumentation": "^0.208.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,7 +54,7 @@ importers:
         specifier: ^11.2.0
         version: 11.2.0(react@19.1.5)
       '@makeswift/runtime':
-        specifier: ^0.26.0
+        specifier: ^0.26.3
         version: 0.26.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(next@16.1.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(babel-plugin-macros@3.1.0)(react-dom@19.1.5(react@19.1.5))(react@19.1.5))(react-dom@19.1.5(react@19.1.5))(react@19.1.5)
       '@opentelemetry/api':
         specifier: ^1.9.0


### PR DESCRIPTION
## Summary

- Upgrades `@makeswift/runtime` from `^0.26.0` to `^0.26.3`, which replaces `<Suspense>` with the `<Activity>` API to eliminate layout shift when navigating between Makeswift and non-Makeswift pages

## Testing

### Before:

There was layout shift when loading a Makeswift page (e.g., home page) on Catalyst.

https://github.com/user-attachments/assets/1a34b91a-20ef-4a36-980b-9419bffc2434

There was layout shift when client-side navigating from a non-Makeswift page (e.g., login) to a Makeswift page after a hard refresh (i.e., before client-side Makeswift components have loaded).

https://github.com/user-attachments/assets/7aeef966-8d90-4ff3-b606-7de660d4faa8

### After

Manually verified no layout shift in both dev and production modes:

**Dev (`pnpm dev`):**

https://github.com/user-attachments/assets/e228ce3b-7864-4363-9929-1b70294da362

**Production (`pnpm build && pnpm start`):**

https://github.com/user-attachments/assets/c0ea34bd-c9ca-4f1e-a64d-249e766b1af1

