### PR TITLE
fix(catalyst): TRAC-279 default brand PLP sort to featured

### DIFF
--- a/.changeset/fix-brand-plp-sort.md
+++ b/.changeset/fix-brand-plp-sort.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Default brand PLP sort to `featured` to honor the merchant's product sort order.

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
@@ -116,12 +116,14 @@ export default async function Brand(props: Props) {
 
     const loadSearchParams = await createBrandSearchParamsLoader(slug, customerAccessToken);
     const parsedSearchParams = loadSearchParams?.(searchParams) ?? {};
+    const sort = typeof searchParams.sort === 'string' ? searchParams.sort : 'featured';
 
     const search = await fetchFacetedSearch(
       {
         ...searchParams,
         ...parsedSearchParams,
         brand: [slug],
+        sort,
       },
       currencyCode,
       customerAccessToken,


### PR DESCRIPTION
## JIRA
[TRAC-279](https://bigcommercecloud.atlassian.net/browse/TRAC-279)

## What / Why
Brand pages weren't showing products in the order the merchant set in the
Control Panel.

Catalyst wasn't telling the backend which sort to use when a shopper landed
on a brand page without picking one. The backend then fell back to its own
default, which doesn't honor the merchant's chosen order. Asking for
"featured" explicitly fixes this and matches the sort dropdown's default
selection.

## Rollout / Rollback
No flag. Backwards compatible: the new default only applies when no `?sort=` param is set, so any existing URL with a sort param is unaffected. Rollback is reverting the single line.

## Testing
Tested in catalyst store. The first screenshot is featured items all with sort = 0. The second screenshot is featured items where Spray Bottle was assigned 1, Snake Plant was assigned -1, and ZZ Plant was left at 0.

<img width="813" height="461" alt="Screenshot 2026-05-20 at 1 40 35 PM" src="https://github.com/user-attachments/assets/f019daa2-394a-4e16-9113-850b86877229" />

<img width="805" height="457" alt="Screenshot 2026-05-20 at 2 15 41 PM" src="https://github.com/user-attachments/assets/91f7ef8f-26aa-4ab0-b340-2207e3e9e4d8" />

:robot: Generated with [Claude Code](https://claude.com/claude-code)

[TRAC-279]: https://bigcommercecloud.atlassian.net/browse/TRAC-279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ