### PR TITLE
feat(core): TRAC-421 consume merchant-configured locale subfolders from BC backend

### DIFF
--- a/.changeset/trac-421-custom-locale-subfolders.md
+++ b/.changeset/trac-421-custom-locale-subfolders.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Consume merchant-configured per-locale URL subfolders from the BigCommerce Storefront GraphQL API (`Locale.path`). The locale that sits at the bare root URL (`/`) is derived from the CP configuration: if the default locale has no path, it sits at root; otherwise, if exactly one non-default locale has no path, that one sits at root; otherwise every locale gets a prefix. Locales with a path use it; locales without a path fall back to their locale code.

--- a/core/build-config/schema.ts
+++ b/core/build-config/schema.ts
@@ -5,6 +5,7 @@ export const buildConfigSchema = z.object({
     z.object({
       code: z.string(),
       isDefault: z.boolean(),
+      path: z.string().nullable(),
     }),
   ),
   urls: z.object({

--- a/core/i18n/locales.ts
+++ b/core/i18n/locales.ts
@@ -1,6 +1,33 @@
 import { buildConfig } from '~/build-config/reader';
 
 const localeNodes = buildConfig.get('locales');
+const defaultLocaleNode = localeNodes.find((locale) => locale.isDefault);
 
 export const locales = localeNodes.map((locale) => locale.code);
-export const defaultLocale = localeNodes.find((locale) => locale.isDefault)?.code ?? 'en';
+export const defaultLocale = defaultLocaleNode?.code ?? 'en';
+
+export const prefixes = localeNodes.reduce<Record<string, `/${string}`>>((acc, locale) => {
+  if (locale.path) acc[locale.code] = `/${locale.path}`;
+
+  return acc;
+}, {});
+
+// The locale that should occupy the bare root URL ("/").
+//
+// Rule:
+//   1. If the default locale has no CP path, default lives at "/".
+//   2. Else, if exactly one non-default locale has no CP path, that one lives at "/".
+//   3. Otherwise, no locale lives at "/" and every locale gets a prefix.
+function computeRootLocale(): string | null {
+  if (!defaultLocaleNode) return defaultLocale;
+  if (!defaultLocaleNode.path) return defaultLocaleNode.code;
+
+  const blankNonDefaults = localeNodes.filter((locale) => !locale.isDefault && !locale.path);
+  const [onlyBlank, ...rest] = blankNonDefaults;
+
+  if (onlyBlank && rest.length === 0) return onlyBlank.code;
+
+  return null;
+}
+
+export const rootLocale = computeRootLocale();

--- a/core/i18n/routing.ts
+++ b/core/i18n/routing.ts
@@ -1,21 +1,28 @@
 import { createNavigation } from 'next-intl/navigation';
 import { defineRouting } from 'next-intl/routing';
 
-import { defaultLocale, locales } from './locales';
+import { defaultLocale, locales, prefixes, rootLocale } from './locales';
 
 enum LocalePrefixes {
   ALWAYS = 'always',
-  // Don't use NEVER as there is a issue that causes cache problems and returns the wrong messages.
+  // Don't use NEVER as there is an issue that causes cache problems and returns the wrong messages.
   // More info: https://github.com/amannn/next-intl/issues/786
   // NEVER = 'never',
   ASNEEDED = 'as-needed', // removes prefix on default locale
 }
 
-const localePrefix = LocalePrefixes.ASNEEDED;
+// `rootLocale` is the locale (if any) that occupies the bare "/" URL. We hand it
+// to next-intl as the routing default so URLs like "/" resolve correctly. When no
+// locale lives at "/", every locale needs a prefix, so we use `always` mode and
+// fall back to the BC default for next-intl's defaultLocale.
+const localePrefix =
+  rootLocale === null
+    ? { mode: LocalePrefixes.ALWAYS, prefixes }
+    : { mode: LocalePrefixes.ASNEEDED, prefixes };
 
 export const routing = defineRouting({
   locales,
-  defaultLocale,
+  defaultLocale: rootLocale ?? defaultLocale,
   localePrefix,
 });
 

--- a/core/lib/seo/canonical.ts
+++ b/core/lib/seo/canonical.ts
@@ -3,7 +3,7 @@ import { cache } from 'react';
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
-import { defaultLocale, locales } from '~/i18n/locales';
+import { defaultLocale, locales, prefixes, rootLocale } from '~/i18n/locales';
 
 interface CanonicalUrlOptions {
   /**
@@ -90,7 +90,10 @@ function buildLocalizedUrl(baseUrl: string, pathname: string, locale: string): s
 
   const url = new URL(pathname, baseUrl);
 
-  url.pathname = locale === defaultLocale ? url.pathname : `/${locale}${url.pathname}`;
+  const prefix = prefixes[locale] ?? `/${locale}`;
+  const skipPrefix = locale === rootLocale;
+
+  url.pathname = skipPrefix ? url.pathname : `${prefix}${url.pathname}`;
 
   if (trailingSlash && !url.pathname.endsWith('/')) {
     url.pathname += '/';

--- a/core/next.config.ts
+++ b/core/next.config.ts
@@ -25,6 +25,7 @@ const SettingsQuery = graphql(`
         locales {
           code
           isDefault
+          path
         }
       }
     }

--- a/core/proxies/with-routes.ts
+++ b/core/proxies/with-routes.ts
@@ -5,6 +5,7 @@ import { auth } from '~/auth';
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
+import { prefixes } from '~/i18n/locales';
 import { getVisitIdCookie, getVisitorIdCookie } from '~/lib/analytics/bigcommerce';
 import { sendProductViewedEvent } from '~/lib/analytics/bigcommerce/data-events';
 import { kvKey, STORE_STATUS_KEY } from '~/lib/kv/keys';
@@ -218,12 +219,14 @@ const updateStatusCache = async (
 };
 
 const clearLocaleFromPath = (path: string, locale: string) => {
-  if (path === `/${locale}` || path === `/${locale}/`) {
+  const prefix = prefixes[locale] ?? `/${locale}`;
+
+  if (path === prefix || path === `${prefix}/`) {
     return '/';
   }
 
-  if (path.startsWith(`/${locale}/`)) {
-    return path.replace(`/${locale}`, '');
+  if (path.startsWith(`${prefix}/`)) {
+    return path.replace(prefix, '');
   }
 
   return path;


### PR DESCRIPTION
## What / Why

[PROJECT-5002](https://bigcommercecloud.atlassian.net/browse/PROJECT-5002) added merchant-configurable per-locale URL subfolders in the BC Control Panel — e.g., `fr-CA` can be served at `/fr/` instead of `/fr-CA/`. The Storefront GraphQL API exposes this as `Locale.fullPath`.

This PR teaches Catalyst to use that configured subfolder for URL routing, while keeping the locale code for translations, `<html lang>`, `Accept-Language`, and BC content negotiation.

## JIRA
[TRAC-421](https://bigcommercecloud.atlassian.net/browse/TRAC-421)

## Testing

Tested 5 cases in Integration.

Case 1 — No custom subfolders (legacy)

{locale = fr, isDefault=true, path=""}
{locale = es-es, isDefault=false, path=""}
{locale = es-mx, isDefault=false, path=""}
{locale = uk, isDefault=false, path=""}

Expected URLs:

site.com/               <-- fr locale
site.com/es-es/    <-- es-es locale
site.com/es-mx/   <-- es-mx locale
site.com/uk/          <-- uk locale

- [x] Tested

Case 2 — One non-default has a subfolder

{locale = fr, isDefault=true, path="" }
{locale = es-es, isDefault=false, path="es"}
{locale = es-mx, isDefault=false, path=""}
{locale = uk, isDefault=false, path=""}

Expected URLs:

site.com/               <-- fr locale
site.com/es/          <-- es-es locale
site.com/es-mx/   <-- es-mx locale
site.com/uk/          <-- uk locale

- [x] Tested

Case 3 — Default and one non-default have subfolders

{locale = fr, isDefault=true, path="fr" }
{locale = es-es, isDefault=false, path="es"}
{locale = es-mx, isDefault=false, path=""}
{locale = uk,    isDefault=false, path=""}

Expected URLs:

site.com/fr/           <-- fr locale
site.com/es/          <-- es-es locale
site.com/es-mx/   <-- es-mx locale
site.com/uk/          <-- uk locale

Note: nobody lives at bare /. Hitting site.com/ redirects to site.com/fr/.

- [x] Tested

Case 4 — Every non-default has a subfolder, default blank

{locale = fr, isDefault=true, path="" }
{locale = es-es, isDefault=false, path="es"}
{locale = es-mx, isDefault=false, path="mx"}
{locale = uk,    isDefault=false, path="uk"}

Expected URLs:

site.com/                 <-- fr locale
site.com/es/            <-- es-es locale
site.com/mx/           <-- es-mx locale
site.com/uk/            <-- uk locale

- [x] Tested

Case 5 — Default has a path, one non-default left blank

{locale = fr, isDefault=true, path="fr" }
{locale = es-es, isDefault=false, path="es"}
{locale = es-mx, isDefault=false, path="ex-mx"}
{locale = uk,    isDefault=false, path=""}

- [x] Tested

site.com/fr/             <-- fr locale
site.com/es/            <-- es-mx locale
site.com/es-mx/     <-- es-mx locale
site.com/                 <-- uk locale

- [x] Tested

## Migration
None needed.

[PROJECT-5002]: https://bigcommercecloud.atlassian.net/browse/PROJECT-5002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TRAC-421]: https://bigcommercecloud.atlassian.net/browse/TRAC-421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ