### PR TITLE
Update One-Click Catalyst flow to specify Node v24

### DIFF
--- a/packages/create-catalyst/bin/index.cjs
+++ b/packages/create-catalyst/bin/index.cjs
@@ -6,7 +6,7 @@ const semver = require('semver');
  * Discourage use of odd-numbered versions of Node.js
  * @see https://nodejs.org/en/about/previous-releases#nodejs-releases
  */
-const catalystRequiredNodeVersions = ['^20', '^22'];
+const catalystRequiredNodeVersions = ['^24'];
 const userNodeVersion = process.version;
 
 if (!catalystRequiredNodeVersions.some((version) => semver.satisfies(userNodeVersion, version))) {


### PR DESCRIPTION
## What/Why?

Catalyst has recently been updated to require Node v24 instead of the previously required v20 or v22. We're needing to update the One-Click Catalyst flow to reflect this change as currently if you try to follow the process it'll request v20 or v22 which does not work.

This update changes the versions listed in the below file to reflect v24
https://github.com/bigcommerce/catalyst/blob/6a5b019083aa3e000e5989f6f13256b57c22c479/packages/create-catalyst/bin/index.cjs#L19

## Testing

Node 24 has been confirmed through testing to work with the latest version of Catalyst, along with being confirmed by the Catalyst engineers to be the new supported version

## Migration

No files have been moved, only the listed Node version requirement has been changed for the One-Click Catalyst flow
