### PR TITLE
fix(core): TRAC-294 show manual checkout discounts in cart summary

### DIFF
--- a/.changeset/cold-foxes-lie.md
+++ b/.changeset/cold-foxes-lie.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Fix cart summary Discounts row not showing manual discounts applied via the Management Checkout API

--- a/core/app/[locale]/(default)/cart/page-data.ts
+++ b/core/app/[locale]/(default)/cart/page-data.ts
@@ -28,6 +28,10 @@ export const PhysicalItemFragment = graphql(`
       currencyCode
       value
     }
+    discountedAmount {
+      currencyCode
+      value
+    }
     selectedOptions {
       __typename
       entityId
@@ -84,6 +88,10 @@ export const DigitalItemFragment = graphql(`
       value
     }
     salePrice {
+      currencyCode
+      value
+    }
+    discountedAmount {
       currencyCode
       value
     }

--- a/core/app/[locale]/(default)/cart/page.tsx
+++ b/core/app/[locale]/(default)/cart/page.tsx
@@ -213,6 +213,13 @@ export default async function Cart({ params }: Props) {
   const totalCouponDiscount =
     checkout?.coupons.reduce((sum, coupon) => sum + coupon.discountedAmount.value, 0) ?? 0;
 
+  const totalLineItemDiscount = [
+    ...cart.lineItems.physicalItems,
+    ...cart.lineItems.digitalItems,
+  ].reduce((sum, item) => sum + item.discountedAmount.value, 0);
+
+  const totalDiscount = cart.discountedAmount.value + totalLineItemDiscount;
+
   const giftCertificatesSummary =
     checkout?.giftCertificates.reduce<Array<{ code: string; used: number }>>((acc, c) => {
       acc.push({
@@ -278,10 +285,10 @@ export default async function Cart({ params }: Props) {
                   currency: cart.currencyCode,
                 }),
               },
-              cart.discountedAmount.value > 0
+              totalDiscount > 0
                 ? {
                     label: t('CheckoutSummary.discounts'),
-                    value: `-${format.number(cart.discountedAmount.value, {
+                    value: `-${format.number(totalDiscount, {
                       style: 'currency',
                       currency: cart.currencyCode,
                     })}`,


### PR DESCRIPTION
[TRAC-294](https://bigcommercecloud.atlassian.net/browse/TRAC-294)

## What/Why?
The cart’s “Discounts” row previously relied only on `cart.discountedAmount`. Because of that, line item discounts applied via the Management Checkout API directly to the cart weren’t shown in the summary, so customers had no visibility into them.

To fix this, we now account for both sources by adding each line item’s `discountedAmount` to the cart-level discount. This way, the Cart summary accurately reflects what Shoppers see at checkout.

## Testing
Locally, using the following steps:
1. Add item to Cart
2. Apply a manual discount to Line Item using the [Add Checkout Discount](https://docs.bigcommerce.com/developer/api-reference/rest/admin/management/checkouts/discounts/add-checkout-discount) endpoint
3. Verify that Line Item discount is visible

Before fix:

https://github.com/user-attachments/assets/a63e9e06-8fa0-4b7f-bea3-376365da6531

After fix:

https://github.com/user-attachments/assets/364f2ebe-e385-4f47-8932-7f608e0992e5



## Migration
No need


[TRAC-294]: https://bigcommercecloud.atlassian.net/browse/TRAC-294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ