### PR TITLE
fix: prevent internal error details from being exposed to end users

### DIFF
--- a/core/app/api/customer/groups/route.ts
+++ b/core/app/api/customer/groups/route.ts
@@ -25,7 +25,10 @@ export async function GET(): Promise<NextResponse> {
   );
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch customer groups: ${response.statusText}`);
+    // eslint-disable-next-line no-console
+    console.error(`Failed to fetch customer groups: ${response.status} ${response.statusText}`);
+
+    return NextResponse.json(null, { status: 500 });
   }
 
   // `/v2/customer_groups` endpoint returns a `204 No Content` response if there are no customer groups

--- a/core/b2b/client.ts
+++ b/core/b2b/client.ts
@@ -67,10 +67,9 @@ export async function loginWithB2B({ customerId, customerAccessToken }: LoginWit
   if (!response.ok) {
     const errorMessage = ErrorResponse.parse(await response.json()).detail;
 
-    // Use the resolved `apiHost` variable in the error message for accuracy
-    throw new Error(
-      `Failed to login with ${apiHost}. Status: ${response.status}, Message: ${errorMessage}`
-    );
+    // eslint-disable-next-line no-console
+    console.error(`B2B login failed. Host: ${apiHost}, Status: ${response.status}, Message: ${errorMessage}`);
+    throw new Error('Failed to authenticate with B2B API.');
   }
 
   return B2BTokenResponseSchema.parse(await response.json()).data.token[0];

--- a/core/b2b/server-login.ts
+++ b/core/b2b/server-login.ts
@@ -20,7 +20,7 @@ export const login = async (email: string, password: string) => {
     console.error(error);
 
     if (error instanceof BigCommerceGQLError) {
-      return error.errors.map(({ message }) => message).join(', ');
+      return t('somethingWentWrong');
     }
 
     if (

--- a/core/client/queries/get-customer.ts
+++ b/core/client/queries/get-customer.ts
@@ -21,7 +21,12 @@ export async function getCustomerGroupId() {
   });
 
   if (errors) {
-    throw new Error(errors.map((error) => error.message).join(', '));
+    // eslint-disable-next-line no-console
+    console.error(
+      'Failed to fetch customer group:',
+      errors.map((error) => error.message).join(', '),
+    );
+    throw new Error('Failed to fetch customer group.');
   }
 
   return { data };


### PR DESCRIPTION
## What/Why?

This PR replaces raw API error details with generic user-facing messages 
and moves the internal details to server-side logs only.