### PR TITLE
fix: update create-catalyst client id

### DIFF
--- a/.changeset/hip-ways-complain.md
+++ b/.changeset/hip-ways-complain.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": patch
+---
+
+Update the client id to the new one.

--- a/packages/create-catalyst/src/utils/auth.ts
+++ b/packages/create-catalyst/src/utils/auth.ts
@@ -9,7 +9,7 @@ interface AuthConfig {
 
 export class Auth {
   private client: Https;
-  private readonly DEVICE_OAUTH_CLIENT_ID = 's1q4io7mah2lm1i6uwp9yl1eit80n3b';
+  private readonly DEVICE_OAUTH_CLIENT_ID = 'b8063bu6hhml4e0lqh22yut63atsbyv';
 
   constructor({ baseUrl }: AuthConfig) {
     this.client = new Https({ baseUrl });


### PR DESCRIPTION
## What/Why?
We recently revoked exposed client ids as part of a security incident and this was one of them. Updating to the new client id to get things working again.

## Testing
N/A

## Migration
N/A
