### PR TITLE
chore: change @makeswift/runtime to 0.26.4

### DIFF
--- a/.changeset/upgrade-makeswift-runtime.md
+++ b/.changeset/upgrade-makeswift-runtime.md
@@ -1,5 +1,5 @@
 ---
-"@bigcommerce/catalyst-makeswift": minor
+"@bigcommerce/catalyst-makeswift": patch
 ---
 
-Upgrade `@makeswift/runtime` from `0.26.3` to `0.28.2`. The `apiOrigin` and `appOrigin` configuration now lives on the `ReactRuntimeCore` constructor instead of being passed separately to `ReactRuntimeProvider`, `Makeswift` client, and `MakeswiftApiHandler`.
+Upgrade `@makeswift/runtime` from `0.26.3` to `0.26.4`.

--- a/core/app/api/makeswift/[...makeswift]/route.ts
+++ b/core/app/api/makeswift/[...makeswift]/route.ts
@@ -24,6 +24,8 @@ const defaultVariants: Font['variants'] = [
 
 const handler = MakeswiftApiHandler(process.env.MAKESWIFT_SITE_API_KEY, {
   runtime,
+  apiOrigin: process.env.NEXT_PUBLIC_MAKESWIFT_API_ORIGIN ?? process.env.MAKESWIFT_API_ORIGIN,
+  appOrigin: process.env.NEXT_PUBLIC_MAKESWIFT_APP_ORIGIN ?? process.env.MAKESWIFT_APP_ORIGIN,
   getFonts() {
     return [
       {

--- a/core/lib/makeswift/client.ts
+++ b/core/lib/makeswift/client.ts
@@ -11,6 +11,7 @@ strict(process.env.MAKESWIFT_SITE_API_KEY, 'MAKESWIFT_SITE_API_KEY is required')
 
 export const client = new Makeswift(process.env.MAKESWIFT_SITE_API_KEY, {
   runtime,
+  apiOrigin: process.env.NEXT_PUBLIC_MAKESWIFT_API_ORIGIN ?? process.env.MAKESWIFT_API_ORIGIN,
 });
 
 export const getPageSnapshot = async ({ path, locale }: { path: string; locale: string }) =>

--- a/core/lib/makeswift/provider.tsx
+++ b/core/lib/makeswift/provider.tsx
@@ -13,7 +13,12 @@ export function MakeswiftProvider({
   siteVersion: SiteVersion | null;
 }) {
   return (
-    <ReactRuntimeProvider runtime={runtime} siteVersion={siteVersion}>
+    <ReactRuntimeProvider
+      apiOrigin={process.env.NEXT_PUBLIC_MAKESWIFT_API_ORIGIN}
+      appOrigin={process.env.NEXT_PUBLIC_MAKESWIFT_APP_ORIGIN}
+      runtime={runtime}
+      siteVersion={siteVersion}
+    >
       <RootStyleRegistry enableCssReset={false}>{children}</RootStyleRegistry>
     </ReactRuntimeProvider>
   );

--- a/core/lib/makeswift/runtime.ts
+++ b/core/lib/makeswift/runtime.ts
@@ -10,15 +10,12 @@ import { registerVideoComponent } from '@makeswift/runtime/react/builtins/video'
 import { ReactRuntimeCore } from '@makeswift/runtime/react/core';
 
 const runtime = new ReactRuntimeCore({
-  apiOrigin: process.env.NEXT_PUBLIC_MAKESWIFT_API_ORIGIN ?? process.env.MAKESWIFT_API_ORIGIN,
-  appOrigin: process.env.NEXT_PUBLIC_MAKESWIFT_APP_ORIGIN ?? process.env.MAKESWIFT_APP_ORIGIN,
   breakpoints: {
     small: { width: 640, viewport: 390, label: 'Small' },
     medium: { width: 768, viewport: 765, label: 'Medium' },
     large: { width: 1024, viewport: 1000, label: 'Large' },
     screen: { width: 1280, label: 'XL' },
   },
-  fetch,
 });
 
 // Only register necessary built-in components. Omitted components are:

--- a/core/package.json
+++ b/core/package.json
@@ -22,7 +22,7 @@
     "@conform-to/react": "^1.6.1",
     "@conform-to/zod": "^1.6.1",
     "@icons-pack/react-simple-icons": "^11.2.0",
-    "@makeswift/runtime": "0.28.2",
+    "@makeswift/runtime": "0.26.4",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/api-logs": "^0.208.0",
     "@opentelemetry/instrumentation": "^0.208.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: ^11.2.0
         version: 11.2.0(react@19.1.5)
       '@makeswift/runtime':
-        specifier: 0.28.2
-        version: 0.28.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(next@16.1.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(babel-plugin-macros@3.1.0)(react-dom@19.1.5(react@19.1.5))(react@19.1.5))(react-dom@19.1.5(react@19.1.5))(react@19.1.5)
+        specifier: 0.26.4
+        version: 0.26.4(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(next@16.1.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(babel-plugin-macros@3.1.0)(react-dom@19.1.5(react@19.1.5))(react@19.1.5))(react-dom@19.1.5(react@19.1.5))(react@19.1.5)
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.0
@@ -2563,8 +2563,8 @@ packages:
   '@makeswift/prop-controllers@0.4.10':
     resolution: {integrity: sha512-rqiUsEKe+3I0eyJNosTuef3Z0FG3UnPz6rOXY2G7SbKk1h+jyKGVulNPVmsafM9SzuMTfzZNtNL0ouDRsQym+Q==}
 
-  '@makeswift/runtime@0.28.2':
-    resolution: {integrity: sha512-ZzF2yZoBeuDTPOFbj5ZPyyifHjgxGAvZ2HYxQ45P2vVlOi7c1nenYua/u8FfQTQBjEjzhD16m/8JSYr0VHIb1A==}
+  '@makeswift/runtime@0.26.4':
+    resolution: {integrity: sha512-hCmXv5h94j+MMOgPh7F0yteFvGOmSztlr6tTjrPEfxr9OCwr+gmE3crlXgO/SQW34NtQXVZLtg5ZcCoD6kFzlw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@types/react': ^18.0.0 || ^19.0.0
@@ -13733,7 +13733,7 @@ snapshots:
       ts-pattern: 5.9.0
       zod: 3.25.51
 
-  '@makeswift/runtime@0.28.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(next@16.1.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(babel-plugin-macros@3.1.0)(react-dom@19.1.5(react@19.1.5))(react@19.1.5))(react-dom@19.1.5(react@19.1.5))(react@19.1.5)':
+  '@makeswift/runtime@0.26.4(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(next@16.1.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(babel-plugin-macros@3.1.0)(react-dom@19.1.5(react@19.1.5))(react@19.1.5))(react-dom@19.1.5(react@19.1.5))(react@19.1.5)':
     dependencies:
       '@emotion/cache': 11.14.0
       '@emotion/css': 11.13.5


### PR DESCRIPTION
## What/Why?
Change `@makeswift/runtime` to 0.26.4. We had bumped to `0.28.0`, but instead we decided to hotfix the `0.26.x` version. For this reason, it also reverts the changes we had to make for `0.27.0+`.

## Testing
Builder works

## Migration
Bump version.