### PR TITLE
fix(core): TRAC-275 align formField.required with field.required for checkbox-group

### DIFF
--- a/.changeset/fix-checkbox-group-required.md
+++ b/.changeset/fix-checkbox-group-required.md
@@ -1,0 +1,6 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Fix `formField.required` mismatch for `checkbox-group` fields in `DynamicForm`. The schema branch was missing `.optional()` for non-required checkbox groups.
+

--- a/core/vibes/soul/form/dynamic-form/schema.ts
+++ b/core/vibes/soul/form/dynamic-form/schema.ts
@@ -298,11 +298,10 @@ function getFieldSchema(
       if (field.required !== true) fieldSchema = fieldSchema.optional();
 
       break;
-
+    
     case 'checkbox-group':
-      fieldSchema = z.string().array();
-
-      if (field.required === true) fieldSchema = fieldSchema.nonempty();
+      fieldSchema =
+        field.required === true ? z.string().array().nonempty() : z.string().array().optional();
 
       break;
 

--- a/core/vibes/soul/form/dynamic-form/schema.ts
+++ b/core/vibes/soul/form/dynamic-form/schema.ts
@@ -298,7 +298,7 @@ function getFieldSchema(
       if (field.required !== true) fieldSchema = fieldSchema.optional();
 
       break;
-    
+
     case 'checkbox-group':
       fieldSchema =
         field.required === true ? z.string().array().nonempty() : z.string().array().optional();

--- a/core/vibes/soul/form/dynamic-form/schema.ts
+++ b/core/vibes/soul/form/dynamic-form/schema.ts
@@ -300,8 +300,13 @@ function getFieldSchema(
       break;
 
     case 'checkbox-group':
-      fieldSchema =
-        field.required === true ? z.string().array().nonempty() : z.string().array().optional();
+      fieldSchema = z.string().array();
+
+      if (field.required === true) {
+        fieldSchema = fieldSchema.nonempty();
+      } else {
+        fieldSchema = fieldSchema.optional();
+      }
 
       break;
 


### PR DESCRIPTION
## What/Why?
The checkbox-group branch in DynamicForm's schema builder does not call .optional() for non-required fields. This causes formField.required = true even when BigCommerce reports isRequired: false, putting field.required and formField.required out of sync for this one field type. No visible UI bug today (the render reads field.required directly), but could cause an issue down the line.

Refs: TRAC-275

## Testing
Logged field.required vs formField.required for each rendered field on /register to verify the fix.

Before:

[DynamicFormField] {
  name: 'customCustomer_Newsletter Topics (O)',
  type: 'checkbox-group',
  label: 'Newsletter Topics (O)',
  'field.required': false,
  'formField.required': true,
  match: false
}

After:

[DynamicFormField] {
  name: 'customCustomer_Newsletter Topics (O)',
  type: 'checkbox-group',
  label: 'Newsletter Topics (O)',
  'field.required': false,
  'formField.required': false,
  match: true
}

Regression-tested the registration page with four custom fields added in the BC control panel. Field labels marked (O) are configured as optional in BC; (R) is configured as required. All rendered and submitted as expected. Screenshot attached.

<img width="819" height="690" alt="Screenshot 2026-05-07 at 4 26 30 PM" src="https://github.com/user-attachments/assets/4beb74cd-5884-4cf6-990f-df0b5a08478b" />

## Migration
No migration required. This was a simple internal bug fix.
