### PR TITLE
test(cli): make path assertions OS-agnostic

### DIFF
--- a/packages/catalyst/src/cli/commands/build.spec.ts
+++ b/packages/catalyst/src/cli/commands/build.spec.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import { execa } from 'execa';
+import { join } from 'node:path';
 import { expect, test, vi } from 'vitest';
 
 import { program } from '../program';
@@ -33,7 +34,7 @@ test('calls execa with Next.js build if framework is nextjs', async () => {
   await program.parseAsync(['node', 'catalyst', 'build', '--framework', 'nextjs', '--debug']);
 
   expect(execa).toHaveBeenCalledWith(
-    'node_modules/.bin/next',
+    join('node_modules', '.bin', 'next'),
     ['build', '--debug'],
     expect.objectContaining({
       stdio: 'inherit',

--- a/packages/catalyst/src/cli/commands/dev.spec.ts
+++ b/packages/catalyst/src/cli/commands/dev.spec.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import { execa } from 'execa';
+import { join } from 'node:path';
 import { expect, test, vi } from 'vitest';
 
 import { program } from '../program';
@@ -25,7 +26,7 @@ test('calls execa with Next.js development server', async () => {
   await program.parseAsync(['node', 'catalyst', 'dev', '-p', '3001']);
 
   expect(execa).toHaveBeenCalledWith(
-    'node_modules/.bin/next',
+    join('node_modules', '.bin', 'next'),
     ['dev', '-p', '3001'],
     expect.objectContaining({
       stdio: 'inherit',

--- a/packages/catalyst/src/cli/commands/start.spec.ts
+++ b/packages/catalyst/src/cli/commands/start.spec.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import { execa } from 'execa';
+import { join } from 'node:path';
 import { afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import { consola } from '../lib/logger';
@@ -66,7 +67,7 @@ test('calls execa with Next.js production optimized server', async () => {
   ]);
 
   expect(execa).toHaveBeenCalledWith(
-    'node_modules/.bin/next',
+    join('node_modules', '.bin', 'next'),
     ['start', '--port', '3001'],
     expect.objectContaining({
       stdio: 'inherit',
@@ -93,7 +94,7 @@ test('calls execa with OpenNext production optimized server', async () => {
       'opennextjs-cloudflare',
       'preview',
       '--config',
-      '.bigcommerce/wrangler.jsonc',
+      join('.bigcommerce', 'wrangler.jsonc'),
       '--port',
       '3001',
     ],


### PR DESCRIPTION
Jira: [LTRAC-594](https://linear.app/commerce/issue/LTRAC-594/cli-tests-fail-on-windows-due-to-hardcoded-posix-path-separators)

## What/Why?

`CLI Tests (windows-latest)` started failing on the `Basic` workflow. Four tests in `packages/catalyst/src/cli/commands/{build,dev,start}.spec.ts` assert that execa is invoked with a specific path string, but they hardcoded POSIX separators (`node_modules/.bin/next`, `.bigcommerce/wrangler.jsonc`) while the production code builds those paths with `path.join`, which returns `\`-separated paths on Windows.

The ubuntu and macOS matrix legs still pass because their separator matches. This was latent until the GitHub `windows-latest` runner image rolled from `20260405.77.1` → `20260413.84.1` between 2026-04-14 (last green canary run) and 2026-04-23 (first red PR run) — same CLI source, different observed arg through the Vitest spy.

Fix: build the expected path in the spec via `join(...)` too, so the assertion mirrors production and matches whatever separator the current OS produces.

Surfaced by PR #2989 (LTRAC-578). The failure was not caused by that PR.

## Rollout/Rollback

- Test-only change in `@bigcommerce/catalyst` (which is in the changeset `ignore` list), so no release is cut and no changeset is needed.
- Rollback is a straight revert.

## Testing

- `pnpm --filter @bigcommerce/catalyst test` locally on macOS: all 44 tests pass, including the 4 previously Windows-only failing ones.
- On CI, verify all three `CLI Tests` matrix legs (ubuntu / windows / macos) go green.

Fixes LTRAC-594
Refs LTRAC-578