### PR TITLE
feat(core): wrap layout-level guest queries in unstable_cache

### DIFF
--- a/.changeset/guest-cache-layout.md
+++ b/.changeset/guest-cache-layout.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Wrap layout-level guest queries (home page, header, footer, SEO canonical, reCAPTCHA, root layout metadata) in `unstable_cache` with configurable revalidation. Authenticated requests continue to bypass the cache.

--- a/.changeset/locale-param-client.md
+++ b/.changeset/locale-param-client.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-client": patch
+---
+
+Add optional `locale` parameter to `client.fetch()`. This allows locale to be passed explicitly for use in cached contexts where `getLocale()` is unavailable.

--- a/.changeset/locale-param-core.md
+++ b/.changeset/locale-param-core.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Wrap IP forwarding headers (`X-Forwarded-For`, `True-Client-IP`) in try/catch for safety inside `unstable_cache` contexts where `headers()` is unavailable.

--- a/core/app/[locale]/(default)/page-data.ts
+++ b/core/app/[locale]/(default)/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -77,15 +78,35 @@ const HomePageQuery = graphql(
   [FeaturedProductsCarouselFragment, FeaturedProductsListFragment],
 );
 
-export const getPageData = cache(
-  async (currencyCode?: CurrencyCode, customerAccessToken?: string) => {
+const getCachedPageData = unstable_cache(
+  async (locale: string, currencyCode?: CurrencyCode) => {
     const { data } = await client.fetch({
       document: HomePageQuery,
-      customerAccessToken,
       variables: { currencyCode },
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
+      locale,
+      fetchOptions: { cache: 'no-store' },
     });
 
     return data;
+  },
+  ['home-page-data'],
+  { revalidate },
+);
+
+export const getPageData = cache(
+  async (locale: string, currencyCode?: CurrencyCode, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const { data } = await client.fetch({
+        document: HomePageQuery,
+        customerAccessToken,
+        variables: { currencyCode },
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return data;
+    }
+
+    return getCachedPageData(locale, currencyCode);
   },
 );

--- a/core/app/[locale]/(default)/page.tsx
+++ b/core/app/[locale]/(default)/page.tsx
@@ -38,7 +38,7 @@ export default async function Home({ params }: Props) {
     const customerAccessToken = await getSessionCustomerAccessToken();
     const currencyCode = await getPreferredCurrencyCode();
 
-    return getPageData(currencyCode, customerAccessToken);
+    return getPageData(locale, currencyCode, customerAccessToken);
   });
 
   const streamableFeaturedProducts = Streamable.from(async () => {

--- a/core/app/[locale]/layout.tsx
+++ b/core/app/[locale]/layout.tsx
@@ -1,6 +1,7 @@
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import type { Metadata } from 'next';
+import { unstable_cache } from 'next/cache';
 import { notFound } from 'next/navigation';
 import { NextIntlClientProvider } from 'next-intl';
 import { setRequestLocale } from 'next-intl/server';
@@ -53,15 +54,29 @@ const RootLayoutMetadataQuery = graphql(
   [WebAnalyticsFragment, ScriptsFragment],
 );
 
-const fetchRootLayoutMetadata = cache(async () => {
-  return await client.fetch({
-    document: RootLayoutMetadataQuery,
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedRootLayoutMetadata = unstable_cache(
+  async (locale: string) => {
+    return await client.fetch({
+      document: RootLayoutMetadataQuery,
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
+  },
+  ['root-layout-metadata'],
+  { revalidate },
+);
+
+const fetchRootLayoutMetadata = cache(async (locale: string) => {
+  return getCachedRootLayoutMetadata(locale);
 });
 
-export async function generateMetadata(): Promise<Metadata> {
-  const { data } = await fetchRootLayoutMetadata();
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const { data } = await fetchRootLayoutMetadata(locale);
 
   const storeName = data.site.settings?.storeName ?? '';
 
@@ -119,7 +134,7 @@ interface Props extends PropsWithChildren {
 export default async function RootLayout({ params, children }: Props) {
   const { locale } = await params;
 
-  const rootData = await fetchRootLayoutMetadata();
+  const rootData = await fetchRootLayoutMetadata(locale);
   const toastNotificationCookieData = await getToastNotification();
 
   if (!routing.locales.includes(locale)) {

--- a/core/client/index.ts
+++ b/core/client/index.ts
@@ -41,11 +41,11 @@ export const client = createClient({
   logger:
     (process.env.NODE_ENV !== 'production' && process.env.CLIENT_LOGGER !== 'false') ||
     process.env.CLIENT_LOGGER === 'true',
-  getChannelId: async (defaultChannelId: string) => {
-    const locale = await getLocale();
+  getChannelId: async (defaultChannelId: string, locale?: string) => {
+    const resolvedLocale = locale ?? (await getLocale());
 
     // We use the default channelId as a fallback, but it is not ideal in some scenarios.
-    return getChannelIdFromLocale(locale) ?? defaultChannelId;
+    return getChannelIdFromLocale(resolvedLocale) ?? defaultChannelId;
   },
   beforeRequest: async (fetchOptions) => {
     // We can't serialize a `Headers` object within this method so we have to opt into using a plain object
@@ -53,12 +53,16 @@ export const client = createClient({
     const locale = await getLocale();
 
     if (fetchOptions?.cache && ['no-store', 'no-cache'].includes(fetchOptions.cache)) {
-      const { headers } = await import('next/headers');
-      const ipAddress = (await headers()).get('X-Forwarded-For');
+      try {
+        const { headers } = await import('next/headers');
+        const ipAddress = (await headers()).get('X-Forwarded-For');
 
-      if (ipAddress) {
-        requestHeaders['X-Forwarded-For'] = ipAddress;
-        requestHeaders['True-Client-IP'] = ipAddress;
+        if (ipAddress) {
+          requestHeaders['X-Forwarded-For'] = ipAddress;
+          requestHeaders['True-Client-IP'] = ipAddress;
+        }
+      } catch {
+        // headers() is unavailable inside unstable_cache / 'use cache' contexts
       }
     }
 

--- a/core/components/footer/index.tsx
+++ b/core/components/footer/index.tsx
@@ -6,7 +6,8 @@ import {
   SiX,
   SiYoutube,
 } from '@icons-pack/react-simple-icons';
-import { getTranslations } from 'next-intl/server';
+import { unstable_cache } from 'next/cache';
+import { getLocale, getTranslations } from 'next-intl/server';
 import { cache, JSX } from 'react';
 
 import { Streamable } from '@/vibes/soul/lib/streamable';
@@ -46,34 +47,63 @@ const socialIcons: Record<string, { icon: JSX.Element }> = {
   YouTube: { icon: <SiYoutube title="YouTube" /> },
 };
 
-const getFooterSections = cache(
-  async (customerAccessToken?: string, currencyCode?: CurrencyCode) => {
+const getCachedFooterSections = unstable_cache(
+  async (locale: string, currencyCode?: CurrencyCode) => {
     const { data: response } = await client.fetch({
       document: GetLinksAndSectionsQuery,
-      customerAccessToken,
       variables: { currencyCode },
-      // Since this query is needed on every page, it's a good idea not to validate the customer access token.
-      // The 'cache' function also caches errors, so we might get caught in a redirect loop if the cache saves an invalid token error response.
+      locale,
       validateCustomerAccessToken: false,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
+      fetchOptions: { cache: 'no-store' },
     });
 
     return readFragment(FooterSectionsFragment, response).site;
   },
+  ['footer-sections'],
+  { revalidate },
 );
 
-const getFooterData = cache(async () => {
-  const { data: response } = await client.fetch({
-    document: LayoutQuery,
-    fetchOptions: { next: { revalidate } },
-  });
+const getFooterSections = cache(
+  async (locale: string, customerAccessToken?: string, currencyCode?: CurrencyCode) => {
+    if (customerAccessToken) {
+      const { data: response } = await client.fetch({
+        document: GetLinksAndSectionsQuery,
+        customerAccessToken,
+        variables: { currencyCode },
+        locale,
+        validateCustomerAccessToken: false,
+        fetchOptions: { cache: 'no-store' },
+      });
 
-  return readFragment(FooterFragment, response).site;
+      return readFragment(FooterSectionsFragment, response).site;
+    }
+
+    return getCachedFooterSections(locale, currencyCode);
+  },
+);
+
+const getCachedFooterData = unstable_cache(
+  async (locale: string) => {
+    const { data: response } = await client.fetch({
+      document: LayoutQuery,
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
+
+    return readFragment(FooterFragment, response).site;
+  },
+  ['footer-data'],
+  { revalidate },
+);
+
+const getFooterData = cache(async (locale: string) => {
+  return getCachedFooterData(locale);
 });
 
 export const Footer = async () => {
   const t = await getTranslations('Components.Footer');
-  const data = await getFooterData();
+  const locale = await getLocale();
+  const data = await getFooterData(locale);
 
   const logo = data.settings ? logoTransformer(data.settings) : '';
 
@@ -96,7 +126,7 @@ export const Footer = async () => {
   const streamableSections = Streamable.from(async () => {
     const customerAccessToken = await getSessionCustomerAccessToken();
     const currencyCode = await getPreferredCurrencyCode();
-    const sectionsData = await getFooterSections(customerAccessToken, currencyCode);
+    const sectionsData = await getFooterSections(locale, customerAccessToken, currencyCode);
 
     return [
       {

--- a/core/components/header/index.tsx
+++ b/core/components/header/index.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { getLocale, getTranslations } from 'next-intl/server';
 import { cache } from 'react';
 
@@ -47,34 +48,64 @@ const getCartCount = cache(async (cartId: string, customerAccessToken?: string) 
   return response.data.site.cart?.lineItems.totalQuantity ?? null;
 });
 
-const getHeaderLinks = cache(async (customerAccessToken?: string, currencyCode?: CurrencyCode) => {
-  const { data: response } = await client.fetch({
-    document: GetLinksAndSectionsQuery,
-    customerAccessToken,
-    variables: { currencyCode },
-    // Since this query is needed on every page, it's a good idea not to validate the customer access token.
-    // The 'cache' function also caches errors, so we might get caught in a redirect loop if the cache saves an invalid token error response.
-    validateCustomerAccessToken: false,
-    fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
-  });
+const getCachedHeaderLinks = unstable_cache(
+  async (locale: string, currencyCode?: CurrencyCode) => {
+    const { data: response } = await client.fetch({
+      document: GetLinksAndSectionsQuery,
+      variables: { currencyCode },
+      locale,
+      validateCustomerAccessToken: false,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return readFragment(HeaderLinksFragment, response).site;
-});
+    return readFragment(HeaderLinksFragment, response).site;
+  },
+  ['header-links'],
+  { revalidate },
+);
 
-const getHeaderData = cache(async () => {
-  const { data: response } = await client.fetch({
-    document: LayoutQuery,
-    fetchOptions: { next: { revalidate } },
-  });
+const getHeaderLinks = cache(
+  async (locale: string, customerAccessToken?: string, currencyCode?: CurrencyCode) => {
+    if (customerAccessToken) {
+      const { data: response } = await client.fetch({
+        document: GetLinksAndSectionsQuery,
+        customerAccessToken,
+        variables: { currencyCode },
+        locale,
+        validateCustomerAccessToken: false,
+        fetchOptions: { cache: 'no-store' },
+      });
 
-  return readFragment(HeaderFragment, response).site;
+      return readFragment(HeaderLinksFragment, response).site;
+    }
+
+    return getCachedHeaderLinks(locale, currencyCode);
+  },
+);
+
+const getCachedHeaderData = unstable_cache(
+  async (locale: string) => {
+    const { data: response } = await client.fetch({
+      document: LayoutQuery,
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
+
+    return readFragment(HeaderFragment, response).site;
+  },
+  ['header-data'],
+  { revalidate },
+);
+
+const getHeaderData = cache(async (locale: string) => {
+  return getCachedHeaderData(locale);
 });
 
 export const Header = async () => {
   const t = await getTranslations('Components.Header');
   const locale = await getLocale();
 
-  const data = await getHeaderData();
+  const data = await getHeaderData(locale);
 
   const logo = data.settings ? logoTransformer(data.settings) : '';
 
@@ -101,7 +132,8 @@ export const Header = async () => {
     ]);
     // const customerAccessToken = await getSessionCustomerAccessToken();
     // const currencyCode = await getPreferredCurrencyCode();
-    const categoryTree = (await getHeaderLinks(customerAccessToken, currencyCode)).categoryTree;
+    const headerLinks = await getHeaderLinks(locale, customerAccessToken, currencyCode);
+    const categoryTree = headerLinks.categoryTree;
 
     /**  To prevent the navigation menu from overflowing, we limit the number of categories to 6.
    To show a full list of categories, modify the `slice` method to remove the limit.
@@ -128,8 +160,8 @@ export const Header = async () => {
       getSessionCustomerAccessToken(),
       getPreferredCurrencyCode(),
     ]);
-    const giftCertificateSettings = (await getHeaderLinks(customerAccessToken, currencyCode))
-      .settings?.giftCertificates;
+    const headerLinksData = await getHeaderLinks(locale, customerAccessToken, currencyCode);
+    const giftCertificateSettings = headerLinksData.settings?.giftCertificates;
 
     return giftCertificateSettings?.isEnabled ?? false;
   });

--- a/core/lib/recaptcha.ts
+++ b/core/lib/recaptcha.ts
@@ -1,5 +1,6 @@
 import 'server-only';
 
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -24,22 +25,30 @@ export const ReCaptchaSettingsQuery = graphql(`
   }
 `);
 
+const getCachedReCaptchaSettings = unstable_cache(
+  async (): Promise<ReCaptchaSettings | null> => {
+    const { data } = await client.fetch({
+      document: ReCaptchaSettingsQuery,
+      fetchOptions: { cache: 'no-store' },
+    });
+
+    const reCaptcha = data.site.settings?.reCaptcha;
+
+    if (!reCaptcha?.siteKey) {
+      return null;
+    }
+
+    return {
+      isEnabledOnStorefront: reCaptcha.isEnabledOnStorefront,
+      siteKey: reCaptcha.siteKey,
+    };
+  },
+  ['recaptcha-settings'],
+  { revalidate },
+);
+
 export const getReCaptchaSettings = cache(async (): Promise<ReCaptchaSettings | null> => {
-  const { data } = await client.fetch({
-    document: ReCaptchaSettingsQuery,
-    fetchOptions: { next: { revalidate } },
-  });
-
-  const reCaptcha = data.site.settings?.reCaptcha;
-
-  if (!reCaptcha?.siteKey) {
-    return null;
-  }
-
-  return {
-    isEnabledOnStorefront: reCaptcha.isEnabledOnStorefront,
-    siteKey: reCaptcha.siteKey,
-  };
+  return getCachedReCaptchaSettings();
 });
 
 export const getRecaptchaSiteKey = cache(async (): Promise<string | undefined> => {

--- a/core/lib/seo/canonical.ts
+++ b/core/lib/seo/canonical.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -45,19 +46,27 @@ const VanityUrlQuery = graphql(`
   }
 `);
 
+const getCachedVanityUrl = unstable_cache(
+  async () => {
+    const { data } = await client.fetch({
+      document: VanityUrlQuery,
+      fetchOptions: { cache: 'no-store' },
+    });
+
+    const vanityUrl = data.site.settings?.url.vanityUrl;
+
+    if (!vanityUrl) {
+      throw new Error('Vanity URL not found in site settings');
+    }
+
+    return vanityUrl;
+  },
+  ['vanity-url'],
+  { revalidate },
+);
+
 const getVanityUrl = cache(async () => {
-  const { data } = await client.fetch({
-    document: VanityUrlQuery,
-    fetchOptions: { next: { revalidate } },
-  });
-
-  const vanityUrl = data.site.settings?.url.vanityUrl;
-
-  if (!vanityUrl) {
-    throw new Error('Vanity URL not found in site settings');
-  }
-
-  return vanityUrl;
+  return getCachedVanityUrl();
 });
 
 export async function getMetadataAlternates(options: CanonicalUrlOptions) {

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -49,7 +49,7 @@ type GraphQLErrorPolicy = 'none' | 'all' | 'auth' | 'ignore';
 class Client<FetcherRequestInit extends RequestInit = RequestInit> {
   private backendUserAgent: string;
   private readonly defaultChannelId: string;
-  private getChannelId: (defaultChannelId: string) => Promise<string> | string;
+  private getChannelId: (defaultChannelId: string, locale?: string) => Promise<string> | string;
   private beforeRequest?: (
     fetchOptions?: FetcherRequestInit,
   ) => Promise<Partial<FetcherRequestInit> | undefined> | Partial<FetcherRequestInit> | undefined;
@@ -85,6 +85,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     customerAccessToken?: string;
     fetchOptions?: FetcherRequestInit;
     channelId?: string;
+    locale?: string;
     errorPolicy?: GraphQLErrorPolicy;
     validateCustomerAccessToken?: boolean;
   }): Promise<BigCommerceResponse<TResult>>;
@@ -96,6 +97,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     customerAccessToken?: string;
     fetchOptions?: FetcherRequestInit;
     channelId?: string;
+    locale?: string;
     errorPolicy?: GraphQLErrorPolicy;
     validateCustomerAccessToken?: boolean;
   }): Promise<BigCommerceResponse<TResult>>;
@@ -106,6 +108,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     customerAccessToken,
     fetchOptions = {} as FetcherRequestInit,
     channelId,
+    locale,
     errorPolicy = 'none',
     validateCustomerAccessToken = true,
   }: {
@@ -114,6 +117,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     customerAccessToken?: string;
     fetchOptions?: FetcherRequestInit;
     channelId?: string;
+    locale?: string;
     errorPolicy?: GraphQLErrorPolicy;
     validateCustomerAccessToken?: boolean;
   }): Promise<BigCommerceResponse<TResult>> {
@@ -126,6 +130,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
       channelId,
       operationInfo.name,
       operationInfo.type,
+      locale,
     );
     const { headers: additionalFetchHeaders = {}, ...additionalFetchOptions } =
       (await this.beforeRequest?.(fetchOptions)) ?? {};
@@ -143,6 +148,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
         ...(this.trustedProxySecret && { 'X-BC-Trusted-Proxy-Secret': this.trustedProxySecret }),
         ...Object.fromEntries(new Headers(additionalFetchHeaders).entries()),
         ...Object.fromEntries(new Headers(headers).entries()),
+        ...(locale && { 'Accept-Language': locale }),
       },
       body: JSON.stringify({
         query,
@@ -210,8 +216,8 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     return response.text();
   }
 
-  private async getCanonicalUrl(channelId?: string) {
-    const resolvedChannelId = channelId ?? (await this.getChannelId(this.defaultChannelId));
+  private async getCanonicalUrl(channelId?: string, locale?: string) {
+    const resolvedChannelId = channelId ?? (await this.getChannelId(this.defaultChannelId, locale));
 
     return `https://store-${this.config.storeHash}-${resolvedChannelId}.${graphqlApiDomain}`;
   }
@@ -220,8 +226,9 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     channelId?: string,
     operationName?: string,
     operationType?: string,
+    locale?: string,
   ) {
-    const baseUrl = new URL(`${await this.getCanonicalUrl(channelId)}/graphql`);
+    const baseUrl = new URL(`${await this.getCanonicalUrl(channelId, locale)}/graphql`);
 
     if (operationName) {
       baseUrl.searchParams.set('operation', operationName);


### PR DESCRIPTION
Linear: [LTRAC-226](https://linear.app/commerce/issue/LTRAC-226/)

## What/Why?

Wraps shared layout-level data-fetching functions in `unstable_cache` for guest (unauthenticated) visitors. This caches the return values server-side with a configurable revalidation interval, reducing redundant GraphQL calls for anonymous traffic.

Functions migrated:
- `getPageData` (home page)
- `fetchRootLayoutMetadata` (root layout)
- `getHeaderData`, `getHeaderLinks` (header)
- `getFooterData`, `getFooterSections` (footer)
- `getVanityUrl` (SEO canonical)
- `getReCaptchaSettings` (reCAPTCHA)

Authenticated requests continue to bypass the cache entirely (`cache: 'no-store'`).

Third in a series of PRs splitting #2910. Depends on #2977.

## Rollout/Rollback

No feature flag. Rollback is a simple revert. Cache revalidation interval is controlled by `DEFAULT_REVALIDATE_TARGET` env var (defaults to 3600s).

## Testing

- `pnpm build` passes
- `pnpm lint` passes
- Home page loads correctly for guest users (cached path)
- Home page loads correctly for authenticated users (uncached path)
- Header/footer navigation renders correctly
- Canonical URLs resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)