### PR TITLE
feat: upgrade @makeswift/runtime to 0.28.2

### DIFF
--- a/.changeset/upgrade-makeswift-runtime.md
+++ b/.changeset/upgrade-makeswift-runtime.md
@@ -2,4 +2,4 @@
 "@bigcommerce/catalyst-makeswift": minor
 ---
 
-Upgrade `@makeswift/runtime` from `0.26.3` to `0.28.2`. The `apiOrigin` and `appOrigin` configuration now lives on the `ReactRuntime` constructor instead of being passed separately to `ReactRuntimeProvider`, `Makeswift` client, and `MakeswiftApiHandler`.
+Upgrade `@makeswift/runtime` from `0.26.3` to `0.28.2`. The `apiOrigin` and `appOrigin` configuration now lives on the `ReactRuntimeCore` constructor instead of being passed separately to `ReactRuntimeProvider`, `Makeswift` client, and `MakeswiftApiHandler`.

--- a/.changeset/upgrade-makeswift-runtime.md
+++ b/.changeset/upgrade-makeswift-runtime.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-makeswift": minor
+---
+
+Upgrade `@makeswift/runtime` from `0.26.3` to `0.28.2`. The `apiOrigin` and `appOrigin` configuration now lives on the `ReactRuntime` constructor instead of being passed separately to `ReactRuntimeProvider`, `Makeswift` client, and `MakeswiftApiHandler`.

--- a/core/app/api/makeswift/[...makeswift]/route.ts
+++ b/core/app/api/makeswift/[...makeswift]/route.ts
@@ -24,8 +24,6 @@ const defaultVariants: Font['variants'] = [
 
 const handler = MakeswiftApiHandler(process.env.MAKESWIFT_SITE_API_KEY, {
   runtime,
-  apiOrigin: process.env.NEXT_PUBLIC_MAKESWIFT_API_ORIGIN ?? process.env.MAKESWIFT_API_ORIGIN,
-  appOrigin: process.env.NEXT_PUBLIC_MAKESWIFT_APP_ORIGIN ?? process.env.MAKESWIFT_APP_ORIGIN,
   getFonts() {
     return [
       {

--- a/core/lib/makeswift/client.ts
+++ b/core/lib/makeswift/client.ts
@@ -11,7 +11,6 @@ strict(process.env.MAKESWIFT_SITE_API_KEY, 'MAKESWIFT_SITE_API_KEY is required')
 
 export const client = new Makeswift(process.env.MAKESWIFT_SITE_API_KEY, {
   runtime,
-  apiOrigin: process.env.NEXT_PUBLIC_MAKESWIFT_API_ORIGIN ?? process.env.MAKESWIFT_API_ORIGIN,
 });
 
 export const getPageSnapshot = async ({ path, locale }: { path: string; locale: string }) =>

--- a/core/lib/makeswift/provider.tsx
+++ b/core/lib/makeswift/provider.tsx
@@ -14,8 +14,6 @@ export function MakeswiftProvider({
 }) {
   return (
     <ReactRuntimeProvider
-      apiOrigin={process.env.NEXT_PUBLIC_MAKESWIFT_API_ORIGIN}
-      appOrigin={process.env.NEXT_PUBLIC_MAKESWIFT_APP_ORIGIN}
       runtime={runtime}
       siteVersion={siteVersion}
     >

--- a/core/lib/makeswift/provider.tsx
+++ b/core/lib/makeswift/provider.tsx
@@ -13,10 +13,7 @@ export function MakeswiftProvider({
   siteVersion: SiteVersion | null;
 }) {
   return (
-    <ReactRuntimeProvider
-      runtime={runtime}
-      siteVersion={siteVersion}
-    >
+    <ReactRuntimeProvider runtime={runtime} siteVersion={siteVersion}>
       <RootStyleRegistry enableCssReset={false}>{children}</RootStyleRegistry>
     </ReactRuntimeProvider>
   );

--- a/core/lib/makeswift/runtime.ts
+++ b/core/lib/makeswift/runtime.ts
@@ -1,4 +1,3 @@
-import { ReactRuntime } from '@makeswift/runtime/next';
 import { registerBoxComponent } from '@makeswift/runtime/react/builtins/box';
 import { registerDividerComponent } from '@makeswift/runtime/react/builtins/divider';
 import { registerEmbedComponent } from '@makeswift/runtime/react/builtins/embed';
@@ -8,8 +7,9 @@ import { registerSlotComponent } from '@makeswift/runtime/react/builtins/slot';
 import { registerSocialLinksComponent } from '@makeswift/runtime/react/builtins/social-links';
 import { registerTextComponent } from '@makeswift/runtime/react/builtins/text';
 import { registerVideoComponent } from '@makeswift/runtime/react/builtins/video';
+import { ReactRuntimeCore } from '@makeswift/runtime/react/core';
 
-const runtime = new ReactRuntime({
+const runtime = new ReactRuntimeCore({
   apiOrigin: process.env.NEXT_PUBLIC_MAKESWIFT_API_ORIGIN ?? process.env.MAKESWIFT_API_ORIGIN,
   appOrigin: process.env.NEXT_PUBLIC_MAKESWIFT_APP_ORIGIN ?? process.env.MAKESWIFT_APP_ORIGIN,
   breakpoints: {
@@ -18,6 +18,7 @@ const runtime = new ReactRuntime({
     large: { width: 1024, viewport: 1000, label: 'Large' },
     screen: { width: 1280, label: 'XL' },
   },
+  fetch,
 });
 
 // Only register necessary built-in components. Omitted components are:

--- a/core/lib/makeswift/runtime.ts
+++ b/core/lib/makeswift/runtime.ts
@@ -1,3 +1,4 @@
+import { ReactRuntime } from '@makeswift/runtime/next';
 import { registerBoxComponent } from '@makeswift/runtime/react/builtins/box';
 import { registerDividerComponent } from '@makeswift/runtime/react/builtins/divider';
 import { registerEmbedComponent } from '@makeswift/runtime/react/builtins/embed';
@@ -7,7 +8,6 @@ import { registerSlotComponent } from '@makeswift/runtime/react/builtins/slot';
 import { registerSocialLinksComponent } from '@makeswift/runtime/react/builtins/social-links';
 import { registerTextComponent } from '@makeswift/runtime/react/builtins/text';
 import { registerVideoComponent } from '@makeswift/runtime/react/builtins/video';
-import { ReactRuntime } from '@makeswift/runtime/next';
 
 const runtime = new ReactRuntime({
   apiOrigin: process.env.NEXT_PUBLIC_MAKESWIFT_API_ORIGIN ?? process.env.MAKESWIFT_API_ORIGIN,

--- a/core/lib/makeswift/runtime.ts
+++ b/core/lib/makeswift/runtime.ts
@@ -7,9 +7,11 @@ import { registerSlotComponent } from '@makeswift/runtime/react/builtins/slot';
 import { registerSocialLinksComponent } from '@makeswift/runtime/react/builtins/social-links';
 import { registerTextComponent } from '@makeswift/runtime/react/builtins/text';
 import { registerVideoComponent } from '@makeswift/runtime/react/builtins/video';
-import { ReactRuntimeCore } from '@makeswift/runtime/react/core';
+import { ReactRuntime } from '@makeswift/runtime/next';
 
-const runtime = new ReactRuntimeCore({
+const runtime = new ReactRuntime({
+  apiOrigin: process.env.NEXT_PUBLIC_MAKESWIFT_API_ORIGIN ?? process.env.MAKESWIFT_API_ORIGIN,
+  appOrigin: process.env.NEXT_PUBLIC_MAKESWIFT_APP_ORIGIN ?? process.env.MAKESWIFT_APP_ORIGIN,
   breakpoints: {
     small: { width: 640, viewport: 390, label: 'Small' },
     medium: { width: 768, viewport: 765, label: 'Medium' },

--- a/core/package.json
+++ b/core/package.json
@@ -22,7 +22,7 @@
     "@conform-to/react": "^1.6.1",
     "@conform-to/zod": "^1.6.1",
     "@icons-pack/react-simple-icons": "^11.2.0",
-    "@makeswift/runtime": "^0.26.3",
+    "@makeswift/runtime": "0.28.2",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/api-logs": "^0.208.0",
     "@opentelemetry/instrumentation": "^0.208.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: ^11.2.0
         version: 11.2.0(react@19.1.5)
       '@makeswift/runtime':
-        specifier: ^0.26.3
-        version: 0.26.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(next@16.1.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(babel-plugin-macros@3.1.0)(react-dom@19.1.5(react@19.1.5))(react@19.1.5))(react-dom@19.1.5(react@19.1.5))(react@19.1.5)
+        specifier: 0.28.2
+        version: 0.28.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(next@16.1.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(babel-plugin-macros@3.1.0)(react-dom@19.1.5(react@19.1.5))(react@19.1.5))(react-dom@19.1.5(react@19.1.5))(react@19.1.5)
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.0
@@ -2563,8 +2563,8 @@ packages:
   '@makeswift/prop-controllers@0.4.10':
     resolution: {integrity: sha512-rqiUsEKe+3I0eyJNosTuef3Z0FG3UnPz6rOXY2G7SbKk1h+jyKGVulNPVmsafM9SzuMTfzZNtNL0ouDRsQym+Q==}
 
-  '@makeswift/runtime@0.26.3':
-    resolution: {integrity: sha512-zDvTmiUHsbYI2a2FUpFV6LPSNgTVsmUuX8pCbrvuJyoloXNMu9JPMtNiyay50Rq7+w2tvycfMcacJYQIyct0PA==}
+  '@makeswift/runtime@0.28.2':
+    resolution: {integrity: sha512-ZzF2yZoBeuDTPOFbj5ZPyyifHjgxGAvZ2HYxQ45P2vVlOi7c1nenYua/u8FfQTQBjEjzhD16m/8JSYr0VHIb1A==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@types/react': ^18.0.0 || ^19.0.0
@@ -13733,7 +13733,7 @@ snapshots:
       ts-pattern: 5.9.0
       zod: 3.25.51
 
-  '@makeswift/runtime@0.26.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(next@16.1.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(babel-plugin-macros@3.1.0)(react-dom@19.1.5(react@19.1.5))(react@19.1.5))(react-dom@19.1.5(react@19.1.5))(react@19.1.5)':
+  '@makeswift/runtime@0.28.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(next@16.1.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(babel-plugin-macros@3.1.0)(react-dom@19.1.5(react@19.1.5))(react@19.1.5))(react-dom@19.1.5(react@19.1.5))(react@19.1.5)':
     dependencies:
       '@emotion/cache': 11.14.0
       '@emotion/css': 11.13.5


### PR DESCRIPTION
## Summary
- Upgrade `@makeswift/runtime` from `0.26.3` to `0.28.2`
- Move `apiOrigin` and `appOrigin` configuration to the `ReactRuntime` constructor, removing redundant passing to `ReactRuntimeProvider`, `Makeswift` client, and `MakeswiftApiHandler`
- Add changeset for minor version bump of `@bigcommerce/catalyst-makeswift`

## Test plan
- [x] Verify Makeswift visual builder loads correctly with the new runtime version
- [ ] Confirm `apiOrigin` and `appOrigin` overrides still work via environment variables
- [x] Test page rendering in both preview and published modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)