### PR TITLE
CATALYST-1570: Fix extra thick border on dropdown menu

### DIFF
--- a/.changeset/fix-dropdown-menu-border.md
+++ b/.changeset/fix-dropdown-menu-border.md
@@ -1,0 +1,5 @@
+---
+'@bigcommerce/catalyst-core': patch
+---
+
+Fix extra thick border on dropdown menu by changing `ring` (3px) to `ring-1` (1px) to match the Select component styling.

--- a/core/vibes/soul/primitives/dropdown-menu/index.tsx
+++ b/core/vibes/soul/primitives/dropdown-menu/index.tsx
@@ -62,7 +62,7 @@ export const DropdownMenu = ({
         <DropdownMenuPrimitive.Content
           align={align}
           className={clsx(
-            'z-50 max-h-80 max-w-lg overflow-y-auto rounded-2xl bg-[var(--dropdown-menu-background,hsl(var(--background)))] p-2 shadow-xl ring ring-contrast-100 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 @4xl:w-32 @4xl:rounded-2xl @4xl:p-2',
+            'z-50 max-h-80 max-w-lg overflow-y-auto rounded-2xl bg-[var(--dropdown-menu-background,hsl(var(--background)))] p-2 shadow-xl ring-1 ring-contrast-100 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 @4xl:w-32 @4xl:rounded-2xl @4xl:p-2',
             className,
           )}
           sideOffset={slideOffset}


### PR DESCRIPTION
Jira: [CATALYST-1570](https://bigcommercecloud.atlassian.net/browse/CATALYST-1570)

## What/Why?

The `DropdownMenu` component used Tailwind's `ring` class (3px default width) for its border, while the `Select` component used `ring-1` (1px). This caused a noticeably thick border on dropdown menus across the site, most visible on the wishlist page. Changed to `ring-1` for consistency.

## Testing

<table>
<tr>
	<td>Before
	<td>After
<tr>
	<td><img width="228" height="267" alt="Screenshot 2026-03-19 at 11 45 19" src="https://github.com/user-attachments/assets/5b739183-1ebe-4ea7-a6ba-10d1ff329cd8" />
	<td><img width="271" height="265" alt="Screenshot 2026-03-19 at 11 47 35" src="https://github.com/user-attachments/assets/c64871fd-92fe-4dee-af9c-29c6b1c025f9" />
</table>

1. Navigate to a product page with wishlists enabled (e.g. `/sale-3-plant-bundle/`)
2. Open the wishlist dropdown menu
3. Verify the border is now a thin 1px ring matching other dropdowns/selects on the site

## Migration

N/A

[CATALYST-1570]: https://bigcommercecloud.atlassian.net/browse/CATALYST-1570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ