### PR TITLE
fix: add repository field to published packages

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -2,6 +2,11 @@
   "name": "@bigcommerce/catalyst-client",
   "description": "BigCommerce API client for Catalyst.",
   "version": "1.0.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bigcommerce/catalyst",
+    "directory": "packages/client"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/create-catalyst/package.json
+++ b/packages/create-catalyst/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@bigcommerce/create-catalyst",
   "version": "1.0.2",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bigcommerce/catalyst",
+    "directory": "packages/create-catalyst"
+  },
   "type": "module",
   "bin": "bin/index.cjs",
   "files": [

--- a/packages/eslint-config-catalyst/package.json
+++ b/packages/eslint-config-catalyst/package.json
@@ -2,6 +2,11 @@
   "name": "@bigcommerce/eslint-config-catalyst",
   "description": "Eslint configs for catalyst",
   "version": "1.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bigcommerce/catalyst",
+    "directory": "packages/eslint-config-catalyst"
+  },
   "files": [
     "./base.js",
     "./next.js",


### PR DESCRIPTION
## What/Why?

npm's sigstore provenance verification requires `package.json` to include a `repository.url` that matches the GitHub repository URL. Without this, `changeset publish` fails with `E422 Unprocessable Entity` for all published packages.

Adds the `repository` field (with `directory` for monorepo support) to:
- `@bigcommerce/create-catalyst`
- `@bigcommerce/catalyst-client`
- `@bigcommerce/eslint-config-catalyst`

## Rollout/Rollback

No rollout needed — metadata-only change. Rollback is a simple revert.

## Testing

Verify each published `package.json` has a valid `repository` field:
```bash
jq '.repository' packages/create-catalyst/package.json packages/client/package.json packages/eslint-config-catalyst/package.json
```