### PR TITLE
feat(core): wrap remaining guest queries in unstable_cache

### DIFF
--- a/.changeset/guest-cache-content.md
+++ b/.changeset/guest-cache-content.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Wrap remaining guest queries (blog, web pages, gift certificates, public wishlist, auth forms, shipping countries) in `unstable_cache` with configurable revalidation.

--- a/.changeset/guest-cache-faceted.md
+++ b/.changeset/guest-cache-faceted.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Wrap faceted search, brand, category, compare, and quick search guest queries in `unstable_cache` with configurable revalidation. Authenticated requests continue to bypass the cache.

--- a/.changeset/guest-cache-layout.md
+++ b/.changeset/guest-cache-layout.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Wrap layout-level guest queries (home page, header, footer, SEO canonical, reCAPTCHA, root layout metadata) in `unstable_cache` with configurable revalidation. Authenticated requests continue to bypass the cache.

--- a/.changeset/guest-cache-product.md
+++ b/.changeset/guest-cache-product.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Wrap product page guest queries in `unstable_cache` with configurable revalidation. Includes product details, pricing, inventory, reviews, and related products. Authenticated requests continue to bypass the cache.

--- a/.changeset/locale-param-client.md
+++ b/.changeset/locale-param-client.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-client": patch
+---
+
+Add optional `locale` parameter to `client.fetch()`. This allows locale to be passed explicitly for use in cached contexts where `getLocale()` is unavailable.

--- a/.changeset/locale-param-core.md
+++ b/.changeset/locale-param-core.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Wrap IP forwarding headers (`X-Forwarded-For`, `True-Client-IP`) in try/catch for safety inside `unstable_cache` contexts where `headers()` is unavailable.

--- a/core/app/[locale]/(default)/(auth)/change-password/page-data.ts
+++ b/core/app/[locale]/(default)/(auth)/change-password/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -24,16 +25,24 @@ const ChangePasswordQuery = graphql(`
   }
 `);
 
+const getCachedChangePasswordQuery = unstable_cache(
+  async () => {
+    const response = await client.fetch({
+      document: ChangePasswordQuery,
+      fetchOptions: { cache: 'no-store' },
+    });
+
+    const passwordComplexitySettings =
+      response.data.site.settings?.customers?.passwordComplexitySettings;
+
+    return {
+      passwordComplexitySettings,
+    };
+  },
+  ['change-password-data'],
+  { revalidate },
+);
+
 export const getChangePasswordQuery = cache(async () => {
-  const response = await client.fetch({
-    document: ChangePasswordQuery,
-    fetchOptions: { next: { revalidate } },
-  });
-
-  const passwordComplexitySettings =
-    response.data.site.settings?.customers?.passwordComplexitySettings;
-
-  return {
-    passwordComplexitySettings,
-  };
+  return getCachedChangePasswordQuery();
 });

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -38,13 +39,35 @@ const BrandPageQuery = graphql(`
   }
 `);
 
-export const getBrandPageData = cache(async (entityId: number, customerAccessToken?: string) => {
-  const response = await client.fetch({
-    document: BrandPageQuery,
-    variables: { entityId },
-    customerAccessToken,
-    fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
-  });
+const getCachedBrandPageData = unstable_cache(
+  async (locale: string, entityId: number) => {
+    const response = await client.fetch({
+      document: BrandPageQuery,
+      variables: { entityId },
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return response.data.site;
-});
+    return response.data.site;
+  },
+  ['brand-page-data'],
+  { revalidate },
+);
+
+export const getBrandPageData = cache(
+  async (locale: string, entityId: number, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const response = await client.fetch({
+        document: BrandPageQuery,
+        variables: { entityId },
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return response.data.site;
+    }
+
+    return getCachedBrandPageData(locale, entityId);
+  },
+);

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
@@ -30,9 +30,14 @@ const getCachedBrand = cache((brandId: string) => {
 const compareLoader = createCompareLoader();
 
 const createBrandSearchParamsLoader = cache(
-  async (brandId: string, customerAccessToken?: string) => {
+  async (locale: string, brandId: string, customerAccessToken?: string) => {
     const cachedBrand = getCachedBrand(brandId);
-    const brandSearch = await fetchFacetedSearch(cachedBrand, undefined, customerAccessToken);
+    const brandSearch = await fetchFacetedSearch(
+      locale,
+      cachedBrand,
+      undefined,
+      customerAccessToken,
+    );
     const brandFacets = brandSearch.facets.items.filter(
       (facet) => facet.__typename !== 'BrandSearchFilter',
     );
@@ -73,7 +78,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 
   const brandId = Number(slug);
 
-  const { brand } = await getBrandPageData(brandId, customerAccessToken);
+  const { brand } = await getBrandPageData(locale, brandId, customerAccessToken);
 
   if (!brand) {
     return notFound();
@@ -99,7 +104,7 @@ export default async function Brand(props: Props) {
 
   const brandId = Number(slug);
 
-  const { brand, settings } = await getBrandPageData(brandId, customerAccessToken);
+  const { brand, settings } = await getBrandPageData(locale, brandId, customerAccessToken);
 
   if (!brand) {
     return notFound();
@@ -114,10 +119,11 @@ export default async function Brand(props: Props) {
     const searchParams = await props.searchParams;
     const currencyCode = await getPreferredCurrencyCode();
 
-    const loadSearchParams = await createBrandSearchParamsLoader(slug, customerAccessToken);
+    const loadSearchParams = await createBrandSearchParamsLoader(locale, slug, customerAccessToken);
     const parsedSearchParams = loadSearchParams?.(searchParams) ?? {};
 
     const search = await fetchFacetedSearch(
+      locale,
       {
         ...searchParams,
         ...parsedSearchParams,
@@ -162,10 +168,15 @@ export default async function Brand(props: Props) {
 
   const streamableFilters = Streamable.from(async () => {
     const searchParams = await props.searchParams;
-    const loadSearchParams = await createBrandSearchParamsLoader(slug, customerAccessToken);
+    const loadSearchParams = await createBrandSearchParamsLoader(locale, slug, customerAccessToken);
     const parsedSearchParams = loadSearchParams?.(searchParams) ?? {};
     const cachedBrand = getCachedBrand(slug);
-    const categorySearch = await fetchFacetedSearch(cachedBrand, undefined, customerAccessToken);
+    const categorySearch = await fetchFacetedSearch(
+      locale,
+      cachedBrand,
+      undefined,
+      customerAccessToken,
+    );
     const refinedSearch = await streamableFacetedSearch;
 
     const allFacets = categorySearch.facets.items.filter(
@@ -195,7 +206,7 @@ export default async function Brand(props: Props) {
 
     const compareIds = { entityIds: compare ? compare.map((id: string) => Number(id)) : [] };
 
-    const products = await getCompareProductsData(compareIds, customerAccessToken);
+    const products = await getCompareProductsData(locale, compareIds, customerAccessToken);
 
     return products.map((product) => ({
       id: product.entityId.toString(),

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -58,13 +59,35 @@ const CategoryPageQuery = graphql(
   [BreadcrumbsCategoryFragment],
 );
 
-export const getCategoryPageData = cache(async (entityId: number, customerAccessToken?: string) => {
-  const response = await client.fetch({
-    document: CategoryPageQuery,
-    variables: { entityId },
-    customerAccessToken,
-    fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
-  });
+const getCachedCategoryPageData = unstable_cache(
+  async (locale: string, entityId: number) => {
+    const response = await client.fetch({
+      document: CategoryPageQuery,
+      variables: { entityId },
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return response.data.site;
-});
+    return response.data.site;
+  },
+  ['category-page-data'],
+  { revalidate },
+);
+
+export const getCategoryPageData = cache(
+  async (locale: string, entityId: number, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const response = await client.fetch({
+        document: CategoryPageQuery,
+        variables: { entityId },
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return response.data.site;
+    }
+
+    return getCachedCategoryPageData(locale, entityId);
+  },
+);

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -32,9 +32,14 @@ const getCachedCategory = cache((categoryId: number) => {
 const compareLoader = createCompareLoader();
 
 const createCategorySearchParamsLoader = cache(
-  async (categoryId: number, customerAccessToken?: string) => {
+  async (locale: string, categoryId: number, customerAccessToken?: string) => {
     const cachedCategory = getCachedCategory(categoryId);
-    const categorySearch = await fetchFacetedSearch(cachedCategory, undefined, customerAccessToken);
+    const categorySearch = await fetchFacetedSearch(
+      locale,
+      cachedCategory,
+      undefined,
+      customerAccessToken,
+    );
     const categoryFacets = categorySearch.facets.items.filter(
       (facet) => facet.__typename !== 'CategorySearchFilter',
     );
@@ -75,7 +80,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 
   const categoryId = Number(slug);
 
-  const { category } = await getCategoryPageData(categoryId, customerAccessToken);
+  const { category } = await getCategoryPageData(locale, categoryId, customerAccessToken);
 
   if (!category) {
     return notFound();
@@ -107,6 +112,7 @@ export default async function Category(props: Props) {
   const categoryId = Number(slug);
 
   const { category, settings, categoryTree } = await getCategoryPageData(
+    locale,
     categoryId,
     customerAccessToken,
   );
@@ -130,12 +136,14 @@ export default async function Category(props: Props) {
     const currencyCode = await getPreferredCurrencyCode();
 
     const loadSearchParams = await createCategorySearchParamsLoader(
+      locale,
       categoryId,
       customerAccessToken,
     );
     const parsedSearchParams = loadSearchParams?.(searchParams) ?? {};
 
     const search = await fetchFacetedSearch(
+      locale,
       {
         ...searchParams,
         ...parsedSearchParams,
@@ -182,12 +190,18 @@ export default async function Category(props: Props) {
     const searchParams = await props.searchParams;
 
     const loadSearchParams = await createCategorySearchParamsLoader(
+      locale,
       categoryId,
       customerAccessToken,
     );
     const parsedSearchParams = loadSearchParams?.(searchParams) ?? {};
     const cachedCategory = getCachedCategory(categoryId);
-    const categorySearch = await fetchFacetedSearch(cachedCategory, undefined, customerAccessToken);
+    const categorySearch = await fetchFacetedSearch(
+      locale,
+      cachedCategory,
+      undefined,
+      customerAccessToken,
+    );
     const refinedSearch = await streamableFacetedSearch;
 
     const allFacets = categorySearch.facets.items.filter(
@@ -234,7 +248,7 @@ export default async function Category(props: Props) {
 
     const compareIds = { entityIds: compare ? compare.map((id: string) => Number(id)) : [] };
 
-    const products = await getCompareProducts(compareIds, customerAccessToken);
+    const products = await getCompareProducts(locale, compareIds, customerAccessToken);
 
     return products.map((product) => ({
       id: product.entityId.toString(),

--- a/core/app/[locale]/(default)/(faceted)/fetch-compare-products.ts
+++ b/core/app/[locale]/(default)/(faceted)/fetch-compare-products.ts
@@ -1,5 +1,6 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
 import { VariablesOf } from 'gql.tada';
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 import { z } from 'zod';
 
@@ -42,8 +43,8 @@ const CompareProductsQuery = graphql(`
 
 type Variables = VariablesOf<typeof CompareProductsQuery>;
 
-export const getCompareProducts = cache(
-  async (variables: Variables, customerAccessToken?: string) => {
+const getCachedCompareProducts = unstable_cache(
+  async (locale: string, variables: Variables) => {
     const parsedVariables = CompareProductsSchema.parse(variables);
 
     if (parsedVariables.entityIds.length === 0) {
@@ -53,10 +54,36 @@ export const getCompareProducts = cache(
     const response = await client.fetch({
       document: CompareProductsQuery,
       variables: { ...parsedVariables, first: MAX_COMPARE_LIMIT },
-      customerAccessToken,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
+      locale,
+      fetchOptions: { cache: 'no-store' },
     });
 
     return removeEdgesAndNodes(response.data.site.products);
+  },
+  ['compare-products-faceted'],
+  { revalidate },
+);
+
+export const getCompareProducts = cache(
+  async (locale: string, variables: Variables, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const parsedVariables = CompareProductsSchema.parse(variables);
+
+      if (parsedVariables.entityIds.length === 0) {
+        return [];
+      }
+
+      const response = await client.fetch({
+        document: CompareProductsQuery,
+        variables: { ...parsedVariables, first: MAX_COMPARE_LIMIT },
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return removeEdgesAndNodes(response.data.site.products);
+    }
+
+    return getCachedCompareProducts(locale, variables);
   },
 );

--- a/core/app/[locale]/(default)/(faceted)/fetch-faceted-search.ts
+++ b/core/app/[locale]/(default)/(faceted)/fetch-faceted-search.ts
@@ -1,4 +1,5 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 import { z } from 'zod';
 
@@ -178,8 +179,28 @@ interface ProductSearch {
   filters: SearchProductsFiltersInput;
 }
 
+const getCachedProductSearchResults = unstable_cache(
+  async (locale: string, search: ProductSearch, currencyCode?: CurrencyCode) => {
+    const { limit = 9, after, before, sort, filters } = search;
+    const filterArgs = { filters, sort };
+    const paginationArgs = before ? { last: limit, before } : { first: limit, after };
+
+    const response = await client.fetch({
+      document: GetProductSearchResultsQuery,
+      variables: { ...filterArgs, ...paginationArgs, currencyCode },
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
+
+    return response;
+  },
+  ['product-search-results'],
+  { revalidate: 300 },
+);
+
 const getProductSearchResults = cache(
   async (
+    locale: string,
     { limit = 9, after, before, sort, filters }: ProductSearch,
     currencyCode?: CurrencyCode,
     customerAccessToken?: string,
@@ -187,12 +208,23 @@ const getProductSearchResults = cache(
     const filterArgs = { filters, sort };
     const paginationArgs = before ? { last: limit, before } : { first: limit, after };
 
-    const response = await client.fetch({
-      document: GetProductSearchResultsQuery,
-      variables: { ...filterArgs, ...paginationArgs, currencyCode },
-      customerAccessToken,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate: 300 } },
-    });
+    let response;
+
+    if (customerAccessToken) {
+      response = await client.fetch({
+        document: GetProductSearchResultsQuery,
+        variables: { ...filterArgs, ...paginationArgs, currencyCode },
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+    } else {
+      response = await getCachedProductSearchResults(
+        locale,
+        { limit, after, before, sort, filters },
+        currencyCode,
+      );
+    }
 
     const { site } = response.data;
 
@@ -406,6 +438,7 @@ export const PublicToPrivateParams = PublicSearchParamsSchema.catchall(SearchPar
 export const fetchFacetedSearch = cache(
   // We need to make sure the reference passed into this function is the same if we want it to be memoized.
   async (
+    locale: string,
     params: z.input<typeof PublicSearchParamsSchema>,
     currencyCode?: CurrencyCode,
     customerAccessToken?: string,
@@ -413,6 +446,7 @@ export const fetchFacetedSearch = cache(
     const { after, before, limit = 9, sort, filters } = PublicToPrivateParams.parse(params);
 
     return getProductSearchResults(
+      locale,
       {
         after,
         before,

--- a/core/app/[locale]/(default)/(faceted)/search/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/search/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -29,11 +30,19 @@ const SearchPageQuery = graphql(`
   }
 `);
 
-export const getSearchPageData = cache(async () => {
-  const response = await client.fetch({
-    document: SearchPageQuery,
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedSearchPageData = unstable_cache(
+  async () => {
+    const response = await client.fetch({
+      document: SearchPageQuery,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return response.data.site;
+    return response.data.site;
+  },
+  ['search-page-data'],
+  { revalidate },
+);
+
+export const getSearchPageData = cache(async () => {
+  return getCachedSearchPageData();
 });

--- a/core/app/[locale]/(default)/(faceted)/search/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/search/page.tsx
@@ -22,14 +22,14 @@ import { getSearchPageData } from './page-data';
 const compareLoader = createCompareLoader();
 
 const createSearchSearchParamsLoader = cache(
-  async (searchParams: SearchParams, customerAccessToken?: string) => {
+  async (locale: string, searchParams: SearchParams, customerAccessToken?: string) => {
     const searchTerm = typeof searchParams.term === 'string' ? searchParams.term : '';
 
     if (!searchTerm) {
       return null;
     }
 
-    const search = await fetchFacetedSearch(searchParams, undefined, customerAccessToken);
+    const search = await fetchFacetedSearch(locale, searchParams, undefined, customerAccessToken);
     const searchFacets = search.facets.items;
     const transformedSearchFacets = await facetsTransformer({
       refinedFacets: searchFacets,
@@ -89,12 +89,14 @@ export default async function Search(props: Props) {
     const currencyCode = await getPreferredCurrencyCode();
 
     const loadSearchParams = await createSearchSearchParamsLoader(
+      locale,
       searchParams,
       customerAccessToken,
     );
     const parsedSearchParams = loadSearchParams?.(searchParams) ?? {};
 
     const search = await fetchFacetedSearch(
+      locale,
       {
         ...searchParams,
         ...parsedSearchParams,
@@ -186,11 +188,12 @@ export default async function Search(props: Props) {
     }
 
     const loadSearchParams = await createSearchSearchParamsLoader(
+      locale,
       searchParams,
       customerAccessToken,
     );
     const parsedSearchParams = loadSearchParams?.(searchParams) ?? {};
-    const categorySearch = await fetchFacetedSearch({}, undefined, customerAccessToken);
+    const categorySearch = await fetchFacetedSearch(locale, {}, undefined, customerAccessToken);
     const refinedSearch = await streamableFacetedSearch;
 
     const allFacets = categorySearch.facets.items.filter(
@@ -221,7 +224,7 @@ export default async function Search(props: Props) {
 
     const compareIds = { entityIds: compare ? compare.map((id: string) => Number(id)) : [] };
 
-    const products = await getCompareProductsData(compareIds, customerAccessToken);
+    const products = await getCompareProductsData(locale, compareIds, customerAccessToken);
 
     return products.map((product) => ({
       id: product.entityId.toString(),

--- a/core/app/[locale]/(default)/blog/[blogId]/page-data.ts
+++ b/core/app/[locale]/(default)/blog/[blogId]/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -38,18 +39,26 @@ const BlogPageQuery = graphql(`
 
 type Variables = VariablesOf<typeof BlogPageQuery>;
 
+const getCachedBlogPageData = unstable_cache(
+  async (variables: Variables) => {
+    const response = await client.fetch({
+      document: BlogPageQuery,
+      variables,
+      fetchOptions: { cache: 'no-store' },
+    });
+
+    const { blog } = response.data.site.content;
+
+    if (!blog?.post) {
+      return null;
+    }
+
+    return blog;
+  },
+  ['blog-page-data'],
+  { revalidate },
+);
+
 export const getBlogPageData = cache(async (variables: Variables) => {
-  const response = await client.fetch({
-    document: BlogPageQuery,
-    variables,
-    fetchOptions: { next: { revalidate } },
-  });
-
-  const { blog } = response.data.site.content;
-
-  if (!blog?.post) {
-    return null;
-  }
-
-  return blog;
+  return getCachedBlogPageData(variables);
 });

--- a/core/app/[locale]/(default)/blog/page-data.ts
+++ b/core/app/[locale]/(default)/blog/page-data.ts
@@ -1,4 +1,5 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
+import { unstable_cache } from 'next/cache';
 import { getFormatter } from 'next-intl/server';
 import { cache } from 'react';
 
@@ -72,24 +73,32 @@ interface Pagination {
   after: string | null;
 }
 
-export const getBlog = cache(async () => {
-  const response = await client.fetch({
-    document: BlogQuery,
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedBlog = unstable_cache(
+  async () => {
+    const response = await client.fetch({
+      document: BlogQuery,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return response.data.site.content.blog;
+    return response.data.site.content.blog;
+  },
+  ['blog-data'],
+  { revalidate },
+);
+
+export const getBlog = cache(async () => {
+  return getCachedBlog();
 });
 
-export const getBlogPosts = cache(
-  async ({ tag, limit = 9, before, after }: BlogPostsFiltersInput & Pagination) => {
+const getCachedBlogPosts = unstable_cache(
+  async (tag: string | null, limit: number, before: string | null, after: string | null) => {
     const filterArgs = tag ? { filters: { tags: [tag] } } : {};
     const paginationArgs = before ? { last: limit, before } : { first: limit, after };
 
     const response = await client.fetch({
       document: BlogPostsPageQuery,
       variables: { ...filterArgs, ...paginationArgs },
-      fetchOptions: { next: { revalidate } },
+      fetchOptions: { cache: 'no-store' },
     });
 
     const { blog } = response.data.site.content;
@@ -98,15 +107,13 @@ export const getBlogPosts = cache(
       return null;
     }
 
-    const format = await getFormatter();
-
     return {
       pageInfo: blog.posts.pageInfo,
       posts: removeEdgesAndNodes(blog.posts).map((post) => ({
         id: String(post.entityId),
         author: post.author,
         content: post.plainTextSummary,
-        date: format.dateTime(new Date(post.publishedDate.utc)),
+        publishedDateUtc: post.publishedDate.utc,
         image: post.thumbnailImage
           ? {
               src: post.thumbnailImage.url,
@@ -115,6 +122,28 @@ export const getBlogPosts = cache(
           : undefined,
         href: post.path,
         title: post.name,
+      })),
+    };
+  },
+  ['blog-posts'],
+  { revalidate },
+);
+
+export const getBlogPosts = cache(
+  async ({ tag, limit = 9, before, after }: BlogPostsFiltersInput & Pagination) => {
+    const result = await getCachedBlogPosts(tag, limit, before ?? null, after ?? null);
+
+    if (!result) {
+      return null;
+    }
+
+    const format = await getFormatter();
+
+    return {
+      pageInfo: result.pageInfo,
+      posts: result.posts.map((post) => ({
+        ...post,
+        date: format.dateTime(new Date(post.publishedDateUtc)),
       })),
     };
   },

--- a/core/app/[locale]/(default)/cart/page-data.ts
+++ b/core/app/[locale]/(default)/cart/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { getSessionCustomerAccessToken } from '~/auth';
@@ -336,11 +337,19 @@ const SupportedShippingDestinationsQuery = graphql(`
   }
 `);
 
-export const getShippingCountries = cache(async () => {
-  const { data } = await client.fetch({
-    document: SupportedShippingDestinationsQuery,
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedShippingCountries = unstable_cache(
+  async () => {
+    const { data } = await client.fetch({
+      document: SupportedShippingDestinationsQuery,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return data.site.settings?.shipping?.supportedShippingDestinations.countries ?? [];
+    return data.site.settings?.shipping?.supportedShippingDestinations.countries ?? [];
+  },
+  ['shipping-countries'],
+  { revalidate },
+);
+
+export const getShippingCountries = cache(async () => {
+  return getCachedShippingCountries();
 });

--- a/core/app/[locale]/(default)/compare/page-data.ts
+++ b/core/app/[locale]/(default)/compare/page-data.ts
@@ -1,4 +1,5 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -55,12 +56,8 @@ const ComparedProductsQuery = graphql(
   [ProductCardFragment],
 );
 
-export const getComparedProducts = cache(
-  async (productIds: number[] = [], currencyCode?: CurrencyCode, customerAccessToken?: string) => {
-    if (productIds.length === 0) {
-      return [];
-    }
-
+const getCachedComparedProducts = unstable_cache(
+  async (locale: string, productIds: number[], currencyCode?: CurrencyCode) => {
     const { data } = await client.fetch({
       document: ComparedProductsQuery,
       variables: {
@@ -68,10 +65,43 @@ export const getComparedProducts = cache(
         first: productIds.length ? MAX_COMPARE_LIMIT : 0,
         currencyCode,
       },
-      customerAccessToken,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
+      locale,
+      fetchOptions: { cache: 'no-store' },
     });
 
     return removeEdgesAndNodes(data.site.products);
+  },
+  ['compared-products'],
+  { revalidate },
+);
+
+export const getComparedProducts = cache(
+  async (
+    locale: string,
+    productIds: number[] = [],
+    currencyCode?: CurrencyCode,
+    customerAccessToken?: string,
+  ) => {
+    if (productIds.length === 0) {
+      return [];
+    }
+
+    if (customerAccessToken) {
+      const { data } = await client.fetch({
+        document: ComparedProductsQuery,
+        variables: {
+          entityIds: productIds,
+          first: productIds.length ? MAX_COMPARE_LIMIT : 0,
+          currencyCode,
+        },
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return removeEdgesAndNodes(data.site.products);
+    }
+
+    return getCachedComparedProducts(locale, productIds, currencyCode);
   },
 );

--- a/core/app/[locale]/(default)/compare/page.tsx
+++ b/core/app/[locale]/(default)/compare/page.tsx
@@ -64,7 +64,12 @@ export default async function Compare(props: Props) {
     const parsed = CompareParamsSchema.parse(searchParams);
     const productIds = parsed.ids?.filter((id) => !Number.isNaN(id));
 
-    const products = await getComparedProducts(productIds, currencyCode, customerAccessToken);
+    const products = await getComparedProducts(
+      locale,
+      productIds,
+      currencyCode,
+      customerAccessToken,
+    );
     const format = await getFormatter();
 
     return products.map((product) => ({
@@ -97,7 +102,12 @@ export default async function Compare(props: Props) {
     const parsed = CompareParamsSchema.parse(searchParams);
     const productIds = parsed.ids?.filter((id) => !Number.isNaN(id));
 
-    const products = await getComparedProducts(productIds, currencyCode, customerAccessToken);
+    const products = await getComparedProducts(
+      locale,
+      productIds,
+      currencyCode,
+      customerAccessToken,
+    );
 
     return products.map((product) => {
       return {

--- a/core/app/[locale]/(default)/gift-certificates/page-data.ts
+++ b/core/app/[locale]/(default)/gift-certificates/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -26,16 +27,24 @@ const GiftCertificatesRootQuery = graphql(
   [StoreLogoFragment],
 );
 
-export const getGiftCertificatesData = cache(async (currencyCode?: CurrencyCode) => {
-  const response = await client.fetch({
-    document: GiftCertificatesRootQuery,
-    variables: { currencyCode },
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedGiftCertificatesData = unstable_cache(
+  async (currencyCode?: CurrencyCode) => {
+    const response = await client.fetch({
+      document: GiftCertificatesRootQuery,
+      variables: { currencyCode },
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return {
-    giftCertificatesEnabled: response.data.site.settings?.giftCertificates?.isEnabled ?? false,
-    defaultCurrency: response.data.site.settings?.currency.defaultCurrency ?? undefined,
-    logo: response.data.site.settings ? logoTransformer(response.data.site.settings) : '',
-  };
+    return {
+      giftCertificatesEnabled: response.data.site.settings?.giftCertificates?.isEnabled ?? false,
+      defaultCurrency: response.data.site.settings?.currency.defaultCurrency ?? undefined,
+      logo: response.data.site.settings ? logoTransformer(response.data.site.settings) : '',
+    };
+  },
+  ['gift-certificates-data'],
+  { revalidate },
+);
+
+export const getGiftCertificatesData = cache(async (currencyCode?: CurrencyCode) => {
+  return getCachedGiftCertificatesData(currencyCode);
 });

--- a/core/app/[locale]/(default)/gift-certificates/purchase/page-data.ts
+++ b/core/app/[locale]/(default)/gift-certificates/purchase/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -29,17 +30,25 @@ const GiftCertificatePurchaseSettingsQuery = graphql(
   [GiftCertificateSettingsFragment, StoreLogoFragment],
 );
 
-export const getGiftCertificatePurchaseData = cache(async (currencyCode?: CurrencyCode) => {
-  const response = await client.fetch({
-    document: GiftCertificatePurchaseSettingsQuery,
-    variables: { currencyCode },
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedGiftCertificatePurchaseData = unstable_cache(
+  async (currencyCode?: CurrencyCode) => {
+    const response = await client.fetch({
+      document: GiftCertificatePurchaseSettingsQuery,
+      variables: { currencyCode },
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return {
-    giftCertificateSettings: response.data.site.settings?.giftCertificates ?? null,
-    logo: response.data.site.settings ? logoTransformer(response.data.site.settings) : '',
-    storeName: response.data.site.settings?.storeName ?? undefined,
-    defaultCurrency: response.data.site.settings?.currency.defaultCurrency ?? undefined,
-  };
+    return {
+      giftCertificateSettings: response.data.site.settings?.giftCertificates ?? null,
+      logo: response.data.site.settings ? logoTransformer(response.data.site.settings) : '',
+      storeName: response.data.site.settings?.storeName ?? undefined,
+      defaultCurrency: response.data.site.settings?.currency.defaultCurrency ?? undefined,
+    };
+  },
+  ['gift-certificate-purchase-data'],
+  { revalidate },
+);
+
+export const getGiftCertificatePurchaseData = cache(async (currencyCode?: CurrencyCode) => {
+  return getCachedGiftCertificatePurchaseData(currencyCode);
 });

--- a/core/app/[locale]/(default)/page-data.ts
+++ b/core/app/[locale]/(default)/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -77,15 +78,35 @@ const HomePageQuery = graphql(
   [FeaturedProductsCarouselFragment, FeaturedProductsListFragment],
 );
 
-export const getPageData = cache(
-  async (currencyCode?: CurrencyCode, customerAccessToken?: string) => {
+const getCachedPageData = unstable_cache(
+  async (locale: string, currencyCode?: CurrencyCode) => {
     const { data } = await client.fetch({
       document: HomePageQuery,
-      customerAccessToken,
       variables: { currencyCode },
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
+      locale,
+      fetchOptions: { cache: 'no-store' },
     });
 
     return data;
+  },
+  ['home-page-data'],
+  { revalidate },
+);
+
+export const getPageData = cache(
+  async (locale: string, currencyCode?: CurrencyCode, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const { data } = await client.fetch({
+        document: HomePageQuery,
+        customerAccessToken,
+        variables: { currencyCode },
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return data;
+    }
+
+    return getCachedPageData(locale, currencyCode);
   },
 );

--- a/core/app/[locale]/(default)/page.tsx
+++ b/core/app/[locale]/(default)/page.tsx
@@ -38,7 +38,7 @@ export default async function Home({ params }: Props) {
     const customerAccessToken = await getSessionCustomerAccessToken();
     const currencyCode = await getPreferredCurrencyCode();
 
-    return getPageData(currencyCode, customerAccessToken);
+    return getPageData(locale, currencyCode, customerAccessToken);
   });
 
   const streamableFeaturedProducts = Streamable.from(async () => {

--- a/core/app/[locale]/(default)/product/[slug]/_components/reviews.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/_components/reviews.tsx
@@ -1,4 +1,5 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
+import { unstable_cache } from 'next/cache';
 import { getFormatter, getTranslations } from 'next-intl/server';
 import { createLoader, parseAsString, SearchParams } from 'nuqs/server';
 import { cache } from 'react';
@@ -64,14 +65,22 @@ const ReviewsQuery = graphql(
   [ProductReviewSchemaFragment, PaginationFragment],
 );
 
-const getReviews = cache(async (productId: number, paginationArgs: object) => {
-  const { data } = await client.fetch({
-    document: ReviewsQuery,
-    variables: { ...paginationArgs, entityId: productId },
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedReviews = unstable_cache(
+  async (productId: number, paginationArgs: object) => {
+    const { data } = await client.fetch({
+      document: ReviewsQuery,
+      variables: { ...paginationArgs, entityId: productId },
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return data.site.product;
+    return data.site.product;
+  },
+  ['product-reviews'],
+  { revalidate },
+);
+
+const getReviews = cache(async (productId: number, paginationArgs: object) => {
+  return getCachedReviews(productId, paginationArgs);
 });
 
 interface Props {

--- a/core/app/[locale]/(default)/product/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/product/[slug]/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -154,16 +155,36 @@ const ProductPageMetadataQuery = graphql(`
   }
 `);
 
-export const getProductPageMetadata = cache(
-  async (entityId: number, customerAccessToken?: string) => {
+const getCachedProductPageMetadata = unstable_cache(
+  async (locale: string, entityId: number) => {
     const { data } = await client.fetch({
       document: ProductPageMetadataQuery,
       variables: { entityId },
-      customerAccessToken,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
+      locale,
+      fetchOptions: { cache: 'no-store' },
     });
 
     return data.site.product;
+  },
+  ['product-page-metadata'],
+  { revalidate },
+);
+
+export const getProductPageMetadata = cache(
+  async (locale: string, entityId: number, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const { data } = await client.fetch({
+        document: ProductPageMetadataQuery,
+        variables: { entityId },
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return data.site.product;
+    }
+
+    return getCachedProductPageMetadata(locale, entityId);
   },
 );
 
@@ -200,16 +221,38 @@ const ProductQuery = graphql(
   [ProductOptionsFragment],
 );
 
-export const getProduct = cache(async (entityId: number, customerAccessToken?: string) => {
-  const { data } = await client.fetch({
-    document: ProductQuery,
-    variables: { entityId },
-    customerAccessToken,
-    fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
-  });
+const getCachedProduct = unstable_cache(
+  async (locale: string, entityId: number) => {
+    const { data } = await client.fetch({
+      document: ProductQuery,
+      variables: { entityId },
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return data.site;
-});
+    return data.site;
+  },
+  ['product-data'],
+  { revalidate },
+);
+
+export const getProduct = cache(
+  async (locale: string, entityId: number, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const { data } = await client.fetch({
+        document: ProductQuery,
+        variables: { entityId },
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return data.site;
+    }
+
+    return getCachedProduct(locale, entityId);
+  },
+);
 
 const StreamableProductVariantInventoryBySkuQuery = graphql(`
   query ProductVariantBySkuQuery($productId: Int!, $sku: String!) {
@@ -249,16 +292,36 @@ const StreamableProductVariantInventoryBySkuQuery = graphql(`
 
 type VariantInventoryVariables = VariablesOf<typeof StreamableProductVariantInventoryBySkuQuery>;
 
-export const getStreamableProductVariantInventory = cache(
-  async (variables: VariantInventoryVariables, customerAccessToken?: string) => {
+const getCachedStreamableProductVariantInventory = unstable_cache(
+  async (locale: string, variables: VariantInventoryVariables) => {
     const { data } = await client.fetch({
       document: StreamableProductVariantInventoryBySkuQuery,
       variables,
-      customerAccessToken,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate: 60 } },
+      locale,
+      fetchOptions: { cache: 'no-store' },
     });
 
     return data.site.product?.variants;
+  },
+  ['product-variant-inventory'],
+  { revalidate: 60 },
+);
+
+export const getStreamableProductVariantInventory = cache(
+  async (locale: string, variables: VariantInventoryVariables, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const { data } = await client.fetch({
+        document: StreamableProductVariantInventoryBySkuQuery,
+        variables,
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return data.site.product?.variants;
+    }
+
+    return getCachedStreamableProductVariantInventory(locale, variables);
   },
 );
 
@@ -322,16 +385,36 @@ const StreamableProductQuery = graphql(
 
 type Variables = VariablesOf<typeof StreamableProductQuery>;
 
-export const getStreamableProduct = cache(
-  async (variables: Variables, customerAccessToken?: string) => {
+const getCachedStreamableProduct = unstable_cache(
+  async (locale: string, variables: Variables) => {
     const { data } = await client.fetch({
       document: StreamableProductQuery,
       variables,
-      customerAccessToken,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
+      locale,
+      fetchOptions: { cache: 'no-store' },
     });
 
     return data.site.product;
+  },
+  ['streamable-product'],
+  { revalidate },
+);
+
+export const getStreamableProduct = cache(
+  async (locale: string, variables: Variables, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const { data } = await client.fetch({
+        document: StreamableProductQuery,
+        variables,
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return data.site.product;
+    }
+
+    return getCachedStreamableProduct(locale, variables);
   },
 );
 
@@ -365,16 +448,36 @@ const StreamableProductInventoryQuery = graphql(
 
 type ProductInventoryVariables = VariablesOf<typeof StreamableProductQuery>;
 
-export const getStreamableProductInventory = cache(
-  async (variables: ProductInventoryVariables, customerAccessToken?: string) => {
+const getCachedStreamableProductInventory = unstable_cache(
+  async (locale: string, variables: ProductInventoryVariables) => {
     const { data } = await client.fetch({
       document: StreamableProductInventoryQuery,
       variables,
-      customerAccessToken,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate: 60 } },
+      locale,
+      fetchOptions: { cache: 'no-store' },
     });
 
     return data.site.product;
+  },
+  ['streamable-product-inventory'],
+  { revalidate: 60 },
+);
+
+export const getStreamableProductInventory = cache(
+  async (locale: string, variables: ProductInventoryVariables, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const { data } = await client.fetch({
+        document: StreamableProductInventoryQuery,
+        variables,
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return data.site.product;
+    }
+
+    return getCachedStreamableProductInventory(locale, variables);
   },
 );
 
@@ -409,16 +512,36 @@ const ProductPricingAndRelatedProductsQuery = graphql(
   [PricingFragment, FeaturedProductsCarouselFragment],
 );
 
-export const getProductPricingAndRelatedProducts = cache(
-  async (variables: Variables, customerAccessToken?: string) => {
+const getCachedProductPricingAndRelatedProducts = unstable_cache(
+  async (locale: string, variables: Variables) => {
     const { data } = await client.fetch({
       document: ProductPricingAndRelatedProductsQuery,
       variables,
-      customerAccessToken,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
+      locale,
+      fetchOptions: { cache: 'no-store' },
     });
 
     return data.site.product;
+  },
+  ['product-pricing-related'],
+  { revalidate },
+);
+
+export const getProductPricingAndRelatedProducts = cache(
+  async (locale: string, variables: Variables, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const { data } = await client.fetch({
+        document: ProductPricingAndRelatedProductsQuery,
+        variables,
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return data.site.product;
+    }
+
+    return getCachedProductPricingAndRelatedProducts(locale, variables);
   },
 );
 
@@ -440,12 +563,33 @@ const InventorySettingsQuery = graphql(`
   }
 `);
 
-export const getStreamableInventorySettingsQuery = cache(async (customerAccessToken?: string) => {
-  const { data } = await client.fetch({
-    document: InventorySettingsQuery,
-    customerAccessToken,
-    fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
-  });
+const getCachedInventorySettings = unstable_cache(
+  async (locale: string) => {
+    const { data } = await client.fetch({
+      document: InventorySettingsQuery,
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return data.site.settings?.inventory;
-});
+    return data.site.settings?.inventory;
+  },
+  ['inventory-settings'],
+  { revalidate },
+);
+
+export const getStreamableInventorySettingsQuery = cache(
+  async (locale: string, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const { data } = await client.fetch({
+        document: InventorySettingsQuery,
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return data.site.settings?.inventory;
+    }
+
+    return getCachedInventorySettings(locale);
+  },
+);

--- a/core/app/[locale]/(default)/product/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/page.tsx
@@ -45,7 +45,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   const productId = Number(slug);
 
-  const product = await getProductPageMetadata(productId, customerAccessToken);
+  const product = await getProductPageMetadata(locale, productId, customerAccessToken);
 
   if (!product) {
     return notFound();
@@ -78,7 +78,7 @@ export default async function Product({ params, searchParams }: Props) {
   const productId = Number(slug);
 
   const [{ product: baseProduct, settings }, recaptchaSiteKey] = await Promise.all([
-    getProduct(productId, customerAccessToken),
+    getProduct(locale, productId, customerAccessToken),
     getRecaptchaSiteKey(),
   ]);
 
@@ -107,7 +107,7 @@ export default async function Product({ params, searchParams }: Props) {
       useDefaultOptionSelections: true,
     };
 
-    const product = await getStreamableProduct(variables, customerAccessToken);
+    const product = await getStreamableProduct(locale, variables, customerAccessToken);
 
     if (!product) {
       return notFound();
@@ -123,7 +123,7 @@ export default async function Product({ params, searchParams }: Props) {
       entityId: Number(productId),
     };
 
-    const product = await getStreamableProductInventory(variables, customerAccessToken);
+    const product = await getStreamableProductInventory(locale, variables, customerAccessToken);
 
     if (!product) {
       return notFound();
@@ -144,7 +144,11 @@ export default async function Product({ params, searchParams }: Props) {
       sku: product.sku,
     };
 
-    const variants = await getStreamableProductVariantInventory(variables, customerAccessToken);
+    const variants = await getStreamableProductVariantInventory(
+      locale,
+      variables,
+      customerAccessToken,
+    );
 
     if (!variants) {
       return undefined;
@@ -174,7 +178,7 @@ export default async function Product({ params, searchParams }: Props) {
       currencyCode,
     };
 
-    return await getProductPricingAndRelatedProducts(variables, customerAccessToken);
+    return await getProductPricingAndRelatedProducts(locale, variables, customerAccessToken);
   });
 
   const streamablePrices = Streamable.from(async () => {
@@ -242,7 +246,7 @@ export default async function Product({ params, searchParams }: Props) {
   });
 
   const streamableInventorySettings = Streamable.from(async () => {
-    return await getStreamableInventorySettingsQuery(customerAccessToken);
+    return await getStreamableInventorySettingsQuery(locale, customerAccessToken);
   });
 
   const getBackorderAvailabilityPrompt = ({

--- a/core/app/[locale]/(default)/webpages/[id]/contact/page-data.ts
+++ b/core/app/[locale]/(default)/webpages/[id]/contact/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -31,12 +32,20 @@ const ContactPageQuery = graphql(
 
 type Variables = VariablesOf<typeof ContactPageQuery>;
 
-export const getWebpageData = cache(async (variables: Variables) => {
-  const { data } = await client.fetch({
-    document: ContactPageQuery,
-    variables,
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedWebpageData = unstable_cache(
+  async (variables: Variables) => {
+    const { data } = await client.fetch({
+      document: ContactPageQuery,
+      variables,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return data;
+    return data;
+  },
+  ['contact-webpage-data'],
+  { revalidate },
+);
+
+export const getWebpageData = cache(async (variables: Variables) => {
+  return getCachedWebpageData(variables);
 });

--- a/core/app/[locale]/(default)/webpages/[id]/layout.tsx
+++ b/core/app/[locale]/(default)/webpages/[id]/layout.tsx
@@ -1,4 +1,5 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
+import { unstable_cache } from 'next/cache';
 import { setRequestLocale } from 'next-intl/server';
 import { cache } from 'react';
 
@@ -45,34 +46,42 @@ interface PageLink {
   href: string;
 }
 
+const getCachedWebPageChildren = unstable_cache(
+  async (id: string): Promise<PageLink[]> => {
+    const { data } = await client.fetch({
+      document: WebPageChildrenQuery,
+      variables: { id: decodeURIComponent(id) },
+      fetchOptions: { cache: 'no-store' },
+    });
+
+    if (!data.node) {
+      return [];
+    }
+
+    if (!('children' in data.node)) {
+      return [];
+    }
+
+    const { children } = data.node;
+
+    return removeEdgesAndNodes(children).reduce((acc: PageLink[], child) => {
+      if ('path' in child) {
+        return [...acc, { label: child.name, href: child.path }];
+      }
+
+      if ('link' in child) {
+        return [...acc, { label: child.name, href: child.link }];
+      }
+
+      return acc;
+    }, []);
+  },
+  ['webpage-children'],
+  { revalidate },
+);
+
 const getWebPageChildren = cache(async (id: string): Promise<PageLink[]> => {
-  const { data } = await client.fetch({
-    document: WebPageChildrenQuery,
-    variables: { id: decodeURIComponent(id) },
-    fetchOptions: { next: { revalidate } },
-  });
-
-  if (!data.node) {
-    return [];
-  }
-
-  if (!('children' in data.node)) {
-    return [];
-  }
-
-  const { children } = data.node;
-
-  return removeEdgesAndNodes(children).reduce((acc: PageLink[], child) => {
-    if ('path' in child) {
-      return [...acc, { label: child.name, href: child.path }];
-    }
-
-    if ('link' in child) {
-      return [...acc, { label: child.name, href: child.link }];
-    }
-
-    return acc;
-  }, []);
+  return getCachedWebPageChildren(id);
 });
 
 export default async function WebPageLayout({ params, children }: Props) {

--- a/core/app/[locale]/(default)/webpages/[id]/normal/page-data.ts
+++ b/core/app/[locale]/(default)/webpages/[id]/normal/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -29,12 +30,20 @@ const NormalPageQuery = graphql(
 
 type Variables = VariablesOf<typeof NormalPageQuery>;
 
-export const getWebpageData = cache(async (variables: Variables) => {
-  const { data } = await client.fetch({
-    document: NormalPageQuery,
-    variables,
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedWebpageData = unstable_cache(
+  async (variables: Variables) => {
+    const { data } = await client.fetch({
+      document: NormalPageQuery,
+      variables,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return data;
+    return data;
+  },
+  ['normal-webpage-data'],
+  { revalidate },
+);
+
+export const getWebpageData = cache(async (variables: Variables) => {
+  return getCachedWebpageData(variables);
 });

--- a/core/app/[locale]/(default)/wishlist/[token]/page-data.ts
+++ b/core/app/[locale]/(default)/wishlist/[token]/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -5,6 +6,7 @@ import { PaginationFragment } from '~/client/fragments/pagination';
 import { graphql } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
 import { TAGS } from '~/client/tags';
+import { CurrencyCode } from '~/components/header/fragment';
 import { ProductCardFragment } from '~/components/product-card/fragment';
 import { WishlistItemFragment } from '~/components/wishlist/fragment';
 import { getPreferredCurrencyCode } from '~/lib/currency';
@@ -50,22 +52,36 @@ interface Pagination {
   after?: string | null;
 }
 
+const getCachedPublicWishlist = unstable_cache(
+  async (
+    token: string,
+    limit: number,
+    before: string | null | undefined,
+    after: string | null | undefined,
+    currencyCode?: CurrencyCode,
+  ) => {
+    const paginationArgs = before ? { last: limit, before } : { first: limit, after };
+    const response = await client.fetch({
+      document: PublicWishlistQuery,
+      variables: { ...paginationArgs, currencyCode, token },
+      fetchOptions: { cache: 'no-store' },
+    });
+
+    const wishlist = response.data.site.publicWishlist;
+
+    if (!wishlist) {
+      return null;
+    }
+
+    return wishlist;
+  },
+  ['public-wishlist'],
+  { revalidate, tags: [TAGS.customer] },
+);
+
 export const getPublicWishlist = cache(async (token: string, pagination: Pagination) => {
   const { before, after, limit = 9 } = pagination;
   const currencyCode = await getPreferredCurrencyCode();
-  const paginationArgs = before ? { last: limit, before } : { first: limit, after };
-  const response = await client.fetch({
-    document: PublicWishlistQuery,
-    variables: { ...paginationArgs, currencyCode, token },
-    // Since the wishlist is public, it's okay that we cache this request
-    fetchOptions: { next: { revalidate, tags: [TAGS.customer] } },
-  });
 
-  const wishlist = response.data.site.publicWishlist;
-
-  if (!wishlist) {
-    return null;
-  }
-
-  return wishlist;
+  return getCachedPublicWishlist(token, limit, before, after, currencyCode);
 });

--- a/core/app/[locale]/layout.tsx
+++ b/core/app/[locale]/layout.tsx
@@ -1,6 +1,7 @@
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import type { Metadata } from 'next';
+import { unstable_cache } from 'next/cache';
 import { notFound } from 'next/navigation';
 import { NextIntlClientProvider } from 'next-intl';
 import { setRequestLocale } from 'next-intl/server';
@@ -53,15 +54,29 @@ const RootLayoutMetadataQuery = graphql(
   [WebAnalyticsFragment, ScriptsFragment],
 );
 
-const fetchRootLayoutMetadata = cache(async () => {
-  return await client.fetch({
-    document: RootLayoutMetadataQuery,
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedRootLayoutMetadata = unstable_cache(
+  async (locale: string) => {
+    return await client.fetch({
+      document: RootLayoutMetadataQuery,
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
+  },
+  ['root-layout-metadata'],
+  { revalidate },
+);
+
+const fetchRootLayoutMetadata = cache(async (locale: string) => {
+  return getCachedRootLayoutMetadata(locale);
 });
 
-export async function generateMetadata(): Promise<Metadata> {
-  const { data } = await fetchRootLayoutMetadata();
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const { data } = await fetchRootLayoutMetadata(locale);
 
   const storeName = data.site.settings?.storeName ?? '';
 
@@ -119,7 +134,7 @@ interface Props extends PropsWithChildren {
 export default async function RootLayout({ params, children }: Props) {
   const { locale } = await params;
 
-  const rootData = await fetchRootLayoutMetadata();
+  const rootData = await fetchRootLayoutMetadata(locale);
   const toastNotificationCookieData = await getToastNotification();
 
   if (!routing.locales.includes(locale)) {

--- a/core/client/index.ts
+++ b/core/client/index.ts
@@ -41,11 +41,11 @@ export const client = createClient({
   logger:
     (process.env.NODE_ENV !== 'production' && process.env.CLIENT_LOGGER !== 'false') ||
     process.env.CLIENT_LOGGER === 'true',
-  getChannelId: async (defaultChannelId: string) => {
-    const locale = await getLocale();
+  getChannelId: async (defaultChannelId: string, locale?: string) => {
+    const resolvedLocale = locale ?? (await getLocale());
 
     // We use the default channelId as a fallback, but it is not ideal in some scenarios.
-    return getChannelIdFromLocale(locale) ?? defaultChannelId;
+    return getChannelIdFromLocale(resolvedLocale) ?? defaultChannelId;
   },
   beforeRequest: async (fetchOptions) => {
     // We can't serialize a `Headers` object within this method so we have to opt into using a plain object
@@ -53,12 +53,16 @@ export const client = createClient({
     const locale = await getLocale();
 
     if (fetchOptions?.cache && ['no-store', 'no-cache'].includes(fetchOptions.cache)) {
-      const { headers } = await import('next/headers');
-      const ipAddress = (await headers()).get('X-Forwarded-For');
+      try {
+        const { headers } = await import('next/headers');
+        const ipAddress = (await headers()).get('X-Forwarded-For');
 
-      if (ipAddress) {
-        requestHeaders['X-Forwarded-For'] = ipAddress;
-        requestHeaders['True-Client-IP'] = ipAddress;
+        if (ipAddress) {
+          requestHeaders['X-Forwarded-For'] = ipAddress;
+          requestHeaders['True-Client-IP'] = ipAddress;
+        }
+      } catch {
+        // headers() is unavailable inside unstable_cache / 'use cache' contexts
       }
     }
 

--- a/core/components/footer/index.tsx
+++ b/core/components/footer/index.tsx
@@ -6,7 +6,8 @@ import {
   SiX,
   SiYoutube,
 } from '@icons-pack/react-simple-icons';
-import { getTranslations } from 'next-intl/server';
+import { unstable_cache } from 'next/cache';
+import { getLocale, getTranslations } from 'next-intl/server';
 import { cache, JSX } from 'react';
 
 import { Streamable } from '@/vibes/soul/lib/streamable';
@@ -46,34 +47,63 @@ const socialIcons: Record<string, { icon: JSX.Element }> = {
   YouTube: { icon: <SiYoutube title="YouTube" /> },
 };
 
-const getFooterSections = cache(
-  async (customerAccessToken?: string, currencyCode?: CurrencyCode) => {
+const getCachedFooterSections = unstable_cache(
+  async (locale: string, currencyCode?: CurrencyCode) => {
     const { data: response } = await client.fetch({
       document: GetLinksAndSectionsQuery,
-      customerAccessToken,
       variables: { currencyCode },
-      // Since this query is needed on every page, it's a good idea not to validate the customer access token.
-      // The 'cache' function also caches errors, so we might get caught in a redirect loop if the cache saves an invalid token error response.
+      locale,
       validateCustomerAccessToken: false,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
+      fetchOptions: { cache: 'no-store' },
     });
 
     return readFragment(FooterSectionsFragment, response).site;
   },
+  ['footer-sections'],
+  { revalidate },
 );
 
-const getFooterData = cache(async () => {
-  const { data: response } = await client.fetch({
-    document: LayoutQuery,
-    fetchOptions: { next: { revalidate } },
-  });
+const getFooterSections = cache(
+  async (locale: string, customerAccessToken?: string, currencyCode?: CurrencyCode) => {
+    if (customerAccessToken) {
+      const { data: response } = await client.fetch({
+        document: GetLinksAndSectionsQuery,
+        customerAccessToken,
+        variables: { currencyCode },
+        locale,
+        validateCustomerAccessToken: false,
+        fetchOptions: { cache: 'no-store' },
+      });
 
-  return readFragment(FooterFragment, response).site;
+      return readFragment(FooterSectionsFragment, response).site;
+    }
+
+    return getCachedFooterSections(locale, currencyCode);
+  },
+);
+
+const getCachedFooterData = unstable_cache(
+  async (locale: string) => {
+    const { data: response } = await client.fetch({
+      document: LayoutQuery,
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
+
+    return readFragment(FooterFragment, response).site;
+  },
+  ['footer-data'],
+  { revalidate },
+);
+
+const getFooterData = cache(async (locale: string) => {
+  return getCachedFooterData(locale);
 });
 
 export const Footer = async () => {
   const t = await getTranslations('Components.Footer');
-  const data = await getFooterData();
+  const locale = await getLocale();
+  const data = await getFooterData(locale);
 
   const logo = data.settings ? logoTransformer(data.settings) : '';
 
@@ -96,7 +126,7 @@ export const Footer = async () => {
   const streamableSections = Streamable.from(async () => {
     const customerAccessToken = await getSessionCustomerAccessToken();
     const currencyCode = await getPreferredCurrencyCode();
-    const sectionsData = await getFooterSections(customerAccessToken, currencyCode);
+    const sectionsData = await getFooterSections(locale, customerAccessToken, currencyCode);
 
     return [
       {

--- a/core/components/header/_actions/search.ts
+++ b/core/components/header/_actions/search.ts
@@ -12,6 +12,7 @@ import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
+import { CurrencyCode } from '~/components/header/fragment';
 import { searchResultsTransformer } from '~/data-transformers/search-results-transformer';
 import { getPreferredCurrencyCode } from '~/lib/currency';
 
@@ -87,7 +88,7 @@ export async function search(
   const locale = await getLocale();
 
   const getCachedQuickSearchResults = unstable_cache(
-    async (searchTerm: string, searchCurrencyCode?: string) => {
+    async (searchTerm: string, searchCurrencyCode?: CurrencyCode) => {
       const response = await client.fetch({
         document: GetQuickSearchResultsQuery,
         variables: { filters: { searchTerm }, currencyCode: searchCurrencyCode },

--- a/core/components/header/_actions/search.ts
+++ b/core/components/header/_actions/search.ts
@@ -3,7 +3,8 @@
 import { BigCommerceGQLError, removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
 import { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
-import { getTranslations } from 'next-intl/server';
+import { unstable_cache } from 'next/cache';
+import { getLocale, getTranslations } from 'next-intl/server';
 import { z } from 'zod';
 
 import { SearchResult } from '@/vibes/soul/primitives/navigation';
@@ -83,15 +84,39 @@ export async function search(
 
   const currencyCode = await getPreferredCurrencyCode();
 
-  try {
-    const response = await client.fetch({
-      document: GetQuickSearchResultsQuery,
-      variables: { filters: { searchTerm: submission.value.term }, currencyCode },
-      customerAccessToken,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
-    });
+  const locale = await getLocale();
 
-    const { products } = response.data.site.search.searchProducts;
+  const getCachedQuickSearchResults = unstable_cache(
+    async (searchTerm: string, searchCurrencyCode?: string) => {
+      const response = await client.fetch({
+        document: GetQuickSearchResultsQuery,
+        variables: { filters: { searchTerm }, currencyCode: searchCurrencyCode },
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return response.data.site.search.searchProducts.products;
+    },
+    ['quick-search-results'],
+    { revalidate },
+  );
+
+  try {
+    let products;
+
+    if (customerAccessToken) {
+      const response = await client.fetch({
+        document: GetQuickSearchResultsQuery,
+        variables: { filters: { searchTerm: submission.value.term }, currencyCode },
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      products = response.data.site.search.searchProducts.products;
+    } else {
+      products = await getCachedQuickSearchResults(submission.value.term, currencyCode);
+    }
 
     return {
       lastResult: submission.reply(),

--- a/core/components/header/index.tsx
+++ b/core/components/header/index.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { getLocale, getTranslations } from 'next-intl/server';
 import { cache } from 'react';
 
@@ -47,34 +48,64 @@ const getCartCount = cache(async (cartId: string, customerAccessToken?: string) 
   return response.data.site.cart?.lineItems.totalQuantity ?? null;
 });
 
-const getHeaderLinks = cache(async (customerAccessToken?: string, currencyCode?: CurrencyCode) => {
-  const { data: response } = await client.fetch({
-    document: GetLinksAndSectionsQuery,
-    customerAccessToken,
-    variables: { currencyCode },
-    // Since this query is needed on every page, it's a good idea not to validate the customer access token.
-    // The 'cache' function also caches errors, so we might get caught in a redirect loop if the cache saves an invalid token error response.
-    validateCustomerAccessToken: false,
-    fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
-  });
+const getCachedHeaderLinks = unstable_cache(
+  async (locale: string, currencyCode?: CurrencyCode) => {
+    const { data: response } = await client.fetch({
+      document: GetLinksAndSectionsQuery,
+      variables: { currencyCode },
+      locale,
+      validateCustomerAccessToken: false,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return readFragment(HeaderLinksFragment, response).site;
-});
+    return readFragment(HeaderLinksFragment, response).site;
+  },
+  ['header-links'],
+  { revalidate },
+);
 
-const getHeaderData = cache(async () => {
-  const { data: response } = await client.fetch({
-    document: LayoutQuery,
-    fetchOptions: { next: { revalidate } },
-  });
+const getHeaderLinks = cache(
+  async (locale: string, customerAccessToken?: string, currencyCode?: CurrencyCode) => {
+    if (customerAccessToken) {
+      const { data: response } = await client.fetch({
+        document: GetLinksAndSectionsQuery,
+        customerAccessToken,
+        variables: { currencyCode },
+        locale,
+        validateCustomerAccessToken: false,
+        fetchOptions: { cache: 'no-store' },
+      });
 
-  return readFragment(HeaderFragment, response).site;
+      return readFragment(HeaderLinksFragment, response).site;
+    }
+
+    return getCachedHeaderLinks(locale, currencyCode);
+  },
+);
+
+const getCachedHeaderData = unstable_cache(
+  async (locale: string) => {
+    const { data: response } = await client.fetch({
+      document: LayoutQuery,
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
+
+    return readFragment(HeaderFragment, response).site;
+  },
+  ['header-data'],
+  { revalidate },
+);
+
+const getHeaderData = cache(async (locale: string) => {
+  return getCachedHeaderData(locale);
 });
 
 export const Header = async () => {
   const t = await getTranslations('Components.Header');
   const locale = await getLocale();
 
-  const data = await getHeaderData();
+  const data = await getHeaderData(locale);
 
   const logo = data.settings ? logoTransformer(data.settings) : '';
 
@@ -101,7 +132,8 @@ export const Header = async () => {
     ]);
     // const customerAccessToken = await getSessionCustomerAccessToken();
     // const currencyCode = await getPreferredCurrencyCode();
-    const categoryTree = (await getHeaderLinks(customerAccessToken, currencyCode)).categoryTree;
+    const headerLinks = await getHeaderLinks(locale, customerAccessToken, currencyCode);
+    const categoryTree = headerLinks.categoryTree;
 
     /**  To prevent the navigation menu from overflowing, we limit the number of categories to 6.
    To show a full list of categories, modify the `slice` method to remove the limit.
@@ -128,8 +160,8 @@ export const Header = async () => {
       getSessionCustomerAccessToken(),
       getPreferredCurrencyCode(),
     ]);
-    const giftCertificateSettings = (await getHeaderLinks(customerAccessToken, currencyCode))
-      .settings?.giftCertificates;
+    const headerLinksData = await getHeaderLinks(locale, customerAccessToken, currencyCode);
+    const giftCertificateSettings = headerLinksData.settings?.giftCertificates;
 
     return giftCertificateSettings?.isEnabled ?? false;
   });

--- a/core/lib/recaptcha.ts
+++ b/core/lib/recaptcha.ts
@@ -1,5 +1,6 @@
 import 'server-only';
 
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -24,22 +25,30 @@ export const ReCaptchaSettingsQuery = graphql(`
   }
 `);
 
+const getCachedReCaptchaSettings = unstable_cache(
+  async (): Promise<ReCaptchaSettings | null> => {
+    const { data } = await client.fetch({
+      document: ReCaptchaSettingsQuery,
+      fetchOptions: { cache: 'no-store' },
+    });
+
+    const reCaptcha = data.site.settings?.reCaptcha;
+
+    if (!reCaptcha?.siteKey) {
+      return null;
+    }
+
+    return {
+      isEnabledOnStorefront: reCaptcha.isEnabledOnStorefront,
+      siteKey: reCaptcha.siteKey,
+    };
+  },
+  ['recaptcha-settings'],
+  { revalidate },
+);
+
 export const getReCaptchaSettings = cache(async (): Promise<ReCaptchaSettings | null> => {
-  const { data } = await client.fetch({
-    document: ReCaptchaSettingsQuery,
-    fetchOptions: { next: { revalidate } },
-  });
-
-  const reCaptcha = data.site.settings?.reCaptcha;
-
-  if (!reCaptcha?.siteKey) {
-    return null;
-  }
-
-  return {
-    isEnabledOnStorefront: reCaptcha.isEnabledOnStorefront,
-    siteKey: reCaptcha.siteKey,
-  };
+  return getCachedReCaptchaSettings();
 });
 
 export const getRecaptchaSiteKey = cache(async (): Promise<string | undefined> => {

--- a/core/lib/seo/canonical.ts
+++ b/core/lib/seo/canonical.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -45,19 +46,27 @@ const VanityUrlQuery = graphql(`
   }
 `);
 
+const getCachedVanityUrl = unstable_cache(
+  async () => {
+    const { data } = await client.fetch({
+      document: VanityUrlQuery,
+      fetchOptions: { cache: 'no-store' },
+    });
+
+    const vanityUrl = data.site.settings?.url.vanityUrl;
+
+    if (!vanityUrl) {
+      throw new Error('Vanity URL not found in site settings');
+    }
+
+    return vanityUrl;
+  },
+  ['vanity-url'],
+  { revalidate },
+);
+
 const getVanityUrl = cache(async () => {
-  const { data } = await client.fetch({
-    document: VanityUrlQuery,
-    fetchOptions: { next: { revalidate } },
-  });
-
-  const vanityUrl = data.site.settings?.url.vanityUrl;
-
-  if (!vanityUrl) {
-    throw new Error('Vanity URL not found in site settings');
-  }
-
-  return vanityUrl;
+  return getCachedVanityUrl();
 });
 
 export async function getMetadataAlternates(options: CanonicalUrlOptions) {

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -49,7 +49,7 @@ type GraphQLErrorPolicy = 'none' | 'all' | 'auth' | 'ignore';
 class Client<FetcherRequestInit extends RequestInit = RequestInit> {
   private backendUserAgent: string;
   private readonly defaultChannelId: string;
-  private getChannelId: (defaultChannelId: string) => Promise<string> | string;
+  private getChannelId: (defaultChannelId: string, locale?: string) => Promise<string> | string;
   private beforeRequest?: (
     fetchOptions?: FetcherRequestInit,
   ) => Promise<Partial<FetcherRequestInit> | undefined> | Partial<FetcherRequestInit> | undefined;
@@ -85,6 +85,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     customerAccessToken?: string;
     fetchOptions?: FetcherRequestInit;
     channelId?: string;
+    locale?: string;
     errorPolicy?: GraphQLErrorPolicy;
     validateCustomerAccessToken?: boolean;
   }): Promise<BigCommerceResponse<TResult>>;
@@ -96,6 +97,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     customerAccessToken?: string;
     fetchOptions?: FetcherRequestInit;
     channelId?: string;
+    locale?: string;
     errorPolicy?: GraphQLErrorPolicy;
     validateCustomerAccessToken?: boolean;
   }): Promise<BigCommerceResponse<TResult>>;
@@ -106,6 +108,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     customerAccessToken,
     fetchOptions = {} as FetcherRequestInit,
     channelId,
+    locale,
     errorPolicy = 'none',
     validateCustomerAccessToken = true,
   }: {
@@ -114,6 +117,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     customerAccessToken?: string;
     fetchOptions?: FetcherRequestInit;
     channelId?: string;
+    locale?: string;
     errorPolicy?: GraphQLErrorPolicy;
     validateCustomerAccessToken?: boolean;
   }): Promise<BigCommerceResponse<TResult>> {
@@ -126,6 +130,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
       channelId,
       operationInfo.name,
       operationInfo.type,
+      locale,
     );
     const { headers: additionalFetchHeaders = {}, ...additionalFetchOptions } =
       (await this.beforeRequest?.(fetchOptions)) ?? {};
@@ -143,6 +148,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
         ...(this.trustedProxySecret && { 'X-BC-Trusted-Proxy-Secret': this.trustedProxySecret }),
         ...Object.fromEntries(new Headers(additionalFetchHeaders).entries()),
         ...Object.fromEntries(new Headers(headers).entries()),
+        ...(locale && { 'Accept-Language': locale }),
       },
       body: JSON.stringify({
         query,
@@ -210,8 +216,8 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     return response.text();
   }
 
-  private async getCanonicalUrl(channelId?: string) {
-    const resolvedChannelId = channelId ?? (await this.getChannelId(this.defaultChannelId));
+  private async getCanonicalUrl(channelId?: string, locale?: string) {
+    const resolvedChannelId = channelId ?? (await this.getChannelId(this.defaultChannelId, locale));
 
     return `https://store-${this.config.storeHash}-${resolvedChannelId}.${graphqlApiDomain}`;
   }
@@ -220,8 +226,9 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     channelId?: string,
     operationName?: string,
     operationType?: string,
+    locale?: string,
   ) {
-    const baseUrl = new URL(`${await this.getCanonicalUrl(channelId)}/graphql`);
+    const baseUrl = new URL(`${await this.getCanonicalUrl(channelId, locale)}/graphql`);
 
     if (operationName) {
       baseUrl.searchParams.set('operation', operationName);


### PR DESCRIPTION
Linear: [LTRAC-226](https://linear.app/commerce/issue/LTRAC-226/)

## What/Why?

Wraps the remaining guest data-fetching functions in `unstable_cache`, completing the guest query caching migration started in #2910.

Functions migrated:
- `getBlog`, `getBlogPosts` (blog)
- `getBlogPageData` (blog post)
- `getWebpageData` (normal + contact web pages)
- `getWebPageChildren` (web page sidebar)
- `getGiftCertificatesData`, `getGiftCertificatePurchaseData` (gift certificates)
- `getPublicWishlist` (shared wishlist)
- `getChangePasswordQuery` (change password form)
- `getShippingCountries` (cart shipping)

Notable: `getPublicWishlist` required extracting `getPreferredCurrencyCode()` out of the cached function since it calls `cookies()` internally. `getBlogPosts` required extracting `getFormatter()` for the same reason.

Final PR in the series splitting #2910. Depends on #2980.

## Rollout/Rollback

No feature flag. Rollback is a simple revert.

## Testing

- `pnpm build` passes
- `pnpm lint` passes
- Blog index and post pages load correctly
- Web pages (normal + contact) load correctly
- Gift certificate pages load correctly
- Public wishlist page loads correctly
- Change password page loads correctly
- Cart shipping country selector works

🤖 Generated with [Claude Code](https://claude.com/claude-code)