### PR TITLE
LTRAC-444: fix(cli) - Read store hash and access token from project.json

### DIFF
--- a/packages/catalyst/src/cli/commands/logs.spec.ts
+++ b/packages/catalyst/src/cli/commands/logs.spec.ts
@@ -1,15 +1,22 @@
 import { Command } from 'commander';
+import Conf from 'conf';
 import { http, HttpResponse } from 'msw';
-import { afterEach, beforeAll, describe, expect, MockInstance, test, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, MockInstance, test, vi } from 'vitest';
 
 import { server } from '../../../tests/mocks/node';
 import { consola } from '../lib/logger';
+import { mkTempDir } from '../lib/mk-temp-dir';
+import { getProjectConfig, ProjectConfigSchema } from '../lib/project-config';
 import { program } from '../program';
 
 import { logs, parseSSEEvent, tailLogs } from './logs';
 
 let exitMock: MockInstance;
 let stdoutWriteMock: MockInstance;
+
+let tmpDir: string;
+let cleanup: () => Promise<void>;
+let config: Conf<ProjectConfigSchema>;
 
 const projectUuid = '6b202364-10f3-11f1-8bc7-fe9b9d8b14ab';
 const storeHash = 'test-store';
@@ -69,15 +76,28 @@ const callTailLogs = async (format: Parameters<typeof tailLogs>[4], events?: str
   });
 };
 
-beforeAll(() => {
+beforeAll(async () => {
   consola.mockTypes(() => vi.fn());
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   exitMock = vi.spyOn(process, 'exit').mockImplementation(() => null as never);
   stdoutWriteMock = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+  [tmpDir, cleanup] = await mkTempDir();
+
+  vi.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+
+  config = getProjectConfig();
 });
 
 afterEach(() => {
   vi.clearAllMocks();
+  config.delete('storeHash');
+  config.delete('accessToken');
+  config.delete('projectUuid');
+});
+
+afterAll(async () => {
+  await cleanup();
 });
 
 describe('command configuration', () => {
@@ -486,6 +506,39 @@ describe('retry and reconnect', () => {
   });
 });
 
+describe('credential resolution', () => {
+  test('falls back to project.json for storeHash and accessToken', async () => {
+    config.set('storeHash', storeHash);
+    config.set('accessToken', accessToken);
+
+    server.use(createOneShotLogHandler([`data: ${JSON.stringify(validLogEvent)}\n\n`]));
+
+    await program.parseAsync(['node', 'catalyst', 'logs', 'tail', '--project-uuid', projectUuid]);
+
+    expect(consola.info).toHaveBeenCalledWith('Tailing logs...');
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining('hello world'));
+  });
+
+  test('exits with error when no credentials are provided', async () => {
+    const savedStoreHash = process.env.CATALYST_STORE_HASH;
+    const savedAccessToken = process.env.CATALYST_ACCESS_TOKEN;
+
+    delete process.env.CATALYST_STORE_HASH;
+    delete process.env.CATALYST_ACCESS_TOKEN;
+
+    await program.parseAsync(['node', 'catalyst', 'logs', 'tail', '--project-uuid', projectUuid]);
+
+    if (savedStoreHash !== undefined) process.env.CATALYST_STORE_HASH = savedStoreHash;
+    if (savedAccessToken !== undefined) process.env.CATALYST_ACCESS_TOKEN = savedAccessToken;
+
+    expect(consola.error).toHaveBeenCalledWith('Missing credentials.');
+    expect(consola.info).toHaveBeenCalledWith(
+      'Run `catalyst auth login`, or provide --store-hash and --access-token flags (or set CATALYST_STORE_HASH and CATALYST_ACCESS_TOKEN environment variables).',
+    );
+    expect(exitMock).toHaveBeenCalledWith(1);
+  });
+});
+
 describe('query subcommand', () => {
   test('exits with error as not yet implemented', async () => {
     await program.parseAsync([
@@ -500,6 +553,24 @@ describe('query subcommand', () => {
     ]);
 
     expect(consola.error).toHaveBeenCalledWith('The query command is not yet implemented.');
+    expect(exitMock).toHaveBeenCalledWith(1);
+  });
+
+  test('exits with missing credentials error when none are provided', async () => {
+    const savedStoreHash = process.env.CATALYST_STORE_HASH;
+    const savedAccessToken = process.env.CATALYST_ACCESS_TOKEN;
+
+    delete process.env.CATALYST_STORE_HASH;
+    delete process.env.CATALYST_ACCESS_TOKEN;
+
+    await expect(program.parseAsync(['node', 'catalyst', 'logs', 'query'])).rejects.toThrow(
+      'Missing credentials',
+    );
+
+    if (savedStoreHash !== undefined) process.env.CATALYST_STORE_HASH = savedStoreHash;
+    if (savedAccessToken !== undefined) process.env.CATALYST_ACCESS_TOKEN = savedAccessToken;
+
+    expect(consola.error).toHaveBeenCalledWith('Missing credentials.');
     expect(exitMock).toHaveBeenCalledWith(1);
   });
 });

--- a/packages/catalyst/src/cli/commands/logs.ts
+++ b/packages/catalyst/src/cli/commands/logs.ts
@@ -3,6 +3,8 @@ import { colorize } from 'consola/utils';
 import { z } from 'zod';
 
 import { consola } from '../lib/logger';
+import { getProjectConfig } from '../lib/project-config';
+import { resolveCredentials } from '../lib/resolve-credentials';
 import {
   accessTokenOption,
   apiHostOption,
@@ -245,8 +247,8 @@ Examples:
   # Tail logs as raw JSON (useful for piping to other tools)
   $ catalyst logs tail --format json`,
   )
-  .addOption(storeHashOption().makeOptionMandatory())
-  .addOption(accessTokenOption().makeOptionMandatory())
+  .addOption(storeHashOption())
+  .addOption(accessTokenOption())
   .addOption(apiHostOption())
   .addOption(projectUuidOption())
   .addOption(
@@ -256,17 +258,14 @@ Examples:
   )
   .action(async (options) => {
     try {
-      await telemetry.identify(options.storeHash);
+      const config = getProjectConfig();
+      const { storeHash, accessToken } = resolveCredentials(options, config);
+
+      await telemetry.identify(storeHash);
 
       const projectUuid = resolveProjectUuid(options);
 
-      await tailLogs(
-        projectUuid,
-        options.storeHash,
-        options.accessToken,
-        options.apiHost,
-        options.format,
-      );
+      await tailLogs(projectUuid, storeHash, accessToken, options.apiHost, options.format);
     } catch (error) {
       consola.error(error);
       process.exit(1);
@@ -281,12 +280,15 @@ const query = new Command('query')
 Example:
   $ catalyst logs query`,
   )
-  .addOption(storeHashOption().makeOptionMandatory())
-  .addOption(accessTokenOption().makeOptionMandatory())
+  .addOption(storeHashOption())
+  .addOption(accessTokenOption())
   .addOption(apiHostOption())
   .addOption(projectUuidOption())
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  .action((_options) => {
+  .action((options) => {
+    const config = getProjectConfig();
+
+    resolveCredentials(options, config);
+
     consola.error('The query command is not yet implemented.');
     process.exit(1);
   });

--- a/packages/catalyst/src/cli/lib/shared-options.ts
+++ b/packages/catalyst/src/cli/lib/shared-options.ts
@@ -24,7 +24,7 @@ export const projectUuidOption = () =>
   new Option(
     '--project-uuid <uuid>',
     'BigCommerce infrastructure project UUID. Can be found via the BigCommerce API (GET /v3/infrastructure/projects).',
-  ).env('BIGCOMMERCE_PROJECT_UUID');
+  ).env('CATALYST_PROJECT_UUID');
 
 export const resolveProjectUuid = (options: { projectUuid?: string }) => {
   const config = getProjectConfig();

--- a/packages/catalyst/src/cli/lib/shared-options.ts
+++ b/packages/catalyst/src/cli/lib/shared-options.ts
@@ -6,13 +6,13 @@ export const storeHashOption = () =>
   new Option(
     '--store-hash <hash>',
     'BigCommerce store hash. Can be found in the URL of your store Control Panel.',
-  ).env('BIGCOMMERCE_STORE_HASH');
+  ).env('CATALYST_STORE_HASH');
 
 export const accessTokenOption = () =>
   new Option(
     '--access-token <token>',
     'BigCommerce access token. Can be found after creating a store-level API account.',
-  ).env('BIGCOMMERCE_ACCESS_TOKEN');
+  ).env('CATALYST_ACCESS_TOKEN');
 
 export const apiHostOption = () =>
   new Option('--api-host <host>', 'BigCommerce API host. The default is api.bigcommerce.com.')


### PR DESCRIPTION
Jira: [LTRAC-444](https://bigcommercecloud.atlassian.net/browse/LTRAC-444)

## What/Why?

`catalyst logs tail` and `catalyst logs query` previously required `--store-hash` and `--access-token` on every invocation (via `.makeOptionMandatory()`). After running `catalyst project link` / `project create`, those credentials are already persisted to `.bigcommerce/project.json`, but `logs` wasn't reading them.

This switches both subcommands to `resolveCredentials(options, getProjectConfig())` — the same helper used by `project`, `deploy`, and `build` — so flags > `CATALYST_*` env vars > `project.json`.

While here, also migrates the shared `--store-hash` / `--access-token` / `--project-uuid` option helpers in `lib/shared-options.ts` from `BIGCOMMERCE_*` to `CATALYST_*` env var names. This was the env-var fallback the rest of the CLI moved to in the recent ` fix-env-var-names` changeset; `logs` was the last command still on the legacy names.

Note the legacy `BIGCOMMERCE_STORE_HASH` / `BIGCOMMERCE_ACCESS_TOKEN` / `BIGCOMMERCE_PROJECT_UUID` env vars are no longer read by `logs tail` / `logs query`.

Fixes LTRAC-444

## Testing

Unit tests added:
- `falls back to project.json for storeHash and accessToken` — writes credentials to a tmp `project.json` and runs `logs tail` with no flags.
- `exits with error when no credentials are provided` — asserts `Missing credentials.` and `process.exit(1)` for both `tail` and `query`.

Manual verification in a Catalyst project that's already run `catalyst project link`:

- ` catalyst logs tail` (no flags, no env vars) — connects and tails using `project.json` credentials.
- ` catalyst logs tail --store-hash X --access-token Y` — flag values override `project.json`.
- ` CATALYST_STORE_HASH=X CATALYST_ACCESS_TOKEN=Y catalyst logs tail` — env values used.
- In a directory with no `project.json` and no flags/env — fails with the standard `Missing credentials.` message pointing at `catalyst auth login`.

`pnpm --filter @bigcommerce/catalyst test`, `typecheck`, and `lint` all clean.

## Migration

The legacy `BIGCOMMERCE_STORE_HASH` / `BIGCOMMERCE_ACCESS_TOKEN` / `BIGCOMMERCE_PROJECT_UUID` env vars are no longer read by `logs tail` / `logs query`. Anyone relying on them needs to switch to `CATALYST_STORE_HASH` / `CATALYST_ACCESS_TOKEN` / `CATALYST_PROJECT_UUID` (or use `catalyst project link` to persist credentials). All other CLI commands already require the `CATALYST_*` names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)