### PR TITLE
Update required version of Node in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Check out the [Catalyst.dev One-Click Catalyst Documentation](https://www.cataly
 **Requirements:**
 
 - A [BigCommerce account](https://www.bigcommerce.com/start-your-trial)
-- Node.js version 20 or 22
+- Node.js version 24
 - Corepack-enabled `pnpm`
 
   ```bash


### PR DESCRIPTION
## What/Why?

A recent update to Catalyst has changed the version of Node required to version 24, where previously only v20 or v22 were required. This change is updating the README.md file to reflect this new requirement. 

## Testing

Node v24 has been tested and confirmed working, along with confirmation from Catalyst engineers that this is the new requirement

## Migration

N/A