### PR TITLE
refactor(core): use safeParse for consent cookie validation

### DIFF
--- a/core/lib/consent-manager/cookies/client.ts
+++ b/core/lib/consent-manager/cookies/client.ts
@@ -16,11 +16,7 @@ export const getConsentCookie = () => {
 
   if (!cookie) return null;
 
-  try {
-    const consent = parseCompactFormat(cookie);
+  const result = ConsentCookieSchema.safeParse(parseCompactFormat(cookie));
 
-    return ConsentCookieSchema.parse(consent);
-  } catch {
-    return null;
-  }
+  return result.success ? result.data : null;
 };

--- a/core/lib/consent-manager/cookies/server.ts
+++ b/core/lib/consent-manager/cookies/server.ts
@@ -11,11 +11,7 @@ export const getConsentCookie = async () => {
 
   if (!cookie) return null;
 
-  try {
-    const consent = parseCompactFormat(cookie);
+  const result = ConsentCookieSchema.safeParse(parseCompactFormat(cookie));
 
-    return ConsentCookieSchema.parse(consent);
-  } catch {
-    return null;
-  }
+  return result.success ? result.data : null;
 };


### PR DESCRIPTION
## Summary
- Replace try/catch around `ConsentCookieSchema.parse` with `.safeParse()` in `core/lib/consent-manager/cookies/client.ts` and `server.ts`
- Cookies are graceful-failure territory; `.safeParse()` expresses that intent more directly than wrapping a throwing parse in try/catch
- No behavior change: both still return `null` when the cookie is missing or fails validation

## Test plan
- [x] `pnpm exec tsc --noEmit lib/consent-manager/cookies/client.ts lib/consent-manager/cookies/server.ts` passes
- [x] `pnpm exec eslint lib/consent-manager/cookies/client.ts lib/consent-manager/cookies/server.ts --max-warnings 0` passes
- [ ] Manual: verify consent cookie still parses correctly on client and server