### PR TITLE
feat(cli): LTRAC-612 show global options in subcommand help

### DIFF
--- a/.changeset/cli-show-env-path-in-help.md
+++ b/.changeset/cli-show-env-path-in-help.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst": patch
+---
+
+Show the global `--env-path` option in every subcommand's `--help` output.

--- a/packages/catalyst/src/cli/commands/auth.ts
+++ b/packages/catalyst/src/cli/commands/auth.ts
@@ -39,6 +39,7 @@ async function fetchStoreProfile(storeHash: string, accessToken: string, apiHost
 }
 
 const whoami = new Command('whoami')
+  .configureHelp({ showGlobalOptions: true })
   .description('Verify stored credentials and display store/project info.')
   .addHelpText(
     'after',
@@ -119,6 +120,7 @@ Example:
   });
 
 const login = new Command('login')
+  .configureHelp({ showGlobalOptions: true })
   .description(
     'Authenticate via browser using the OAuth device code flow. If already logged in, displays current credentials and suggests running `catalyst auth logout` to re-authenticate.',
   )
@@ -204,6 +206,7 @@ Examples:
   });
 
 const logout = new Command('logout')
+  .configureHelp({ showGlobalOptions: true })
   .description('Remove stored credentials for the current project.')
   .addHelpText(
     'after',
@@ -239,6 +242,7 @@ Example:
   });
 
 export const auth = new Command('auth')
+  .configureHelp({ showGlobalOptions: true })
   .description('Manage authentication for the BigCommerce CLI.')
   .addCommand(whoami)
   .addCommand(login)

--- a/packages/catalyst/src/cli/commands/build.ts
+++ b/packages/catalyst/src/cli/commands/build.ts
@@ -76,6 +76,7 @@ export async function buildCatalystProject(projectUuid: string): Promise<void> {
 }
 
 export const build = new Command('build')
+  .configureHelp({ showGlobalOptions: true })
   .description(
     'Build your Catalyst project using the OpenNext/Cloudflare build pipeline. Also runs a Wrangler dry-run to generate deployment artifacts.',
   )

--- a/packages/catalyst/src/cli/commands/deploy.ts
+++ b/packages/catalyst/src/cli/commands/deploy.ts
@@ -369,6 +369,7 @@ export const fetchProject = async (
 };
 
 export const deploy = new Command('deploy')
+  .configureHelp({ showGlobalOptions: true })
   .description('Deploy your application to Cloudflare.')
   .addHelpText(
     'after',

--- a/packages/catalyst/src/cli/commands/logs.ts
+++ b/packages/catalyst/src/cli/commands/logs.ts
@@ -232,6 +232,7 @@ export const tailLogs = async (
 };
 
 const tail = new Command('tail')
+  .configureHelp({ showGlobalOptions: true })
   .description('Tail live logs from your deployed application.')
   .addHelpText(
     'after',
@@ -274,6 +275,7 @@ Examples:
   });
 
 const query = new Command('query')
+  .configureHelp({ showGlobalOptions: true })
   .description('Query historical logs from your deployed application.')
   .addHelpText(
     'after',
@@ -292,6 +294,7 @@ Example:
   });
 
 export const logs = new Command('logs')
+  .configureHelp({ showGlobalOptions: true })
   .description('View logs from your deployed application.')
   .addCommand(tail, { isDefault: true })
   .addCommand(query);

--- a/packages/catalyst/src/cli/commands/project.ts
+++ b/packages/catalyst/src/cli/commands/project.ts
@@ -7,6 +7,7 @@ import { resolveCredentials } from '../lib/resolve-credentials';
 import { getTelemetry } from '../lib/telemetry';
 
 const list = new Command('list')
+  .configureHelp({ showGlobalOptions: true })
   .description('List BigCommerce infrastructure projects for your store.')
   .addHelpText(
     'after',
@@ -59,6 +60,7 @@ Example:
   });
 
 const create = new Command('create')
+  .configureHelp({ showGlobalOptions: true })
   .description(
     'Create a new BigCommerce infrastructure project and link it to your local Catalyst project.',
   )
@@ -110,6 +112,7 @@ Example:
   });
 
 export const link = new Command('link')
+  .configureHelp({ showGlobalOptions: true })
   .description(
     'Link your local Catalyst project to a BigCommerce infrastructure project. You can provide a project UUID directly, or fetch and select from available projects using your store credentials.',
   )
@@ -221,6 +224,7 @@ Examples:
   });
 
 export const project = new Command('project')
+  .configureHelp({ showGlobalOptions: true })
   .description('Manage your BigCommerce infrastructure project.')
   .addCommand(create)
   .addCommand(list)

--- a/packages/catalyst/src/cli/commands/start.ts
+++ b/packages/catalyst/src/cli/commands/start.ts
@@ -6,6 +6,7 @@ import { join, relative } from 'node:path';
 import { consola } from '../lib/logger';
 
 export const start = new Command('start')
+  .configureHelp({ showGlobalOptions: true })
   .description(
     'Start a local preview of your Catalyst storefront using the OpenNext Cloudflare adapter.',
   )

--- a/packages/catalyst/src/cli/commands/telemetry.ts
+++ b/packages/catalyst/src/cli/commands/telemetry.ts
@@ -8,6 +8,7 @@ const telemetryService = getTelemetry();
 let isEnabled = telemetryService.isEnabled();
 
 export const telemetry = new Command('telemetry')
+  .configureHelp({ showGlobalOptions: true })
   .description(
     'View or change CLI telemetry collection status. Enabling telemetry helps BigCommerce support diagnose and troubleshoot errors you encounter when using the CLI.',
   )

--- a/packages/catalyst/src/cli/commands/version.ts
+++ b/packages/catalyst/src/cli/commands/version.ts
@@ -4,6 +4,7 @@ import PACKAGE_INFO from '../../../package.json';
 import { consola } from '../lib/logger';
 
 export const version = new Command('version')
+  .configureHelp({ showGlobalOptions: true })
   .description('Display detailed version information.')
   .addHelpText(
     'after',

--- a/packages/catalyst/src/cli/program.ts
+++ b/packages/catalyst/src/cli/program.ts
@@ -28,6 +28,7 @@ program
   .description(
     'CLI tool for Catalyst development.\n\nConfiguration priority: flags > env file (--env-path) > process.env > .bigcommerce/project.json.\nRun `catalyst <command> --help` for details on a specific command.',
   )
+  .configureHelp({ showGlobalOptions: true })
   .addOption(
     new Option(
       '--env-path <path>',


### PR DESCRIPTION
Jira: [LTRAC-612](https://bigcommercecloud.atlassian.net/browse/LTRAC-612)

## What/Why?

The root-level `--env-path` option (and `-V, --version`) are defined on the root `program` in `packages/catalyst/src/cli/program.ts`, but Commander does not include parent/global options in subcommand `--help` output by default. Running `catalyst deploy --help`, `catalyst auth login --help`, etc. omitted `--env-path` entirely, which made the option feel hidden to users reading per-command help.

This change applies `.configureHelp({ showGlobalOptions: true })` directly at each `Command` definition site (root, every top-level command, and every nested subcommand like `auth login`, `logs tail`, `project create`). Commander's per-command config does not propagate to subcommands automatically, so the setting has to be repeated — an explicit per-command call was chosen over a recursive helper for readability.

Output is unchanged on `catalyst --help`; every subcommand now includes a new `Global Options:` section listing `--env-path` and `-V, --version`.

## Testing

No runtime behavior changes — purely help-text formatting.

- `pnpm typecheck`, `pnpm lint`, and `pnpm test` (131 tests) pass in `packages/catalyst`.
- Manual verification via `node dist/cli.js <cmd> --help`:
  - `catalyst --help` — unchanged, still lists `--env-path` under Options.
  - `catalyst deploy --help`, `build --help`, `start --help`, `version --help`, `telemetry --help`, `logs --help`, `logs tail --help`, `auth --help`, `auth login --help`, `project --help`, `project create --help` — all now render a `Global Options:` section containing `--env-path <path>` and `-V, --version`.

## Migration

None. No public API or behavior change.