### PR TITLE
build(cli): TRAC-668 bump wrangler to 4.90.0

### DIFF
--- a/packages/catalyst/src/cli/commands/build.ts
+++ b/packages/catalyst/src/cli/commands/build.ts
@@ -9,7 +9,7 @@ import { getProjectConfig } from '../lib/project-config';
 import { getProjectState } from '../lib/project-state';
 import { getWranglerConfig } from '../lib/wrangler-config';
 
-const WRANGLER_VERSION = '4.24.3';
+const WRANGLER_VERSION = '4.90.0';
 
 export async function buildCatalystProject(projectUuid: string): Promise<void> {
   const coreDir = process.cwd();


### PR DESCRIPTION
Jira: [TRAC-668](https://bigcommercecloud.atlassian.net/browse/TRAC-668)

## What/Why?

`wrangler@4.24.3` produces a broken worker bundle for Next.js 16.2.x: the webpack runtime inside `app-page-turbo.runtime.prod.js` fails to initialize at request time with "Cannot read properties of undefined (reading 'require')", returning 500 on every page. `wrangler@4.90.0` bundles it correctly.

This unblocks the Next.js 16.2.x security patches (TRAC-668) from working on native hosting. Once this lands and a new alpha ships, the native-hosting workflow can drop its manual re-bundle workaround.

## Testing

Build a Next.js 16.2.x app with `catalyst build` and confirm pages return 200. The existing native-hosting workflow on `TRAC-668/security-bump-nextjs-react` validates this end-to-end.

## Migration

No migration required.

Refs TRAC-668

[TRAC-668]: https://bigcommercecloud.atlassian.net/browse/TRAC-668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ