### PR TITLE
feat(core): make locale required on client.fetch()

### DIFF
--- a/.changeset/guest-cache-content.md
+++ b/.changeset/guest-cache-content.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Wrap remaining guest queries (blog, web pages, gift certificates, public wishlist, auth forms, shipping countries) in `unstable_cache` with configurable revalidation.

--- a/.changeset/guest-cache-faceted.md
+++ b/.changeset/guest-cache-faceted.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Wrap faceted search, brand, category, compare, and quick search guest queries in `unstable_cache` with configurable revalidation. Authenticated requests continue to bypass the cache.

--- a/.changeset/guest-cache-layout.md
+++ b/.changeset/guest-cache-layout.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Wrap layout-level guest queries (home page, header, footer, SEO canonical, reCAPTCHA, root layout metadata) in `unstable_cache` with configurable revalidation. Authenticated requests continue to bypass the cache.

--- a/.changeset/guest-cache-product.md
+++ b/.changeset/guest-cache-product.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Wrap product page guest queries in `unstable_cache` with configurable revalidation. Includes product details, pricing, inventory, reviews, and related products. Authenticated requests continue to bypass the cache.

--- a/.changeset/locale-param-client.md
+++ b/.changeset/locale-param-client.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-client": patch
+---
+
+Add optional `locale` parameter to `client.fetch()`. This allows locale to be passed explicitly for use in cached contexts where `getLocale()` is unavailable.

--- a/.changeset/locale-param-core.md
+++ b/.changeset/locale-param-core.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Wrap IP forwarding headers (`X-Forwarded-For`, `True-Client-IP`) in try/catch for safety inside `unstable_cache` contexts where `headers()` is unavailable.

--- a/.changeset/locale-required.md
+++ b/.changeset/locale-required.md
@@ -1,0 +1,6 @@
+---
+"@bigcommerce/catalyst-client": minor
+"@bigcommerce/catalyst-core": minor
+---
+
+Make `locale` a required parameter on `client.fetch()`. All call sites now explicitly pass locale for correct channel resolution and `Accept-Language` header, including inside `unstable_cache` contexts where `getLocale()` is unavailable.

--- a/core/app/[locale]/(default)/(auth)/change-password/_actions/change-password.ts
+++ b/core/app/[locale]/(default)/(auth)/change-password/_actions/change-password.ts
@@ -3,7 +3,7 @@
 import { BigCommerceGQLError } from '@bigcommerce/catalyst-client';
 import { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
-import { getTranslations } from 'next-intl/server';
+import { getLocale, getTranslations } from 'next-intl/server';
 import { z } from 'zod';
 
 import { client } from '~/client';
@@ -35,6 +35,7 @@ export async function changePassword(
   formData: FormData,
 ) {
   const t = await getTranslations('Auth.ChangePassword');
+  const locale = await getLocale();
   const submission = parseWithZod(formData, { schema });
 
   if (submission.status !== 'success') {
@@ -44,6 +45,7 @@ export async function changePassword(
   try {
     const response = await client.fetch({
       document: ChangePasswordMutation,
+      locale,
       variables: {
         input: {
           token,

--- a/core/app/[locale]/(default)/(auth)/change-password/page-data.ts
+++ b/core/app/[locale]/(default)/(auth)/change-password/page-data.ts
@@ -1,4 +1,5 @@
 import { unstable_cache } from 'next/cache';
+import { getLocale } from 'next-intl/server';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -26,9 +27,10 @@ const ChangePasswordQuery = graphql(`
 `);
 
 const getCachedChangePasswordQuery = unstable_cache(
-  async () => {
+  async (locale: string) => {
     const response = await client.fetch({
       document: ChangePasswordQuery,
+      locale,
       fetchOptions: { cache: 'no-store' },
     });
 
@@ -44,5 +46,7 @@ const getCachedChangePasswordQuery = unstable_cache(
 );
 
 export const getChangePasswordQuery = cache(async () => {
-  return getCachedChangePasswordQuery();
+  const locale = await getLocale();
+
+  return getCachedChangePasswordQuery(locale);
 });

--- a/core/app/[locale]/(default)/(auth)/change-password/page-data.ts
+++ b/core/app/[locale]/(default)/(auth)/change-password/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -24,16 +25,24 @@ const ChangePasswordQuery = graphql(`
   }
 `);
 
+const getCachedChangePasswordQuery = unstable_cache(
+  async () => {
+    const response = await client.fetch({
+      document: ChangePasswordQuery,
+      fetchOptions: { cache: 'no-store' },
+    });
+
+    const passwordComplexitySettings =
+      response.data.site.settings?.customers?.passwordComplexitySettings;
+
+    return {
+      passwordComplexitySettings,
+    };
+  },
+  ['change-password-data'],
+  { revalidate },
+);
+
 export const getChangePasswordQuery = cache(async () => {
-  const response = await client.fetch({
-    document: ChangePasswordQuery,
-    fetchOptions: { next: { revalidate } },
-  });
-
-  const passwordComplexitySettings =
-    response.data.site.settings?.customers?.passwordComplexitySettings;
-
-  return {
-    passwordComplexitySettings,
-  };
+  return getCachedChangePasswordQuery();
 });

--- a/core/app/[locale]/(default)/(auth)/login/forgot-password/_actions/reset-password.ts
+++ b/core/app/[locale]/(default)/(auth)/login/forgot-password/_actions/reset-password.ts
@@ -3,7 +3,7 @@
 import { BigCommerceGQLError } from '@bigcommerce/catalyst-client';
 import { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
-import { getTranslations } from 'next-intl/server';
+import { getLocale, getTranslations } from 'next-intl/server';
 
 import { schema } from '@/vibes/soul/sections/forgot-password-section/schema';
 import { client } from '~/client';
@@ -30,6 +30,7 @@ export const resetPassword = async (
   formData: FormData,
 ): Promise<{ lastResult: SubmissionResult | null; successMessage?: string }> => {
   const t = await getTranslations('Auth.Login.ForgotPassword');
+  const locale = await getLocale();
 
   const submission = parseWithZod(formData, { schema });
 
@@ -40,6 +41,7 @@ export const resetPassword = async (
   try {
     const response = await client.fetch({
       document: ResetPasswordMutation,
+      locale,
       variables: {
         input: {
           email: submission.value.email,

--- a/core/app/[locale]/(default)/(auth)/register/_actions/register-customer.ts
+++ b/core/app/[locale]/(default)/(auth)/register/_actions/register-customer.ts
@@ -373,6 +373,7 @@ export async function registerCustomer<F extends Field>(
     const input = parseRegisterCustomerInput(submission.value, fields);
     const response = await client.fetch({
       document: RegisterCustomerMutation,
+      locale,
       variables: {
         input,
         reCaptchaV2:

--- a/core/app/[locale]/(default)/(auth)/register/page-data.ts
+++ b/core/app/[locale]/(default)/(auth)/register/page-data.ts
@@ -1,3 +1,4 @@
+import { getLocale } from 'next-intl/server';
 import { cache } from 'react';
 
 import { getSessionCustomerAccessToken } from '~/auth';
@@ -63,6 +64,7 @@ interface Props {
 
 export const getRegisterCustomerQuery = cache(async ({ address, customer }: Props) => {
   const customerAccessToken = await getSessionCustomerAccessToken();
+  const locale = await getLocale();
 
   const response = await client.fetch({
     document: RegisterCustomerQuery,
@@ -72,6 +74,7 @@ export const getRegisterCustomerQuery = cache(async ({ address, customer }: Prop
       customerFilters: customer?.filters,
       customerSortBy: customer?.sortBy,
     },
+    locale,
     fetchOptions: { cache: 'no-store' },
     customerAccessToken,
   });

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -38,13 +39,35 @@ const BrandPageQuery = graphql(`
   }
 `);
 
-export const getBrandPageData = cache(async (entityId: number, customerAccessToken?: string) => {
-  const response = await client.fetch({
-    document: BrandPageQuery,
-    variables: { entityId },
-    customerAccessToken,
-    fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
-  });
+const getCachedBrandPageData = unstable_cache(
+  async (locale: string, entityId: number) => {
+    const response = await client.fetch({
+      document: BrandPageQuery,
+      variables: { entityId },
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return response.data.site;
-});
+    return response.data.site;
+  },
+  ['brand-page-data'],
+  { revalidate },
+);
+
+export const getBrandPageData = cache(
+  async (locale: string, entityId: number, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const response = await client.fetch({
+        document: BrandPageQuery,
+        variables: { entityId },
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return response.data.site;
+    }
+
+    return getCachedBrandPageData(locale, entityId);
+  },
+);

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
@@ -30,9 +30,14 @@ const getCachedBrand = cache((brandId: string) => {
 const compareLoader = createCompareLoader();
 
 const createBrandSearchParamsLoader = cache(
-  async (brandId: string, customerAccessToken?: string) => {
+  async (locale: string, brandId: string, customerAccessToken?: string) => {
     const cachedBrand = getCachedBrand(brandId);
-    const brandSearch = await fetchFacetedSearch(cachedBrand, undefined, customerAccessToken);
+    const brandSearch = await fetchFacetedSearch(
+      locale,
+      cachedBrand,
+      undefined,
+      customerAccessToken,
+    );
     const brandFacets = brandSearch.facets.items.filter(
       (facet) => facet.__typename !== 'BrandSearchFilter',
     );
@@ -73,7 +78,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 
   const brandId = Number(slug);
 
-  const { brand } = await getBrandPageData(brandId, customerAccessToken);
+  const { brand } = await getBrandPageData(locale, brandId, customerAccessToken);
 
   if (!brand) {
     return notFound();
@@ -99,7 +104,7 @@ export default async function Brand(props: Props) {
 
   const brandId = Number(slug);
 
-  const { brand, settings } = await getBrandPageData(brandId, customerAccessToken);
+  const { brand, settings } = await getBrandPageData(locale, brandId, customerAccessToken);
 
   if (!brand) {
     return notFound();
@@ -114,10 +119,11 @@ export default async function Brand(props: Props) {
     const searchParams = await props.searchParams;
     const currencyCode = await getPreferredCurrencyCode();
 
-    const loadSearchParams = await createBrandSearchParamsLoader(slug, customerAccessToken);
+    const loadSearchParams = await createBrandSearchParamsLoader(locale, slug, customerAccessToken);
     const parsedSearchParams = loadSearchParams?.(searchParams) ?? {};
 
     const search = await fetchFacetedSearch(
+      locale,
       {
         ...searchParams,
         ...parsedSearchParams,
@@ -162,10 +168,15 @@ export default async function Brand(props: Props) {
 
   const streamableFilters = Streamable.from(async () => {
     const searchParams = await props.searchParams;
-    const loadSearchParams = await createBrandSearchParamsLoader(slug, customerAccessToken);
+    const loadSearchParams = await createBrandSearchParamsLoader(locale, slug, customerAccessToken);
     const parsedSearchParams = loadSearchParams?.(searchParams) ?? {};
     const cachedBrand = getCachedBrand(slug);
-    const categorySearch = await fetchFacetedSearch(cachedBrand, undefined, customerAccessToken);
+    const categorySearch = await fetchFacetedSearch(
+      locale,
+      cachedBrand,
+      undefined,
+      customerAccessToken,
+    );
     const refinedSearch = await streamableFacetedSearch;
 
     const allFacets = categorySearch.facets.items.filter(
@@ -195,7 +206,7 @@ export default async function Brand(props: Props) {
 
     const compareIds = { entityIds: compare ? compare.map((id: string) => Number(id)) : [] };
 
-    const products = await getCompareProductsData(compareIds, customerAccessToken);
+    const products = await getCompareProductsData(locale, compareIds, customerAccessToken);
 
     return products.map((product) => ({
       id: product.entityId.toString(),

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -58,13 +59,35 @@ const CategoryPageQuery = graphql(
   [BreadcrumbsCategoryFragment],
 );
 
-export const getCategoryPageData = cache(async (entityId: number, customerAccessToken?: string) => {
-  const response = await client.fetch({
-    document: CategoryPageQuery,
-    variables: { entityId },
-    customerAccessToken,
-    fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
-  });
+const getCachedCategoryPageData = unstable_cache(
+  async (locale: string, entityId: number) => {
+    const response = await client.fetch({
+      document: CategoryPageQuery,
+      variables: { entityId },
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return response.data.site;
-});
+    return response.data.site;
+  },
+  ['category-page-data'],
+  { revalidate },
+);
+
+export const getCategoryPageData = cache(
+  async (locale: string, entityId: number, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const response = await client.fetch({
+        document: CategoryPageQuery,
+        variables: { entityId },
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return response.data.site;
+    }
+
+    return getCachedCategoryPageData(locale, entityId);
+  },
+);

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -32,9 +32,14 @@ const getCachedCategory = cache((categoryId: number) => {
 const compareLoader = createCompareLoader();
 
 const createCategorySearchParamsLoader = cache(
-  async (categoryId: number, customerAccessToken?: string) => {
+  async (locale: string, categoryId: number, customerAccessToken?: string) => {
     const cachedCategory = getCachedCategory(categoryId);
-    const categorySearch = await fetchFacetedSearch(cachedCategory, undefined, customerAccessToken);
+    const categorySearch = await fetchFacetedSearch(
+      locale,
+      cachedCategory,
+      undefined,
+      customerAccessToken,
+    );
     const categoryFacets = categorySearch.facets.items.filter(
       (facet) => facet.__typename !== 'CategorySearchFilter',
     );
@@ -75,7 +80,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 
   const categoryId = Number(slug);
 
-  const { category } = await getCategoryPageData(categoryId, customerAccessToken);
+  const { category } = await getCategoryPageData(locale, categoryId, customerAccessToken);
 
   if (!category) {
     return notFound();
@@ -107,6 +112,7 @@ export default async function Category(props: Props) {
   const categoryId = Number(slug);
 
   const { category, settings, categoryTree } = await getCategoryPageData(
+    locale,
     categoryId,
     customerAccessToken,
   );
@@ -130,12 +136,14 @@ export default async function Category(props: Props) {
     const currencyCode = await getPreferredCurrencyCode();
 
     const loadSearchParams = await createCategorySearchParamsLoader(
+      locale,
       categoryId,
       customerAccessToken,
     );
     const parsedSearchParams = loadSearchParams?.(searchParams) ?? {};
 
     const search = await fetchFacetedSearch(
+      locale,
       {
         ...searchParams,
         ...parsedSearchParams,
@@ -182,12 +190,18 @@ export default async function Category(props: Props) {
     const searchParams = await props.searchParams;
 
     const loadSearchParams = await createCategorySearchParamsLoader(
+      locale,
       categoryId,
       customerAccessToken,
     );
     const parsedSearchParams = loadSearchParams?.(searchParams) ?? {};
     const cachedCategory = getCachedCategory(categoryId);
-    const categorySearch = await fetchFacetedSearch(cachedCategory, undefined, customerAccessToken);
+    const categorySearch = await fetchFacetedSearch(
+      locale,
+      cachedCategory,
+      undefined,
+      customerAccessToken,
+    );
     const refinedSearch = await streamableFacetedSearch;
 
     const allFacets = categorySearch.facets.items.filter(
@@ -234,7 +248,7 @@ export default async function Category(props: Props) {
 
     const compareIds = { entityIds: compare ? compare.map((id: string) => Number(id)) : [] };
 
-    const products = await getCompareProducts(compareIds, customerAccessToken);
+    const products = await getCompareProducts(locale, compareIds, customerAccessToken);
 
     return products.map((product) => ({
       id: product.entityId.toString(),

--- a/core/app/[locale]/(default)/(faceted)/fetch-compare-products.ts
+++ b/core/app/[locale]/(default)/(faceted)/fetch-compare-products.ts
@@ -1,5 +1,6 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
 import { VariablesOf } from 'gql.tada';
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 import { z } from 'zod';
 
@@ -42,8 +43,8 @@ const CompareProductsQuery = graphql(`
 
 type Variables = VariablesOf<typeof CompareProductsQuery>;
 
-export const getCompareProducts = cache(
-  async (variables: Variables, customerAccessToken?: string) => {
+const getCachedCompareProducts = unstable_cache(
+  async (locale: string, variables: Variables) => {
     const parsedVariables = CompareProductsSchema.parse(variables);
 
     if (parsedVariables.entityIds.length === 0) {
@@ -53,10 +54,36 @@ export const getCompareProducts = cache(
     const response = await client.fetch({
       document: CompareProductsQuery,
       variables: { ...parsedVariables, first: MAX_COMPARE_LIMIT },
-      customerAccessToken,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
+      locale,
+      fetchOptions: { cache: 'no-store' },
     });
 
     return removeEdgesAndNodes(response.data.site.products);
+  },
+  ['compare-products-faceted'],
+  { revalidate },
+);
+
+export const getCompareProducts = cache(
+  async (locale: string, variables: Variables, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const parsedVariables = CompareProductsSchema.parse(variables);
+
+      if (parsedVariables.entityIds.length === 0) {
+        return [];
+      }
+
+      const response = await client.fetch({
+        document: CompareProductsQuery,
+        variables: { ...parsedVariables, first: MAX_COMPARE_LIMIT },
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return removeEdgesAndNodes(response.data.site.products);
+    }
+
+    return getCachedCompareProducts(locale, variables);
   },
 );

--- a/core/app/[locale]/(default)/(faceted)/fetch-faceted-search.ts
+++ b/core/app/[locale]/(default)/(faceted)/fetch-faceted-search.ts
@@ -1,4 +1,5 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 import { z } from 'zod';
 
@@ -178,8 +179,28 @@ interface ProductSearch {
   filters: SearchProductsFiltersInput;
 }
 
+const getCachedProductSearchResults = unstable_cache(
+  async (locale: string, search: ProductSearch, currencyCode?: CurrencyCode) => {
+    const { limit = 9, after, before, sort, filters } = search;
+    const filterArgs = { filters, sort };
+    const paginationArgs = before ? { last: limit, before } : { first: limit, after };
+
+    const response = await client.fetch({
+      document: GetProductSearchResultsQuery,
+      variables: { ...filterArgs, ...paginationArgs, currencyCode },
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
+
+    return response;
+  },
+  ['product-search-results'],
+  { revalidate: 300 },
+);
+
 const getProductSearchResults = cache(
   async (
+    locale: string,
     { limit = 9, after, before, sort, filters }: ProductSearch,
     currencyCode?: CurrencyCode,
     customerAccessToken?: string,
@@ -187,12 +208,23 @@ const getProductSearchResults = cache(
     const filterArgs = { filters, sort };
     const paginationArgs = before ? { last: limit, before } : { first: limit, after };
 
-    const response = await client.fetch({
-      document: GetProductSearchResultsQuery,
-      variables: { ...filterArgs, ...paginationArgs, currencyCode },
-      customerAccessToken,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate: 300 } },
-    });
+    let response;
+
+    if (customerAccessToken) {
+      response = await client.fetch({
+        document: GetProductSearchResultsQuery,
+        variables: { ...filterArgs, ...paginationArgs, currencyCode },
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+    } else {
+      response = await getCachedProductSearchResults(
+        locale,
+        { limit, after, before, sort, filters },
+        currencyCode,
+      );
+    }
 
     const { site } = response.data;
 
@@ -406,6 +438,7 @@ export const PublicToPrivateParams = PublicSearchParamsSchema.catchall(SearchPar
 export const fetchFacetedSearch = cache(
   // We need to make sure the reference passed into this function is the same if we want it to be memoized.
   async (
+    locale: string,
     params: z.input<typeof PublicSearchParamsSchema>,
     currencyCode?: CurrencyCode,
     customerAccessToken?: string,
@@ -413,6 +446,7 @@ export const fetchFacetedSearch = cache(
     const { after, before, limit = 9, sort, filters } = PublicToPrivateParams.parse(params);
 
     return getProductSearchResults(
+      locale,
       {
         after,
         before,

--- a/core/app/[locale]/(default)/(faceted)/search/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/search/page-data.ts
@@ -1,4 +1,5 @@
 import { unstable_cache } from 'next/cache';
+import { getLocale } from 'next-intl/server';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -31,9 +32,10 @@ const SearchPageQuery = graphql(`
 `);
 
 const getCachedSearchPageData = unstable_cache(
-  async () => {
+  async (locale: string) => {
     const response = await client.fetch({
       document: SearchPageQuery,
+      locale,
       fetchOptions: { cache: 'no-store' },
     });
 
@@ -44,5 +46,7 @@ const getCachedSearchPageData = unstable_cache(
 );
 
 export const getSearchPageData = cache(async () => {
-  return getCachedSearchPageData();
+  const locale = await getLocale();
+
+  return getCachedSearchPageData(locale);
 });

--- a/core/app/[locale]/(default)/(faceted)/search/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/search/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -29,11 +30,19 @@ const SearchPageQuery = graphql(`
   }
 `);
 
-export const getSearchPageData = cache(async () => {
-  const response = await client.fetch({
-    document: SearchPageQuery,
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedSearchPageData = unstable_cache(
+  async () => {
+    const response = await client.fetch({
+      document: SearchPageQuery,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return response.data.site;
+    return response.data.site;
+  },
+  ['search-page-data'],
+  { revalidate },
+);
+
+export const getSearchPageData = cache(async () => {
+  return getCachedSearchPageData();
 });

--- a/core/app/[locale]/(default)/(faceted)/search/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/search/page.tsx
@@ -22,14 +22,14 @@ import { getSearchPageData } from './page-data';
 const compareLoader = createCompareLoader();
 
 const createSearchSearchParamsLoader = cache(
-  async (searchParams: SearchParams, customerAccessToken?: string) => {
+  async (locale: string, searchParams: SearchParams, customerAccessToken?: string) => {
     const searchTerm = typeof searchParams.term === 'string' ? searchParams.term : '';
 
     if (!searchTerm) {
       return null;
     }
 
-    const search = await fetchFacetedSearch(searchParams, undefined, customerAccessToken);
+    const search = await fetchFacetedSearch(locale, searchParams, undefined, customerAccessToken);
     const searchFacets = search.facets.items;
     const transformedSearchFacets = await facetsTransformer({
       refinedFacets: searchFacets,
@@ -89,12 +89,14 @@ export default async function Search(props: Props) {
     const currencyCode = await getPreferredCurrencyCode();
 
     const loadSearchParams = await createSearchSearchParamsLoader(
+      locale,
       searchParams,
       customerAccessToken,
     );
     const parsedSearchParams = loadSearchParams?.(searchParams) ?? {};
 
     const search = await fetchFacetedSearch(
+      locale,
       {
         ...searchParams,
         ...parsedSearchParams,
@@ -186,11 +188,12 @@ export default async function Search(props: Props) {
     }
 
     const loadSearchParams = await createSearchSearchParamsLoader(
+      locale,
       searchParams,
       customerAccessToken,
     );
     const parsedSearchParams = loadSearchParams?.(searchParams) ?? {};
-    const categorySearch = await fetchFacetedSearch({}, undefined, customerAccessToken);
+    const categorySearch = await fetchFacetedSearch(locale, {}, undefined, customerAccessToken);
     const refinedSearch = await streamableFacetedSearch;
 
     const allFacets = categorySearch.facets.items.filter(
@@ -221,7 +224,7 @@ export default async function Search(props: Props) {
 
     const compareIds = { entityIds: compare ? compare.map((id: string) => Number(id)) : [] };
 
-    const products = await getCompareProductsData(compareIds, customerAccessToken);
+    const products = await getCompareProductsData(locale, compareIds, customerAccessToken);
 
     return products.map((product) => ({
       id: product.entityId.toString(),

--- a/core/app/[locale]/(default)/account/addresses/_actions/create-address.ts
+++ b/core/app/[locale]/(default)/account/addresses/_actions/create-address.ts
@@ -1,7 +1,7 @@
 import { BigCommerceAPIError, BigCommerceGQLError } from '@bigcommerce/catalyst-client';
 import { parseWithZod } from '@conform-to/zod';
 import { revalidateTag } from 'next/cache';
-import { getTranslations } from 'next-intl/server';
+import { getLocale, getTranslations } from 'next-intl/server';
 import { z } from 'zod';
 
 import { Field, FieldGroup } from '@/vibes/soul/form/dynamic-form/schema';
@@ -202,6 +202,7 @@ export async function createAddress(
   formData: FormData,
 ): Promise<State> {
   const t = await getTranslations('Account.Addresses');
+  const locale = await getLocale();
   const customerAccessToken = await getSessionCustomerAccessToken();
 
   const submission = parseWithZod(formData, { schema });
@@ -218,6 +219,7 @@ export async function createAddress(
 
     const response = await client.fetch({
       document: AddCustomerAddressMutation,
+      locale,
       customerAccessToken,
       fetchOptions: { cache: 'no-store' },
       variables: {

--- a/core/app/[locale]/(default)/account/addresses/_actions/delete-address.ts
+++ b/core/app/[locale]/(default)/account/addresses/_actions/delete-address.ts
@@ -1,7 +1,7 @@
 import { BigCommerceGQLError } from '@bigcommerce/catalyst-client';
 import { parseWithZod } from '@conform-to/zod';
 import { revalidateTag } from 'next/cache';
-import { getTranslations } from 'next-intl/server';
+import { getLocale, getTranslations } from 'next-intl/server';
 import { z } from 'zod';
 
 import { schema } from '@/vibes/soul/sections/address-list-section/schema';
@@ -46,6 +46,7 @@ function parseDeleteAddressInput(
 
 export async function deleteAddress(prevState: Awaited<State>, formData: FormData): Promise<State> {
   const t = await getTranslations('Account.Addresses');
+  const locale = await getLocale();
   const customerAccessToken = await getSessionCustomerAccessToken();
 
   const submission = parseWithZod(formData, { schema });
@@ -62,6 +63,7 @@ export async function deleteAddress(prevState: Awaited<State>, formData: FormDat
 
     const response = await client.fetch({
       document: DeleteCustomerAddressMutation,
+      locale,
       customerAccessToken,
       fetchOptions: { cache: 'no-store' },
       variables: {

--- a/core/app/[locale]/(default)/account/addresses/_actions/update-address.ts
+++ b/core/app/[locale]/(default)/account/addresses/_actions/update-address.ts
@@ -1,7 +1,7 @@
 import { BigCommerceGQLError } from '@bigcommerce/catalyst-client';
 import { parseWithZod } from '@conform-to/zod';
 import { revalidateTag } from 'next/cache';
-import { getTranslations } from 'next-intl/server';
+import { getLocale, getTranslations } from 'next-intl/server';
 import { z } from 'zod';
 
 import { Field, FieldGroup } from '@/vibes/soul/form/dynamic-form/schema';
@@ -215,6 +215,7 @@ export async function updateAddress(
   formData: FormData,
 ): Promise<State> {
   const t = await getTranslations('Account.Addresses');
+  const locale = await getLocale();
   const customerAccessToken = await getSessionCustomerAccessToken();
 
   const submission = parseWithZod(formData, { schema });
@@ -231,6 +232,7 @@ export async function updateAddress(
 
     const response = await client.fetch({
       document: UpdateCustomerAddressMutation,
+      locale,
       customerAccessToken,
       fetchOptions: { cache: 'no-store' },
       variables: {

--- a/core/app/[locale]/(default)/account/addresses/page-data.ts
+++ b/core/app/[locale]/(default)/account/addresses/page-data.ts
@@ -1,4 +1,5 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
+import { getLocale } from 'next-intl/server';
 import { cache } from 'react';
 
 import { getSessionCustomerAccessToken } from '~/auth';
@@ -72,12 +73,14 @@ interface Pagination {
 export const getCustomerAddresses = cache(
   async ({ before = '', after = '', limit = 10 }: Pagination) => {
     const customerAccessToken = await getSessionCustomerAccessToken();
+    const locale = await getLocale();
     const paginationArgs = before ? { last: limit, before } : { first: limit, after };
 
     const response = await client.fetch({
       document: GetCustomerAddressesQuery,
       variables: { ...paginationArgs },
       customerAccessToken,
+      locale,
       fetchOptions: { cache: 'no-store', next: { tags: [TAGS.customer] } },
     });
 

--- a/core/app/[locale]/(default)/account/orders/[id]/page-data.tsx
+++ b/core/app/[locale]/(default)/account/orders/[id]/page-data.tsx
@@ -1,4 +1,5 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
+import { getLocale } from 'next-intl/server';
 import { cache } from 'react';
 
 import { getSessionCustomerAccessToken } from '~/auth';
@@ -157,6 +158,7 @@ const CustomerOrderDetails = graphql(
 
 export const getCustomerOrderDetails = cache(async (id: number) => {
   const customerAccessToken = await getSessionCustomerAccessToken();
+  const locale = await getLocale();
 
   const response = await client.fetch({
     document: CustomerOrderDetails,
@@ -165,6 +167,7 @@ export const getCustomerOrderDetails = cache(async (id: number) => {
         entityId: id,
       },
     },
+    locale,
     fetchOptions: { cache: 'no-store', next: { tags: [TAGS.customer] } },
     customerAccessToken,
     errorPolicy: 'auth',

--- a/core/app/[locale]/(default)/account/orders/page-data.ts
+++ b/core/app/[locale]/(default)/account/orders/page-data.ts
@@ -1,4 +1,5 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
+import { getLocale } from 'next-intl/server';
 import { cache } from 'react';
 
 import { getSessionCustomerAccessToken } from '~/auth';
@@ -104,10 +105,12 @@ export const getCustomerOrders = cache(
         ...(filterByStatus && { status: filterByStatus }),
       },
     };
+    const locale = await getLocale();
     const response = await client.fetch({
       document: CustomerAllOrders,
       variables: { ...paginationArgs, ...filtersArgs },
       customerAccessToken,
+      locale,
       fetchOptions: { cache: 'no-store', next: { tags: [TAGS.customer] } },
       errorPolicy: 'auth',
     });

--- a/core/app/[locale]/(default)/account/settings/_actions/change-password.ts
+++ b/core/app/[locale]/(default)/account/settings/_actions/change-password.ts
@@ -2,7 +2,7 @@
 
 import { BigCommerceGQLError } from '@bigcommerce/catalyst-client';
 import { parseWithZod } from '@conform-to/zod';
-import { getTranslations } from 'next-intl/server';
+import { getLocale, getTranslations } from 'next-intl/server';
 import { z } from 'zod';
 
 import { ChangePasswordAction } from '@/vibes/soul/sections/account-settings/change-password-form';
@@ -41,6 +41,7 @@ const schema = z.object({
 
 export const changePassword: ChangePasswordAction = async (prevState, formData) => {
   const t = await getTranslations('Account.Settings');
+  const locale = await getLocale();
   const customerAccessToken = await getSessionCustomerAccessToken();
   const submission = parseWithZod(formData, { schema });
 
@@ -56,6 +57,7 @@ export const changePassword: ChangePasswordAction = async (prevState, formData) 
   try {
     const response = await client.fetch({
       document: CustomerChangePasswordMutation,
+      locale,
       variables: {
         input,
       },

--- a/core/app/[locale]/(default)/account/settings/_actions/update-customer.ts
+++ b/core/app/[locale]/(default)/account/settings/_actions/update-customer.ts
@@ -3,7 +3,7 @@
 import { BigCommerceGQLError } from '@bigcommerce/catalyst-client';
 import { parseWithZod } from '@conform-to/zod';
 import { revalidateTag } from 'next/cache';
-import { getTranslations } from 'next-intl/server';
+import { getLocale, getTranslations } from 'next-intl/server';
 
 import { updateAccountSchema } from '@/vibes/soul/sections/account-settings/schema';
 import { UpdateAccountAction } from '@/vibes/soul/sections/account-settings/update-account-form';
@@ -45,6 +45,7 @@ const UpdateCustomerMutation = graphql(`
 
 export const updateCustomer: UpdateAccountAction = async (prevState, formData) => {
   const t = await getTranslations('Account.Settings');
+  const locale = await getLocale();
   const customerAccessToken = await getSessionCustomerAccessToken();
 
   const submission = parseWithZod(formData, { schema: updateAccountSchema });
@@ -59,6 +60,7 @@ export const updateCustomer: UpdateAccountAction = async (prevState, formData) =
   try {
     const response = await client.fetch({
       document: UpdateCustomerMutation,
+      locale,
       customerAccessToken,
       variables: {
         input: submission.value,

--- a/core/app/[locale]/(default)/account/settings/_actions/update-newsletter-subscription.ts
+++ b/core/app/[locale]/(default)/account/settings/_actions/update-newsletter-subscription.ts
@@ -4,7 +4,7 @@ import { BigCommerceGQLError } from '@bigcommerce/catalyst-client';
 import { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
 import { revalidateTag } from 'next/cache';
-import { getTranslations } from 'next-intl/server';
+import { getLocale, getTranslations } from 'next-intl/server';
 import { z } from 'zod';
 
 import { client } from '~/client';
@@ -74,6 +74,7 @@ export const updateNewsletterSubscription = async (
   formData: FormData,
 ) => {
   const t = await getTranslations('Account.Settings.NewsletterSubscription');
+  const locale = await getLocale();
 
   const submission = parseWithZod(formData, { schema: updateNewsletterSubscriptionSchema });
 
@@ -87,6 +88,7 @@ export const updateNewsletterSubscription = async (
     if (submission.value.intent === 'subscribe') {
       const response = await client.fetch({
         document: SubscribeToNewsletterMutation,
+        locale,
         variables: {
           input: {
             email: customerInfo.email,
@@ -100,6 +102,7 @@ export const updateNewsletterSubscription = async (
     } else {
       const response = await client.fetch({
         document: UnsubscribeFromNewsletterMutation,
+        locale,
         variables: {
           input: {
             email: customerInfo.email,

--- a/core/app/[locale]/(default)/account/settings/page-data.tsx
+++ b/core/app/[locale]/(default)/account/settings/page-data.tsx
@@ -1,3 +1,4 @@
+import { getLocale } from 'next-intl/server';
 import { cache } from 'react';
 
 import { getSessionCustomerAccessToken } from '~/auth';
@@ -69,6 +70,7 @@ interface Props {
 
 export const getAccountSettingsQuery = cache(async ({ address, customer }: Props = {}) => {
   const customerAccessToken = await getSessionCustomerAccessToken();
+  const locale = await getLocale();
 
   const response = await client.fetch({
     document: AccountSettingsQuery,
@@ -78,6 +80,7 @@ export const getAccountSettingsQuery = cache(async ({ address, customer }: Props
       customerFilters: customer?.filters,
       customerSortBy: customer?.sortBy,
     },
+    locale,
     fetchOptions: { cache: 'no-store', next: { tags: [TAGS.customer] } },
     customerAccessToken,
   });

--- a/core/app/[locale]/(default)/account/wishlists/[id]/page-data.ts
+++ b/core/app/[locale]/(default)/account/wishlists/[id]/page-data.ts
@@ -1,3 +1,4 @@
+import { getLocale } from 'next-intl/server';
 import { cache } from 'react';
 
 import { getSessionCustomerAccessToken } from '~/auth';
@@ -42,10 +43,12 @@ export const getCustomerWishlist = cache(async (entityId: number, pagination: Pa
   const customerAccessToken = await getSessionCustomerAccessToken();
   const currencyCode = await getPreferredCurrencyCode();
   const paginationArgs = before ? { last: limit, before } : { first: limit, after };
+  const locale = await getLocale();
   const response = await client.fetch({
     document: WishlistDetailsQuery,
     variables: { ...paginationArgs, currencyCode, entityId },
     customerAccessToken,
+    locale,
     fetchOptions: { cache: 'no-store', next: { tags: [TAGS.customer] } },
   });
 

--- a/core/app/[locale]/(default)/account/wishlists/_actions/change-wishlist-visibility.ts
+++ b/core/app/[locale]/(default)/account/wishlists/_actions/change-wishlist-visibility.ts
@@ -4,7 +4,7 @@ import { BigCommerceAuthError } from '@bigcommerce/catalyst-client';
 import { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
 import { revalidateTag } from 'next/cache';
-import { getTranslations } from 'next-intl/server';
+import { getLocale, getTranslations } from 'next-intl/server';
 
 import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
@@ -25,6 +25,7 @@ export async function toggleWishlistVisibility(
 ): Promise<State> {
   const customerAccessToken = await getSessionCustomerAccessToken();
   const t = await getTranslations('Wishlist');
+  const locale = await getLocale();
   const submission = parseWithZod(formData, { schema: toggleWishlistVisibilitySchema });
 
   if (submission.status !== 'success') {
@@ -48,6 +49,7 @@ export async function toggleWishlistVisibility(
 
     const response = await client.fetch({
       document: UpdateWishlistMutation,
+      locale,
       customerAccessToken,
       fetchOptions: { cache: 'no-store' },
       variables: { wishlistId, input: { isPublic } },

--- a/core/app/[locale]/(default)/account/wishlists/_actions/delete-wishlist.ts
+++ b/core/app/[locale]/(default)/account/wishlists/_actions/delete-wishlist.ts
@@ -4,7 +4,7 @@ import { BigCommerceAuthError } from '@bigcommerce/catalyst-client';
 import { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
 import { revalidateTag } from 'next/cache';
-import { getTranslations } from 'next-intl/server';
+import { getLocale, getTranslations } from 'next-intl/server';
 
 import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
@@ -25,6 +25,7 @@ export async function deleteWishlist(
 ): Promise<State> {
   const customerAccessToken = await getSessionCustomerAccessToken();
   const t = await getTranslations('Wishlist');
+  const locale = await getLocale();
   const submission = parseWithZod(formData, { schema: deleteWishlistSchema });
 
   if (submission.status !== 'success') {
@@ -46,6 +47,7 @@ export async function deleteWishlist(
 
     const response = await client.fetch({
       document: DeleteWishlistMutation,
+      locale,
       customerAccessToken,
       fetchOptions: { cache: 'no-store' },
       variables: { wishlistId },

--- a/core/app/[locale]/(default)/account/wishlists/_actions/new-wishlist.ts
+++ b/core/app/[locale]/(default)/account/wishlists/_actions/new-wishlist.ts
@@ -4,7 +4,7 @@ import { BigCommerceAuthError } from '@bigcommerce/catalyst-client';
 import { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
 import { revalidateTag } from 'next/cache';
-import { getTranslations } from 'next-intl/server';
+import { getLocale, getTranslations } from 'next-intl/server';
 
 import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
@@ -21,6 +21,7 @@ interface State {
 export async function newWishlist(prevState: Awaited<State>, formData: FormData): Promise<State> {
   const customerAccessToken = await getSessionCustomerAccessToken();
   const t = await getTranslations('Wishlist');
+  const locale = await getLocale();
   const schema = newWishlistSchema({ required_error: t('Errors.nameRequired') });
   const submission = parseWithZod(formData, { schema });
 
@@ -44,6 +45,7 @@ export async function newWishlist(prevState: Awaited<State>, formData: FormData)
 
     const response = await client.fetch({
       document: CreateWishlistMutation,
+      locale,
       customerAccessToken,
       fetchOptions: { cache: 'no-store' },
       variables: { input: { name: wishlistName, isPublic, items: wishlistItems } },

--- a/core/app/[locale]/(default)/account/wishlists/_actions/remove-wishlist-item.ts
+++ b/core/app/[locale]/(default)/account/wishlists/_actions/remove-wishlist-item.ts
@@ -4,7 +4,7 @@ import { BigCommerceAuthError } from '@bigcommerce/catalyst-client';
 import { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
 import { revalidateTag } from 'next/cache';
-import { getTranslations } from 'next-intl/server';
+import { getLocale, getTranslations } from 'next-intl/server';
 
 import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
@@ -25,6 +25,7 @@ export async function removeWishlistItem(
 ): Promise<State> {
   const customerAccessToken = await getSessionCustomerAccessToken();
   const t = await getTranslations('Wishlist');
+  const locale = await getLocale();
   const submission = parseWithZod(formData, { schema: removeWishlistItemSchema });
 
   if (submission.status !== 'success') {
@@ -48,6 +49,7 @@ export async function removeWishlistItem(
 
     const response = await client.fetch({
       document: DeleteWishlistItemsMutation,
+      locale,
       customerAccessToken,
       fetchOptions: { cache: 'no-store' },
       variables: { wishlistId, itemIds: [wishlistItemId] },

--- a/core/app/[locale]/(default)/account/wishlists/_actions/rename-wishlist.ts
+++ b/core/app/[locale]/(default)/account/wishlists/_actions/rename-wishlist.ts
@@ -4,7 +4,7 @@ import { BigCommerceAuthError } from '@bigcommerce/catalyst-client';
 import { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
 import { revalidateTag } from 'next/cache';
-import { getTranslations } from 'next-intl/server';
+import { getLocale, getTranslations } from 'next-intl/server';
 
 import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
@@ -24,6 +24,7 @@ export async function renameWishlist(
 ): Promise<State> {
   const customerAccessToken = await getSessionCustomerAccessToken();
   const t = await getTranslations('Wishlist');
+  const locale = await getLocale();
   const schema = renameWishlistSchema({ required_error: t('Errors.nameRequired') });
   const submission = parseWithZod(formData, { schema });
 
@@ -46,6 +47,7 @@ export async function renameWishlist(
 
     const response = await client.fetch({
       document: UpdateWishlistMutation,
+      locale,
       customerAccessToken,
       fetchOptions: { cache: 'no-store' },
       variables: { wishlistId, input: { name: wishlistName } },

--- a/core/app/[locale]/(default)/account/wishlists/page-data.ts
+++ b/core/app/[locale]/(default)/account/wishlists/page-data.ts
@@ -1,3 +1,4 @@
+import { getLocale } from 'next-intl/server';
 import { cache } from 'react';
 
 import { getSessionCustomerAccessToken } from '~/auth';
@@ -37,10 +38,12 @@ export const getCustomerWishlists = cache(async ({ limit = 9, before, after }: P
   const customerAccessToken = await getSessionCustomerAccessToken();
   const currencyCode = await getPreferredCurrencyCode();
   const paginationArgs = before ? { last: limit, before } : { first: limit, after };
+  const locale = await getLocale();
   const response = await client.fetch({
     document: WishlistsPageQuery,
     variables: { ...paginationArgs, currencyCode },
     customerAccessToken,
+    locale,
     fetchOptions: { cache: 'no-store', next: { tags: [TAGS.customer] } },
   });
 

--- a/core/app/[locale]/(default)/blog/[blogId]/page-data.ts
+++ b/core/app/[locale]/(default)/blog/[blogId]/page-data.ts
@@ -1,4 +1,5 @@
 import { unstable_cache } from 'next/cache';
+import { getLocale } from 'next-intl/server';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -40,10 +41,11 @@ const BlogPageQuery = graphql(`
 type Variables = VariablesOf<typeof BlogPageQuery>;
 
 const getCachedBlogPageData = unstable_cache(
-  async (variables: Variables) => {
+  async (variables: Variables, locale: string) => {
     const response = await client.fetch({
       document: BlogPageQuery,
       variables,
+      locale,
       fetchOptions: { cache: 'no-store' },
     });
 
@@ -60,5 +62,7 @@ const getCachedBlogPageData = unstable_cache(
 );
 
 export const getBlogPageData = cache(async (variables: Variables) => {
-  return getCachedBlogPageData(variables);
+  const locale = await getLocale();
+
+  return getCachedBlogPageData(variables, locale);
 });

--- a/core/app/[locale]/(default)/blog/[blogId]/page-data.ts
+++ b/core/app/[locale]/(default)/blog/[blogId]/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -38,18 +39,26 @@ const BlogPageQuery = graphql(`
 
 type Variables = VariablesOf<typeof BlogPageQuery>;
 
+const getCachedBlogPageData = unstable_cache(
+  async (variables: Variables) => {
+    const response = await client.fetch({
+      document: BlogPageQuery,
+      variables,
+      fetchOptions: { cache: 'no-store' },
+    });
+
+    const { blog } = response.data.site.content;
+
+    if (!blog?.post) {
+      return null;
+    }
+
+    return blog;
+  },
+  ['blog-page-data'],
+  { revalidate },
+);
+
 export const getBlogPageData = cache(async (variables: Variables) => {
-  const response = await client.fetch({
-    document: BlogPageQuery,
-    variables,
-    fetchOptions: { next: { revalidate } },
-  });
-
-  const { blog } = response.data.site.content;
-
-  if (!blog?.post) {
-    return null;
-  }
-
-  return blog;
+  return getCachedBlogPageData(variables);
 });

--- a/core/app/[locale]/(default)/blog/page-data.ts
+++ b/core/app/[locale]/(default)/blog/page-data.ts
@@ -1,6 +1,6 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
 import { unstable_cache } from 'next/cache';
-import { getFormatter } from 'next-intl/server';
+import { getFormatter, getLocale } from 'next-intl/server';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -74,9 +74,10 @@ interface Pagination {
 }
 
 const getCachedBlog = unstable_cache(
-  async () => {
+  async (locale: string) => {
     const response = await client.fetch({
       document: BlogQuery,
+      locale,
       fetchOptions: { cache: 'no-store' },
     });
 
@@ -87,17 +88,26 @@ const getCachedBlog = unstable_cache(
 );
 
 export const getBlog = cache(async () => {
-  return getCachedBlog();
+  const locale = await getLocale();
+
+  return getCachedBlog(locale);
 });
 
 const getCachedBlogPosts = unstable_cache(
-  async (tag: string | null, limit: number, before: string | null, after: string | null) => {
+  async (
+    tag: string | null,
+    limit: number,
+    before: string | null,
+    after: string | null,
+    locale: string,
+  ) => {
     const filterArgs = tag ? { filters: { tags: [tag] } } : {};
     const paginationArgs = before ? { last: limit, before } : { first: limit, after };
 
     const response = await client.fetch({
       document: BlogPostsPageQuery,
       variables: { ...filterArgs, ...paginationArgs },
+      locale,
       fetchOptions: { cache: 'no-store' },
     });
 
@@ -131,7 +141,8 @@ const getCachedBlogPosts = unstable_cache(
 
 export const getBlogPosts = cache(
   async ({ tag, limit = 9, before, after }: BlogPostsFiltersInput & Pagination) => {
-    const result = await getCachedBlogPosts(tag, limit, before ?? null, after ?? null);
+    const locale = await getLocale();
+    const result = await getCachedBlogPosts(tag, limit, before ?? null, after ?? null, locale);
 
     if (!result) {
       return null;

--- a/core/app/[locale]/(default)/blog/page-data.ts
+++ b/core/app/[locale]/(default)/blog/page-data.ts
@@ -1,4 +1,5 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
+import { unstable_cache } from 'next/cache';
 import { getFormatter } from 'next-intl/server';
 import { cache } from 'react';
 
@@ -72,24 +73,32 @@ interface Pagination {
   after: string | null;
 }
 
-export const getBlog = cache(async () => {
-  const response = await client.fetch({
-    document: BlogQuery,
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedBlog = unstable_cache(
+  async () => {
+    const response = await client.fetch({
+      document: BlogQuery,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return response.data.site.content.blog;
+    return response.data.site.content.blog;
+  },
+  ['blog-data'],
+  { revalidate },
+);
+
+export const getBlog = cache(async () => {
+  return getCachedBlog();
 });
 
-export const getBlogPosts = cache(
-  async ({ tag, limit = 9, before, after }: BlogPostsFiltersInput & Pagination) => {
+const getCachedBlogPosts = unstable_cache(
+  async (tag: string | null, limit: number, before: string | null, after: string | null) => {
     const filterArgs = tag ? { filters: { tags: [tag] } } : {};
     const paginationArgs = before ? { last: limit, before } : { first: limit, after };
 
     const response = await client.fetch({
       document: BlogPostsPageQuery,
       variables: { ...filterArgs, ...paginationArgs },
-      fetchOptions: { next: { revalidate } },
+      fetchOptions: { cache: 'no-store' },
     });
 
     const { blog } = response.data.site.content;
@@ -98,15 +107,13 @@ export const getBlogPosts = cache(
       return null;
     }
 
-    const format = await getFormatter();
-
     return {
       pageInfo: blog.posts.pageInfo,
       posts: removeEdgesAndNodes(blog.posts).map((post) => ({
         id: String(post.entityId),
         author: post.author,
         content: post.plainTextSummary,
-        date: format.dateTime(new Date(post.publishedDate.utc)),
+        publishedDateUtc: post.publishedDate.utc,
         image: post.thumbnailImage
           ? {
               src: post.thumbnailImage.url,
@@ -115,6 +122,28 @@ export const getBlogPosts = cache(
           : undefined,
         href: post.path,
         title: post.name,
+      })),
+    };
+  },
+  ['blog-posts'],
+  { revalidate },
+);
+
+export const getBlogPosts = cache(
+  async ({ tag, limit = 9, before, after }: BlogPostsFiltersInput & Pagination) => {
+    const result = await getCachedBlogPosts(tag, limit, before ?? null, after ?? null);
+
+    if (!result) {
+      return null;
+    }
+
+    const format = await getFormatter();
+
+    return {
+      pageInfo: result.pageInfo,
+      posts: result.posts.map((post) => ({
+        ...post,
+        date: format.dateTime(new Date(post.publishedDateUtc)),
       })),
     };
   },

--- a/core/app/[locale]/(default)/cart/_actions/add-shipping-cost.ts
+++ b/core/app/[locale]/(default)/cart/_actions/add-shipping-cost.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { revalidateTag } from 'next/cache';
+import { getLocale } from 'next-intl/server';
 
 import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
@@ -31,9 +32,11 @@ export const addShippingCost = async ({
   shippingOptionEntityId,
 }: Props) => {
   const customerAccessToken = await getSessionCustomerAccessToken();
+  const locale = await getLocale();
 
   const response = await client.fetch({
     document: SelectCheckoutShippingOptionMutation,
+    locale,
     variables: {
       input: {
         checkoutEntityId,

--- a/core/app/[locale]/(default)/cart/_actions/add-shipping-info.ts
+++ b/core/app/[locale]/(default)/cart/_actions/add-shipping-info.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { revalidateTag } from 'next/cache';
+import { getLocale } from 'next-intl/server';
 
 import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
@@ -45,9 +46,11 @@ export const addCheckoutShippingConsignments = async ({
   lineItems,
 }: AddProps) => {
   const customerAccessToken = await getSessionCustomerAccessToken();
+  const locale = await getLocale();
 
   const response = await client.fetch({
     document: AddCheckoutShippingConsignmentsMutation,
+    locale,
     variables: {
       input: {
         checkoutEntityId,
@@ -113,9 +116,11 @@ export const updateCheckoutShippingConsignment = async ({
   lineItems,
 }: UpdateProps) => {
   const customerAccessToken = await getSessionCustomerAccessToken();
+  const locale = await getLocale();
 
   const response = await client.fetch({
     document: UpdateCheckoutShippingConsignmentMutation,
+    locale,
     variables: {
       input: {
         checkoutEntityId,

--- a/core/app/[locale]/(default)/cart/_actions/apply-coupon-code.ts
+++ b/core/app/[locale]/(default)/cart/_actions/apply-coupon-code.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { revalidateTag } from 'next/cache';
+import { getLocale } from 'next-intl/server';
 
 import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
@@ -28,9 +29,11 @@ interface Props {
 
 export const applyCouponCode = async ({ checkoutEntityId, couponCode }: Props) => {
   const customerAccessToken = await getSessionCustomerAccessToken();
+  const locale = await getLocale();
 
   const response = await client.fetch({
     document: ApplyCheckoutCouponMutation,
+    locale,
     variables: {
       applyCheckoutCouponInput: {
         checkoutEntityId,

--- a/core/app/[locale]/(default)/cart/_actions/apply-gift-certificate.ts
+++ b/core/app/[locale]/(default)/cart/_actions/apply-gift-certificate.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { revalidateTag } from 'next/cache';
+import { getLocale } from 'next-intl/server';
 
 import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
@@ -30,9 +31,11 @@ interface Props {
 
 export const applyGiftCertificate = async ({ checkoutEntityId, giftCertificateCode }: Props) => {
   const customerAccessToken = await getSessionCustomerAccessToken();
+  const locale = await getLocale();
 
   const response = await client.fetch({
     document: ApplyCheckoutGiftCertificateMutation,
+    locale,
     variables: {
       applyCheckoutGiftCertificateInput: {
         checkoutEntityId,

--- a/core/app/[locale]/(default)/cart/_actions/remove-coupon-code.ts
+++ b/core/app/[locale]/(default)/cart/_actions/remove-coupon-code.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { revalidateTag } from 'next/cache';
+import { getLocale } from 'next-intl/server';
 
 import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
@@ -28,9 +29,11 @@ interface Props {
 
 export const removeCouponCode = async ({ checkoutEntityId, couponCode }: Props) => {
   const customerAccessToken = await getSessionCustomerAccessToken();
+  const locale = await getLocale();
 
   const response = await client.fetch({
     document: UnapplyCheckoutCouponMutation,
+    locale,
     variables: {
       unapplyCheckoutCouponInput: {
         checkoutEntityId,

--- a/core/app/[locale]/(default)/cart/_actions/remove-gift-certificate.ts
+++ b/core/app/[locale]/(default)/cart/_actions/remove-gift-certificate.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { revalidateTag } from 'next/cache';
+import { getLocale } from 'next-intl/server';
 
 import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
@@ -30,9 +31,11 @@ interface Props {
 
 export const removeGiftCertificate = async ({ checkoutEntityId, giftCertificateCode }: Props) => {
   const customerAccessToken = await getSessionCustomerAccessToken();
+  const locale = await getLocale();
 
   const response = await client.fetch({
     document: UnapplyCheckoutGiftCertificateMutation,
+    locale,
     variables: {
       unapplyCheckoutGiftCertificateInput: {
         checkoutEntityId,

--- a/core/app/[locale]/(default)/cart/_actions/remove-item.ts
+++ b/core/app/[locale]/(default)/cart/_actions/remove-item.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { revalidateTag } from 'next/cache';
-import { getTranslations } from 'next-intl/server';
+import { getLocale, getTranslations } from 'next-intl/server';
 
 import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
@@ -28,6 +28,7 @@ export async function removeItem({
   lineItemEntityId,
 }: Omit<DeleteCartLineItemInput, 'cartEntityId'>) {
   const t = await getTranslations('Cart.Errors');
+  const locale = await getLocale();
 
   const customerAccessToken = await getSessionCustomerAccessToken();
 
@@ -43,6 +44,7 @@ export async function removeItem({
 
   const response = await client.fetch({
     document: DeleteCartLineItemMutation,
+    locale,
     variables: {
       input: {
         cartEntityId: cartId,

--- a/core/app/[locale]/(default)/cart/_actions/update-quantity.ts
+++ b/core/app/[locale]/(default)/cart/_actions/update-quantity.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { getTranslations } from 'next-intl/server';
+import { getLocale, getTranslations } from 'next-intl/server';
 
 import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
@@ -41,6 +41,7 @@ export const updateQuantity = async ({
   selectedOptions,
 }: UpdateProductQuantityParams) => {
   const t = await getTranslations('Cart.Errors');
+  const locale = await getLocale();
 
   const customerAccessToken = await getSessionCustomerAccessToken();
 
@@ -68,6 +69,7 @@ export const updateQuantity = async ({
 
   const response = await client.fetch({
     document: UpdateCartLineItemMutation,
+    locale,
     variables: {
       input: {
         cartEntityId: cartId,

--- a/core/app/[locale]/(default)/cart/page-data.ts
+++ b/core/app/[locale]/(default)/cart/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { getSessionCustomerAccessToken } from '~/auth';
@@ -336,11 +337,19 @@ const SupportedShippingDestinationsQuery = graphql(`
   }
 `);
 
-export const getShippingCountries = cache(async () => {
-  const { data } = await client.fetch({
-    document: SupportedShippingDestinationsQuery,
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedShippingCountries = unstable_cache(
+  async () => {
+    const { data } = await client.fetch({
+      document: SupportedShippingDestinationsQuery,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return data.site.settings?.shipping?.supportedShippingDestinations.countries ?? [];
+    return data.site.settings?.shipping?.supportedShippingDestinations.countries ?? [];
+  },
+  ['shipping-countries'],
+  { revalidate },
+);
+
+export const getShippingCountries = cache(async () => {
+  return getCachedShippingCountries();
 });

--- a/core/app/[locale]/(default)/cart/page-data.ts
+++ b/core/app/[locale]/(default)/cart/page-data.ts
@@ -1,4 +1,5 @@
 import { unstable_cache } from 'next/cache';
+import { getLocale } from 'next-intl/server';
 import { cache } from 'react';
 
 import { getSessionCustomerAccessToken } from '~/auth';
@@ -298,11 +299,13 @@ type Variables = VariablesOf<typeof CartPageQuery>;
 
 export const getCart = async (variables: Variables) => {
   const customerAccessToken = await getSessionCustomerAccessToken();
+  const locale = await getLocale();
 
   const { data } = await client.fetch({
     document: CartPageQuery,
     variables,
     customerAccessToken,
+    locale,
     fetchOptions: {
       cache: 'no-store',
       next: {
@@ -338,9 +341,10 @@ const SupportedShippingDestinationsQuery = graphql(`
 `);
 
 const getCachedShippingCountries = unstable_cache(
-  async () => {
+  async (locale: string) => {
     const { data } = await client.fetch({
       document: SupportedShippingDestinationsQuery,
+      locale,
       fetchOptions: { cache: 'no-store' },
     });
 
@@ -351,5 +355,7 @@ const getCachedShippingCountries = unstable_cache(
 );
 
 export const getShippingCountries = cache(async () => {
-  return getCachedShippingCountries();
+  const locale = await getLocale();
+
+  return getCachedShippingCountries(locale);
 });

--- a/core/app/[locale]/(default)/checkout/route.ts
+++ b/core/app/[locale]/(default)/checkout/route.ts
@@ -85,6 +85,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ loca
       fetchOptions: { cache: 'no-store' },
       customerAccessToken,
       channelId,
+      locale,
     });
 
     if (

--- a/core/app/[locale]/(default)/compare/page-data.ts
+++ b/core/app/[locale]/(default)/compare/page-data.ts
@@ -1,4 +1,5 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -55,12 +56,8 @@ const ComparedProductsQuery = graphql(
   [ProductCardFragment],
 );
 
-export const getComparedProducts = cache(
-  async (productIds: number[] = [], currencyCode?: CurrencyCode, customerAccessToken?: string) => {
-    if (productIds.length === 0) {
-      return [];
-    }
-
+const getCachedComparedProducts = unstable_cache(
+  async (locale: string, productIds: number[], currencyCode?: CurrencyCode) => {
     const { data } = await client.fetch({
       document: ComparedProductsQuery,
       variables: {
@@ -68,10 +65,43 @@ export const getComparedProducts = cache(
         first: productIds.length ? MAX_COMPARE_LIMIT : 0,
         currencyCode,
       },
-      customerAccessToken,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
+      locale,
+      fetchOptions: { cache: 'no-store' },
     });
 
     return removeEdgesAndNodes(data.site.products);
+  },
+  ['compared-products'],
+  { revalidate },
+);
+
+export const getComparedProducts = cache(
+  async (
+    locale: string,
+    productIds: number[] = [],
+    currencyCode?: CurrencyCode,
+    customerAccessToken?: string,
+  ) => {
+    if (productIds.length === 0) {
+      return [];
+    }
+
+    if (customerAccessToken) {
+      const { data } = await client.fetch({
+        document: ComparedProductsQuery,
+        variables: {
+          entityIds: productIds,
+          first: productIds.length ? MAX_COMPARE_LIMIT : 0,
+          currencyCode,
+        },
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return removeEdgesAndNodes(data.site.products);
+    }
+
+    return getCachedComparedProducts(locale, productIds, currencyCode);
   },
 );

--- a/core/app/[locale]/(default)/compare/page.tsx
+++ b/core/app/[locale]/(default)/compare/page.tsx
@@ -64,7 +64,12 @@ export default async function Compare(props: Props) {
     const parsed = CompareParamsSchema.parse(searchParams);
     const productIds = parsed.ids?.filter((id) => !Number.isNaN(id));
 
-    const products = await getComparedProducts(productIds, currencyCode, customerAccessToken);
+    const products = await getComparedProducts(
+      locale,
+      productIds,
+      currencyCode,
+      customerAccessToken,
+    );
     const format = await getFormatter();
 
     return products.map((product) => ({
@@ -97,7 +102,12 @@ export default async function Compare(props: Props) {
     const parsed = CompareParamsSchema.parse(searchParams);
     const productIds = parsed.ids?.filter((id) => !Number.isNaN(id));
 
-    const products = await getComparedProducts(productIds, currencyCode, customerAccessToken);
+    const products = await getComparedProducts(
+      locale,
+      productIds,
+      currencyCode,
+      customerAccessToken,
+    );
 
     return products.map((product) => {
       return {

--- a/core/app/[locale]/(default)/gift-certificates/balance/_actions/get-gift-certificate-by-code.ts
+++ b/core/app/[locale]/(default)/gift-certificates/balance/_actions/get-gift-certificate-by-code.ts
@@ -2,7 +2,7 @@
 
 import { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
-import { getFormatter, getTranslations } from 'next-intl/server';
+import { getFormatter, getLocale, getTranslations } from 'next-intl/server';
 
 import { GiftCertificateData } from '@/vibes/soul/sections/gift-certificate-balance-section';
 import { giftCertificateCodeSchema } from '@/vibes/soul/sections/gift-certificate-balance-section/schema';
@@ -59,6 +59,7 @@ export async function getGiftCertificateByCode(
   formData: FormData,
 ): Promise<State> {
   const t = await getTranslations('GiftCertificates.CheckBalance');
+  const locale = await getLocale();
   const format = await getFormatter();
   const schema = giftCertificateCodeSchema({ required_error: t('Errors.codeRequired') });
   const submission = parseWithZod(formData, { schema });
@@ -74,6 +75,7 @@ export async function getGiftCertificateByCode(
     const { code } = schema.parse(submission.value);
     const response = await client.fetch({
       document: GetGiftCertificateByCodeQuery,
+      locale,
       fetchOptions: { cache: 'no-store' },
       variables: { code },
     });

--- a/core/app/[locale]/(default)/gift-certificates/page-data.ts
+++ b/core/app/[locale]/(default)/gift-certificates/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -26,16 +27,24 @@ const GiftCertificatesRootQuery = graphql(
   [StoreLogoFragment],
 );
 
-export const getGiftCertificatesData = cache(async (currencyCode?: CurrencyCode) => {
-  const response = await client.fetch({
-    document: GiftCertificatesRootQuery,
-    variables: { currencyCode },
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedGiftCertificatesData = unstable_cache(
+  async (currencyCode?: CurrencyCode) => {
+    const response = await client.fetch({
+      document: GiftCertificatesRootQuery,
+      variables: { currencyCode },
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return {
-    giftCertificatesEnabled: response.data.site.settings?.giftCertificates?.isEnabled ?? false,
-    defaultCurrency: response.data.site.settings?.currency.defaultCurrency ?? undefined,
-    logo: response.data.site.settings ? logoTransformer(response.data.site.settings) : '',
-  };
+    return {
+      giftCertificatesEnabled: response.data.site.settings?.giftCertificates?.isEnabled ?? false,
+      defaultCurrency: response.data.site.settings?.currency.defaultCurrency ?? undefined,
+      logo: response.data.site.settings ? logoTransformer(response.data.site.settings) : '',
+    };
+  },
+  ['gift-certificates-data'],
+  { revalidate },
+);
+
+export const getGiftCertificatesData = cache(async (currencyCode?: CurrencyCode) => {
+  return getCachedGiftCertificatesData(currencyCode);
 });

--- a/core/app/[locale]/(default)/gift-certificates/page-data.ts
+++ b/core/app/[locale]/(default)/gift-certificates/page-data.ts
@@ -1,4 +1,5 @@
 import { unstable_cache } from 'next/cache';
+import { getLocale } from 'next-intl/server';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -28,10 +29,11 @@ const GiftCertificatesRootQuery = graphql(
 );
 
 const getCachedGiftCertificatesData = unstable_cache(
-  async (currencyCode?: CurrencyCode) => {
+  async (currencyCode: CurrencyCode | undefined, locale: string) => {
     const response = await client.fetch({
       document: GiftCertificatesRootQuery,
       variables: { currencyCode },
+      locale,
       fetchOptions: { cache: 'no-store' },
     });
 
@@ -46,5 +48,7 @@ const getCachedGiftCertificatesData = unstable_cache(
 );
 
 export const getGiftCertificatesData = cache(async (currencyCode?: CurrencyCode) => {
-  return getCachedGiftCertificatesData(currencyCode);
+  const locale = await getLocale();
+
+  return getCachedGiftCertificatesData(currencyCode, locale);
 });

--- a/core/app/[locale]/(default)/gift-certificates/purchase/_actions/add-to-cart.tsx
+++ b/core/app/[locale]/(default)/gift-certificates/purchase/_actions/add-to-cart.tsx
@@ -3,7 +3,7 @@
 import { BigCommerceGQLError } from '@bigcommerce/catalyst-client';
 import { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
-import { getFormatter, getTranslations } from 'next-intl/server';
+import { getFormatter, getLocale, getTranslations } from 'next-intl/server';
 import { ReactNode } from 'react';
 import { z } from 'zod';
 
@@ -106,10 +106,12 @@ export async function addGiftCertificateToCart<F extends Field>(
   formData: FormData,
 ): Promise<State> {
   const t = await getTranslations('GiftCertificates.Purchase');
+  const locale = await getLocale();
   const format = await getFormatter();
   const currencyCode = await getPreferredCurrencyCode();
   const settingsResp = await client.fetch({
     document: GiftCertificateSettingsQuery,
+    locale,
     variables: { currencyCode },
   });
 

--- a/core/app/[locale]/(default)/gift-certificates/purchase/page-data.ts
+++ b/core/app/[locale]/(default)/gift-certificates/purchase/page-data.ts
@@ -1,4 +1,5 @@
 import { unstable_cache } from 'next/cache';
+import { getLocale } from 'next-intl/server';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -31,10 +32,11 @@ const GiftCertificatePurchaseSettingsQuery = graphql(
 );
 
 const getCachedGiftCertificatePurchaseData = unstable_cache(
-  async (currencyCode?: CurrencyCode) => {
+  async (currencyCode: CurrencyCode | undefined, locale: string) => {
     const response = await client.fetch({
       document: GiftCertificatePurchaseSettingsQuery,
       variables: { currencyCode },
+      locale,
       fetchOptions: { cache: 'no-store' },
     });
 
@@ -50,5 +52,7 @@ const getCachedGiftCertificatePurchaseData = unstable_cache(
 );
 
 export const getGiftCertificatePurchaseData = cache(async (currencyCode?: CurrencyCode) => {
-  return getCachedGiftCertificatePurchaseData(currencyCode);
+  const locale = await getLocale();
+
+  return getCachedGiftCertificatePurchaseData(currencyCode, locale);
 });

--- a/core/app/[locale]/(default)/gift-certificates/purchase/page-data.ts
+++ b/core/app/[locale]/(default)/gift-certificates/purchase/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -29,17 +30,25 @@ const GiftCertificatePurchaseSettingsQuery = graphql(
   [GiftCertificateSettingsFragment, StoreLogoFragment],
 );
 
-export const getGiftCertificatePurchaseData = cache(async (currencyCode?: CurrencyCode) => {
-  const response = await client.fetch({
-    document: GiftCertificatePurchaseSettingsQuery,
-    variables: { currencyCode },
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedGiftCertificatePurchaseData = unstable_cache(
+  async (currencyCode?: CurrencyCode) => {
+    const response = await client.fetch({
+      document: GiftCertificatePurchaseSettingsQuery,
+      variables: { currencyCode },
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return {
-    giftCertificateSettings: response.data.site.settings?.giftCertificates ?? null,
-    logo: response.data.site.settings ? logoTransformer(response.data.site.settings) : '',
-    storeName: response.data.site.settings?.storeName ?? undefined,
-    defaultCurrency: response.data.site.settings?.currency.defaultCurrency ?? undefined,
-  };
+    return {
+      giftCertificateSettings: response.data.site.settings?.giftCertificates ?? null,
+      logo: response.data.site.settings ? logoTransformer(response.data.site.settings) : '',
+      storeName: response.data.site.settings?.storeName ?? undefined,
+      defaultCurrency: response.data.site.settings?.currency.defaultCurrency ?? undefined,
+    };
+  },
+  ['gift-certificate-purchase-data'],
+  { revalidate },
+);
+
+export const getGiftCertificatePurchaseData = cache(async (currencyCode?: CurrencyCode) => {
+  return getCachedGiftCertificatePurchaseData(currencyCode);
 });

--- a/core/app/[locale]/(default)/page-data.ts
+++ b/core/app/[locale]/(default)/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -77,15 +78,35 @@ const HomePageQuery = graphql(
   [FeaturedProductsCarouselFragment, FeaturedProductsListFragment],
 );
 
-export const getPageData = cache(
-  async (currencyCode?: CurrencyCode, customerAccessToken?: string) => {
+const getCachedPageData = unstable_cache(
+  async (locale: string, currencyCode?: CurrencyCode) => {
     const { data } = await client.fetch({
       document: HomePageQuery,
-      customerAccessToken,
       variables: { currencyCode },
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
+      locale,
+      fetchOptions: { cache: 'no-store' },
     });
 
     return data;
+  },
+  ['home-page-data'],
+  { revalidate },
+);
+
+export const getPageData = cache(
+  async (locale: string, currencyCode?: CurrencyCode, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const { data } = await client.fetch({
+        document: HomePageQuery,
+        customerAccessToken,
+        variables: { currencyCode },
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return data;
+    }
+
+    return getCachedPageData(locale, currencyCode);
   },
 );

--- a/core/app/[locale]/(default)/page.tsx
+++ b/core/app/[locale]/(default)/page.tsx
@@ -38,7 +38,7 @@ export default async function Home({ params }: Props) {
     const customerAccessToken = await getSessionCustomerAccessToken();
     const currencyCode = await getPreferredCurrencyCode();
 
-    return getPageData(currencyCode, customerAccessToken);
+    return getPageData(locale, currencyCode, customerAccessToken);
   });
 
   const streamableFeaturedProducts = Streamable.from(async () => {

--- a/core/app/[locale]/(default)/product/[slug]/_actions/get-more-images.ts
+++ b/core/app/[locale]/(default)/product/[slug]/_actions/get-more-images.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
+import { getLocale } from 'next-intl/server';
 
 import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
@@ -37,9 +38,11 @@ export async function getMoreProductImages(
   pageInfo: { hasNextPage: boolean; endCursor: string | null };
 }> {
   const customerAccessToken = await getSessionCustomerAccessToken();
+  const locale = await getLocale();
 
   const { data } = await client.fetch({
     document: MoreProductImagesQuery,
+    locale,
     variables: { entityId: productId, first: limit, after: cursor },
     customerAccessToken,
     fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },

--- a/core/app/[locale]/(default)/product/[slug]/_actions/submit-review.ts
+++ b/core/app/[locale]/(default)/product/[slug]/_actions/submit-review.ts
@@ -3,7 +3,7 @@
 import { BigCommerceGQLError } from '@bigcommerce/catalyst-client';
 import { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
-import { getTranslations } from 'next-intl/server';
+import { getLocale, getTranslations } from 'next-intl/server';
 
 import { schema } from '@/vibes/soul/sections/reviews/schema';
 import { getSessionCustomerAccessToken } from '~/auth';
@@ -35,6 +35,7 @@ export async function submitReview(
   payload: FormData,
 ) {
   const t = await getTranslations('Product.Reviews.Form');
+  const locale = await getLocale();
   const customerAccessToken = await getSessionCustomerAccessToken();
   const submission = parseWithZod(payload, { schema });
 
@@ -57,6 +58,7 @@ export async function submitReview(
   try {
     const response = await client.fetch({
       document: AddProductReviewMutation,
+      locale,
       customerAccessToken,
       fetchOptions: { cache: 'no-store' },
       variables: {

--- a/core/app/[locale]/(default)/product/[slug]/_actions/wishlist-action.ts
+++ b/core/app/[locale]/(default)/product/[slug]/_actions/wishlist-action.ts
@@ -102,8 +102,11 @@ interface WishlistRemoveMutationVariables {
 }
 
 async function getVariantIdFromSku(productId: number, sku: string, customerAccessToken?: string) {
+  const locale = await getLocale();
+
   const { data } = await client.fetch({
     document: VariantIdFromSkuQuery,
+    locale,
     variables: { productId, sku },
     customerAccessToken,
     fetchOptions: { cache: 'no-store' },
@@ -122,8 +125,11 @@ async function addToDefaultWishlist(
   productId: number,
   variantId?: number,
 ) {
+  const locale = await getLocale();
+
   const { data } = await client.fetch({
     document: CreateWishlistMutation,
+    locale,
     variables: {
       input: {
         name: wishlistName,
@@ -141,8 +147,11 @@ async function addToDefaultWishlist(
 }
 
 async function addToWishlist(customerAccessToken: string, variables: WishlistAddMutationVariables) {
+  const locale = await getLocale();
+
   const { data } = await client.fetch({
     document: AddToWishlistMutation,
+    locale,
     variables,
     customerAccessToken,
     fetchOptions: { cache: 'no-store' },
@@ -157,8 +166,11 @@ async function removeFromWishlist(
   customerAccessToken: string,
   variables: WishlistRemoveMutationVariables,
 ) {
+  const locale = await getLocale();
+
   const { data } = await client.fetch({
     document: DeleteWishlistItemsMutation,
+    locale,
     variables,
     customerAccessToken,
     fetchOptions: { cache: 'no-store' },

--- a/core/app/[locale]/(default)/product/[slug]/_components/reviews.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/_components/reviews.tsx
@@ -1,6 +1,6 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
 import { unstable_cache } from 'next/cache';
-import { getFormatter, getTranslations } from 'next-intl/server';
+import { getFormatter, getLocale, getTranslations } from 'next-intl/server';
 import { createLoader, parseAsString, SearchParams } from 'nuqs/server';
 import { cache } from 'react';
 
@@ -66,10 +66,11 @@ const ReviewsQuery = graphql(
 );
 
 const getCachedReviews = unstable_cache(
-  async (productId: number, paginationArgs: object) => {
+  async (productId: number, paginationArgs: object, locale: string) => {
     const { data } = await client.fetch({
       document: ReviewsQuery,
       variables: { ...paginationArgs, entityId: productId },
+      locale,
       fetchOptions: { cache: 'no-store' },
     });
 
@@ -80,7 +81,9 @@ const getCachedReviews = unstable_cache(
 );
 
 const getReviews = cache(async (productId: number, paginationArgs: object) => {
-  return getCachedReviews(productId, paginationArgs);
+  const locale = await getLocale();
+
+  return getCachedReviews(productId, paginationArgs, locale);
 });
 
 interface Props {

--- a/core/app/[locale]/(default)/product/[slug]/_components/reviews.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/_components/reviews.tsx
@@ -1,4 +1,5 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
+import { unstable_cache } from 'next/cache';
 import { getFormatter, getTranslations } from 'next-intl/server';
 import { createLoader, parseAsString, SearchParams } from 'nuqs/server';
 import { cache } from 'react';
@@ -64,14 +65,22 @@ const ReviewsQuery = graphql(
   [ProductReviewSchemaFragment, PaginationFragment],
 );
 
-const getReviews = cache(async (productId: number, paginationArgs: object) => {
-  const { data } = await client.fetch({
-    document: ReviewsQuery,
-    variables: { ...paginationArgs, entityId: productId },
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedReviews = unstable_cache(
+  async (productId: number, paginationArgs: object) => {
+    const { data } = await client.fetch({
+      document: ReviewsQuery,
+      variables: { ...paginationArgs, entityId: productId },
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return data.site.product;
+    return data.site.product;
+  },
+  ['product-reviews'],
+  { revalidate },
+);
+
+const getReviews = cache(async (productId: number, paginationArgs: object) => {
+  return getCachedReviews(productId, paginationArgs);
 });
 
 interface Props {

--- a/core/app/[locale]/(default)/product/[slug]/_components/wishlist-button/index.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/_components/wishlist-button/index.tsx
@@ -1,5 +1,5 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
-import { getTranslations } from 'next-intl/server';
+import { getLocale, getTranslations } from 'next-intl/server';
 import { cache } from 'react';
 
 import { Streamable } from '@/vibes/soul/lib/streamable';
@@ -55,10 +55,12 @@ const getWishlistButtonData = cache(async (productId: number, customerAccessToke
     return null;
   }
 
+  const locale = await getLocale();
   const { data } = await client.fetch({
     document: WishlistButtonQuery,
     variables: { productId, first: wishlistButtonLimit },
     customerAccessToken,
+    locale,
     fetchOptions: { cache: 'no-store', next: { tags: [TAGS.customer] } },
   });
 

--- a/core/app/[locale]/(default)/product/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/product/[slug]/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -154,16 +155,36 @@ const ProductPageMetadataQuery = graphql(`
   }
 `);
 
-export const getProductPageMetadata = cache(
-  async (entityId: number, customerAccessToken?: string) => {
+const getCachedProductPageMetadata = unstable_cache(
+  async (locale: string, entityId: number) => {
     const { data } = await client.fetch({
       document: ProductPageMetadataQuery,
       variables: { entityId },
-      customerAccessToken,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
+      locale,
+      fetchOptions: { cache: 'no-store' },
     });
 
     return data.site.product;
+  },
+  ['product-page-metadata'],
+  { revalidate },
+);
+
+export const getProductPageMetadata = cache(
+  async (locale: string, entityId: number, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const { data } = await client.fetch({
+        document: ProductPageMetadataQuery,
+        variables: { entityId },
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return data.site.product;
+    }
+
+    return getCachedProductPageMetadata(locale, entityId);
   },
 );
 
@@ -200,16 +221,38 @@ const ProductQuery = graphql(
   [ProductOptionsFragment],
 );
 
-export const getProduct = cache(async (entityId: number, customerAccessToken?: string) => {
-  const { data } = await client.fetch({
-    document: ProductQuery,
-    variables: { entityId },
-    customerAccessToken,
-    fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
-  });
+const getCachedProduct = unstable_cache(
+  async (locale: string, entityId: number) => {
+    const { data } = await client.fetch({
+      document: ProductQuery,
+      variables: { entityId },
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return data.site;
-});
+    return data.site;
+  },
+  ['product-data'],
+  { revalidate },
+);
+
+export const getProduct = cache(
+  async (locale: string, entityId: number, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const { data } = await client.fetch({
+        document: ProductQuery,
+        variables: { entityId },
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return data.site;
+    }
+
+    return getCachedProduct(locale, entityId);
+  },
+);
 
 const StreamableProductVariantInventoryBySkuQuery = graphql(`
   query ProductVariantBySkuQuery($productId: Int!, $sku: String!) {
@@ -249,16 +292,36 @@ const StreamableProductVariantInventoryBySkuQuery = graphql(`
 
 type VariantInventoryVariables = VariablesOf<typeof StreamableProductVariantInventoryBySkuQuery>;
 
-export const getStreamableProductVariantInventory = cache(
-  async (variables: VariantInventoryVariables, customerAccessToken?: string) => {
+const getCachedStreamableProductVariantInventory = unstable_cache(
+  async (locale: string, variables: VariantInventoryVariables) => {
     const { data } = await client.fetch({
       document: StreamableProductVariantInventoryBySkuQuery,
       variables,
-      customerAccessToken,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate: 60 } },
+      locale,
+      fetchOptions: { cache: 'no-store' },
     });
 
     return data.site.product?.variants;
+  },
+  ['product-variant-inventory'],
+  { revalidate: 60 },
+);
+
+export const getStreamableProductVariantInventory = cache(
+  async (locale: string, variables: VariantInventoryVariables, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const { data } = await client.fetch({
+        document: StreamableProductVariantInventoryBySkuQuery,
+        variables,
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return data.site.product?.variants;
+    }
+
+    return getCachedStreamableProductVariantInventory(locale, variables);
   },
 );
 
@@ -322,16 +385,36 @@ const StreamableProductQuery = graphql(
 
 type Variables = VariablesOf<typeof StreamableProductQuery>;
 
-export const getStreamableProduct = cache(
-  async (variables: Variables, customerAccessToken?: string) => {
+const getCachedStreamableProduct = unstable_cache(
+  async (locale: string, variables: Variables) => {
     const { data } = await client.fetch({
       document: StreamableProductQuery,
       variables,
-      customerAccessToken,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
+      locale,
+      fetchOptions: { cache: 'no-store' },
     });
 
     return data.site.product;
+  },
+  ['streamable-product'],
+  { revalidate },
+);
+
+export const getStreamableProduct = cache(
+  async (locale: string, variables: Variables, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const { data } = await client.fetch({
+        document: StreamableProductQuery,
+        variables,
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return data.site.product;
+    }
+
+    return getCachedStreamableProduct(locale, variables);
   },
 );
 
@@ -365,16 +448,36 @@ const StreamableProductInventoryQuery = graphql(
 
 type ProductInventoryVariables = VariablesOf<typeof StreamableProductQuery>;
 
-export const getStreamableProductInventory = cache(
-  async (variables: ProductInventoryVariables, customerAccessToken?: string) => {
+const getCachedStreamableProductInventory = unstable_cache(
+  async (locale: string, variables: ProductInventoryVariables) => {
     const { data } = await client.fetch({
       document: StreamableProductInventoryQuery,
       variables,
-      customerAccessToken,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate: 60 } },
+      locale,
+      fetchOptions: { cache: 'no-store' },
     });
 
     return data.site.product;
+  },
+  ['streamable-product-inventory'],
+  { revalidate: 60 },
+);
+
+export const getStreamableProductInventory = cache(
+  async (locale: string, variables: ProductInventoryVariables, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const { data } = await client.fetch({
+        document: StreamableProductInventoryQuery,
+        variables,
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return data.site.product;
+    }
+
+    return getCachedStreamableProductInventory(locale, variables);
   },
 );
 
@@ -409,16 +512,36 @@ const ProductPricingAndRelatedProductsQuery = graphql(
   [PricingFragment, FeaturedProductsCarouselFragment],
 );
 
-export const getProductPricingAndRelatedProducts = cache(
-  async (variables: Variables, customerAccessToken?: string) => {
+const getCachedProductPricingAndRelatedProducts = unstable_cache(
+  async (locale: string, variables: Variables) => {
     const { data } = await client.fetch({
       document: ProductPricingAndRelatedProductsQuery,
       variables,
-      customerAccessToken,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
+      locale,
+      fetchOptions: { cache: 'no-store' },
     });
 
     return data.site.product;
+  },
+  ['product-pricing-related'],
+  { revalidate },
+);
+
+export const getProductPricingAndRelatedProducts = cache(
+  async (locale: string, variables: Variables, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const { data } = await client.fetch({
+        document: ProductPricingAndRelatedProductsQuery,
+        variables,
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return data.site.product;
+    }
+
+    return getCachedProductPricingAndRelatedProducts(locale, variables);
   },
 );
 
@@ -440,12 +563,33 @@ const InventorySettingsQuery = graphql(`
   }
 `);
 
-export const getStreamableInventorySettingsQuery = cache(async (customerAccessToken?: string) => {
-  const { data } = await client.fetch({
-    document: InventorySettingsQuery,
-    customerAccessToken,
-    fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
-  });
+const getCachedInventorySettings = unstable_cache(
+  async (locale: string) => {
+    const { data } = await client.fetch({
+      document: InventorySettingsQuery,
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return data.site.settings?.inventory;
-});
+    return data.site.settings?.inventory;
+  },
+  ['inventory-settings'],
+  { revalidate },
+);
+
+export const getStreamableInventorySettingsQuery = cache(
+  async (locale: string, customerAccessToken?: string) => {
+    if (customerAccessToken) {
+      const { data } = await client.fetch({
+        document: InventorySettingsQuery,
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return data.site.settings?.inventory;
+    }
+
+    return getCachedInventorySettings(locale);
+  },
+);

--- a/core/app/[locale]/(default)/product/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/page.tsx
@@ -45,7 +45,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   const productId = Number(slug);
 
-  const product = await getProductPageMetadata(productId, customerAccessToken);
+  const product = await getProductPageMetadata(locale, productId, customerAccessToken);
 
   if (!product) {
     return notFound();
@@ -78,7 +78,7 @@ export default async function Product({ params, searchParams }: Props) {
   const productId = Number(slug);
 
   const [{ product: baseProduct, settings }, recaptchaSiteKey] = await Promise.all([
-    getProduct(productId, customerAccessToken),
+    getProduct(locale, productId, customerAccessToken),
     getRecaptchaSiteKey(),
   ]);
 
@@ -107,7 +107,7 @@ export default async function Product({ params, searchParams }: Props) {
       useDefaultOptionSelections: true,
     };
 
-    const product = await getStreamableProduct(variables, customerAccessToken);
+    const product = await getStreamableProduct(locale, variables, customerAccessToken);
 
     if (!product) {
       return notFound();
@@ -123,7 +123,7 @@ export default async function Product({ params, searchParams }: Props) {
       entityId: Number(productId),
     };
 
-    const product = await getStreamableProductInventory(variables, customerAccessToken);
+    const product = await getStreamableProductInventory(locale, variables, customerAccessToken);
 
     if (!product) {
       return notFound();
@@ -144,7 +144,11 @@ export default async function Product({ params, searchParams }: Props) {
       sku: product.sku,
     };
 
-    const variants = await getStreamableProductVariantInventory(variables, customerAccessToken);
+    const variants = await getStreamableProductVariantInventory(
+      locale,
+      variables,
+      customerAccessToken,
+    );
 
     if (!variants) {
       return undefined;
@@ -174,7 +178,7 @@ export default async function Product({ params, searchParams }: Props) {
       currencyCode,
     };
 
-    return await getProductPricingAndRelatedProducts(variables, customerAccessToken);
+    return await getProductPricingAndRelatedProducts(locale, variables, customerAccessToken);
   });
 
   const streamablePrices = Streamable.from(async () => {
@@ -242,7 +246,7 @@ export default async function Product({ params, searchParams }: Props) {
   });
 
   const streamableInventorySettings = Streamable.from(async () => {
-    return await getStreamableInventorySettingsQuery(customerAccessToken);
+    return await getStreamableInventorySettingsQuery(locale, customerAccessToken);
   });
 
   const getBackorderAvailabilityPrompt = ({

--- a/core/app/[locale]/(default)/webpages/[id]/contact/_actions/submit-contact-form.ts
+++ b/core/app/[locale]/(default)/webpages/[id]/contact/_actions/submit-contact-form.ts
@@ -88,6 +88,7 @@ export async function submitContactForm<F extends Field>(
     const input = parseContactFormInput(submission.value);
     const response = await client.fetch({
       document: SubmitContactUsMutation,
+      locale,
       variables: {
         input,
         reCaptchaV2:

--- a/core/app/[locale]/(default)/webpages/[id]/contact/page-data.ts
+++ b/core/app/[locale]/(default)/webpages/[id]/contact/page-data.ts
@@ -1,4 +1,5 @@
 import { unstable_cache } from 'next/cache';
+import { getLocale } from 'next-intl/server';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -33,10 +34,11 @@ const ContactPageQuery = graphql(
 type Variables = VariablesOf<typeof ContactPageQuery>;
 
 const getCachedWebpageData = unstable_cache(
-  async (variables: Variables) => {
+  async (variables: Variables, locale: string) => {
     const { data } = await client.fetch({
       document: ContactPageQuery,
       variables,
+      locale,
       fetchOptions: { cache: 'no-store' },
     });
 
@@ -47,5 +49,7 @@ const getCachedWebpageData = unstable_cache(
 );
 
 export const getWebpageData = cache(async (variables: Variables) => {
-  return getCachedWebpageData(variables);
+  const locale = await getLocale();
+
+  return getCachedWebpageData(variables, locale);
 });

--- a/core/app/[locale]/(default)/webpages/[id]/contact/page-data.ts
+++ b/core/app/[locale]/(default)/webpages/[id]/contact/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -31,12 +32,20 @@ const ContactPageQuery = graphql(
 
 type Variables = VariablesOf<typeof ContactPageQuery>;
 
-export const getWebpageData = cache(async (variables: Variables) => {
-  const { data } = await client.fetch({
-    document: ContactPageQuery,
-    variables,
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedWebpageData = unstable_cache(
+  async (variables: Variables) => {
+    const { data } = await client.fetch({
+      document: ContactPageQuery,
+      variables,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return data;
+    return data;
+  },
+  ['contact-webpage-data'],
+  { revalidate },
+);
+
+export const getWebpageData = cache(async (variables: Variables) => {
+  return getCachedWebpageData(variables);
 });

--- a/core/app/[locale]/(default)/webpages/[id]/layout.tsx
+++ b/core/app/[locale]/(default)/webpages/[id]/layout.tsx
@@ -1,6 +1,6 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
 import { unstable_cache } from 'next/cache';
-import { setRequestLocale } from 'next-intl/server';
+import { getLocale, setRequestLocale } from 'next-intl/server';
 import { cache } from 'react';
 
 import { SidebarMenu } from '@/vibes/soul/sections/sidebar-menu';
@@ -47,10 +47,11 @@ interface PageLink {
 }
 
 const getCachedWebPageChildren = unstable_cache(
-  async (id: string): Promise<PageLink[]> => {
+  async (id: string, locale: string): Promise<PageLink[]> => {
     const { data } = await client.fetch({
       document: WebPageChildrenQuery,
       variables: { id: decodeURIComponent(id) },
+      locale,
       fetchOptions: { cache: 'no-store' },
     });
 
@@ -81,7 +82,9 @@ const getCachedWebPageChildren = unstable_cache(
 );
 
 const getWebPageChildren = cache(async (id: string): Promise<PageLink[]> => {
-  return getCachedWebPageChildren(id);
+  const locale = await getLocale();
+
+  return getCachedWebPageChildren(id, locale);
 });
 
 export default async function WebPageLayout({ params, children }: Props) {

--- a/core/app/[locale]/(default)/webpages/[id]/layout.tsx
+++ b/core/app/[locale]/(default)/webpages/[id]/layout.tsx
@@ -1,4 +1,5 @@
 import { removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
+import { unstable_cache } from 'next/cache';
 import { setRequestLocale } from 'next-intl/server';
 import { cache } from 'react';
 
@@ -45,34 +46,42 @@ interface PageLink {
   href: string;
 }
 
+const getCachedWebPageChildren = unstable_cache(
+  async (id: string): Promise<PageLink[]> => {
+    const { data } = await client.fetch({
+      document: WebPageChildrenQuery,
+      variables: { id: decodeURIComponent(id) },
+      fetchOptions: { cache: 'no-store' },
+    });
+
+    if (!data.node) {
+      return [];
+    }
+
+    if (!('children' in data.node)) {
+      return [];
+    }
+
+    const { children } = data.node;
+
+    return removeEdgesAndNodes(children).reduce((acc: PageLink[], child) => {
+      if ('path' in child) {
+        return [...acc, { label: child.name, href: child.path }];
+      }
+
+      if ('link' in child) {
+        return [...acc, { label: child.name, href: child.link }];
+      }
+
+      return acc;
+    }, []);
+  },
+  ['webpage-children'],
+  { revalidate },
+);
+
 const getWebPageChildren = cache(async (id: string): Promise<PageLink[]> => {
-  const { data } = await client.fetch({
-    document: WebPageChildrenQuery,
-    variables: { id: decodeURIComponent(id) },
-    fetchOptions: { next: { revalidate } },
-  });
-
-  if (!data.node) {
-    return [];
-  }
-
-  if (!('children' in data.node)) {
-    return [];
-  }
-
-  const { children } = data.node;
-
-  return removeEdgesAndNodes(children).reduce((acc: PageLink[], child) => {
-    if ('path' in child) {
-      return [...acc, { label: child.name, href: child.path }];
-    }
-
-    if ('link' in child) {
-      return [...acc, { label: child.name, href: child.link }];
-    }
-
-    return acc;
-  }, []);
+  return getCachedWebPageChildren(id);
 });
 
 export default async function WebPageLayout({ params, children }: Props) {

--- a/core/app/[locale]/(default)/webpages/[id]/normal/page-data.ts
+++ b/core/app/[locale]/(default)/webpages/[id]/normal/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -29,12 +30,20 @@ const NormalPageQuery = graphql(
 
 type Variables = VariablesOf<typeof NormalPageQuery>;
 
-export const getWebpageData = cache(async (variables: Variables) => {
-  const { data } = await client.fetch({
-    document: NormalPageQuery,
-    variables,
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedWebpageData = unstable_cache(
+  async (variables: Variables) => {
+    const { data } = await client.fetch({
+      document: NormalPageQuery,
+      variables,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return data;
+    return data;
+  },
+  ['normal-webpage-data'],
+  { revalidate },
+);
+
+export const getWebpageData = cache(async (variables: Variables) => {
+  return getCachedWebpageData(variables);
 });

--- a/core/app/[locale]/(default)/webpages/[id]/normal/page-data.ts
+++ b/core/app/[locale]/(default)/webpages/[id]/normal/page-data.ts
@@ -1,4 +1,5 @@
 import { unstable_cache } from 'next/cache';
+import { getLocale } from 'next-intl/server';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -31,10 +32,11 @@ const NormalPageQuery = graphql(
 type Variables = VariablesOf<typeof NormalPageQuery>;
 
 const getCachedWebpageData = unstable_cache(
-  async (variables: Variables) => {
+  async (variables: Variables, locale: string) => {
     const { data } = await client.fetch({
       document: NormalPageQuery,
       variables,
+      locale,
       fetchOptions: { cache: 'no-store' },
     });
 
@@ -45,5 +47,7 @@ const getCachedWebpageData = unstable_cache(
 );
 
 export const getWebpageData = cache(async (variables: Variables) => {
-  return getCachedWebpageData(variables);
+  const locale = await getLocale();
+
+  return getCachedWebpageData(variables, locale);
 });

--- a/core/app/[locale]/(default)/wishlist/[token]/page-data.ts
+++ b/core/app/[locale]/(default)/wishlist/[token]/page-data.ts
@@ -1,4 +1,5 @@
 import { unstable_cache } from 'next/cache';
+import { getLocale } from 'next-intl/server';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -58,12 +59,14 @@ const getCachedPublicWishlist = unstable_cache(
     limit: number,
     before: string | null | undefined,
     after: string | null | undefined,
-    currencyCode?: CurrencyCode,
+    currencyCode: CurrencyCode | undefined,
+    locale: string,
   ) => {
     const paginationArgs = before ? { last: limit, before } : { first: limit, after };
     const response = await client.fetch({
       document: PublicWishlistQuery,
       variables: { ...paginationArgs, currencyCode, token },
+      locale,
       fetchOptions: { cache: 'no-store' },
     });
 
@@ -82,6 +85,7 @@ const getCachedPublicWishlist = unstable_cache(
 export const getPublicWishlist = cache(async (token: string, pagination: Pagination) => {
   const { before, after, limit = 9 } = pagination;
   const currencyCode = await getPreferredCurrencyCode();
+  const locale = await getLocale();
 
-  return getCachedPublicWishlist(token, limit, before, after, currencyCode);
+  return getCachedPublicWishlist(token, limit, before, after, currencyCode, locale);
 });

--- a/core/app/[locale]/(default)/wishlist/[token]/page-data.ts
+++ b/core/app/[locale]/(default)/wishlist/[token]/page-data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -5,6 +6,7 @@ import { PaginationFragment } from '~/client/fragments/pagination';
 import { graphql } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
 import { TAGS } from '~/client/tags';
+import { CurrencyCode } from '~/components/header/fragment';
 import { ProductCardFragment } from '~/components/product-card/fragment';
 import { WishlistItemFragment } from '~/components/wishlist/fragment';
 import { getPreferredCurrencyCode } from '~/lib/currency';
@@ -50,22 +52,36 @@ interface Pagination {
   after?: string | null;
 }
 
+const getCachedPublicWishlist = unstable_cache(
+  async (
+    token: string,
+    limit: number,
+    before: string | null | undefined,
+    after: string | null | undefined,
+    currencyCode?: CurrencyCode,
+  ) => {
+    const paginationArgs = before ? { last: limit, before } : { first: limit, after };
+    const response = await client.fetch({
+      document: PublicWishlistQuery,
+      variables: { ...paginationArgs, currencyCode, token },
+      fetchOptions: { cache: 'no-store' },
+    });
+
+    const wishlist = response.data.site.publicWishlist;
+
+    if (!wishlist) {
+      return null;
+    }
+
+    return wishlist;
+  },
+  ['public-wishlist'],
+  { revalidate, tags: [TAGS.customer] },
+);
+
 export const getPublicWishlist = cache(async (token: string, pagination: Pagination) => {
   const { before, after, limit = 9 } = pagination;
   const currencyCode = await getPreferredCurrencyCode();
-  const paginationArgs = before ? { last: limit, before } : { first: limit, after };
-  const response = await client.fetch({
-    document: PublicWishlistQuery,
-    variables: { ...paginationArgs, currencyCode, token },
-    // Since the wishlist is public, it's okay that we cache this request
-    fetchOptions: { next: { revalidate, tags: [TAGS.customer] } },
-  });
 
-  const wishlist = response.data.site.publicWishlist;
-
-  if (!wishlist) {
-    return null;
-  }
-
-  return wishlist;
+  return getCachedPublicWishlist(token, limit, before, after, currencyCode);
 });

--- a/core/app/[locale]/layout.tsx
+++ b/core/app/[locale]/layout.tsx
@@ -1,6 +1,7 @@
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import type { Metadata } from 'next';
+import { unstable_cache } from 'next/cache';
 import { notFound } from 'next/navigation';
 import { NextIntlClientProvider } from 'next-intl';
 import { setRequestLocale } from 'next-intl/server';
@@ -53,15 +54,29 @@ const RootLayoutMetadataQuery = graphql(
   [WebAnalyticsFragment, ScriptsFragment],
 );
 
-const fetchRootLayoutMetadata = cache(async () => {
-  return await client.fetch({
-    document: RootLayoutMetadataQuery,
-    fetchOptions: { next: { revalidate } },
-  });
+const getCachedRootLayoutMetadata = unstable_cache(
+  async (locale: string) => {
+    return await client.fetch({
+      document: RootLayoutMetadataQuery,
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
+  },
+  ['root-layout-metadata'],
+  { revalidate },
+);
+
+const fetchRootLayoutMetadata = cache(async (locale: string) => {
+  return getCachedRootLayoutMetadata(locale);
 });
 
-export async function generateMetadata(): Promise<Metadata> {
-  const { data } = await fetchRootLayoutMetadata();
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const { data } = await fetchRootLayoutMetadata(locale);
 
   const storeName = data.site.settings?.storeName ?? '';
 
@@ -119,7 +134,7 @@ interface Props extends PropsWithChildren {
 export default async function RootLayout({ params, children }: Props) {
   const { locale } = await params;
 
-  const rootData = await fetchRootLayoutMetadata();
+  const rootData = await fetchRootLayoutMetadata(locale);
   const toastNotificationCookieData = await getToastNotification();
 
   if (!routing.locales.includes(locale)) {

--- a/core/app/[locale]/maintenance/page.tsx
+++ b/core/app/[locale]/maintenance/page.tsx
@@ -55,6 +55,7 @@ export default async function Maintenance({ params }: Props) {
 
   const { data } = await client.fetch({
     document: MaintenancePageQuery,
+    locale,
   });
 
   const storeSettings = data.site.settings;

--- a/core/app/favicon.ico/route.ts
+++ b/core/app/favicon.ico/route.ts
@@ -28,6 +28,7 @@ export const GET = async () => {
   const { data } = await client.fetch({
     document: GetFaviconQuery,
     channelId: getChannelIdFromLocale(defaultLocale),
+    locale: '',
   });
 
   const faviconUrl = data.site.settings?.faviconUrl;

--- a/core/app/robots.txt/route.ts
+++ b/core/app/robots.txt/route.ts
@@ -44,6 +44,7 @@ export const GET = async () => {
   const { data } = await client.fetch({
     document: RobotsTxtQuery,
     channelId: getChannelIdFromLocale(defaultLocale),
+    locale: '',
     fetchOptions: { cache: 'no-store' }, // disable caching to get the latest robots.txt at build time
   });
 

--- a/core/auth/index.ts
+++ b/core/auth/index.ts
@@ -2,7 +2,7 @@ import { decodeJwt } from 'jose';
 import NextAuth, { type NextAuthConfig, User } from 'next-auth';
 import 'next-auth/jwt';
 import CredentialsProvider from 'next-auth/providers/credentials';
-import { getTranslations } from 'next-intl/server';
+import { getLocale, getTranslations } from 'next-intl/server';
 import { z } from 'zod';
 
 import { anonymousSignIn, clearAnonymousSession } from '~/auth/anonymous-session';
@@ -104,10 +104,12 @@ async function handleLoginCart(guestCartId?: string, loginResultCartId?: string)
 
 async function loginWithPassword(credentials: unknown): Promise<User | null> {
   const { email, password, cartId } = PasswordCredentials.parse(credentials);
+  const locale = await getLocale();
 
   const response = await client.fetch({
     document: LoginMutation,
     variables: { email, password, cartEntityId: cartId },
+    locale,
     fetchOptions: {
       cache: 'no-store',
     },
@@ -137,6 +139,7 @@ async function loginWithPassword(credentials: unknown): Promise<User | null> {
 
 async function loginWithJwt(credentials: unknown): Promise<User | null> {
   const { jwt, cartId } = JwtCredentials.parse(credentials);
+  const locale = await getLocale();
 
   const claims = decodeJwt(jwt);
   const channelId = claims.channel_id?.toString() ?? process.env.BIGCOMMERCE_CHANNEL_ID;
@@ -145,6 +148,7 @@ async function loginWithJwt(credentials: unknown): Promise<User | null> {
     document: LoginWithTokenMutation,
     variables: { jwt, cartEntityId: cartId },
     channelId,
+    locale,
     fetchOptions: {
       cache: 'no-store',
     },
@@ -267,12 +271,14 @@ const config = {
 
       if (customerAccessToken) {
         try {
+          const locale = await getLocale();
           const logoutResponse = await client.fetch({
             document: LogoutMutation,
             variables: {
               cartEntityId,
             },
             customerAccessToken,
+            locale,
             fetchOptions: {
               cache: 'no-store',
             },

--- a/core/client/index.ts
+++ b/core/client/index.ts
@@ -41,11 +41,11 @@ export const client = createClient({
   logger:
     (process.env.NODE_ENV !== 'production' && process.env.CLIENT_LOGGER !== 'false') ||
     process.env.CLIENT_LOGGER === 'true',
-  getChannelId: async (defaultChannelId: string) => {
-    const locale = await getLocale();
+  getChannelId: async (defaultChannelId: string, locale?: string) => {
+    const resolvedLocale = locale ?? (await getLocale());
 
     // We use the default channelId as a fallback, but it is not ideal in some scenarios.
-    return getChannelIdFromLocale(locale) ?? defaultChannelId;
+    return getChannelIdFromLocale(resolvedLocale) ?? defaultChannelId;
   },
   beforeRequest: async (fetchOptions) => {
     // We can't serialize a `Headers` object within this method so we have to opt into using a plain object
@@ -53,12 +53,16 @@ export const client = createClient({
     const locale = await getLocale();
 
     if (fetchOptions?.cache && ['no-store', 'no-cache'].includes(fetchOptions.cache)) {
-      const { headers } = await import('next/headers');
-      const ipAddress = (await headers()).get('X-Forwarded-For');
+      try {
+        const { headers } = await import('next/headers');
+        const ipAddress = (await headers()).get('X-Forwarded-For');
 
-      if (ipAddress) {
-        requestHeaders['X-Forwarded-For'] = ipAddress;
-        requestHeaders['True-Client-IP'] = ipAddress;
+        if (ipAddress) {
+          requestHeaders['X-Forwarded-For'] = ipAddress;
+          requestHeaders['True-Client-IP'] = ipAddress;
+        }
+      } catch {
+        // headers() is unavailable inside unstable_cache / 'use cache' contexts
       }
     }
 

--- a/core/components/footer/index.tsx
+++ b/core/components/footer/index.tsx
@@ -6,7 +6,8 @@ import {
   SiX,
   SiYoutube,
 } from '@icons-pack/react-simple-icons';
-import { getTranslations } from 'next-intl/server';
+import { unstable_cache } from 'next/cache';
+import { getLocale, getTranslations } from 'next-intl/server';
 import { cache, JSX } from 'react';
 
 import { Streamable } from '@/vibes/soul/lib/streamable';
@@ -46,34 +47,63 @@ const socialIcons: Record<string, { icon: JSX.Element }> = {
   YouTube: { icon: <SiYoutube title="YouTube" /> },
 };
 
-const getFooterSections = cache(
-  async (customerAccessToken?: string, currencyCode?: CurrencyCode) => {
+const getCachedFooterSections = unstable_cache(
+  async (locale: string, currencyCode?: CurrencyCode) => {
     const { data: response } = await client.fetch({
       document: GetLinksAndSectionsQuery,
-      customerAccessToken,
       variables: { currencyCode },
-      // Since this query is needed on every page, it's a good idea not to validate the customer access token.
-      // The 'cache' function also caches errors, so we might get caught in a redirect loop if the cache saves an invalid token error response.
+      locale,
       validateCustomerAccessToken: false,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
+      fetchOptions: { cache: 'no-store' },
     });
 
     return readFragment(FooterSectionsFragment, response).site;
   },
+  ['footer-sections'],
+  { revalidate },
 );
 
-const getFooterData = cache(async () => {
-  const { data: response } = await client.fetch({
-    document: LayoutQuery,
-    fetchOptions: { next: { revalidate } },
-  });
+const getFooterSections = cache(
+  async (locale: string, customerAccessToken?: string, currencyCode?: CurrencyCode) => {
+    if (customerAccessToken) {
+      const { data: response } = await client.fetch({
+        document: GetLinksAndSectionsQuery,
+        customerAccessToken,
+        variables: { currencyCode },
+        locale,
+        validateCustomerAccessToken: false,
+        fetchOptions: { cache: 'no-store' },
+      });
 
-  return readFragment(FooterFragment, response).site;
+      return readFragment(FooterSectionsFragment, response).site;
+    }
+
+    return getCachedFooterSections(locale, currencyCode);
+  },
+);
+
+const getCachedFooterData = unstable_cache(
+  async (locale: string) => {
+    const { data: response } = await client.fetch({
+      document: LayoutQuery,
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
+
+    return readFragment(FooterFragment, response).site;
+  },
+  ['footer-data'],
+  { revalidate },
+);
+
+const getFooterData = cache(async (locale: string) => {
+  return getCachedFooterData(locale);
 });
 
 export const Footer = async () => {
   const t = await getTranslations('Components.Footer');
-  const data = await getFooterData();
+  const locale = await getLocale();
+  const data = await getFooterData(locale);
 
   const logo = data.settings ? logoTransformer(data.settings) : '';
 
@@ -96,7 +126,7 @@ export const Footer = async () => {
   const streamableSections = Streamable.from(async () => {
     const customerAccessToken = await getSessionCustomerAccessToken();
     const currencyCode = await getPreferredCurrencyCode();
-    const sectionsData = await getFooterSections(customerAccessToken, currencyCode);
+    const sectionsData = await getFooterSections(locale, customerAccessToken, currencyCode);
 
     return [
       {

--- a/core/components/header/_actions/search.ts
+++ b/core/components/header/_actions/search.ts
@@ -12,6 +12,7 @@ import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
+import { CurrencyCode } from '~/components/header/fragment';
 import { searchResultsTransformer } from '~/data-transformers/search-results-transformer';
 import { getPreferredCurrencyCode } from '~/lib/currency';
 
@@ -87,7 +88,7 @@ export async function search(
   const locale = await getLocale();
 
   const getCachedQuickSearchResults = unstable_cache(
-    async (searchTerm: string, searchCurrencyCode?: string) => {
+    async (searchTerm: string, searchCurrencyCode?: CurrencyCode) => {
       const response = await client.fetch({
         document: GetQuickSearchResultsQuery,
         variables: { filters: { searchTerm }, currencyCode: searchCurrencyCode },

--- a/core/components/header/_actions/search.ts
+++ b/core/components/header/_actions/search.ts
@@ -3,7 +3,8 @@
 import { BigCommerceGQLError, removeEdgesAndNodes } from '@bigcommerce/catalyst-client';
 import { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
-import { getTranslations } from 'next-intl/server';
+import { unstable_cache } from 'next/cache';
+import { getLocale, getTranslations } from 'next-intl/server';
 import { z } from 'zod';
 
 import { SearchResult } from '@/vibes/soul/primitives/navigation';
@@ -83,15 +84,39 @@ export async function search(
 
   const currencyCode = await getPreferredCurrencyCode();
 
-  try {
-    const response = await client.fetch({
-      document: GetQuickSearchResultsQuery,
-      variables: { filters: { searchTerm: submission.value.term }, currencyCode },
-      customerAccessToken,
-      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
-    });
+  const locale = await getLocale();
 
-    const { products } = response.data.site.search.searchProducts;
+  const getCachedQuickSearchResults = unstable_cache(
+    async (searchTerm: string, searchCurrencyCode?: string) => {
+      const response = await client.fetch({
+        document: GetQuickSearchResultsQuery,
+        variables: { filters: { searchTerm }, currencyCode: searchCurrencyCode },
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      return response.data.site.search.searchProducts.products;
+    },
+    ['quick-search-results'],
+    { revalidate },
+  );
+
+  try {
+    let products;
+
+    if (customerAccessToken) {
+      const response = await client.fetch({
+        document: GetQuickSearchResultsQuery,
+        variables: { filters: { searchTerm: submission.value.term }, currencyCode },
+        customerAccessToken,
+        locale,
+        fetchOptions: { cache: 'no-store' },
+      });
+
+      products = response.data.site.search.searchProducts.products;
+    } else {
+      products = await getCachedQuickSearchResults(submission.value.term, currencyCode);
+    }
 
     return {
       lastResult: submission.reply(),

--- a/core/components/header/_actions/switch-currency.ts
+++ b/core/components/header/_actions/switch-currency.ts
@@ -4,7 +4,7 @@ import { BigCommerceGQLError } from '@bigcommerce/catalyst-client';
 import { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
 import { revalidatePath, revalidateTag } from 'next/cache';
-import { getTranslations } from 'next-intl/server';
+import { getLocale, getTranslations } from 'next-intl/server';
 import { z } from 'zod';
 
 import { client } from '~/client';
@@ -35,8 +35,11 @@ const UpdateCartCurrencyMutation = graphql(`
 `);
 
 const updateCartCurrency = async (cartId: string, currencyCode: CurrencyCode) => {
+  const locale = await getLocale();
+
   const result = await client.fetch({
     document: UpdateCartCurrencyMutation,
+    locale,
     variables: { input: { data: { currencyCode }, cartEntityId: cartId } },
   });
   const newCartId = result.data.cart.updateCartCurrency?.cart?.entityId;

--- a/core/components/header/index.tsx
+++ b/core/components/header/index.tsx
@@ -33,10 +33,12 @@ const GetCartCountQuery = graphql(`
 `);
 
 const getCartCount = cache(async (cartId: string, customerAccessToken?: string) => {
+  const locale = await getLocale();
   const response = await client.fetch({
     document: GetCartCountQuery,
     variables: { cartId },
     customerAccessToken,
+    locale,
     fetchOptions: {
       cache: 'no-store',
       next: {

--- a/core/components/header/index.tsx
+++ b/core/components/header/index.tsx
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { getLocale, getTranslations } from 'next-intl/server';
 import { cache } from 'react';
 
@@ -47,34 +48,64 @@ const getCartCount = cache(async (cartId: string, customerAccessToken?: string) 
   return response.data.site.cart?.lineItems.totalQuantity ?? null;
 });
 
-const getHeaderLinks = cache(async (customerAccessToken?: string, currencyCode?: CurrencyCode) => {
-  const { data: response } = await client.fetch({
-    document: GetLinksAndSectionsQuery,
-    customerAccessToken,
-    variables: { currencyCode },
-    // Since this query is needed on every page, it's a good idea not to validate the customer access token.
-    // The 'cache' function also caches errors, so we might get caught in a redirect loop if the cache saves an invalid token error response.
-    validateCustomerAccessToken: false,
-    fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
-  });
+const getCachedHeaderLinks = unstable_cache(
+  async (locale: string, currencyCode?: CurrencyCode) => {
+    const { data: response } = await client.fetch({
+      document: GetLinksAndSectionsQuery,
+      variables: { currencyCode },
+      locale,
+      validateCustomerAccessToken: false,
+      fetchOptions: { cache: 'no-store' },
+    });
 
-  return readFragment(HeaderLinksFragment, response).site;
-});
+    return readFragment(HeaderLinksFragment, response).site;
+  },
+  ['header-links'],
+  { revalidate },
+);
 
-const getHeaderData = cache(async () => {
-  const { data: response } = await client.fetch({
-    document: LayoutQuery,
-    fetchOptions: { next: { revalidate } },
-  });
+const getHeaderLinks = cache(
+  async (locale: string, customerAccessToken?: string, currencyCode?: CurrencyCode) => {
+    if (customerAccessToken) {
+      const { data: response } = await client.fetch({
+        document: GetLinksAndSectionsQuery,
+        customerAccessToken,
+        variables: { currencyCode },
+        locale,
+        validateCustomerAccessToken: false,
+        fetchOptions: { cache: 'no-store' },
+      });
 
-  return readFragment(HeaderFragment, response).site;
+      return readFragment(HeaderLinksFragment, response).site;
+    }
+
+    return getCachedHeaderLinks(locale, currencyCode);
+  },
+);
+
+const getCachedHeaderData = unstable_cache(
+  async (locale: string) => {
+    const { data: response } = await client.fetch({
+      document: LayoutQuery,
+      locale,
+      fetchOptions: { cache: 'no-store' },
+    });
+
+    return readFragment(HeaderFragment, response).site;
+  },
+  ['header-data'],
+  { revalidate },
+);
+
+const getHeaderData = cache(async (locale: string) => {
+  return getCachedHeaderData(locale);
 });
 
 export const Header = async () => {
   const t = await getTranslations('Components.Header');
   const locale = await getLocale();
 
-  const data = await getHeaderData();
+  const data = await getHeaderData(locale);
 
   const logo = data.settings ? logoTransformer(data.settings) : '';
 
@@ -101,7 +132,8 @@ export const Header = async () => {
     ]);
     // const customerAccessToken = await getSessionCustomerAccessToken();
     // const currencyCode = await getPreferredCurrencyCode();
-    const categoryTree = (await getHeaderLinks(customerAccessToken, currencyCode)).categoryTree;
+    const headerLinks = await getHeaderLinks(locale, customerAccessToken, currencyCode);
+    const categoryTree = headerLinks.categoryTree;
 
     /**  To prevent the navigation menu from overflowing, we limit the number of categories to 6.
    To show a full list of categories, modify the `slice` method to remove the limit.
@@ -128,8 +160,8 @@ export const Header = async () => {
       getSessionCustomerAccessToken(),
       getPreferredCurrencyCode(),
     ]);
-    const giftCertificateSettings = (await getHeaderLinks(customerAccessToken, currencyCode))
-      .settings?.giftCertificates;
+    const headerLinksData = await getHeaderLinks(locale, customerAccessToken, currencyCode);
+    const giftCertificateSettings = headerLinksData.settings?.giftCertificates;
 
     return giftCertificateSettings?.isEnabled ?? false;
   });

--- a/core/components/subscribe/_actions/subscribe.ts
+++ b/core/components/subscribe/_actions/subscribe.ts
@@ -3,7 +3,7 @@
 import { BigCommerceGQLError } from '@bigcommerce/catalyst-client';
 import { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
-import { getTranslations } from 'next-intl/server';
+import { getLocale, getTranslations } from 'next-intl/server';
 
 import { schema } from '@/vibes/soul/primitives/inline-email-form/schema';
 import { client } from '~/client';
@@ -35,6 +35,7 @@ export const subscribe = async (
   formData: FormData,
 ) => {
   const t = await getTranslations('Components.Subscribe');
+  const locale = await getLocale();
   const subscribeSchema = schema({
     requiredMessage: t('Errors.emailRequired'),
     invalidMessage: t('Errors.invalidEmail'),
@@ -48,6 +49,7 @@ export const subscribe = async (
   try {
     const response = await client.fetch({
       document: SubscribeToNewsletterMutation,
+      locale,
       variables: {
         input: {
           email: submission.value.email,

--- a/core/lib/analytics/bigcommerce/data-events.ts
+++ b/core/lib/analytics/bigcommerce/data-events.ts
@@ -1,3 +1,5 @@
+import { getLocale } from 'next-intl/server';
+
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
 
@@ -44,11 +46,13 @@ interface ProductViewedEvent {
 }
 
 export async function sendVisitStartedEvent({ initiator, request }: VisitStartedEvent) {
+  const locale = await getLocale();
   const input = { commonInput: preareCommonInput(initiator, request) };
 
   return client.fetch({
     document: VisitStartedMutation,
     variables: { input },
+    locale,
     fetchOptions: { cache: 'no-store' },
   });
 }
@@ -58,6 +62,7 @@ export async function sendProductViewedEvent({
   initiator,
   request,
 }: ProductViewedEvent) {
+  const locale = await getLocale();
   const input = {
     commonInput: preareCommonInput(initiator, request),
     productInput: { productEntityId: Number(productId) },
@@ -66,6 +71,7 @@ export async function sendProductViewedEvent({
   return await client.fetch({
     document: ProductViewedMutation,
     variables: { input },
+    locale,
     fetchOptions: { cache: 'no-store' },
   });
 }

--- a/core/lib/cart/add-cart-line-item.ts
+++ b/core/lib/cart/add-cart-line-item.ts
@@ -1,3 +1,5 @@
+import { getLocale } from 'next-intl/server';
+
 import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
 import { graphql, VariablesOf } from '~/client/graphql';
@@ -22,11 +24,13 @@ export const addCartLineItem = async (
   data: AddCartLineItemsInput['data'],
 ) => {
   const customerAccessToken = await getSessionCustomerAccessToken();
+  const locale = await getLocale();
 
   return await client.fetch({
     document: AddCartLineItemMutation,
     variables: { input: { cartEntityId, data } },
     customerAccessToken,
+    locale,
     fetchOptions: { cache: 'no-store' },
   });
 };

--- a/core/lib/cart/create-cart.ts
+++ b/core/lib/cart/create-cart.ts
@@ -1,3 +1,5 @@
+import { getLocale } from 'next-intl/server';
+
 import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
 import { graphql, VariablesOf } from '~/client/graphql';
@@ -21,6 +23,7 @@ export type CreateCartInput = Variables['createCartInput'];
 export const createCart = async (data: CreateCartInput) => {
   const customerAccessToken = await getSessionCustomerAccessToken();
   const currencyCode = await getPreferredCurrencyCode();
+  const locale = await getLocale();
 
   return await client.fetch({
     document: CreateCartMutation,
@@ -31,6 +34,7 @@ export const createCart = async (data: CreateCartInput) => {
       },
     },
     customerAccessToken,
+    locale,
     fetchOptions: { cache: 'no-store' },
   });
 };

--- a/core/lib/cart/validate-cart.ts
+++ b/core/lib/cart/validate-cart.ts
@@ -1,3 +1,5 @@
+import { getLocale } from 'next-intl/server';
+
 import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
@@ -15,11 +17,13 @@ const ValidateCartQuery = graphql(`
 
 export async function validateCartId(cartId?: string) {
   const customerAccessToken = await getSessionCustomerAccessToken();
+  const locale = await getLocale();
 
   const response = await client.fetch({
     document: ValidateCartQuery,
     variables: { cartId },
     customerAccessToken,
+    locale,
     fetchOptions: {
       cache: 'no-store',
       next: {

--- a/core/lib/recaptcha.ts
+++ b/core/lib/recaptcha.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 
 import { unstable_cache } from 'next/cache';
+import { getLocale } from 'next-intl/server';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -26,9 +27,10 @@ export const ReCaptchaSettingsQuery = graphql(`
 `);
 
 const getCachedReCaptchaSettings = unstable_cache(
-  async (): Promise<ReCaptchaSettings | null> => {
+  async (locale: string): Promise<ReCaptchaSettings | null> => {
     const { data } = await client.fetch({
       document: ReCaptchaSettingsQuery,
+      locale,
       fetchOptions: { cache: 'no-store' },
     });
 
@@ -48,7 +50,9 @@ const getCachedReCaptchaSettings = unstable_cache(
 );
 
 export const getReCaptchaSettings = cache(async (): Promise<ReCaptchaSettings | null> => {
-  return getCachedReCaptchaSettings();
+  const locale = await getLocale();
+
+  return getCachedReCaptchaSettings(locale);
 });
 
 export const getRecaptchaSiteKey = cache(async (): Promise<string | undefined> => {

--- a/core/lib/recaptcha.ts
+++ b/core/lib/recaptcha.ts
@@ -1,5 +1,6 @@
 import 'server-only';
 
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -24,22 +25,30 @@ export const ReCaptchaSettingsQuery = graphql(`
   }
 `);
 
+const getCachedReCaptchaSettings = unstable_cache(
+  async (): Promise<ReCaptchaSettings | null> => {
+    const { data } = await client.fetch({
+      document: ReCaptchaSettingsQuery,
+      fetchOptions: { cache: 'no-store' },
+    });
+
+    const reCaptcha = data.site.settings?.reCaptcha;
+
+    if (!reCaptcha?.siteKey) {
+      return null;
+    }
+
+    return {
+      isEnabledOnStorefront: reCaptcha.isEnabledOnStorefront,
+      siteKey: reCaptcha.siteKey,
+    };
+  },
+  ['recaptcha-settings'],
+  { revalidate },
+);
+
 export const getReCaptchaSettings = cache(async (): Promise<ReCaptchaSettings | null> => {
-  const { data } = await client.fetch({
-    document: ReCaptchaSettingsQuery,
-    fetchOptions: { next: { revalidate } },
-  });
-
-  const reCaptcha = data.site.settings?.reCaptcha;
-
-  if (!reCaptcha?.siteKey) {
-    return null;
-  }
-
-  return {
-    isEnabledOnStorefront: reCaptcha.isEnabledOnStorefront,
-    siteKey: reCaptcha.siteKey,
-  };
+  return getCachedReCaptchaSettings();
 });
 
 export const getRecaptchaSiteKey = cache(async (): Promise<string | undefined> => {

--- a/core/lib/seo/canonical.ts
+++ b/core/lib/seo/canonical.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -45,19 +46,27 @@ const VanityUrlQuery = graphql(`
   }
 `);
 
+const getCachedVanityUrl = unstable_cache(
+  async () => {
+    const { data } = await client.fetch({
+      document: VanityUrlQuery,
+      fetchOptions: { cache: 'no-store' },
+    });
+
+    const vanityUrl = data.site.settings?.url.vanityUrl;
+
+    if (!vanityUrl) {
+      throw new Error('Vanity URL not found in site settings');
+    }
+
+    return vanityUrl;
+  },
+  ['vanity-url'],
+  { revalidate },
+);
+
 const getVanityUrl = cache(async () => {
-  const { data } = await client.fetch({
-    document: VanityUrlQuery,
-    fetchOptions: { next: { revalidate } },
-  });
-
-  const vanityUrl = data.site.settings?.url.vanityUrl;
-
-  if (!vanityUrl) {
-    throw new Error('Vanity URL not found in site settings');
-  }
-
-  return vanityUrl;
+  return getCachedVanityUrl();
 });
 
 export async function getMetadataAlternates(options: CanonicalUrlOptions) {

--- a/core/lib/seo/canonical.ts
+++ b/core/lib/seo/canonical.ts
@@ -1,4 +1,5 @@
 import { unstable_cache } from 'next/cache';
+import { getLocale } from 'next-intl/server';
 import { cache } from 'react';
 
 import { client } from '~/client';
@@ -47,9 +48,10 @@ const VanityUrlQuery = graphql(`
 `);
 
 const getCachedVanityUrl = unstable_cache(
-  async () => {
+  async (locale: string) => {
     const { data } = await client.fetch({
       document: VanityUrlQuery,
+      locale,
       fetchOptions: { cache: 'no-store' },
     });
 
@@ -66,7 +68,9 @@ const getCachedVanityUrl = unstable_cache(
 );
 
 const getVanityUrl = cache(async () => {
-  return getCachedVanityUrl();
+  const locale = await getLocale();
+
+  return getCachedVanityUrl(locale);
 });
 
 export async function getMetadataAlternates(options: CanonicalUrlOptions) {

--- a/core/next.config.ts
+++ b/core/next.config.ts
@@ -32,7 +32,7 @@ const SettingsQuery = graphql(`
 `);
 
 async function writeSettingsToBuildConfig() {
-  const { data } = await client.fetch({ document: SettingsQuery });
+  const { data } = await client.fetch({ document: SettingsQuery, locale: '' });
 
   const cdnEnvHostnames = process.env.NEXT_PUBLIC_BIGCOMMERCE_CDN_HOSTNAME;
 

--- a/core/proxies/with-routes.ts
+++ b/core/proxies/with-routes.ts
@@ -70,6 +70,7 @@ const getRoute = async (path: string, channelId?: string) => {
     variables: { path },
     fetchOptions: { next: { revalidate } },
     channelId,
+    locale: '',
   });
 
   return response.data.site.route;
@@ -90,6 +91,7 @@ const getRawWebPageContent = async (id: string) => {
   const response = await client.fetch({
     document: getRawWebPageContentQuery,
     variables: { id },
+    locale: '',
   });
 
   const node = response.data.node;
@@ -116,6 +118,7 @@ const getStoreStatus = async (channelId?: string) => {
     document: GetStoreStatusQuery,
     fetchOptions: { next: { revalidate: 300 } },
     channelId,
+    locale: '',
   });
 
   return data.site.settings?.status;

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -85,7 +85,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     customerAccessToken?: string;
     fetchOptions?: FetcherRequestInit;
     channelId?: string;
-    locale?: string;
+    locale: string;
     errorPolicy?: GraphQLErrorPolicy;
     validateCustomerAccessToken?: boolean;
   }): Promise<BigCommerceResponse<TResult>>;
@@ -97,7 +97,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     customerAccessToken?: string;
     fetchOptions?: FetcherRequestInit;
     channelId?: string;
-    locale?: string;
+    locale: string;
     errorPolicy?: GraphQLErrorPolicy;
     validateCustomerAccessToken?: boolean;
   }): Promise<BigCommerceResponse<TResult>>;

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -49,7 +49,7 @@ type GraphQLErrorPolicy = 'none' | 'all' | 'auth' | 'ignore';
 class Client<FetcherRequestInit extends RequestInit = RequestInit> {
   private backendUserAgent: string;
   private readonly defaultChannelId: string;
-  private getChannelId: (defaultChannelId: string) => Promise<string> | string;
+  private getChannelId: (defaultChannelId: string, locale?: string) => Promise<string> | string;
   private beforeRequest?: (
     fetchOptions?: FetcherRequestInit,
   ) => Promise<Partial<FetcherRequestInit> | undefined> | Partial<FetcherRequestInit> | undefined;
@@ -85,6 +85,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     customerAccessToken?: string;
     fetchOptions?: FetcherRequestInit;
     channelId?: string;
+    locale?: string;
     errorPolicy?: GraphQLErrorPolicy;
     validateCustomerAccessToken?: boolean;
   }): Promise<BigCommerceResponse<TResult>>;
@@ -96,6 +97,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     customerAccessToken?: string;
     fetchOptions?: FetcherRequestInit;
     channelId?: string;
+    locale?: string;
     errorPolicy?: GraphQLErrorPolicy;
     validateCustomerAccessToken?: boolean;
   }): Promise<BigCommerceResponse<TResult>>;
@@ -106,6 +108,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     customerAccessToken,
     fetchOptions = {} as FetcherRequestInit,
     channelId,
+    locale,
     errorPolicy = 'none',
     validateCustomerAccessToken = true,
   }: {
@@ -114,6 +117,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     customerAccessToken?: string;
     fetchOptions?: FetcherRequestInit;
     channelId?: string;
+    locale?: string;
     errorPolicy?: GraphQLErrorPolicy;
     validateCustomerAccessToken?: boolean;
   }): Promise<BigCommerceResponse<TResult>> {
@@ -126,6 +130,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
       channelId,
       operationInfo.name,
       operationInfo.type,
+      locale,
     );
     const { headers: additionalFetchHeaders = {}, ...additionalFetchOptions } =
       (await this.beforeRequest?.(fetchOptions)) ?? {};
@@ -143,6 +148,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
         ...(this.trustedProxySecret && { 'X-BC-Trusted-Proxy-Secret': this.trustedProxySecret }),
         ...Object.fromEntries(new Headers(additionalFetchHeaders).entries()),
         ...Object.fromEntries(new Headers(headers).entries()),
+        ...(locale && { 'Accept-Language': locale }),
       },
       body: JSON.stringify({
         query,
@@ -210,8 +216,8 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     return response.text();
   }
 
-  private async getCanonicalUrl(channelId?: string) {
-    const resolvedChannelId = channelId ?? (await this.getChannelId(this.defaultChannelId));
+  private async getCanonicalUrl(channelId?: string, locale?: string) {
+    const resolvedChannelId = channelId ?? (await this.getChannelId(this.defaultChannelId, locale));
 
     return `https://store-${this.config.storeHash}-${resolvedChannelId}.${graphqlApiDomain}`;
   }
@@ -220,8 +226,9 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     channelId?: string,
     operationName?: string,
     operationType?: string,
+    locale?: string,
   ) {
-    const baseUrl = new URL(`${await this.getCanonicalUrl(channelId)}/graphql`);
+    const baseUrl = new URL(`${await this.getCanonicalUrl(channelId, locale)}/graphql`);
 
     if (operationName) {
       baseUrl.searchParams.set('operation', operationName);


### PR DESCRIPTION
Linear: [LTRAC-226](https://linear.app/commerce/issue/LTRAC-226/)

## What/Why?

Makes `locale` a required parameter on `client.fetch()` instead of optional. This ensures every fetch call explicitly provides locale for correct channel resolution and `Accept-Language` header, preventing silent fallback failures inside `unstable_cache` where `getLocale()` is unavailable.

67 files updated across server actions, page-data functions, auth, cart utilities, analytics, components, and route handlers. Build-time contexts (`next.config.ts`, `robots.txt`, `favicon.ico`) and proxies pass `''` as locale since no request context is available there.

Final PR in the series splitting #2910. Depends on #2981.

## Rollout/Rollback

Breaking change for `@bigcommerce/catalyst-client` consumers — `locale` is now required on `client.fetch()`. Rollback is a simple revert.

## Testing

- `tsc --noEmit` passes with 0 errors
- `pnpm lint` passes
- All pages load correctly for guest and authenticated users
- Server actions (cart, account, auth, wishlists) function correctly
- Multi-locale storefronts resolve correct channel and language

🤖 Generated with [Claude Code](https://claude.com/claude-code)