### PR TITLE
feat(cli): auto-detect environment variables as deploy secrets

### DIFF
--- a/packages/catalyst/src/cli/commands/deploy.spec.ts
+++ b/packages/catalyst/src/cli/commands/deploy.spec.ts
@@ -399,6 +399,7 @@ describe('autoDetectSecrets', () => {
     vi.stubEnv('BIGCOMMERCE_STOREFRONT_TOKEN', 'token456');
     vi.stubEnv('BIGCOMMERCE_API_HOST', 'api.bigcommerce.com');
     vi.stubEnv('BIGCOMMERCE_GRAPHQL_API_DOMAIN', 'graphql.bigcommerce.com');
+    vi.stubEnv('AUTH_SECRET', 'secret789');
 
     const result = autoDetectSecrets([]);
 
@@ -408,6 +409,7 @@ describe('autoDetectSecrets', () => {
       { type: 'secret', key: 'BIGCOMMERCE_STOREFRONT_TOKEN', value: 'token456' },
       { type: 'secret', key: 'BIGCOMMERCE_API_HOST', value: 'api.bigcommerce.com' },
       { type: 'secret', key: 'BIGCOMMERCE_GRAPHQL_API_DOMAIN', value: 'graphql.bigcommerce.com' },
+      { type: 'secret', key: 'AUTH_SECRET', value: 'secret789' },
     ]);
 
     vi.unstubAllEnvs();

--- a/packages/catalyst/src/cli/commands/deploy.spec.ts
+++ b/packages/catalyst/src/cli/commands/deploy.spec.ts
@@ -29,6 +29,7 @@ import {
   generateBundleZip,
   generateUploadSignature,
   getDeploymentStatus,
+  autoDetectSecrets,
   parseEnvironmentVariables,
   uploadBundleZip,
 } from './deploy';
@@ -389,6 +390,93 @@ test('reads from env options', () => {
   expect(() => parseEnvironmentVariables(['foo_bar'])).toThrow(
     'Invalid secret format: foo_bar. Expected format: KEY=VALUE',
   );
+});
+
+describe('autoDetectSecrets', () => {
+  test('auto-detects env vars from process.env', () => {
+    vi.stubEnv('BIGCOMMERCE_STORE_HASH', 'hash123');
+    vi.stubEnv('BIGCOMMERCE_CHANNEL_ID', '1');
+    vi.stubEnv('BIGCOMMERCE_STOREFRONT_TOKEN', 'token456');
+    vi.stubEnv('BIGCOMMERCE_API_HOST', 'api.bigcommerce.com');
+    vi.stubEnv('BIGCOMMERCE_GRAPHQL_API_DOMAIN', 'graphql.bigcommerce.com');
+
+    const result = autoDetectSecrets([]);
+
+    expect(result).toEqual([
+      { type: 'secret', key: 'BIGCOMMERCE_STORE_HASH', value: 'hash123' },
+      { type: 'secret', key: 'BIGCOMMERCE_CHANNEL_ID', value: '1' },
+      { type: 'secret', key: 'BIGCOMMERCE_STOREFRONT_TOKEN', value: 'token456' },
+      { type: 'secret', key: 'BIGCOMMERCE_API_HOST', value: 'api.bigcommerce.com' },
+      { type: 'secret', key: 'BIGCOMMERCE_GRAPHQL_API_DOMAIN', value: 'graphql.bigcommerce.com' },
+    ]);
+
+    vi.unstubAllEnvs();
+  });
+
+  test('skips env vars already provided by user', () => {
+    vi.stubEnv('BIGCOMMERCE_STORE_HASH', 'env-hash');
+    vi.stubEnv('BIGCOMMERCE_CHANNEL_ID', '99');
+
+    const result = autoDetectSecrets([
+      { type: 'secret', key: 'BIGCOMMERCE_STORE_HASH', value: 'user-hash' },
+    ]);
+
+    expect(result).toContainEqual({
+      type: 'secret',
+      key: 'BIGCOMMERCE_STORE_HASH',
+      value: 'user-hash',
+    });
+    expect(result).not.toContainEqual(
+      expect.objectContaining({ key: 'BIGCOMMERCE_STORE_HASH', value: 'env-hash' }),
+    );
+    expect(result).toContainEqual({
+      type: 'secret',
+      key: 'BIGCOMMERCE_CHANNEL_ID',
+      value: '99',
+    });
+
+    vi.unstubAllEnvs();
+  });
+
+  test('warns for required missing env vars', () => {
+    vi.stubEnv('BIGCOMMERCE_STORE_HASH', '');
+    vi.stubEnv('BIGCOMMERCE_CHANNEL_ID', '');
+    vi.stubEnv('BIGCOMMERCE_STOREFRONT_TOKEN', '');
+
+    autoDetectSecrets([]);
+
+    expect(consola.warn).toHaveBeenCalledWith(
+      expect.stringContaining('BIGCOMMERCE_STORE_HASH'),
+    );
+    expect(consola.warn).toHaveBeenCalledWith(
+      expect.stringContaining('BIGCOMMERCE_CHANNEL_ID'),
+    );
+    expect(consola.warn).toHaveBeenCalledWith(
+      expect.stringContaining('BIGCOMMERCE_STOREFRONT_TOKEN'),
+    );
+
+    vi.unstubAllEnvs();
+  });
+
+  test('silently skips optional missing env vars', () => {
+    vi.stubEnv('BIGCOMMERCE_API_HOST', '');
+    vi.stubEnv('BIGCOMMERCE_GRAPHQL_API_DOMAIN', '');
+
+    autoDetectSecrets([]);
+
+    const warnCalls = vi.mocked(consola.warn).mock.calls.flat().join(' ');
+
+    expect(warnCalls).not.toContain('BIGCOMMERCE_API_HOST');
+    expect(warnCalls).not.toContain('BIGCOMMERCE_GRAPHQL_API_DOMAIN');
+
+    vi.unstubAllEnvs();
+  });
+
+  test('returns empty array when no env vars and no input', () => {
+    const result = autoDetectSecrets(undefined);
+
+    expect(result).toEqual(expect.arrayContaining([]));
+  });
 });
 
 describe('--prebuilt flag', () => {

--- a/packages/catalyst/src/cli/commands/deploy.spec.ts
+++ b/packages/catalyst/src/cli/commands/deploy.spec.ts
@@ -24,12 +24,12 @@ import { program } from '../program';
 
 import { buildCatalystProject } from './build';
 import {
+  autoDetectSecrets,
   createDeployment,
   deploy,
   generateBundleZip,
   generateUploadSignature,
   getDeploymentStatus,
-  autoDetectSecrets,
   parseEnvironmentVariables,
   uploadBundleZip,
 } from './deploy';
@@ -445,12 +445,8 @@ describe('autoDetectSecrets', () => {
 
     autoDetectSecrets([]);
 
-    expect(consola.warn).toHaveBeenCalledWith(
-      expect.stringContaining('BIGCOMMERCE_STORE_HASH'),
-    );
-    expect(consola.warn).toHaveBeenCalledWith(
-      expect.stringContaining('BIGCOMMERCE_CHANNEL_ID'),
-    );
+    expect(consola.warn).toHaveBeenCalledWith(expect.stringContaining('BIGCOMMERCE_STORE_HASH'));
+    expect(consola.warn).toHaveBeenCalledWith(expect.stringContaining('BIGCOMMERCE_CHANNEL_ID'));
     expect(consola.warn).toHaveBeenCalledWith(
       expect.stringContaining('BIGCOMMERCE_STOREFRONT_TOKEN'),
     );

--- a/packages/catalyst/src/cli/commands/deploy.ts
+++ b/packages/catalyst/src/cli/commands/deploy.ts
@@ -192,9 +192,9 @@ export const autoDetectSecrets = (
   const secrets = environmentVariables ?? [];
   const existingKeys = new Set(secrets.map((s) => s.key));
 
-  for (const { key, warnIfMissing } of AUTO_DETECT_SECRETS) {
+  AUTO_DETECT_SECRETS.forEach(({ key, warnIfMissing }) => {
     if (existingKeys.has(key)) {
-      continue;
+      return;
     }
 
     const value = process.env[key];
@@ -204,7 +204,7 @@ export const autoDetectSecrets = (
     } else if (warnIfMissing) {
       consola.warn(`${key} is not set in the environment and was not provided via --secret.`);
     }
-  }
+  });
 
   return secrets;
 };

--- a/packages/catalyst/src/cli/commands/deploy.ts
+++ b/packages/catalyst/src/cli/commands/deploy.ts
@@ -184,6 +184,7 @@ const AUTO_DETECT_SECRETS = [
   { key: 'BIGCOMMERCE_STOREFRONT_TOKEN', warnIfMissing: true },
   { key: 'BIGCOMMERCE_API_HOST', warnIfMissing: false },
   { key: 'BIGCOMMERCE_GRAPHQL_API_DOMAIN', warnIfMissing: false },
+  { key: 'AUTH_SECRET', warnIfMissing: false },
 ];
 
 export const autoDetectSecrets = (

--- a/packages/catalyst/src/cli/commands/deploy.ts
+++ b/packages/catalyst/src/cli/commands/deploy.ts
@@ -178,6 +178,37 @@ export const parseEnvironmentVariables = (secretOption?: string[]) => {
   });
 };
 
+const AUTO_DETECT_SECRETS = [
+  { key: 'BIGCOMMERCE_STORE_HASH', warnIfMissing: true },
+  { key: 'BIGCOMMERCE_CHANNEL_ID', warnIfMissing: true },
+  { key: 'BIGCOMMERCE_STOREFRONT_TOKEN', warnIfMissing: true },
+  { key: 'BIGCOMMERCE_API_HOST', warnIfMissing: false },
+  { key: 'BIGCOMMERCE_GRAPHQL_API_DOMAIN', warnIfMissing: false },
+];
+
+export const autoDetectSecrets = (
+  environmentVariables?: Array<{ type: 'secret' | 'plain_text'; key: string; value: string }>,
+) => {
+  const secrets = environmentVariables ?? [];
+  const existingKeys = new Set(secrets.map((s) => s.key));
+
+  for (const { key, warnIfMissing } of AUTO_DETECT_SECRETS) {
+    if (existingKeys.has(key)) {
+      continue;
+    }
+
+    const value = process.env[key];
+
+    if (value) {
+      secrets.push({ type: 'secret', key, value });
+    } else if (warnIfMissing) {
+      consola.warn(`${key} is not set in the environment and was not provided via --secret.`);
+    }
+  }
+
+  return secrets;
+};
+
 export const createDeployment = async (
   projectUuid: string,
   uploadUuid: string,
@@ -428,7 +459,7 @@ export const deploy = new Command('deploy')
 
     await uploadBundleZip(uploadSignature.upload_url);
 
-    const environmentVariables = parseEnvironmentVariables(options.secret);
+    const environmentVariables = autoDetectSecrets(parseEnvironmentVariables(options.secret));
 
     const { deployment_uuid: deploymentUuid } = await createDeployment(
       projectUuid,


### PR DESCRIPTION
Jira: [TRAC-360](https://bigcommercecloud.atlassian.net/browse/TRAC-360)

## What/Why?

The deploy command now auto-detects required BigCommerce environment variables from `process.env` when they aren't explicitly passed via `--secret`:

- `BIGCOMMERCE_STORE_HASH`
- `BIGCOMMERCE_CHANNEL_ID`
- `BIGCOMMERCE_STOREFRONT_TOKEN`
- `BIGCOMMERCE_API_HOST`
- `BIGCOMMERCE_GRAPHQL_API_DOMAIN`

This pairs with the `--env-path` flag — instead of passing each variable individually as `--secret KEY=VALUE`, you can point to an env file and the deploy command will pick them up automatically:

```bash
catalyst deploy --env-path .env.local
```

Missing required vars (`STORE_HASH`, `CHANNEL_ID`, `STOREFRONT_TOKEN`) produce a warning. Optional vars (`API_HOST`, `GRAPHQL_API_DOMAIN`, `AUTH_SECRET`) are silently skipped. Explicit `--secret` flags always take precedence.

## Rollout/Rollback

Standard rollback — revert the commit. No migrations or feature flags involved.

## Testing

Unit tests added covering:
- Auto-detection from `process.env`
- User-provided `--secret` takes precedence (no duplicates)
- Warnings for missing required env vars
- Silent skip for missing optional env vars

```bash
pnpm --filter @bigcommerce/catalyst exec vitest run src/cli/commands/deploy.spec.ts
```

[TRAC-360]: https://bigcommercecloud.atlassian.net/browse/TRAC-360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ