### PR TITLE
fix(core): adds root-level not found page

### DIFF
--- a/.changeset/fix-root-not-found.md
+++ b/.changeset/fix-root-not-found.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Add root-level not-found page so /404 renders a branded page instead of the default Vercel error screen

--- a/core/app/[locale]/layout.tsx
+++ b/core/app/[locale]/layout.tsx
@@ -1,6 +1,5 @@
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
-import { clsx } from 'clsx';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { NextIntlClientProvider } from 'next-intl';
@@ -8,9 +7,6 @@ import { setRequestLocale } from 'next-intl/server';
 import { NuqsAdapter } from 'nuqs/adapters/next/app';
 import { cache, PropsWithChildren } from 'react';
 
-import '../../globals.css';
-
-import { fonts } from '~/app/fonts';
 import { CookieNotifications } from '~/app/notifications';
 import { Providers } from '~/app/providers';
 import { client } from '~/client';
@@ -140,34 +136,32 @@ export default async function RootLayout({ params, children }: Props) {
   const privacyPolicyUrl = rootData.data.site.settings?.privacy?.privacyPolicyUrl;
 
   return (
-    <html className={clsx(fonts.map((f) => f.variable))} lang={locale}>
-      <body className="flex min-h-screen flex-col">
-        <NextIntlClientProvider>
-          <ConsentManager
-            isCookieConsentEnabled={isCookieConsentEnabled}
-            privacyPolicyUrl={privacyPolicyUrl}
-            scripts={scripts}
-          >
-            <NuqsAdapter>
-              <AnalyticsProvider
-                channelId={rootData.data.channel.entityId}
-                isCookieConsentEnabled={isCookieConsentEnabled}
-                settings={rootData.data.site.settings}
-              >
-                <Providers>
-                  {toastNotificationCookieData && (
-                    <CookieNotifications {...toastNotificationCookieData} />
-                  )}
-                  {children}
-                </Providers>
-              </AnalyticsProvider>
-            </NuqsAdapter>
-          </ConsentManager>
-        </NextIntlClientProvider>
-        <VercelComponents />
-        <ContainerQueryPolyfill />
-      </body>
-    </html>
+    <>
+      <NextIntlClientProvider>
+        <ConsentManager
+          isCookieConsentEnabled={isCookieConsentEnabled}
+          privacyPolicyUrl={privacyPolicyUrl}
+          scripts={scripts}
+        >
+          <NuqsAdapter>
+            <AnalyticsProvider
+              channelId={rootData.data.channel.entityId}
+              isCookieConsentEnabled={isCookieConsentEnabled}
+              settings={rootData.data.site.settings}
+            >
+              <Providers>
+                {toastNotificationCookieData && (
+                  <CookieNotifications {...toastNotificationCookieData} />
+                )}
+                {children}
+              </Providers>
+            </AnalyticsProvider>
+          </NuqsAdapter>
+        </ConsentManager>
+      </NextIntlClientProvider>
+      <VercelComponents />
+      <ContainerQueryPolyfill />
+    </>
   );
 }
 

--- a/core/app/layout.tsx
+++ b/core/app/layout.tsx
@@ -1,0 +1,14 @@
+import { clsx } from 'clsx';
+import { PropsWithChildren } from 'react';
+
+import '../globals.css';
+
+import { fonts } from '~/app/fonts';
+
+export default function RootLayout({ children }: PropsWithChildren) {
+  return (
+    <html className={clsx(fonts.map((f) => f.variable))} lang="en">
+      <body className="flex min-h-screen flex-col">{children}</body>
+    </html>
+  );
+}

--- a/core/app/not-found.tsx
+++ b/core/app/not-found.tsx
@@ -1,0 +1,22 @@
+export default function RootNotFound() {
+  return (
+    <main className="flex flex-1 items-center justify-center font-[family-name:var(--not-found-font-family,var(--font-family-body))]">
+      <div className="mx-auto w-full max-w-screen-2xl px-3 py-10 @container @xl:px-6 @4xl:px-20">
+        <header className="text-center">
+          <h1 className="mb-3 font-[family-name:var(--not-found-title-font-family,var(--font-family-heading))] text-3xl font-medium leading-none text-[var(--not-found-title,hsl(var(--foreground)))] @xl:text-4xl @4xl:text-5xl">
+            Not found
+          </h1>
+          <p className="mb-4 text-lg text-[var(--not-found-subtitle,hsl(var(--contrast-500)))]">
+            The page you are looking for could not be found.
+          </p>
+          <a
+            className="relative z-0 inline-flex min-h-14 select-none items-center justify-center gap-x-3 overflow-hidden rounded-full border border-[var(--button-primary-border,hsl(var(--primary)))] bg-[var(--button-primary-background,hsl(var(--primary)))] px-6 py-4 text-center font-[family-name:var(--button-font-family)] text-base font-semibold leading-normal text-[var(--button-primary-text)] after:absolute after:inset-0 after:-z-10 after:-translate-x-[105%] after:rounded-full after:bg-[var(--button-primary-background-hover,color-mix(in_oklab,hsl(var(--primary)),white_75%))] after:transition-[opacity,transform] after:duration-300 after:[animation-timing-function:cubic-bezier(0,0.25,0,1)] hover:after:translate-x-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--button-focus,hsl(var(--primary)))] focus-visible:ring-offset-2"
+            href="/"
+          >
+            <span>Go to homepage</span>
+          </a>
+        </header>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## What/Why?
  When navigating to /404 in production, Catalyst renders the default Vercel/Next.js error screen instead of a branded page. This happens because not-found.tsx only exists inside the [locale] segment, so routes that fall outside that
  segment (like the root /404) have no custom not-found page.

  This PR:
  - Adds a root-level app/layout.tsx that owns the <html> and <body> tags (with fonts and global CSS)
  - Moves the <html>/<body> out of app/[locale]/layout.tsx (now renders a fragment)
  - Adds app/not-found.tsx with a branded not-found page styled to match the Vibes NotFound section and ButtonLink primary variant

## Testing
  - Run pnpm dev and navigate to /404 — should show the branded not-found page with "Not found" heading, subtitle, and "Go to homepage" button
  - Navigate to a non-existent route (e.g., /nonexistent) — should also render the branded page
  - Verify existing locale not-found pages still work (e.g., /en/nonexistent)
  - Verify the homepage and other pages render correctly (fonts, global styles still applied)

<img width="581" height="412" alt="Screenshot 2026-03-23 at 10 05 12 AM" src="https://github.com/user-attachments/assets/89de722a-95c9-4eb6-96b2-14f851ba51f7" />


## Migration
  - app/[locale]/layout.tsx no longer renders <html> or <body> — it now returns a fragment
  - A new app/layout.tsx has been added as the root layout. If you have customized the <html> or <body> tags, move those customizations to app/layout.tsx

