### PR TITLE
fix(cli): clean up deployment url output

### DIFF
--- a/packages/catalyst/src/cli/commands/deploy.spec.ts
+++ b/packages/catalyst/src/cli/commands/deploy.spec.ts
@@ -185,7 +185,7 @@ describe('deployment and event streaming', () => {
       'Fetching...',
       'Processing...',
       'Finalizing...',
-      'Deployment completed successfully.\n',
+      'Deployment completed successfully.',
     ]);
   });
 
@@ -234,7 +234,7 @@ describe('deployment and event streaming', () => {
       'Fetching...',
       'Processing...',
       'Finalizing...',
-      'Deployment completed successfully.\n',
+      'Deployment completed successfully.',
     ]);
 
     expect(consola.warn).toHaveBeenCalledWith(

--- a/packages/catalyst/src/cli/commands/deploy.ts
+++ b/packages/catalyst/src/cli/commands/deploy.ts
@@ -1,9 +1,9 @@
 import AdmZip from 'adm-zip';
 import { Command, Option } from 'commander';
+import { colorize } from 'consola/utils';
 import { access, readdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import yoctoSpinner from 'yocto-spinner';
-import { colorize } from 'consola/utils';
 import { z } from 'zod';
 
 import { getDeploymentErrorMessage } from '../lib/deployment-errors';
@@ -302,6 +302,7 @@ export const getDeploymentStatus = async (
 
   if (deploymentUrl) {
     const url = deploymentUrl.startsWith('https://') ? deploymentUrl : `https://${deploymentUrl}`;
+
     consola.success(`View your deployment at: ${colorize('blue', url)}`);
   }
 };

--- a/packages/catalyst/src/cli/commands/deploy.ts
+++ b/packages/catalyst/src/cli/commands/deploy.ts
@@ -3,6 +3,7 @@ import { Command, Option } from 'commander';
 import { access, readdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import yoctoSpinner from 'yocto-spinner';
+import { colorize } from 'consola/utils';
 import { z } from 'zod';
 
 import { getDeploymentErrorMessage } from '../lib/deployment-errors';
@@ -289,7 +290,6 @@ export const getDeploymentStatus = async (
         }
 
         if (data.deployment_url) {
-          console.log(data.deployment_url);
           deploymentUrl = data.deployment_url;
         }
       });
@@ -298,10 +298,11 @@ export const getDeploymentStatus = async (
     done = streamDone;
   }
 
-  spinner.success('Deployment completed successfully.\n');
+  spinner.success('Deployment completed successfully.');
 
   if (deploymentUrl) {
-    consola.success(`View your deployment at: ${deploymentUrl}`);
+    const url = deploymentUrl.startsWith('https://') ? deploymentUrl : `https://${deploymentUrl}`;
+    consola.success(`View your deployment at: ${colorize('blue', url)}`);
   }
 };
 


### PR DESCRIPTION
## What/Why?

The `catalyst deploy` command outputs the deployment URL twice — once as a raw `console.log` and again formatted via `consola.success()`. The spinner success message also has a trailing `\n` that produces an extra blank line. Additionally, the URL is printed without an `https://` scheme, so it isn't clickable in terminal emulators.

This PR:
- Removes the redundant `console.log(data.deployment_url)` call
- Removes the trailing `\n` from the spinner success message
- Prepends `https://` to the displayed URL (with a guard against double-prefixing) and colors it blue

## Testing

Run `catalyst deploy` and verify the output shows:
```
✔ Deployment completed successfully.
✔ View your deployment at: https://<project>.catalyst-sandbox.store
```

**Example:**
<img width="624" height="336" alt="clickable" src="https://github.com/user-attachments/assets/23591dcd-d0f5-4f74-9970-1c9300c39b05" />

- URL appears once (not twice)
- No extra blank line between messages
- URL is blue and CMD+clickable / Ctrl+clickable in terminal

## Migration

N/A