### PR TITLE
fix: exclude /brands path and add PLP brands sampling to unlighthouse config

### DIFF
--- a/unlighthouse.config.ts
+++ b/unlighthouse.config.ts
@@ -26,12 +26,16 @@ export default {
       "/early-access/*/*",
       "/digital-test-product/",
       "/blog/\\?tag=*",
+      "/brands/",
     ],
     customSampling: {
       "/smith-journal-13/|/dustpan-brush/|/utility-caddy/|/canvas-laundry-cart/|/laundry-detergent/|/tiered-wire-basket/|/oak-cheese-grater/|/1-l-le-parfait-jar/|/chemex-coffeemaker-3-cup/|/sample-able-brewing-system/|/orbit-terrarium-small/|/orbit-terrarium-large/|/fog-linen-chambray-towel-beige-stripe/|/zz-plant/":
         { name: "PDP" },
       "/shop-all/|/bath/|/garden/|/kitchen/|/publications/|/early-access/": {
-        name: "PLP",
+        name: "PLP categories",
+      },
+      "/brands/sagaform/|/brands/ofs/|/brands/common-good/": {
+        name: "PLP brands",
       },
     },
     // Disable throttling to avoid issues with cold start and cold cache.


### PR DESCRIPTION
Linear: [LTRAC-484](https://linear.app/commerce/issue/LTRAC-484/update-unlighthouseconfigts-to-exclude-brands-and-add-plp-brands)

## What/Why?

The `/brands` path redirects to a not-found page, causing Unlighthouse to audit a non-existent route and produce false negatives. This updates the config to:

- **Exclude `/brands`** from the scanner so it's no longer crawled
- **Add explicit PLP brands pages** (`/brands/sagaform/`, `/brands/ofs/`, `/brands/common-good/`) to `customSampling` so actual brand PLPs are still audited
- **Rename** the existing PLP sampling group to "PLP categories" for clarity

## Testing

- [ ] Run `pnpm unlighthouse-ci` and verify `/brands` is no longer crawled
- [ ] Verify the three brand PLP pages appear in the "PLP brands" sampling group
- [ ] Verify existing PLP category pages still appear under "PLP categories"