### PR TITLE
fix(core): strip trailing slash when looking up localized Makeswift page

### DIFF
--- a/.changeset/forty-trees-type.md
+++ b/.changeset/forty-trees-type.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-makeswift": patch
+---
+
+Fix 404 error on switching between localized Makeswift pages with locale-specific paths when TRAILING_SLASH=true

--- a/core/vibes/soul/primitives/navigation/_actions/localized-pathname.ts
+++ b/core/vibes/soul/primitives/navigation/_actions/localized-pathname.ts
@@ -25,8 +25,11 @@ const getPageInfo = async ({
 const getPathname = (variants: Array<{ locale: string; path: string }>, locale: string) =>
   variants.find((v) => v.locale === locale)?.path;
 
+const stripTrailingSlash = (pathname: string) =>
+  pathname !== '/' ? pathname.replace(/\/+$/, '') : pathname;
+
 export async function getLocalizedPathname({
-  pathname,
+  pathname: inputPathname,
   activeLocale,
   targetLocale,
 }: {
@@ -34,6 +37,9 @@ export async function getLocalizedPathname({
   activeLocale: string | undefined;
   targetLocale: string;
 }) {
+  // Makeswift page pathnames are always stored without a trailing slash
+  const pathname = stripTrailingSlash(inputPathname);
+
   // fallback to page info for default locale if there is no page info for active locale
   const fallbackPageInfo =
     activeLocale === defaultLocale


### PR DESCRIPTION
## What/Why?

Fix 404 on switching between localized Makeswift pages with locale-specific paths when running with `TRAILING_SLASH=true`.


## Testing

Before:

https://github.com/user-attachments/assets/1896306a-6dcb-4452-9577-11932787e463


After:

https://github.com/user-attachments/assets/bf213a04-7a3d-40f3-9c75-a76aca559193


## Migration

N/A