### PR TITLE
fix(core): TRAC-292 render hidden fields in DynamicForm

### DIFF
--- a/.changeset/fix-hidden-fields-d35665be.md
+++ b/.changeset/fix-hidden-fields-d35665be.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Fix DynamicForm not rendering hidden field types, which caused `pageEntityId` to be `NaN` on contact form submission.

--- a/core/vibes/soul/form/dynamic-form/index.tsx
+++ b/core/vibes/soul/form/dynamic-form/index.tsx
@@ -449,5 +449,8 @@ function DynamicFormField({
           selected={typeof controls.value === 'string' ? new Date(controls.value) : undefined}
         />
       );
+
+    case 'hidden':
+      return <input {...getInputProps(formField, { type: 'hidden' })} key={field.name} />;
   }
 }


### PR DESCRIPTION
Jira: [TRAC-292](https://bigcommercecloud.atlassian.net/browse/TRAC-292)

## What/Why?

The `DynamicFormField` switch statement in `core/vibes/soul/form/dynamic-form/index.tsx` had no `case 'hidden'` (and no `default` case), so hidden inputs like `pageId` and `pagePath` on the contact page were never rendered to the DOM. On form submission, these missing values came through as `undefined` from the parsed FormData, and `Number(undefined)` produced `NaN`, which failed Zod validation in `submit-contact-form.ts`.

The `HiddenInputField` type was already defined in the schema and the `Field` union type included it; the rendering was the only piece missing.

## Testing

1. Navigate to a contact page (e.g., `/contact-us/`)
2. Inspect the form HTML and confirm `<input type="hidden" name="pageId">` and `<input type="hidden" name="pagePath">` elements are present
3. Submit the contact form and verify no Zod validation error for `pageEntityId`
4. After successful submission, verify the redirect to `?success=true` works (this depends on `pagePath`)

## Migration

N/A

[TRAC-292]: https://bigcommercecloud.atlassian.net/browse/TRAC-292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ