### PR TITLE
TRAC-525: fix - client.ts not using `Header` object for default values

### DIFF
--- a/.changeset/fresh-steaks-remain.md
+++ b/.changeset/fresh-steaks-remain.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-client": patch
+---
+
+Fix `client.fetch` so that custom headers passed via `fetchOptions.headers` properly override the client's default headers (including `Authorization`). Previously the merge produced two distinct keys (e.g. `Authorization` and `authorization`) in a plain object, which `fetch` then `append`ed into a comma-joined value. Headers are now built via a `Headers` object using `.set()`, so case-insensitive overrides work as expected.

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -130,20 +130,36 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     const { headers: additionalFetchHeaders = {}, ...additionalFetchOptions } =
       (await this.beforeRequest?.(fetchOptions)) ?? {};
 
+    // Build headers via a Headers object so that case-insensitive overrides work as expected.
+    const requestHeaders = new Headers({
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${this.config.storefrontToken}`,
+      'User-Agent': this.backendUserAgent,
+    });
+
+    if (customerAccessToken) {
+      requestHeaders.set('X-Bc-Customer-Access-Token', customerAccessToken);
+    }
+
+    if (validateCustomerAccessToken) {
+      requestHeaders.set('X-Bc-Error-On-Invalid-Customer-Access-Token', 'true');
+    }
+
+    if (this.trustedProxySecret) {
+      requestHeaders.set('X-BC-Trusted-Proxy-Secret', this.trustedProxySecret);
+    }
+
+    new Headers(additionalFetchHeaders).forEach((value, key) => {
+      requestHeaders.set(key, value);
+    });
+
+    new Headers(headers).forEach((value, key) => {
+      requestHeaders.set(key, value);
+    });
+
     const response = await fetch(graphqlUrl, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${this.config.storefrontToken}`,
-        'User-Agent': this.backendUserAgent,
-        ...(customerAccessToken && { 'X-Bc-Customer-Access-Token': customerAccessToken }),
-        ...(validateCustomerAccessToken && {
-          'X-Bc-Error-On-Invalid-Customer-Access-Token': 'true',
-        }),
-        ...(this.trustedProxySecret && { 'X-BC-Trusted-Proxy-Secret': this.trustedProxySecret }),
-        ...Object.fromEntries(new Headers(additionalFetchHeaders).entries()),
-        ...Object.fromEntries(new Headers(headers).entries()),
-      },
+      headers: requestHeaders,
       body: JSON.stringify({
         query,
         ...(variables && { variables }),


### PR DESCRIPTION
## What/Why?
<!--- 
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
--->
Spreading plain object literals into the `fetch` `headers` field left case-variant keys (e.g. `Authorization` and `authorization`) as distinct properties, which `fetch` then appended together into a single comma-joined value. Build the header set with a `Headers` object so overrides from `beforeRequest` and per-call `headers` replace the defaults instead of duplicating them.

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->
Tested manually. Previously, passing in a header with `Authorization` would append the key to the `authorization` header rather than replacing it.

## Migration
<!---
  If you have moved any files around, or made any breaking changes,
  please provide a migration guide for the developers to make rebases easier.
--->
No migration needed.
