### PR TITLE
feat(core): add X-Correlation-ID header to all GraphQL requests

### DIFF
--- a/.changeset/correlation-id-header.md
+++ b/.changeset/correlation-id-header.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Add X-Correlation-ID header to all GraphQL requests. Each page render gets a stable UUID that persists across all fetches within the same render, enabling easier request tracing in server logs.

--- a/.changeset/correlation-id-header.md
+++ b/.changeset/correlation-id-header.md
@@ -1,5 +1,5 @@
 ---
-"@bigcommerce/catalyst-core": minor
+"@bigcommerce/catalyst-core": patch
 ---
 
 Add X-Correlation-ID header to all GraphQL requests. Each page render gets a stable UUID that persists across all fetches within the same render, enabling easier request tracing in server logs.

--- a/core/client/correlation-id.ts
+++ b/core/client/correlation-id.ts
@@ -1,0 +1,3 @@
+import { cache } from 'react';
+
+export const getCorrelationId = cache(() => crypto.randomUUID());

--- a/core/client/index.ts
+++ b/core/client/index.ts
@@ -52,6 +52,10 @@ export const client = createClient({
     const requestHeaders: Record<string, string> = {};
     const locale = await getLocale();
 
+    const { getCorrelationId } = await import('./correlation-id');
+
+    requestHeaders['X-Correlation-ID'] = getCorrelationId();
+
     if (fetchOptions?.cache && ['no-store', 'no-cache'].includes(fetchOptions.cache)) {
       const { headers } = await import('next/headers');
       const ipAddress = (await headers()).get('X-Forwarded-For');

--- a/core/client/index.ts
+++ b/core/client/index.ts
@@ -52,9 +52,13 @@ export const client = createClient({
     const requestHeaders: Record<string, string> = {};
     const locale = await getLocale();
 
-    const { getCorrelationId } = await import('./correlation-id');
+    try {
+      const { getCorrelationId } = await import('./correlation-id');
 
-    requestHeaders['X-Correlation-ID'] = getCorrelationId();
+      requestHeaders['X-Correlation-ID'] = getCorrelationId();
+    } catch {
+      // correlation-id imports React.cache which is unavailable during next.config.ts resolution
+    }
 
     if (fetchOptions?.cache && ['no-store', 'no-cache'].includes(fetchOptions.cache)) {
       const { headers } = await import('next/headers');


### PR DESCRIPTION
Linear: [LTRAC-226](https://linear.app/commerce/issue/LTRAC-226/)

## What/Why?

Adds a stable `X-Correlation-ID` UUID header to every GraphQL request made during a page render. The UUID is generated once per render via `React.cache` and reused across all fetches in that render, making it straightforward to correlate related requests in server logs.

This is the first in a series of PRs splitting the work from #2910 into smaller, reviewable pieces.

## Rollout/Rollback

No feature flag needed — the header is additive and has no effect on existing behavior. Rollback is a simple revert.

## Testing

- `pnpm build` passes
- `pnpm lint` passes
- Verify in dev tools Network tab that all GraphQL requests within a single page load share the same `X-Correlation-ID` value, and that a new page navigation produces a different UUID

🤖 Generated with [Claude Code](https://claude.com/claude-code)