### PR TITLE
fix: TRAC-293 Pass customer token through routes and webpages

### DIFF
--- a/.changeset/fix-customer-restricted-routes.md
+++ b/.changeset/fix-customer-restricted-routes.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Pass the customer access token through route resolution and the normal/contact webpage queries so customer-restricted web pages are accessible (and appear in navigation) for authenticated customers. The `with-routes` proxy is now wrapped in `auth()`, and webpage `page-data` queries switch to an uncached fetch when a customer token is present.

--- a/core/app/[locale]/(default)/webpages/[id]/contact/page-data.ts
+++ b/core/app/[locale]/(default)/webpages/[id]/contact/page-data.ts
@@ -31,11 +31,12 @@ const ContactPageQuery = graphql(
 
 type Variables = VariablesOf<typeof ContactPageQuery>;
 
-export const getWebpageData = cache(async (variables: Variables) => {
+export const getWebpageData = cache(async (variables: Variables, customerAccessToken?: string) => {
   const { data } = await client.fetch({
     document: ContactPageQuery,
     variables,
-    fetchOptions: { next: { revalidate } },
+    customerAccessToken,
+    fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
   });
 
   return data;

--- a/core/app/[locale]/(default)/webpages/[id]/contact/page.tsx
+++ b/core/app/[locale]/(default)/webpages/[id]/contact/page.tsx
@@ -8,6 +8,7 @@ import type { Field, FieldGroup } from '@/vibes/soul/form/dynamic-form/schema';
 import { Streamable } from '@/vibes/soul/lib/streamable';
 import { ButtonLink } from '@/vibes/soul/primitives/button-link';
 import { Breadcrumb } from '@/vibes/soul/sections/breadcrumbs';
+import { getSessionCustomerAccessToken } from '~/auth';
 import {
   breadcrumbsTransformer,
   truncateBreadcrumbs,
@@ -41,8 +42,8 @@ const fieldMapping = {
 
 type ContactField = keyof typeof fieldMapping;
 
-const getWebPage = cache(async (id: string): Promise<ContactPage> => {
-  const data = await getWebpageData({ id: decodeURIComponent(id) });
+const getWebPage = cache(async (id: string, customerAccessToken?: string): Promise<ContactPage> => {
+  const data = await getWebpageData({ id: decodeURIComponent(id) }, customerAccessToken);
   const webpage = data.node?.__typename === 'ContactPage' ? data.node : null;
 
   if (!webpage) {
@@ -62,10 +63,13 @@ const getWebPage = cache(async (id: string): Promise<ContactPage> => {
   };
 });
 
-async function getWebPageBreadcrumbs(id: string): Promise<Breadcrumb[]> {
+async function getWebPageBreadcrumbs(
+  id: string,
+  customerAccessToken?: string,
+): Promise<Breadcrumb[]> {
   const t = await getTranslations('WebPages.ContactUs');
 
-  const webpage = await getWebPage(id);
+  const webpage = await getWebPage(id, customerAccessToken);
   const [, ...rest] = webpage.breadcrumbs.reverse();
   const breadcrumbs = [
     {
@@ -82,8 +86,12 @@ async function getWebPageBreadcrumbs(id: string): Promise<Breadcrumb[]> {
   return truncateBreadcrumbs(breadcrumbs, 5);
 }
 
-async function getWebPageWithSuccessContent(id: string, message: string) {
-  const webpage = await getWebPage(id);
+async function getWebPageWithSuccessContent(
+  id: string,
+  message: string,
+  customerAccessToken?: string,
+) {
+  const webpage = await getWebPage(id, customerAccessToken);
 
   return {
     ...webpage,
@@ -91,9 +99,9 @@ async function getWebPageWithSuccessContent(id: string, message: string) {
   };
 }
 
-async function getContactFields(id: string) {
+async function getContactFields(id: string, customerAccessToken?: string) {
   const t = await getTranslations('WebPages.ContactUs.Form');
-  const { entityId, path, contactFields } = await getWebPage(id);
+  const { entityId, path, contactFields } = await getWebPage(id, customerAccessToken);
   const toGroupsOfTwo = (fields: Field[]) =>
     fields.reduce<Array<FieldGroup<Field>>>((acc, _, i) => {
       if (i % 2 === 0) {
@@ -156,7 +164,8 @@ async function getContactFields(id: string) {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id, locale } = await params;
-  const webpage = await getWebPage(id);
+  const customerAccessToken = await getSessionCustomerAccessToken();
+  const webpage = await getWebPage(id, customerAccessToken);
   const { pageTitle, metaDescription, metaKeywords } = webpage.seo;
 
   return {
@@ -172,6 +181,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function ContactPage({ params, searchParams }: Props) {
   const { id, locale } = await params;
   const { success } = await searchParams;
+  const customerAccessToken = await getSessionCustomerAccessToken();
 
   setRequestLocale(locale);
 
@@ -180,8 +190,10 @@ export default async function ContactPage({ params, searchParams }: Props) {
   if (success === 'true') {
     return (
       <WebPageContent
-        breadcrumbs={Streamable.from(() => getWebPageBreadcrumbs(id))}
-        webPage={Streamable.from(() => getWebPageWithSuccessContent(id, t('success')))}
+        breadcrumbs={Streamable.from(() => getWebPageBreadcrumbs(id, customerAccessToken))}
+        webPage={Streamable.from(() =>
+          getWebPageWithSuccessContent(id, t('success'), customerAccessToken),
+        )}
       >
         <ButtonLink
           className="mt-8 @2xl:mt-12 @4xl:mt-16"
@@ -200,13 +212,13 @@ export default async function ContactPage({ params, searchParams }: Props) {
 
   return (
     <WebPageContent
-      breadcrumbs={Streamable.from(() => getWebPageBreadcrumbs(id))}
-      webPage={Streamable.from(() => getWebPage(id))}
+      breadcrumbs={Streamable.from(() => getWebPageBreadcrumbs(id, customerAccessToken))}
+      webPage={Streamable.from(() => getWebPage(id, customerAccessToken))}
     >
       <div className="mt-8 @2xl:mt-12 @4xl:mt-16">
         <DynamicForm
           action={submitContactForm}
-          fields={await getContactFields(id)}
+          fields={await getContactFields(id, customerAccessToken)}
           recaptchaSiteKey={recaptchaSiteKey}
           submitLabel={t('cta')}
         />

--- a/core/app/[locale]/(default)/webpages/[id]/normal/page-data.ts
+++ b/core/app/[locale]/(default)/webpages/[id]/normal/page-data.ts
@@ -29,11 +29,12 @@ const NormalPageQuery = graphql(
 
 type Variables = VariablesOf<typeof NormalPageQuery>;
 
-export const getWebpageData = cache(async (variables: Variables) => {
+export const getWebpageData = cache(async (variables: Variables, customerAccessToken?: string) => {
   const { data } = await client.fetch({
     document: NormalPageQuery,
     variables,
-    fetchOptions: { next: { revalidate } },
+    customerAccessToken,
+    fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
   });
 
   return data;

--- a/core/app/[locale]/(default)/webpages/[id]/normal/page.tsx
+++ b/core/app/[locale]/(default)/webpages/[id]/normal/page.tsx
@@ -5,6 +5,7 @@ import { cache } from 'react';
 
 import { Streamable } from '@/vibes/soul/lib/streamable';
 import { Breadcrumb } from '@/vibes/soul/sections/breadcrumbs';
+import { getSessionCustomerAccessToken } from '~/auth';
 import {
   breadcrumbsTransformer,
   truncateBreadcrumbs,
@@ -19,8 +20,8 @@ interface Props {
   params: Promise<{ locale: string; id: string }>;
 }
 
-const getWebPage = cache(async (id: string): Promise<WebPageData> => {
-  const data = await getWebpageData({ id: decodeURIComponent(id) });
+const getWebPage = cache(async (id: string, customerAccessToken?: string): Promise<WebPageData> => {
+  const data = await getWebpageData({ id: decodeURIComponent(id) }, customerAccessToken);
   const webpage = data.node?.__typename === 'NormalPage' ? data.node : null;
 
   if (!webpage) {
@@ -37,10 +38,13 @@ const getWebPage = cache(async (id: string): Promise<WebPageData> => {
   };
 });
 
-async function getWebPageBreadcrumbs(id: string): Promise<Breadcrumb[]> {
+async function getWebPageBreadcrumbs(
+  id: string,
+  customerAccessToken?: string,
+): Promise<Breadcrumb[]> {
   const t = await getTranslations('WebPages.Normal');
 
-  const webpage = await getWebPage(id);
+  const webpage = await getWebPage(id, customerAccessToken);
   const [, ...rest] = webpage.breadcrumbs.reverse();
   const breadcrumbs = [
     {
@@ -59,7 +63,8 @@ async function getWebPageBreadcrumbs(id: string): Promise<Breadcrumb[]> {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id, locale } = await params;
-  const webpage = await getWebPage(id);
+  const customerAccessToken = await getSessionCustomerAccessToken();
+  const webpage = await getWebPage(id, customerAccessToken);
   const { pageTitle, metaDescription, metaKeywords } = webpage.seo;
 
   // Get the path from the last breadcrumb
@@ -75,13 +80,14 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function WebPage({ params }: Props) {
   const { locale, id } = await params;
+  const customerAccessToken = await getSessionCustomerAccessToken();
 
   setRequestLocale(locale);
 
   return (
     <WebPageContent
-      breadcrumbs={Streamable.from(() => getWebPageBreadcrumbs(id))}
-      webPage={Streamable.from(() => getWebPage(id))}
+      breadcrumbs={Streamable.from(() => getWebPageBreadcrumbs(id, customerAccessToken))}
+      webPage={Streamable.from(() => getWebPage(id, customerAccessToken))}
     />
   );
 }

--- a/core/proxies/with-routes.ts
+++ b/core/proxies/with-routes.ts
@@ -1,6 +1,7 @@
 import { NextFetchEvent, NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 
+import { auth } from '~/auth';
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
@@ -64,10 +65,11 @@ const GetRouteQuery = graphql(`
   }
 `);
 
-const getRoute = async (path: string, channelId?: string) => {
+const getRoute = async (path: string, channelId?: string, customerAccessToken?: string) => {
   const response = await client.fetch({
     document: GetRouteQuery,
     variables: { path },
+    customerAccessToken,
     fetchOptions: { next: { revalidate } },
     channelId,
   });
@@ -86,10 +88,12 @@ const getRawWebPageContentQuery = graphql(`
   }
 `);
 
-const getRawWebPageContent = async (id: string) => {
+const getRawWebPageContent = async (id: string, customerAccessToken?: string) => {
   const response = await client.fetch({
     document: getRawWebPageContentQuery,
     variables: { id },
+    fetchOptions: { next: { revalidate } },
+    customerAccessToken,
   });
 
   const node = response.data.node;
@@ -240,7 +244,11 @@ function normalizeForCompare(url: URL): string {
 const sameInternalUrl = (a: URL, b: URL) =>
   a.origin === b.origin && normalizeForCompare(a) === normalizeForCompare(b);
 
-const getRouteInfo = async (request: NextRequest, event: NextFetchEvent) => {
+const getRouteInfo = async (
+  request: NextRequest,
+  event: NextFetchEvent,
+  customerAccessToken?: string,
+) => {
   const locale = request.headers.get('x-bc-locale') ?? '';
   const channelId = request.headers.get('x-bc-channel-id') ?? '';
 
@@ -261,6 +269,19 @@ const getRouteInfo = async (request: NextRequest, event: NextFetchEvent) => {
       statusCache = await updateStatusCache(channelId, event);
     }
 
+    const parsedStatus = StorefrontStatusCacheSchema.safeParse(statusCache);
+    const status = parsedStatus.success ? parsedStatus.data.status : undefined;
+
+    // The KV route cache is shared across customers and isn't namespaced by
+    // identity. Authenticated requests bypass it entirely so customer-specific
+    // route resolutions can't leak across users in either direction.
+    if (customerAccessToken) {
+      return {
+        route: await getRoute(pathname, channelId, customerAccessToken),
+        status,
+      };
+    }
+
     if (routeCache && routeCache.expiryTime < Date.now()) {
       event.waitUntil(updateRouteCache(pathname, channelId, event));
     } else if (!routeCache) {
@@ -268,11 +289,10 @@ const getRouteInfo = async (request: NextRequest, event: NextFetchEvent) => {
     }
 
     const parsedRoute = RouteCacheSchema.safeParse(routeCache);
-    const parsedStatus = StorefrontStatusCacheSchema.safeParse(statusCache);
 
     return {
       route: parsedRoute.success ? parsedRoute.data.route : undefined,
-      status: parsedStatus.success ? parsedStatus.data.status : undefined,
+      status,
     };
   } catch (error) {
     // eslint-disable-next-line no-console
@@ -286,142 +306,145 @@ const getRouteInfo = async (request: NextRequest, event: NextFetchEvent) => {
 };
 
 export const withRoutes: ProxyFactory = () => {
-  // eslint-disable-next-line complexity
-  return async (request, event) => {
-    const locale = request.headers.get('x-bc-locale') ?? '';
+  return (request, event) =>
+    // eslint-disable-next-line complexity
+    auth(async (req) => {
+      const locale = req.headers.get('x-bc-locale') ?? '';
+      const customerAccessToken = req.auth?.user?.customerAccessToken;
 
-    const { route, status } = await getRouteInfo(request, event);
+      const { route, status } = await getRouteInfo(req, event, customerAccessToken);
 
-    if (status === 'MAINTENANCE') {
-      // 503 status code not working - https://github.com/vercel/next.js/issues/50155
-      return NextResponse.rewrite(new URL(`/${locale}/maintenance`, request.url), { status: 503 });
-    }
+      if (status === 'MAINTENANCE') {
+        // 503 status code not working - https://github.com/vercel/next.js/issues/50155
+        return NextResponse.rewrite(new URL(`/${locale}/maintenance`, req.url), { status: 503 });
+      }
 
-    const redirectConfig = {
-      // Use 301 status code as it is more universally supported by crawlers
-      status: 301,
-      nextConfig: {
-        // Preserve the trailing slash if it was present in the original URL
-        // BigCommerce by default returns the trailing slash.
-        trailingSlash: process.env.TRAILING_SLASH !== 'false',
-      },
-    };
+      const redirectConfig = {
+        // Use 301 status code as it is more universally supported by crawlers
+        status: 301,
+        nextConfig: {
+          // Preserve the trailing slash if it was present in the original URL
+          // BigCommerce by default returns the trailing slash.
+          trailingSlash: process.env.TRAILING_SLASH !== 'false',
+        },
+      };
 
-    if (route?.redirect) {
-      // Only carry over query params if the fromPath does not have any, as Bigcommerce 301 redirects support matching by specific query params.
-      const fromPathSearchParams = new URL(route.redirect.fromPath, request.url).search;
-      const searchParams = fromPathSearchParams.length > 0 ? '' : request.nextUrl.search;
+      if (route?.redirect) {
+        // Only carry over query params if the fromPath does not have any, as Bigcommerce 301 redirects support matching by specific query params.
+        const fromPathSearchParams = new URL(route.redirect.fromPath, req.url).search;
+        const searchParams = fromPathSearchParams.length > 0 ? '' : req.nextUrl.search;
 
-      switch (route.redirect.to.__typename) {
-        case 'BlogPostRedirect':
-        case 'BrandRedirect':
-        case 'CategoryRedirect':
-        case 'PageRedirect':
-        case 'ProductRedirect': {
-          // For dynamic redirects, assume an internal redirect and construct the URL from the path
-          const redirectUrl = new URL(route.redirect.to.path + searchParams, request.url);
+        switch (route.redirect.to.__typename) {
+          case 'BlogPostRedirect':
+          case 'BrandRedirect':
+          case 'CategoryRedirect':
+          case 'PageRedirect':
+          case 'ProductRedirect': {
+            // For dynamic redirects, assume an internal redirect and construct the URL from the path
+            const redirectUrl = new URL(route.redirect.to.path + searchParams, req.url);
 
-          if (sameInternalUrl(request.nextUrl, redirectUrl)) {
-            break;
-          }
-
-          return NextResponse.redirect(redirectUrl, redirectConfig);
-        }
-
-        case 'ManualRedirect': {
-          // For manual redirects, to.url will be a relative path if it is an internal redirect and an absolute URL if it is an external redirect.
-          // URL constructor will correctly handle both cases.
-          // If the manual redirect is an external URL, we should not carry query params.
-          const redirectUrl = new URL(route.redirect.to.url, request.url);
-
-          if (redirectUrl.origin === request.nextUrl.origin) {
-            redirectUrl.search = searchParams;
-
-            if (sameInternalUrl(request.nextUrl, redirectUrl)) {
+            if (sameInternalUrl(req.nextUrl, redirectUrl)) {
               break;
             }
+
+            return NextResponse.redirect(redirectUrl, redirectConfig);
           }
 
-          return NextResponse.redirect(redirectUrl, redirectConfig);
+          case 'ManualRedirect': {
+            // For manual redirects, to.url will be a relative path if it is an internal redirect and an absolute URL if it is an external redirect.
+            // URL constructor will correctly handle both cases.
+            // If the manual redirect is an external URL, we should not carry query params.
+            const redirectUrl = new URL(route.redirect.to.url, req.url);
+
+            if (redirectUrl.origin === req.nextUrl.origin) {
+              redirectUrl.search = searchParams;
+
+              if (sameInternalUrl(req.nextUrl, redirectUrl)) {
+                break;
+              }
+            }
+
+            return NextResponse.redirect(redirectUrl, redirectConfig);
+          }
+
+          default: {
+            // If for some reason the redirect type is not recognized, use the toUrl as a fallback
+            return NextResponse.redirect(route.redirect.toUrl, redirectConfig);
+          }
+        }
+      }
+
+      const node = route?.node;
+      let url: string;
+
+      switch (node?.__typename) {
+        case 'Brand': {
+          url = `/${locale}/brand/${node.entityId}`;
+          break;
+        }
+
+        case 'Category': {
+          url = `/${locale}/category/${node.entityId}`;
+          break;
+        }
+
+        case 'Product': {
+          url = `/${locale}/product/${node.entityId}`;
+
+          const isPrefetch = req.headers.get('Next-Router-Prefetch') === '1';
+          const isRSC = req.headers.get('RSC') === '1';
+
+          if (!isPrefetch && !isRSC) {
+            event.waitUntil(recordProductVisit(req, node.entityId));
+          }
+
+          break;
+        }
+
+        case 'NormalPage': {
+          url = `/${locale}/webpages/${node.id}/normal/`;
+          break;
+        }
+
+        case 'ContactPage': {
+          url = `/${locale}/webpages/${node.id}/contact/`;
+          break;
+        }
+
+        case 'RawHtmlPage': {
+          const { htmlBody } = await getRawWebPageContent(node.id, customerAccessToken);
+
+          return new NextResponse(htmlBody, {
+            headers: { 'content-type': 'text/html' },
+          });
+        }
+
+        case 'Blog': {
+          url = `/${locale}/blog`;
+          break;
+        }
+
+        case 'BlogPost': {
+          url = `/${locale}/blog/${node.entityId}`;
+          break;
         }
 
         default: {
-          // If for some reason the redirect type is not recognized, use the toUrl as a fallback
-          return NextResponse.redirect(route.redirect.toUrl, redirectConfig);
+          const { pathname } = new URL(req.url);
+
+          const cleanPathName = clearLocaleFromPath(pathname, locale);
+
+          url = `/${locale}${cleanPathName}`;
         }
       }
-    }
 
-    const node = route?.node;
-    let url: string;
+      const rewriteUrl = new URL(url, req.url);
 
-    switch (node?.__typename) {
-      case 'Brand': {
-        url = `/${locale}/brand/${node.entityId}`;
-        break;
-      }
+      rewriteUrl.search = req.nextUrl.search;
 
-      case 'Category': {
-        url = `/${locale}/category/${node.entityId}`;
-        break;
-      }
-
-      case 'Product': {
-        url = `/${locale}/product/${node.entityId}`;
-
-        const isPrefetch = request.headers.get('Next-Router-Prefetch') === '1';
-        const isRSC = request.headers.get('RSC') === '1';
-
-        if (!isPrefetch && !isRSC) {
-          event.waitUntil(recordProductVisit(request, node.entityId));
-        }
-
-        break;
-      }
-
-      case 'NormalPage': {
-        url = `/${locale}/webpages/${node.id}/normal/`;
-        break;
-      }
-
-      case 'ContactPage': {
-        url = `/${locale}/webpages/${node.id}/contact/`;
-        break;
-      }
-
-      case 'RawHtmlPage': {
-        const { htmlBody } = await getRawWebPageContent(node.id);
-
-        return new NextResponse(htmlBody, {
-          headers: { 'content-type': 'text/html' },
-        });
-      }
-
-      case 'Blog': {
-        url = `/${locale}/blog`;
-        break;
-      }
-
-      case 'BlogPost': {
-        url = `/${locale}/blog/${node.entityId}`;
-        break;
-      }
-
-      default: {
-        const { pathname } = new URL(request.url);
-
-        const cleanPathName = clearLocaleFromPath(pathname, locale);
-
-        url = `/${locale}${cleanPathName}`;
-      }
-    }
-
-    const rewriteUrl = new URL(url, request.url);
-
-    rewriteUrl.search = request.nextUrl.search;
-
-    return NextResponse.rewrite(rewriteUrl);
-  };
+      return NextResponse.rewrite(rewriteUrl);
+      // @ts-expect-error auth() overload expects middleware return type, but we return NextResponse directly for the proxy
+    })(request, event);
 };
 
 async function recordProductVisit(request: Request, productId: number) {


### PR DESCRIPTION
Jira: [TRAC-293](https://bigcommercecloud.atlassian.net/browse/TRAC-293)

## What/Why?

Customer-only webpages were inaccessible and didn't appear in the navigation when a customer was logged in, because the routes that resolve them (and the webpage queries themselves) were being executed anonymously. The Storefront API correctly hides customer-restricted content when no customer token is present, so authenticated customers saw 404s or missing entries despite having access.

Two layers needed the customer access token plumbed in:

1. **`core/proxies/with-routes.ts`** — the URL-to-entity resolution that runs on every navigation. The handler is now wrapped in `auth()`, and `req.auth?.user?.customerAccessToken` is threaded into `getRoute` and `getRawWebPageContent`. Authenticated requests also bypass the shared KV route cache (its key is `(pathname, channelId)` and isn't namespaced by customer identity, so reading or writing it for a logged-in customer could leak customer-specific resolutions across users). The channel-wide status cache is unaffected, and `getStoreStatus` is intentionally untouched.
2. **Normal + Contact webpage routes** (`app/[locale]/(default)/webpages/[id]/{normal,contact}/`) — `page-data.ts` accepts a `customerAccessToken` and switches `fetchOptions` to `{ cache: 'no-store' }` when authenticated (matching the product page pattern). `page.tsx` resolves the token via `getSessionCustomerAccessToken()` in `generateMetadata` and the page component, then threads it through `getWebPage`, `getWebPageBreadcrumbs`, `getWebPageWithSuccessContent`, and `getContactFields`.

The `no-store` switch on authenticated requests is important: without it, a logged-in customer's response could be served from the shared Next.js fetch cache to subsequent anonymous visitors (or vice versa).

Closes #2325.

## Testing

<img width="1720" height="1369" alt="Screenshot 2026-05-14 at 10 45 21" src="https://github.com/user-attachments/assets/28f35dbb-d2c5-4ffe-898f-5065d8f079ed" />

Setup:
1. In the BC control panel, create a customer group (e.g. "VIP").
2. Assign a customer to the group.
3. Create a web page and restrict its visibility to the "VIP" group.
4. If the page is a child of another page, confirm it shows in the parent's sidebar nav only for VIP members.

Verify:
- **Before the fix:** browsing the page URL as the VIP customer returns 404 and the page does not appear in nav.
- **After the fix:** browsing as the VIP customer renders the page correctly and the page appears in nav.
- Browsing as an anonymous user or non-VIP customer still does not see the page.
- Storefront pages that aren't customer-restricted continue to load identically for both anonymous and authenticated traffic.
- Hit a customer-restricted page anonymously, then again as an authenticated VIP customer (and back), and confirm each request sees its correct view (i.e. the KV cache from one identity is not served to the other).

## Migration

No migration required. No public API surface changed.

Refs TRAC-293

[TRAC-293]: https://bigcommercecloud.atlassian.net/browse/TRAC-293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ