### PR TITLE
feat(core): TRAC-188 out-of-the-box inclusive and exclusive tax price display

### DIFF
--- a/.changeset/trac-188-tax-display.md
+++ b/.changeset/trac-188-tax-display.md
@@ -6,11 +6,4 @@ Honor the merchant's Tax Display setting (`Inc.`, `Ex.`, or `Both`) from the Big
 
 ## Migration
 
-For forks that can't rebase cleanly:
-
-- **`PricingFragment`**: bare `prices(currencyCode)` replaced with two aliased fields, `pricesIncludingTax` and `pricesExcludingTax`. Update any direct reads of `product.prices`.
-- **Settings queries**: add `tax { pdp }` (PDP) or `tax { plp }` (every other surface) to each page-data query's `settings` selection.
-- **`pricesTransformer`** signature now `(pricing, format, taxDisplay)` and outputs a new shape with a `mode` field. The `Price` union added `Money` and `PricePlain`. Forks importing `Price` directly need updates.
-- **Page handlers**: read the relevant `settings.tax.<surface>` and pass to `productCardTransformer` / `pricesTransformer`.
-- **Analytics + SEO**: new helper at `core/lib/tax-pricing.ts`. Wire to `product-viewed`, `product-schema`, `category-viewed`, wishlist pages, compare page.
-- **Translations**: four new keys in `core/messages/en.json` under `Components.Price`: `includingTax`, `excludingTax`, `includingTaxFull`, `excludingTaxFull`.
+For forks that can't rebase cleanly: pricing was refactored end-to-end to support inc/ex tax variants and a `Both` mode (`PricingFragment`, `pricesTransformer`, `Price` types, page-data settings queries, analytics helpers). See PR #3024 for the full diff.

--- a/.changeset/trac-188-tax-display.md
+++ b/.changeset/trac-188-tax-display.md
@@ -1,0 +1,16 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Honor the merchant's Tax Display setting (`Inc.`, `Ex.`, or `Both`) from the BigCommerce control panel across PDP, PLP, search, compare, and home. When set to `Both`, prices render stacked with `(Inc. Tax)` and `(Ex. Tax)` labels, including sale strike-throughs per line.
+
+## Migration
+
+For forks that can't rebase cleanly:
+
+- **`PricingFragment`**: bare `prices(currencyCode)` replaced with two aliased fields, `pricesIncludingTax` and `pricesExcludingTax`. Update any direct reads of `product.prices`.
+- **Settings queries**: add `tax { pdp }` (PDP) or `tax { plp }` (every other surface) to each page-data query's `settings` selection.
+- **`pricesTransformer`** signature now `(pricing, format, taxDisplay)` and outputs a new shape with a `mode` field. The `Price` union added `Money` and `PricePlain`. Forks importing `Price` directly need updates.
+- **Page handlers**: read the relevant `settings.tax.<surface>` and pass to `productCardTransformer` / `pricesTransformer`.
+- **Analytics + SEO**: new helper at `core/lib/tax-pricing.ts`. Wire to `product-viewed`, `product-schema`, `category-viewed`, wishlist pages, compare page.
+- **Translations**: four new keys in `core/messages/en.json` under `Components.Price`: `includingTax`, `excludingTax`, `includingTaxFull`, `excludingTaxFull`.

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page-data.ts
@@ -33,6 +33,9 @@ const BrandPageQuery = graphql(`
         reviews {
           enabled
         }
+        tax {
+          plp
+        }
       }
     }
   }

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
@@ -110,6 +110,8 @@ export default async function Brand(props: Props) {
   const productComparisonsEnabled =
     settings?.storefront.catalog?.productComparisonsEnabled ?? false;
 
+  const taxDisplay = settings?.tax?.plp;
+
   const streamableFacetedSearch = Streamable.from(async () => {
     const searchParams = await props.searchParams;
     const currencyCode = await getPreferredCurrencyCode();
@@ -146,6 +148,7 @@ export default async function Brand(props: Props) {
       format,
       showOutOfStockMessage ? defaultOutOfStockMessage : undefined,
       showBackorderMessage,
+      taxDisplay,
     );
   });
 

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/_components/category-viewed.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/_components/category-viewed.tsx
@@ -5,7 +5,9 @@ import { useEffect, useRef } from 'react';
 
 import { FragmentOf } from '~/client/graphql';
 import { ProductCardFragment } from '~/components/product-card/fragment';
+import { TaxDisplay } from '~/data-transformers/prices-transformer';
 import { useAnalytics } from '~/lib/analytics/react';
+import { pickPricesForTaxDisplay } from '~/lib/tax-pricing';
 
 import { getCategoryPageData } from '../page-data';
 
@@ -15,9 +17,10 @@ type productSearchItem = FragmentOf<typeof ProductCardFragment>;
 interface Props {
   category: NonNullable<Category>;
   products: productSearchItem[];
+  taxDisplay?: TaxDisplay | null;
 }
 
-export const CategoryViewed = ({ category, products }: Props) => {
+export const CategoryViewed = ({ category, products, taxDisplay }: Props) => {
   const isMounted = useRef(false);
   const analytics = useAnalytics();
 
@@ -28,21 +31,27 @@ export const CategoryViewed = ({ category, products }: Props) => {
 
     isMounted.current = true;
 
+    const firstProductPrices = products[0]
+      ? pickPricesForTaxDisplay(products[0], taxDisplay)
+      : undefined;
+
     analytics?.navigation.categoryViewed({
       id: category.entityId,
       name: category.name,
-      currency: products[0]?.prices?.price.currencyCode || 'USD',
+      currency: firstProductPrices?.price.currencyCode || 'USD',
       items: products.map((p) => {
+        const prices = pickPricesForTaxDisplay(p, taxDisplay);
+
         return {
           id: p.entityId.toString(),
           name: p.name,
           brand: p.brand?.name,
-          price: p.prices?.price.value,
+          price: prices?.price.value,
           categories: removeEdgesAndNodes(category.breadcrumbs).map(({ name }) => name),
         };
       }),
     });
-  }, [analytics, category, products]);
+  }, [analytics, category, products, taxDisplay]);
 
   return null;
 };

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page-data.ts
@@ -51,6 +51,9 @@ const CategoryPageQuery = graphql(
           reviews {
             enabled
           }
+          tax {
+            plp
+          }
         }
       }
     }

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -125,6 +125,8 @@ export default async function Category(props: Props) {
   const productComparisonsEnabled =
     settings?.storefront.catalog?.productComparisonsEnabled ?? false;
 
+  const taxDisplay = settings?.tax?.plp;
+
   const streamableFacetedSearch = Streamable.from(async () => {
     const searchParams = await props.searchParams;
     const currencyCode = await getPreferredCurrencyCode();
@@ -162,6 +164,7 @@ export default async function Category(props: Props) {
       format,
       showOutOfStockMessage ? defaultOutOfStockMessage : undefined,
       showBackorderMessage,
+      taxDisplay,
     );
   });
 
@@ -284,7 +287,13 @@ export default async function Category(props: Props) {
         totalCount={streamableTotalCount}
       />
       <Stream value={streamableFacetedSearch}>
-        {(search) => <CategoryViewed category={category} products={search.products.items} />}
+        {(search) => (
+          <CategoryViewed
+            category={category}
+            products={search.products.items}
+            taxDisplay={taxDisplay}
+          />
+        )}
       </Stream>
     </>
   );

--- a/core/app/[locale]/(default)/(faceted)/search/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/search/page-data.ts
@@ -24,6 +24,9 @@ const SearchPageQuery = graphql(`
         reviews {
           enabled
         }
+        tax {
+          plp
+        }
       }
     }
   }

--- a/core/app/[locale]/(default)/(faceted)/search/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/search/page.tsx
@@ -83,6 +83,8 @@ export default async function Search(props: Props) {
   const productComparisonsEnabled =
     settings?.storefront.catalog?.productComparisonsEnabled ?? false;
 
+  const taxDisplay = settings?.tax?.plp;
+
   const streamableFacetedSearch = Streamable.from(async () => {
     const searchParams = await props.searchParams;
     const customerAccessToken = await getSessionCustomerAccessToken();
@@ -127,6 +129,7 @@ export default async function Search(props: Props) {
       format,
       showOutOfStockMessage ? defaultOutOfStockMessage : undefined,
       showBackorderMessage,
+      taxDisplay,
     );
   });
 

--- a/core/app/[locale]/(default)/account/wishlists/[id]/page-data.ts
+++ b/core/app/[locale]/(default)/account/wishlists/[id]/page-data.ts
@@ -26,6 +26,13 @@ const WishlistDetailsQuery = graphql(
           }
         }
       }
+      site {
+        settings {
+          tax {
+            plp
+          }
+        }
+      }
     }
   `,
   [WishlistPaginatedItemsFragment],
@@ -55,5 +62,5 @@ export const getCustomerWishlist = cache(async (entityId: number, pagination: Pa
     return null;
   }
 
-  return wishlist;
+  return { wishlist, taxDisplay: response.data.site.settings?.tax?.plp };
 });

--- a/core/app/[locale]/(default)/account/wishlists/[id]/page.tsx
+++ b/core/app/[locale]/(default)/account/wishlists/[id]/page.tsx
@@ -10,6 +10,7 @@ import { ExistingResultType } from '~/client/util';
 import { defaultPageInfo, pageInfoTransformer } from '~/data-transformers/page-info-transformer';
 import { wishlistDetailsTransformer } from '~/data-transformers/wishlists-transformer';
 import { redirect } from '~/i18n/routing';
+import { pickPricesForTaxDisplay } from '~/lib/tax-pricing';
 import { isMobileUser } from '~/lib/user-agent';
 
 import { removeWishlistItem } from '../_actions/remove-wishlist-item';
@@ -43,35 +44,37 @@ async function getWishlist(
   const entityId = Number(id);
   const searchParamsParsed = searchParamsCache.parse(await searchParamsPromise);
   const formatter = await getFormatter();
-  const wishlist = await getCustomerWishlist(entityId, searchParamsParsed);
+  const result = await getCustomerWishlist(entityId, searchParamsParsed);
 
-  if (!wishlist) {
+  if (!result) {
     return redirect({ href: '/account/wishlists/', locale });
   }
 
-  return wishlistDetailsTransformer(wishlist, t, pt, formatter);
+  return wishlistDetailsTransformer(result.wishlist, t, pt, formatter, result.taxDisplay);
 }
 
 const getAnalyticsData = async (id: string, searchParamsPromise: Promise<SearchParams>) => {
   const entityId = Number(id);
   const searchParamsParsed = searchParamsCache.parse(await searchParamsPromise);
-  const wishlist = await getCustomerWishlist(entityId, searchParamsParsed);
+  const result = await getCustomerWishlist(entityId, searchParamsParsed);
 
-  if (!wishlist) {
+  if (!result) {
     return [];
   }
 
-  return removeEdgesAndNodes(wishlist.items)
+  return removeEdgesAndNodes(result.wishlist.items)
     .map(({ product }) => product)
     .filter((product) => product !== null)
     .map((product) => {
+      const prices = pickPricesForTaxDisplay(product, result.taxDisplay);
+
       return {
         id: product.entityId,
         name: product.name,
         sku: product.sku,
         brand: product.brand?.name ?? '',
-        price: product.prices?.price.value ?? 0,
-        currency: product.prices?.price.currencyCode ?? '',
+        price: prices?.price.value ?? 0,
+        currency: prices?.price.currencyCode ?? '',
       };
     });
 };
@@ -82,9 +85,9 @@ async function getPaginationInfo(
 ): Promise<CursorPaginationInfo> {
   const entityId = Number(id);
   const searchParamsParsed = searchParamsCache.parse(await searchParamsPromise);
-  const wishlist = await getCustomerWishlist(entityId, searchParamsParsed);
+  const result = await getCustomerWishlist(entityId, searchParamsParsed);
 
-  return pageInfoTransformer(wishlist?.items.pageInfo ?? defaultPageInfo);
+  return pageInfoTransformer(result?.wishlist.items.pageInfo ?? defaultPageInfo);
 }
 
 export default async function WishlistPage({ params, searchParams }: Props) {

--- a/core/app/[locale]/(default)/account/wishlists/page-data.ts
+++ b/core/app/[locale]/(default)/account/wishlists/page-data.ts
@@ -22,6 +22,13 @@ const WishlistsPageQuery = graphql(
           ...WishlistsFragment
         }
       }
+      site {
+        settings {
+          tax {
+            plp
+          }
+        }
+      }
     }
   `,
   [WishlistsFragment],
@@ -50,5 +57,5 @@ export const getCustomerWishlists = cache(async ({ limit = 9, before, after }: P
     return null;
   }
 
-  return wishlists;
+  return { wishlists, taxDisplay: response.data.site.settings?.tax?.plp };
 });

--- a/core/app/[locale]/(default)/account/wishlists/page.tsx
+++ b/core/app/[locale]/(default)/account/wishlists/page.tsx
@@ -41,22 +41,22 @@ async function listWishlists(
 ): Promise<Wishlist[]> {
   const searchParamsParsed = searchParamsCache.parse(await searchParamsPromise);
   const formatter = await getFormatter();
-  const wishlists = await getCustomerWishlists(searchParamsParsed);
+  const result = await getCustomerWishlists(searchParamsParsed);
 
-  if (!wishlists) {
+  if (!result) {
     return [];
   }
 
-  return wishlistsTransformer(wishlists, t, formatter);
+  return wishlistsTransformer(result.wishlists, t, formatter, result.taxDisplay);
 }
 
 async function getPaginationInfo(
   searchParamsPromise: Promise<SearchParams>,
 ): Promise<CursorPaginationInfo> {
   const searchParamsParsed = searchParamsCache.parse(await searchParamsPromise);
-  const wishlists = await getCustomerWishlists(searchParamsParsed);
+  const result = await getCustomerWishlists(searchParamsParsed);
 
-  return pageInfoTransformer(wishlists?.pageInfo ?? defaultPageInfo);
+  return pageInfoTransformer(result?.wishlists.pageInfo ?? defaultPageInfo);
 }
 
 export default async function Wishlists({ params, searchParams }: Props) {

--- a/core/app/[locale]/(default)/cart/page-data.ts
+++ b/core/app/[locale]/(default)/cart/page-data.ts
@@ -2,129 +2,142 @@ import { cache } from 'react';
 
 import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
+import { PricingFragment } from '~/client/fragments/pricing';
 import { graphql, VariablesOf } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
 import { TAGS } from '~/client/tags';
 
-export const PhysicalItemFragment = graphql(`
-  fragment PhysicalItemFragment on CartPhysicalItem {
-    __typename
-    name
-    brand
-    sku
-    image {
-      url: urlTemplate(lossy: true)
-    }
-    entityId
-    quantity
-    productEntityId
-    variantEntityId
-    parentEntityId
-    listPrice {
-      currencyCode
-      value
-    }
-    salePrice {
-      currencyCode
-      value
-    }
-    discountedAmount {
-      currencyCode
-      value
-    }
-    selectedOptions {
+export const PhysicalItemFragment = graphql(
+  `
+    fragment PhysicalItemFragment on CartPhysicalItem {
       __typename
-      entityId
       name
-      ... on CartSelectedMultipleChoiceOption {
+      brand
+      sku
+      image {
+        url: urlTemplate(lossy: true)
+      }
+      entityId
+      quantity
+      productEntityId
+      variantEntityId
+      parentEntityId
+      listPrice {
+        currencyCode
         value
-        valueEntityId
       }
-      ... on CartSelectedCheckboxOption {
+      salePrice {
+        currencyCode
         value
-        valueEntityId
       }
-      ... on CartSelectedNumberFieldOption {
-        number
+      discountedAmount {
+        currencyCode
+        value
       }
-      ... on CartSelectedMultiLineTextFieldOption {
-        text
+      catalogProductWithOptionSelections {
+        ...PricingFragment
       }
-      ... on CartSelectedTextFieldOption {
-        text
-      }
-      ... on CartSelectedDateFieldOption {
-        date {
-          utc
+      selectedOptions {
+        __typename
+        entityId
+        name
+        ... on CartSelectedMultipleChoiceOption {
+          value
+          valueEntityId
+        }
+        ... on CartSelectedCheckboxOption {
+          value
+          valueEntityId
+        }
+        ... on CartSelectedNumberFieldOption {
+          number
+        }
+        ... on CartSelectedMultiLineTextFieldOption {
+          text
+        }
+        ... on CartSelectedTextFieldOption {
+          text
+        }
+        ... on CartSelectedDateFieldOption {
+          date {
+            utc
+          }
         }
       }
+      url
+      stockPosition {
+        backorderMessage
+        quantityOnHand
+        quantityBackordered
+        quantityOutOfStock
+      }
     }
-    url
-    stockPosition {
-      backorderMessage
-      quantityOnHand
-      quantityBackordered
-      quantityOutOfStock
-    }
-  }
-`);
+  `,
+  [PricingFragment],
+);
 
-export const DigitalItemFragment = graphql(`
-  fragment DigitalItemFragment on CartDigitalItem {
-    __typename
-    name
-    brand
-    sku
-    image {
-      url: urlTemplate(lossy: true)
-    }
-    entityId
-    quantity
-    productEntityId
-    variantEntityId
-    parentEntityId
-    listPrice {
-      currencyCode
-      value
-    }
-    salePrice {
-      currencyCode
-      value
-    }
-    discountedAmount {
-      currencyCode
-      value
-    }
-    selectedOptions {
+export const DigitalItemFragment = graphql(
+  `
+    fragment DigitalItemFragment on CartDigitalItem {
       __typename
-      entityId
       name
-      ... on CartSelectedMultipleChoiceOption {
+      brand
+      sku
+      image {
+        url: urlTemplate(lossy: true)
+      }
+      entityId
+      quantity
+      productEntityId
+      variantEntityId
+      parentEntityId
+      listPrice {
+        currencyCode
         value
-        valueEntityId
       }
-      ... on CartSelectedCheckboxOption {
+      salePrice {
+        currencyCode
         value
-        valueEntityId
       }
-      ... on CartSelectedNumberFieldOption {
-        number
+      discountedAmount {
+        currencyCode
+        value
       }
-      ... on CartSelectedMultiLineTextFieldOption {
-        text
+      catalogProductWithOptionSelections {
+        ...PricingFragment
       }
-      ... on CartSelectedTextFieldOption {
-        text
-      }
-      ... on CartSelectedDateFieldOption {
-        date {
-          utc
+      selectedOptions {
+        __typename
+        entityId
+        name
+        ... on CartSelectedMultipleChoiceOption {
+          value
+          valueEntityId
+        }
+        ... on CartSelectedCheckboxOption {
+          value
+          valueEntityId
+        }
+        ... on CartSelectedNumberFieldOption {
+          number
+        }
+        ... on CartSelectedMultiLineTextFieldOption {
+          text
+        }
+        ... on CartSelectedTextFieldOption {
+          text
+        }
+        ... on CartSelectedDateFieldOption {
+          date {
+            utc
+          }
         }
       }
+      url
     }
-    url
-  }
-`);
+  `,
+  [PricingFragment],
+);
 
 export const CartGiftCertificateFragment = graphql(`
   fragment CartGiftCertificateFragment on CartGiftCertificate {
@@ -238,6 +251,7 @@ const CartPageQuery = graphql(
           entityId
           version
           currencyCode
+          isTaxIncluded
           discountedAmount {
             ...MoneyFieldsFragment
           }

--- a/core/app/[locale]/(default)/cart/page.tsx
+++ b/core/app/[locale]/(default)/cart/page.tsx
@@ -2,8 +2,10 @@ import { Metadata } from 'next';
 import { getFormatter, getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { Streamable } from '@/vibes/soul/lib/streamable';
+import { Price } from '@/vibes/soul/primitives/price-label';
 import { Cart as CartComponent, CartEmptyState } from '@/vibes/soul/sections/cart';
 import { CartAnalyticsProvider } from '~/app/[locale]/(default)/cart/_components/cart-analytics-provider';
+import { pricesTransformer } from '~/data-transformers/prices-transformer';
 import { getCartId } from '~/lib/cart';
 import { getPreferredCurrencyCode } from '~/lib/currency';
 import { exists } from '~/lib/utils';
@@ -97,6 +99,8 @@ export default async function Cart({ params }: Props) {
     );
   }
 
+  const taxIncluded = cart.isTaxIncluded;
+
   const lineItems = [
     ...cart.lineItems.giftCertificates,
     ...cart.lineItems.physicalItems,
@@ -166,18 +170,19 @@ export default async function Cart({ params }: Props) {
       }
     }
 
+    const catalogProduct = item.catalogProductWithOptionSelections;
+    const price: Price =
+      (catalogProduct && pricesTransformer(catalogProduct, format, taxIncluded ? 'INC' : 'EX')) ??
+      format.number(item.listPrice.value, {
+        style: 'currency',
+        currency: item.listPrice.currencyCode,
+      });
+
     return {
       typename: item.__typename,
       id: item.entityId,
       quantity: item.quantity,
-      price: format.number(item.listPrice.value, {
-        style: 'currency',
-        currency: item.listPrice.currencyCode,
-      }),
-      salePrice: format.number(item.salePrice.value, {
-        style: 'currency',
-        currency: item.salePrice.currencyCode,
-      }),
+      price,
       subtitle: item.selectedOptions
         .map((option) => {
           switch (option.__typename) {
@@ -277,6 +282,15 @@ export default async function Cart({ params }: Props) {
               currency: cart.currencyCode,
             }),
             totalLabel: t('CheckoutSummary.total'),
+            totalSubtitle:
+              taxIncluded && checkout?.taxTotal
+                ? t('CheckoutSummary.totalIncludesTax', {
+                    tax: format.number(checkout.taxTotal.value, {
+                      style: 'currency',
+                      currency: cart.currencyCode,
+                    }),
+                  })
+                : undefined,
             summaryItems: [
               {
                 label: t('CheckoutSummary.subTotal'),
@@ -310,13 +324,15 @@ export default async function Cart({ params }: Props) {
                   currency: cart.currencyCode,
                 })}`,
               })),
-              checkout?.taxTotal && {
-                label: t('CheckoutSummary.tax'),
-                value: format.number(checkout.taxTotal.value, {
-                  style: 'currency',
-                  currency: cart.currencyCode,
-                }),
-              },
+              !taxIncluded && checkout?.taxTotal
+                ? {
+                    label: t('CheckoutSummary.tax'),
+                    value: format.number(checkout.taxTotal.value, {
+                      style: 'currency',
+                      currency: cart.currencyCode,
+                    }),
+                  }
+                : null,
             ].filter(exists),
           }}
           checkoutAction={CHECKOUT_URL}
@@ -393,7 +409,9 @@ export default async function Cart({ params }: Props) {
                 }
               : undefined,
             showShippingForm,
-            shippingLabel: t('CheckoutSummary.Shipping.shipping'),
+            shippingLabel: taxIncluded
+              ? t('CheckoutSummary.Shipping.shippingExcludingTax')
+              : t('CheckoutSummary.Shipping.shipping'),
             addLabel: t('CheckoutSummary.Shipping.add'),
             changeLabel: t('CheckoutSummary.Shipping.change'),
             countryLabel: t('CheckoutSummary.Shipping.country'),

--- a/core/app/[locale]/(default)/compare/page-data.ts
+++ b/core/app/[locale]/(default)/compare/page-data.ts
@@ -13,6 +13,11 @@ const ComparedProductsQuery = graphql(
   `
     query ComparedProductsQuery($entityIds: [Int!], $first: Int, $currencyCode: currencyCode) {
       site {
+        settings {
+          tax {
+            plp
+          }
+        }
         products(entityIds: $entityIds, first: $first) {
           edges {
             node {
@@ -58,7 +63,7 @@ const ComparedProductsQuery = graphql(
 export const getComparedProducts = cache(
   async (productIds: number[] = [], currencyCode?: CurrencyCode, customerAccessToken?: string) => {
     if (productIds.length === 0) {
-      return [];
+      return { products: [], taxDisplay: undefined };
     }
 
     const { data } = await client.fetch({
@@ -72,6 +77,9 @@ export const getComparedProducts = cache(
       fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
     });
 
-    return removeEdgesAndNodes(data.site.products);
+    return {
+      products: removeEdgesAndNodes(data.site.products),
+      taxDisplay: data.site.settings?.tax?.plp,
+    };
   },
 );

--- a/core/app/[locale]/(default)/compare/page.tsx
+++ b/core/app/[locale]/(default)/compare/page.tsx
@@ -9,6 +9,7 @@ import { getSessionCustomerAccessToken } from '~/auth';
 import { pricesTransformer } from '~/data-transformers/prices-transformer';
 import { getPreferredCurrencyCode } from '~/lib/currency';
 import { getMetadataAlternates } from '~/lib/seo/canonical';
+import { pickPricesForTaxDisplay } from '~/lib/tax-pricing';
 
 import { addToCart } from './_actions/add-to-cart';
 import { CompareAnalyticsProvider } from './_components/compare-analytics-provider';
@@ -64,7 +65,11 @@ export default async function Compare(props: Props) {
     const parsed = CompareParamsSchema.parse(searchParams);
     const productIds = parsed.ids?.filter((id) => !Number.isNaN(id));
 
-    const products = await getComparedProducts(productIds, currencyCode, customerAccessToken);
+    const { products, taxDisplay } = await getComparedProducts(
+      productIds,
+      currencyCode,
+      customerAccessToken,
+    );
     const format = await getFormatter();
 
     return products.map((product) => ({
@@ -74,7 +79,7 @@ export default async function Compare(props: Props) {
       image: product.defaultImage
         ? { src: product.defaultImage.url, alt: product.defaultImage.altText }
         : undefined,
-      price: pricesTransformer(product.prices, format),
+      price: pricesTransformer(product, format, taxDisplay),
       subtitle: product.brand?.name ?? undefined,
       rating: product.reviewSummary.averageRating,
       description: <div dangerouslySetInnerHTML={{ __html: product.description }} />,
@@ -97,16 +102,22 @@ export default async function Compare(props: Props) {
     const parsed = CompareParamsSchema.parse(searchParams);
     const productIds = parsed.ids?.filter((id) => !Number.isNaN(id));
 
-    const products = await getComparedProducts(productIds, currencyCode, customerAccessToken);
+    const { products, taxDisplay } = await getComparedProducts(
+      productIds,
+      currencyCode,
+      customerAccessToken,
+    );
 
     return products.map((product) => {
+      const prices = pickPricesForTaxDisplay(product, taxDisplay);
+
       return {
         id: product.entityId,
         name: product.name,
         sku: product.sku,
         brand: product.brand?.name ?? '',
-        price: product.prices?.price.value ?? 0,
-        currency: product.prices?.price.currencyCode ?? '',
+        price: prices?.price.value ?? 0,
+        currency: prices?.price.currencyCode ?? '',
       };
     });
   });

--- a/core/app/[locale]/(default)/page-data.ts
+++ b/core/app/[locale]/(default)/page-data.ts
@@ -70,6 +70,9 @@ const HomePageQuery = graphql(
           newsletter {
             showNewsletterSignup
           }
+          tax {
+            plp
+          }
         }
       }
     }

--- a/core/app/[locale]/(default)/page.tsx
+++ b/core/app/[locale]/(default)/page.tsx
@@ -48,12 +48,14 @@ export default async function Home({ params }: Props) {
 
     const { defaultOutOfStockMessage, showOutOfStockMessage, showBackorderMessage } =
       data.site.settings?.inventory ?? {};
+    const taxDisplay = data.site.settings?.tax?.plp;
 
     return productCardTransformer(
       featuredProducts,
       format,
       showOutOfStockMessage ? defaultOutOfStockMessage : undefined,
       showBackorderMessage,
+      taxDisplay,
     );
   });
 
@@ -64,12 +66,14 @@ export default async function Home({ params }: Props) {
 
     const { defaultOutOfStockMessage, showOutOfStockMessage, showBackorderMessage } =
       data.site.settings?.inventory ?? {};
+    const taxDisplay = data.site.settings?.tax?.plp;
 
     return productCardTransformer(
       newestProducts,
       format,
       showOutOfStockMessage ? defaultOutOfStockMessage : undefined,
       showBackorderMessage,
+      taxDisplay,
     );
   });
 

--- a/core/app/[locale]/(default)/product/[slug]/_components/product-schema/index.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/_components/product-schema/index.tsx
@@ -2,14 +2,17 @@ import { Product as ProductSchemaType, WithContext } from 'schema-dts';
 
 import { PricingFragment } from '~/client/fragments/pricing';
 import { FragmentOf } from '~/client/graphql';
+import { TaxDisplay } from '~/data-transformers/prices-transformer';
+import { pickPricesForTaxDisplay } from '~/lib/tax-pricing';
 
 import { ProductSchemaFragment } from './fragment';
 
 interface Props {
   product: FragmentOf<typeof ProductSchemaFragment> & FragmentOf<typeof PricingFragment>;
+  taxDisplay?: TaxDisplay | null;
 }
 
-export const ProductSchema = ({ product }: Props) => {
+export const ProductSchema = ({ product, taxDisplay }: Props) => {
   /* TODO: use common default image when product has no images */
   const image = product.defaultImage ? { image: product.defaultImage.url } : null;
 
@@ -34,15 +37,17 @@ export const ProductSchema = ({ product }: Props) => {
         }
       : null;
 
-  const priceSpecification = product.prices
+  const prices = pickPricesForTaxDisplay(product, taxDisplay);
+
+  const priceSpecification = prices
     ? {
         '@type': 'PriceSpecification' as const,
-        price: product.prices.price.value,
-        priceCurrency: product.prices.price.currencyCode,
-        ...(product.prices.priceRange.min.value !== product.prices.priceRange.max.value
+        price: prices.price.value,
+        priceCurrency: prices.price.currencyCode,
+        ...(prices.priceRange.min.value !== prices.priceRange.max.value
           ? {
-              minPrice: product.prices.priceRange.min.value,
-              maxPrice: product.prices.priceRange.max.value,
+              minPrice: prices.priceRange.min.value,
+              maxPrice: prices.priceRange.max.value,
             }
           : null),
       }

--- a/core/app/[locale]/(default)/product/[slug]/_components/product-viewed/index.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/_components/product-viewed/index.tsx
@@ -4,15 +4,18 @@ import { useEffect, useRef } from 'react';
 
 import { PricingFragment } from '~/client/fragments/pricing';
 import { FragmentOf } from '~/client/graphql';
+import { TaxDisplay } from '~/data-transformers/prices-transformer';
 import { useAnalytics } from '~/lib/analytics/react';
+import { pickPricesForTaxDisplay } from '~/lib/tax-pricing';
 
 import { ProductViewedFragment } from './fragment';
 
 interface Props {
   product: FragmentOf<typeof ProductViewedFragment> & FragmentOf<typeof PricingFragment>;
+  taxDisplay?: TaxDisplay | null;
 }
 
-export const ProductViewed = ({ product }: Props) => {
+export const ProductViewed = ({ product, taxDisplay }: Props) => {
   const isMounted = useRef(false);
   const analytics = useAnalytics();
 
@@ -23,20 +26,22 @@ export const ProductViewed = ({ product }: Props) => {
 
     isMounted.current = true;
 
+    const prices = pickPricesForTaxDisplay(product, taxDisplay);
+
     analytics?.navigation.productViewed({
-      value: product.prices?.price.value ?? 0,
-      currency: product.prices?.price.currencyCode ?? 'USD',
+      value: prices?.price.value ?? 0,
+      currency: prices?.price.currencyCode ?? 'USD',
       items: [
         {
           id: product.entityId.toString(),
           name: product.name,
           brand: product.brand?.name,
           sku: product.sku,
-          price: product.prices?.salePrice?.value,
+          price: prices?.salePrice?.value,
         },
       ],
     });
-  }, [analytics, product]);
+  }, [analytics, product, taxDisplay]);
 
   return null;
 };

--- a/core/app/[locale]/(default)/product/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/product/[slug]/page-data.ts
@@ -178,6 +178,9 @@ const ProductQuery = graphql(
           display {
             showProductRating
           }
+          tax {
+            pdp
+          }
         }
         product(entityId: $entityId) {
           entityId

--- a/core/app/[locale]/(default)/product/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/page.tsx
@@ -85,6 +85,7 @@ export default async function Product({ params, searchParams }: Props) {
 
   const reviewsEnabled = Boolean(settings?.reviews.enabled && !settings.display.showProductRating);
   const showRating = Boolean(settings?.reviews.enabled && settings.display.showProductRating);
+  const taxDisplay = settings?.tax?.pdp;
 
   if (!baseProduct) {
     return notFound();
@@ -185,7 +186,7 @@ export default async function Product({ params, searchParams }: Props) {
       return null;
     }
 
-    return pricesTransformer(product.prices, format) ?? null;
+    return pricesTransformer(product, format, taxDisplay) ?? null;
   });
 
   const streamableImages = Streamable.from(async () => {
@@ -505,7 +506,7 @@ export default async function Product({ params, searchParams }: Props) {
 
     const relatedProducts = removeEdgesAndNodes(product.relatedProducts);
 
-    return productCardTransformer(relatedProducts, format);
+    return productCardTransformer(relatedProducts, format, undefined, undefined, taxDisplay);
   });
 
   const streamableMinQuantity = Streamable.from(async () => {
@@ -531,8 +532,8 @@ export default async function Product({ params, searchParams }: Props) {
       name: extendedProduct.name,
       sku: extendedProduct.sku,
       brand: extendedProduct.brand?.name ?? '',
-      price: pricingProduct?.prices?.price.value ?? 0,
-      currency: pricingProduct?.prices?.price.currencyCode ?? '',
+      price: pricingProduct?.pricesIncludingTax?.price.value ?? 0,
+      currency: pricingProduct?.pricesIncludingTax?.price.currencyCode ?? '',
     };
   });
 
@@ -636,10 +637,20 @@ export default async function Product({ params, searchParams }: Props) {
         {([extendedProduct, pricingProduct]) => (
           <>
             <ProductSchema
-              product={{ ...extendedProduct, prices: pricingProduct?.prices ?? null }}
+              product={{
+                ...extendedProduct,
+                pricesIncludingTax: pricingProduct?.pricesIncludingTax ?? null,
+                pricesExcludingTax: pricingProduct?.pricesExcludingTax ?? null,
+              }}
+              taxDisplay={taxDisplay}
             />
             <ProductViewed
-              product={{ ...extendedProduct, prices: pricingProduct?.prices ?? null }}
+              product={{
+                ...extendedProduct,
+                pricesIncludingTax: pricingProduct?.pricesIncludingTax ?? null,
+                pricesExcludingTax: pricingProduct?.pricesExcludingTax ?? null,
+              }}
+              taxDisplay={taxDisplay}
             />
           </>
         )}

--- a/core/app/[locale]/(default)/wishlist/[token]/page-data.ts
+++ b/core/app/[locale]/(default)/wishlist/[token]/page-data.ts
@@ -38,6 +38,11 @@ const PublicWishlistQuery = graphql(
             }
           }
         }
+        settings {
+          tax {
+            plp
+          }
+        }
       }
     }
   `,
@@ -67,5 +72,5 @@ export const getPublicWishlist = cache(async (token: string, pagination: Paginat
     return null;
   }
 
-  return wishlist;
+  return { wishlist, taxDisplay: response.data.site.settings?.tax?.plp };
 });

--- a/core/app/[locale]/(default)/wishlist/[token]/page.tsx
+++ b/core/app/[locale]/(default)/wishlist/[token]/page.tsx
@@ -20,6 +20,7 @@ import {
 import { defaultPageInfo, pageInfoTransformer } from '~/data-transformers/page-info-transformer';
 import { publicWishlistDetailsTransformer } from '~/data-transformers/wishlists-transformer';
 import { getMetadataAlternates } from '~/lib/seo/canonical';
+import { pickPricesForTaxDisplay } from '~/lib/tax-pricing';
 import { isMobileUser } from '~/lib/user-agent';
 
 import { getPublicWishlist } from './page-data';
@@ -45,13 +46,13 @@ async function getWishlist(
 ): Promise<Wishlist> {
   const searchParamsParsed = searchParamsCache.parse(await searchParams);
   const formatter = await getFormatter();
-  const wishlist = await getPublicWishlist(token, searchParamsParsed);
+  const result = await getPublicWishlist(token, searchParamsParsed);
 
-  if (!wishlist) {
+  if (!result) {
     return notFound();
   }
 
-  return publicWishlistDetailsTransformer(wishlist, t, pt, formatter);
+  return publicWishlistDetailsTransformer(result.wishlist, t, pt, formatter, result.taxDisplay);
 }
 
 async function getPaginationInfo(
@@ -59,9 +60,9 @@ async function getPaginationInfo(
   searchParams: Promise<SearchParams>,
 ): Promise<CursorPaginationInfo> {
   const searchParamsParsed = searchParamsCache.parse(await searchParams);
-  const wishlist = await getPublicWishlist(token, searchParamsParsed);
+  const result = await getPublicWishlist(token, searchParamsParsed);
 
-  return pageInfoTransformer(wishlist?.items.pageInfo ?? defaultPageInfo);
+  return pageInfoTransformer(result?.wishlist.items.pageInfo ?? defaultPageInfo);
 }
 
 export async function generateMetadata({ params, searchParams }: Props): Promise<Metadata> {
@@ -70,33 +71,37 @@ export async function generateMetadata({ params, searchParams }: Props): Promise
   // to make sure we aren't bypassing an existing cache just for the metadata generation.
   const searchParamsParsed = searchParamsCache.parse(await searchParams);
   const t = await getTranslations({ locale, namespace: 'PublicWishlist' });
-  const wishlist = await getPublicWishlist(token, searchParamsParsed);
+  const result = await getPublicWishlist(token, searchParamsParsed);
 
   return {
-    title: wishlist?.name ?? t('title'),
+    title: result?.wishlist.name ?? t('title'),
     alternates: await getMetadataAlternates({ path: `/wishlist/${token}`, locale }),
   };
 }
 
 const getAnalyticsData = async (token: string, searchParamsPromise: Promise<SearchParams>) => {
   const searchParamsParsed = searchParamsCache.parse(await searchParamsPromise);
-  const wishlist = await getPublicWishlist(token, searchParamsParsed);
+  const result = await getPublicWishlist(token, searchParamsParsed);
 
-  if (!wishlist) {
+  if (!result) {
     return [];
   }
+
+  const { wishlist, taxDisplay } = result;
 
   return removeEdgesAndNodes(wishlist.items)
     .map(({ product }) => product)
     .filter((product) => product !== null)
     .map((product) => {
+      const prices = pickPricesForTaxDisplay(product, taxDisplay);
+
       return {
         id: product.entityId,
         name: product.name,
         sku: product.sku,
         brand: product.brand?.name ?? '',
-        price: product.prices?.price.value ?? 0,
-        currency: product.prices?.price.currencyCode ?? '',
+        price: prices?.price.value ?? 0,
+        currency: prices?.price.currencyCode ?? '',
       };
     });
 };
@@ -107,11 +112,11 @@ async function getBreadcrumbs(
 ): Promise<Breadcrumb[]> {
   const t = await getTranslations('PublicWishlist');
   const searchParamsParsed = searchParamsCache.parse(await searchParams);
-  const wishlist = await getPublicWishlist(token, searchParamsParsed);
+  const result = await getPublicWishlist(token, searchParamsParsed);
 
   return [
     { href: '/', label: 'Home' },
-    { href: '#', label: wishlist?.name ?? t('defaultName') },
+    { href: '#', label: result?.wishlist.name ?? t('defaultName') },
   ];
 }
 

--- a/core/client/fragments/pricing.ts
+++ b/core/client/fragments/pricing.ts
@@ -2,7 +2,35 @@ import { graphql } from '../graphql';
 
 export const PricingFragment = graphql(`
   fragment PricingFragment on Product {
-    prices(currencyCode: $currencyCode) {
+    pricesIncludingTax: prices(currencyCode: $currencyCode, includeTax: true) {
+      price {
+        value
+        currencyCode
+      }
+      basePrice {
+        value
+        currencyCode
+      }
+      retailPrice {
+        value
+        currencyCode
+      }
+      salePrice {
+        value
+        currencyCode
+      }
+      priceRange {
+        min {
+          value
+          currencyCode
+        }
+        max {
+          value
+          currencyCode
+        }
+      }
+    }
+    pricesExcludingTax: prices(currencyCode: $currencyCode, includeTax: false) {
       price {
         value
         currencyCode

--- a/core/components/header/_actions/search.ts
+++ b/core/components/header/_actions/search.ts
@@ -23,6 +23,11 @@ const GetQuickSearchResultsQuery = graphql(
       $currencyCode: currencyCode
     ) {
       site {
+        settings {
+          tax {
+            plp
+          }
+        }
         search {
           searchProducts(filters: $filters) {
             products(first: 5) {
@@ -92,10 +97,11 @@ export async function search(
     });
 
     const { products } = response.data.site.search.searchProducts;
+    const taxDisplay = response.data.site.settings?.tax?.plp;
 
     return {
       lastResult: submission.reply(),
-      searchResults: await searchResultsTransformer(removeEdgesAndNodes(products)),
+      searchResults: await searchResultsTransformer(removeEdgesAndNodes(products), taxDisplay),
       emptyStateTitle,
       emptyStateSubtitle,
     };

--- a/core/data-transformers/prices-transformer.ts
+++ b/core/data-transformers/prices-transformer.ts
@@ -1,51 +1,78 @@
 import { ResultOf } from 'gql.tada';
 import { getFormatter } from 'next-intl/server';
 
-import { Price } from '@/vibes/soul/primitives/price-label';
+import { Money, Price } from '@/vibes/soul/primitives/price-label';
 import { PricingFragment } from '~/client/fragments/pricing';
 import { ExistingResultType } from '~/client/util';
 
+type Pricing = ResultOf<typeof PricingFragment>;
+type Format = ExistingResultType<typeof getFormatter>;
+
+export type TaxDisplay = 'INC' | 'EX' | 'BOTH';
+
+const toMoney = (
+  inc: { value: number; currencyCode: string },
+  ex: { value: number; currencyCode: string },
+  format: Format,
+): Money => ({
+  inc: format.number(inc.value, { style: 'currency', currency: inc.currencyCode }),
+  ex: format.number(ex.value, { style: 'currency', currency: ex.currencyCode }),
+});
+
 export const pricesTransformer = (
-  prices: ResultOf<typeof PricingFragment>['prices'],
-  format: ExistingResultType<typeof getFormatter>,
+  pricing: Pricing,
+  format: Format,
+  taxDisplay: TaxDisplay | null | undefined = 'EX',
 ): Price | undefined => {
-  if (!prices) {
+  const inc = pricing.pricesIncludingTax;
+  const ex = pricing.pricesExcludingTax;
+
+  if (!inc || !ex) {
     return undefined;
   }
 
-  const isPriceRange = prices.priceRange.min.value !== prices.priceRange.max.value;
-  const isSalePrice = prices.salePrice?.value !== prices.basePrice?.value;
+  let mode: TaxDisplay = taxDisplay ?? 'EX';
+
+  // Tax-disabled stores, tax-exempt customer groups, and some B2B contexts return identical
+  // values for inc and ex. Degrade BOTH to a single-price render so we don't duplicate the
+  // same number on two lines.
+  if (mode === 'BOTH') {
+    const hasTaxDifference =
+      inc.price.value !== ex.price.value ||
+      inc.basePrice?.value !== ex.basePrice?.value ||
+      inc.salePrice?.value !== ex.salePrice?.value ||
+      inc.priceRange.min.value !== ex.priceRange.min.value ||
+      inc.priceRange.max.value !== ex.priceRange.max.value;
+
+    if (!hasTaxDifference) {
+      mode = 'EX';
+    }
+  }
+
+  const isPriceRange = inc.priceRange.min.value !== inc.priceRange.max.value;
+  const isSalePrice = inc.salePrice?.value !== inc.basePrice?.value;
 
   if (isPriceRange) {
     return {
       type: 'range',
-      minValue: format.number(prices.priceRange.min.value, {
-        style: 'currency',
-        currency: prices.price.currencyCode,
-      }),
-      maxValue: format.number(prices.priceRange.max.value, {
-        style: 'currency',
-        currency: prices.price.currencyCode,
-      }),
+      min: toMoney(inc.priceRange.min, ex.priceRange.min, format),
+      max: toMoney(inc.priceRange.max, ex.priceRange.max, format),
+      mode,
     };
   }
 
-  if (isSalePrice && prices.salePrice && prices.basePrice) {
+  if (isSalePrice && inc.salePrice && inc.basePrice && ex.salePrice && ex.basePrice) {
     return {
       type: 'sale',
-      previousValue: format.number(prices.basePrice.value, {
-        style: 'currency',
-        currency: prices.price.currencyCode,
-      }),
-      currentValue: format.number(prices.price.value, {
-        style: 'currency',
-        currency: prices.price.currencyCode,
-      }),
+      previous: toMoney(inc.basePrice, ex.basePrice, format),
+      current: toMoney(inc.price, ex.price, format),
+      mode,
     };
   }
 
-  return format.number(prices.price.value, {
-    style: 'currency',
-    currency: prices.price.currencyCode,
-  });
+  return {
+    type: 'plain',
+    money: toMoney(inc.price, ex.price, format),
+    mode,
+  };
 };

--- a/core/data-transformers/product-card-transformer.ts
+++ b/core/data-transformers/product-card-transformer.ts
@@ -7,7 +7,7 @@ import { ExistingResultType } from '~/client/util';
 import { ProductCardFragment } from '~/components/product-card/fragment';
 import { WishlistItemProductFragment } from '~/components/wishlist/fragment';
 
-import { pricesTransformer } from './prices-transformer';
+import { pricesTransformer, TaxDisplay } from './prices-transformer';
 
 const getInventoryMessage = (
   product: ResultOf<typeof ProductCardFragment>,
@@ -51,6 +51,7 @@ export const singleProductCardTransformer = (
   format: ExistingResultType<typeof getFormatter>,
   outOfStockMessage?: string,
   showBackorderMessage?: boolean,
+  taxDisplay?: TaxDisplay | null,
 ): Product => {
   return {
     id: product.entityId.toString(),
@@ -59,7 +60,7 @@ export const singleProductCardTransformer = (
     image: product.defaultImage
       ? { src: product.defaultImage.url, alt: product.defaultImage.altText }
       : undefined,
-    price: pricesTransformer(product.prices, format),
+    price: pricesTransformer(product, format, taxDisplay),
     subtitle: product.brand?.name ?? undefined,
     rating: product.reviewSummary.averageRating,
     numberOfReviews: product.reviewSummary.numberOfReviews,
@@ -75,8 +76,15 @@ export const productCardTransformer = (
   format: ExistingResultType<typeof getFormatter>,
   outOfStockMessage?: string,
   showBackorderMessage?: boolean,
+  taxDisplay?: TaxDisplay | null,
 ): Product[] => {
   return products.map((product) =>
-    singleProductCardTransformer(product, format, outOfStockMessage, showBackorderMessage),
+    singleProductCardTransformer(
+      product,
+      format,
+      outOfStockMessage,
+      showBackorderMessage,
+      taxDisplay,
+    ),
   );
 };

--- a/core/data-transformers/search-results-transformer.ts
+++ b/core/data-transformers/search-results-transformer.ts
@@ -4,10 +4,11 @@ import { getFormatter, getTranslations } from 'next-intl/server';
 import { SearchResult } from '@/vibes/soul/primitives/navigation';
 import { SearchProductFragment } from '~/components/header/_actions/fragment';
 
-import { pricesTransformer } from './prices-transformer';
+import { pricesTransformer, TaxDisplay } from './prices-transformer';
 
 export async function searchResultsTransformer(
   searchProducts: Array<ResultOf<typeof SearchProductFragment>>,
+  taxDisplay?: TaxDisplay | null,
 ): Promise<SearchResult[]> {
   const format = await getFormatter();
   const t = await getTranslations('Components.Header.Search');
@@ -16,7 +17,7 @@ export async function searchResultsTransformer(
     type: 'products',
     title: t('products'),
     products: searchProducts.map((product) => {
-      const price = pricesTransformer(product.prices, format);
+      const price = pricesTransformer(product, format, taxDisplay);
 
       return {
         id: product.entityId.toString(),

--- a/core/data-transformers/wishlists-transformer.ts
+++ b/core/data-transformers/wishlists-transformer.ts
@@ -13,6 +13,7 @@ import {
   WishlistsFragment,
 } from '~/components/wishlist/fragment';
 
+import { TaxDisplay } from './prices-transformer';
 import { singleProductCardTransformer } from './product-card-transformer';
 
 const getCtaLabel = (
@@ -54,6 +55,7 @@ function wishlistItemsTransformer(
   wishlistItems: ResultOf<typeof WishlistFragment | typeof WishlistPaginatedItemsFragment>['items'],
   formatter: ExistingResultType<typeof getFormatter>,
   pt?: ExistingResultType<typeof getTranslations<'Product.ProductDetails'>>,
+  taxDisplay?: TaxDisplay | null,
 ): WishlistItem[] {
   return removeEdgesAndNodes(wishlistItems)
     .filter(
@@ -70,7 +72,13 @@ function wishlistItemsTransformer(
             disabled: getCtaDisabled(item.product),
           }
         : undefined,
-      product: singleProductCardTransformer(item.product, formatter),
+      product: singleProductCardTransformer(
+        item.product,
+        formatter,
+        undefined,
+        undefined,
+        taxDisplay,
+      ),
     }));
 }
 
@@ -79,6 +87,7 @@ function wishlistTransformer(
   t: ExistingResultType<typeof getTranslations<'Wishlist'>>,
   formatter: ExistingResultType<typeof getFormatter>,
   pt?: ExistingResultType<typeof getTranslations<'Product.ProductDetails'>>,
+  taxDisplay?: TaxDisplay | null,
 ): Wishlist {
   const totalItems = wishlist.items.collectionInfo?.totalItems ?? 0;
 
@@ -93,7 +102,7 @@ function wishlistTransformer(
       privateLabel: t('Visibility.private'),
     },
     href: `/account/wishlists/${wishlist.entityId}`,
-    items: wishlistItemsTransformer(wishlist.items, formatter, pt),
+    items: wishlistItemsTransformer(wishlist.items, formatter, pt, taxDisplay),
     totalItems: {
       value: totalItems,
       label: t('items', { count: totalItems }),
@@ -105,19 +114,24 @@ export const wishlistsTransformer = (
   wishlists: ResultOf<typeof WishlistsFragment>,
   t: ExistingResultType<typeof getTranslations<'Wishlist'>>,
   formatter: ExistingResultType<typeof getFormatter>,
+  taxDisplay?: TaxDisplay | null,
 ): Wishlist[] =>
-  removeEdgesAndNodes(wishlists).map((wishlist) => wishlistTransformer(wishlist, t, formatter));
+  removeEdgesAndNodes(wishlists).map((wishlist) =>
+    wishlistTransformer(wishlist, t, formatter, undefined, taxDisplay),
+  );
 
 export const wishlistDetailsTransformer = (
   wishlist: ResultOf<typeof WishlistPaginatedItemsFragment>,
   t: ExistingResultType<typeof getTranslations<'Wishlist'>>,
   pt: ExistingResultType<typeof getTranslations<'Product.ProductDetails'>>,
   formatter: ExistingResultType<typeof getFormatter>,
-): Wishlist => wishlistTransformer(wishlist, t, formatter, pt);
+  taxDisplay?: TaxDisplay | null,
+): Wishlist => wishlistTransformer(wishlist, t, formatter, pt, taxDisplay);
 
 export const publicWishlistDetailsTransformer = (
   wishlist: ResultOf<typeof PublicWishlistFragment>,
   t: ExistingResultType<typeof getTranslations<'Wishlist'>>,
   pt: ExistingResultType<typeof getTranslations<'Product.ProductDetails'>>,
   formatter: ExistingResultType<typeof getFormatter>,
-): Wishlist => wishlistTransformer({ ...wishlist, isPublic: true }, t, formatter, pt);
+  taxDisplay?: TaxDisplay | null,
+): Wishlist => wishlistTransformer({ ...wishlist, isPublic: true }, t, formatter, pt, taxDisplay);

--- a/core/lib/tax-pricing.ts
+++ b/core/lib/tax-pricing.ts
@@ -1,0 +1,22 @@
+import { TaxDisplay } from '~/data-transformers/prices-transformer';
+
+// Picks the prices field (`pricesIncludingTax` or `pricesExcludingTax`) that matches the
+// merchant's Tax Display CP setting. Used by analytics, SEO/schema, and any other non-visual
+// consumer that needs one canonical price per product.
+//
+// - `INC`             -> `pricesIncludingTax`
+// - `EX`              -> `pricesExcludingTax`
+// - `BOTH`            -> `pricesIncludingTax` (headline convention)
+// - undefined / null  -> `pricesExcludingTax` (matches BC `prices(currencyCode)` default)
+export function pickPricesForTaxDisplay<
+  T extends { pricesIncludingTax?: unknown; pricesExcludingTax?: unknown },
+>(
+  pricing: T,
+  taxDisplay: TaxDisplay | null | undefined,
+): T['pricesIncludingTax'] | T['pricesExcludingTax'] {
+  if (taxDisplay === 'INC' || taxDisplay === 'BOTH') {
+    return pricing.pricesIncludingTax;
+  }
+
+  return pricing.pricesExcludingTax;
+}

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -379,6 +379,7 @@
       "subTotal": "Subtotal",
       "discounts": "Discounts",
       "tax": "Tax",
+      "totalIncludesTax": "Includes {tax} tax",
       "total": "Total",
       "CouponCode": {
         "apply": "Apply",
@@ -389,6 +390,7 @@
       },
       "Shipping": {
         "shipping": "Shipping",
+        "shippingExcludingTax": "Shipping (Ex. Tax)",
         "add": "Add",
         "change": "Change",
         "cancel": "Cancel",
@@ -648,7 +650,11 @@
     "Price": {
       "originalPrice": "Original price was {price}.",
       "currentPrice": "Current price is {price}.",
-      "range": "Price from {minValue} to {maxValue}."
+      "range": "Price from {minValue} to {maxValue}.",
+      "includingTax": "(Inc. Tax)",
+      "excludingTax": "(Ex. Tax)",
+      "includingTaxFull": "Including Tax",
+      "excludingTaxFull": "Excluding Tax"
     }
   },
   "GiftCertificates": {

--- a/core/vibes/soul/primitives/price-label/index.tsx
+++ b/core/vibes/soul/primitives/price-label/index.tsx
@@ -1,19 +1,34 @@
 import { clsx } from 'clsx';
 import { useTranslations } from 'next-intl';
 
+export type TaxMode = 'INC' | 'EX' | 'BOTH';
+
+export interface Money {
+  inc: string;
+  ex: string;
+}
+
+export interface PricePlain {
+  type: 'plain';
+  money: Money;
+  mode?: TaxMode;
+}
+
 export interface PriceRange {
   type: 'range';
-  minValue: string;
-  maxValue: string;
+  min: Money;
+  max: Money;
+  mode?: TaxMode;
 }
 
 export interface PriceSale {
   type: 'sale';
-  previousValue: string;
-  currentValue: string;
+  previous: Money;
+  current: Money;
+  mode?: TaxMode;
 }
 
-export type Price = string | PriceRange | PriceSale;
+export type Price = string | PricePlain | PriceRange | PriceSale;
 
 interface Props {
   className?: string;
@@ -38,77 +53,98 @@ interface Props {
 export function PriceLabel({ className, colorScheme = 'light', price }: Props) {
   const t = useTranslations('Components.Price');
 
+  const baseColorClass = {
+    light: 'text-[var(--price-light-text,hsl(var(--foreground)))]',
+    dark: 'text-[var(--price-dark-text,hsl(var(--background)))]',
+  }[colorScheme];
+
   if (typeof price === 'string') {
+    return <span className={clsx('block font-semibold', baseColorClass, className)}>{price}</span>;
+  }
+
+  const mode: TaxMode = price.mode ?? 'EX';
+
+  if (mode === 'BOTH') {
+    const includingTaxLabel = t('includingTax');
+    const excludingTaxLabel = t('excludingTax');
+    const includingTaxTooltip = t('includingTaxFull');
+    const excludingTaxTooltip = t('excludingTaxFull');
+
     return (
-      <span
-        className={clsx(
-          'block font-semibold',
-          {
-            light: 'text-[var(--price-light-text,hsl(var(--foreground)))]',
-            dark: 'text-[var(--price-dark-text,hsl(var(--background)))]',
-          }[colorScheme],
-          className,
-        )}
-      >
-        {price}
+      <span className={clsx('block font-semibold', baseColorClass, className)}>
+        <span className="block">
+          <PriceLine colorScheme={colorScheme} price={price} t={t} tax="inc" />{' '}
+          <abbr className="cursor-help font-normal opacity-60" title={includingTaxTooltip}>
+            {includingTaxLabel}
+          </abbr>
+        </span>
+        <span className="block">
+          <PriceLine colorScheme={colorScheme} dim price={price} t={t} tax="ex" />{' '}
+          <abbr className="cursor-help font-normal opacity-60" title={excludingTaxTooltip}>
+            {excludingTaxLabel}
+          </abbr>
+        </span>
       </span>
     );
   }
 
-  switch (price.type) {
-    case 'range':
-      return (
-        <span
-          className={clsx(
-            'block font-semibold',
-            {
-              light: 'text-[var(--price-light-text,hsl(var(--foreground)))]',
-              dark: 'text-[var(--price-dark-text,hsl(var(--background)))]',
-            }[colorScheme],
-            className,
-          )}
-        >
-          <span className="sr-only">
-            {t('range', { minValue: price.minValue, maxValue: price.maxValue })}
-          </span>
-          <span aria-hidden="true">
-            {price.minValue} - {price.maxValue}
-          </span>
-        </span>
-      );
+  const tax: 'inc' | 'ex' = mode === 'EX' ? 'ex' : 'inc';
 
-    case 'sale':
-      return (
-        <span className={clsx('block font-semibold', className)}>
-          <span className="sr-only">{t('originalPrice', { price: price.previousValue })}</span>
-          <span
-            aria-hidden="true"
-            className={clsx(
-              'font-normal line-through opacity-50',
-              {
-                light: 'text-[var(--price-light-text,hsl(var(--foreground)))]',
-                dark: 'text-[var(--price-dark-text,hsl(var(--background)))]',
-              }[colorScheme],
-            )}
-          >
-            {price.previousValue}
-          </span>{' '}
-          <span className="sr-only">{t('currentPrice', { price: price.currentValue })}</span>
-          <span
-            aria-hidden="true"
-            className={clsx(
-              {
-                light: 'text-[var(--price-light-sale-text,hsl(var(--foreground)))]',
-                dark: 'text-[var(--price-dark-sale-text,hsl(var(--background)))]',
-              }[colorScheme],
-            )}
-          >
-            {price.currentValue}
-          </span>
-        </span>
-      );
+  return (
+    <span className={clsx('block font-semibold', baseColorClass, className)}>
+      <PriceLine colorScheme={colorScheme} price={price} t={t} tax={tax} />
+    </span>
+  );
+}
 
-    default:
-      return null;
+function PriceLine({
+  price,
+  tax,
+  t,
+  colorScheme,
+  dim,
+}: {
+  price: PricePlain | PriceRange | PriceSale;
+  tax: 'inc' | 'ex';
+  t: ReturnType<typeof useTranslations<'Components.Price'>>;
+  colorScheme: 'light' | 'dark';
+  dim?: boolean;
+}) {
+  const dimClass = dim ? 'opacity-60' : undefined;
+  const pick = (m: Money) => m[tax];
+
+  if (price.type === 'plain') {
+    return <span className={dimClass}>{pick(price.money)}</span>;
   }
+
+  if (price.type === 'range') {
+    return (
+      <>
+        <span className="sr-only">
+          {t('range', { minValue: pick(price.min), maxValue: pick(price.max) })}
+        </span>
+        <span aria-hidden="true" className={dimClass}>
+          {pick(price.min)} - {pick(price.max)}
+        </span>
+      </>
+    );
+  }
+
+  const saleColorClass = {
+    light: 'text-[var(--price-light-sale-text,hsl(var(--foreground)))]',
+    dark: 'text-[var(--price-dark-sale-text,hsl(var(--background)))]',
+  }[colorScheme];
+
+  return (
+    <>
+      <span className="sr-only">{t('originalPrice', { price: pick(price.previous) })}</span>
+      <span aria-hidden="true" className="font-normal line-through opacity-50">
+        {pick(price.previous)}
+      </span>{' '}
+      <span className="sr-only">{t('currentPrice', { price: pick(price.current) })}</span>
+      <span aria-hidden="true" className={clsx(saleColorClass, dimClass)}>
+        {pick(price.current)}
+      </span>
+    </>
+  );
 }

--- a/core/vibes/soul/primitives/product-card/index.tsx
+++ b/core/vibes/soul/primitives/product-card/index.tsx
@@ -164,7 +164,13 @@ export function ProductCard({
                 {subtitle}
               </span>
             )}
-            {price != null && <PriceLabel colorScheme={colorScheme} price={price} />}
+            {price != null && (
+              <PriceLabel
+                className="[&_abbr]:cursor-default [&_abbr]:no-underline"
+                colorScheme={colorScheme}
+                price={price}
+              />
+            )}
             {showRating && typeof rating === 'number' && rating > 0 && (
               <Rating className="mb-2 mt-1" numberOfReviews={numberOfReviews} rating={rating} />
             )}

--- a/core/vibes/soul/sections/cart/client.tsx
+++ b/core/vibes/soul/sections/cart/client.tsx
@@ -4,7 +4,6 @@ import { getFormProps, getInputProps, SubmissionResult, useForm } from '@conform
 import { parseWithZod } from '@conform-to/zod';
 import { clsx } from 'clsx';
 import { ArrowRight, GiftIcon, Minus, Plus, Trash2 } from 'lucide-react';
-import { useTranslations } from 'next-intl';
 import {
   ComponentPropsWithoutRef,
   startTransition,
@@ -16,6 +15,7 @@ import {
 import { useFormStatus } from 'react-dom';
 
 import { Button } from '@/vibes/soul/primitives/button';
+import { Price, PriceLabel } from '@/vibes/soul/primitives/price-label';
 import * as Skeleton from '@/vibes/soul/primitives/skeleton';
 import { toast } from '@/vibes/soul/primitives/toaster';
 import {
@@ -49,8 +49,7 @@ export interface CartLineItem {
   image?: { alt: string; src: string };
   subtitle: string;
   quantity: number;
-  price: string;
-  salePrice?: string;
+  price: Price;
   href?: string;
   inventoryMessages?: CartLineIteminventoryMessages;
 }
@@ -82,6 +81,7 @@ export interface Cart<LineItem extends CartLineItem> {
   summaryItems: CartSummaryItem[];
   total: string;
   totalLabel?: string;
+  totalSubtitle?: string;
 }
 
 interface CouponCode {
@@ -405,12 +405,19 @@ export function CartClient<LineItem extends CartLineItem>({
                 removeLabel={giftCertificate.removeLabel}
               />
             )}
-            <div className="flex justify-between border-t border-[var(--cart-border,hsl(var(--contrast-100)))] py-6 text-xl font-bold">
-              <dt>{cart.totalLabel ?? 'Total'}</dt>
-              {isLineItemActionPending ? (
-                <Skeleton.Text characterCount={8} className="animate-pulse rounded-md" />
-              ) : (
-                <dd>{cart.total}</dd>
+            <div className="border-t border-[var(--cart-border,hsl(var(--contrast-100)))] py-6">
+              <div className="flex justify-between text-xl font-bold">
+                <dt>{cart.totalLabel ?? 'Total'}</dt>
+                {isLineItemActionPending ? (
+                  <Skeleton.Text characterCount={8} className="animate-pulse rounded-md" />
+                ) : (
+                  <dd>{cart.total}</dd>
+                )}
+              </div>
+              {cart.totalSubtitle != null && (
+                <div className="mt-1 flex justify-end text-sm font-normal opacity-70">
+                  {cart.totalSubtitle}
+                </div>
               )}
             </div>
           </dl>
@@ -522,8 +529,6 @@ function CounterForm({
   action: (payload: FormData) => void;
   onSubmit: (formData: FormData) => void;
 }) {
-  const t = useTranslations('Cart');
-
   const [form, fields] = useForm({
     defaultValue: { id: lineItem.id },
     shouldValidate: 'onBlur',
@@ -543,7 +548,9 @@ function CounterForm({
       <form {...getFormProps(form)} action={action}>
         <input {...getInputProps(fields.id, { type: 'hidden' })} key={fields.id.id} />
         <div className="flex w-full flex-wrap items-center gap-x-5 gap-y-2">
-          <span className="font-medium @xl:ml-auto">{lineItem.price}</span>
+          {typeof lineItem.price === 'string' && (
+            <span className="font-medium @xl:ml-auto">{lineItem.price}</span>
+          )}
 
           <span className="flex flex-1 select-none justify-center px-14 py-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--cart-focus,hsl(var(--primary)))]">
             {lineItem.quantity}
@@ -571,18 +578,7 @@ function CounterForm({
     <form {...getFormProps(form)} action={action}>
       <input {...getInputProps(fields.id, { type: 'hidden' })} key={fields.id.id} />
       <div className="flex w-full flex-wrap items-center gap-x-5 gap-y-2">
-        {lineItem.salePrice && lineItem.salePrice !== lineItem.price ? (
-          <span className="mt-3 self-start font-medium @xl:ml-auto">
-            <span className="sr-only">{t('originalPrice', { price: lineItem.price })}</span>
-            <span aria-hidden="true" className="line-through">
-              {lineItem.price}
-            </span>{' '}
-            <span className="sr-only">{t('currentPrice', { price: lineItem.salePrice })}</span>
-            <span aria-hidden="true">{lineItem.salePrice}</span>
-          </span>
-        ) : (
-          <span className="mt-3 self-start font-medium @xl:ml-auto">{lineItem.price}</span>
-        )}
+        <PriceLabel className="mt-3 self-start @xl:ml-auto" price={lineItem.price} />
         <div className="flex size-min flex-col gap-y-0">
           <div className="mb-1 mt-1 flex items-center gap-x-5">
             {/* Counter */}


### PR DESCRIPTION
## What / Why
BigCommerce control panel lets merchants choose how tax displays on the storefront (`Inc.`, `Ex.`, or `Both`), set independently for product detail pages and product listing pages. Stencil honors this; Catalyst did not. This adds parity so merchants who switch from Stencil to Catalyst keep the same shopper-facing price behavior out of the box.

Cart decisions
Line items show EX or INC only, not BOTH. On product pages, BOTH helps shoppers compare bases while they decide. In the cart they've already decided, so two stacked prices per line is clutter without decision value. We follow BC's cart.isTaxIncluded flag to pick one mode.

Tax info appears as a note under the total instead of a "Tax" row. In INC mode, tax is already inside the line items. A "Tax" row would mislead by looking additive. A "Tax Included in Subtotal" row would also mislead because some tax (shipping tax) isn't actually in the subtotal. A small note under the total ("Includes $X tax") avoids both issues.

Shipping is labeled "(Ex. Tax)" in INC mode. BC's storefront GraphQL doesn't expose shipping with tax included. There's no shippingCostInclusiveTax field, no per-shipping tax rate, and no tax breakdown that maps amounts to shipping vs items. To compute it ourselves we'd have to either assume shipping shares the item tax rate (could be wrong by jurisdiction) or back-solve from grand total (breaks for stores with gift wrap, handling, or custom fees).

Cornerstone:
<img width="593" height="405" alt="Screenshot 2026-05-22 at 12 35 12 PM" src="https://github.com/user-attachments/assets/7a4680c4-f64f-47f6-be59-32492f9a8af4" />

Catalyst Change:
<img width="593" height="316" alt="Screenshot 2026-05-22 at 12 34 59 PM" src="https://github.com/user-attachments/assets/c1b20ef9-05a7-420a-8b98-a21f140d3864" />

## Summary
- Reads `settings.tax.pdp` and `settings.tax.plp` from BigCommerce control panel and threads it through pricing.
- `PricingFragment` now fetches both `pricesIncludingTax` and `pricesExcludingTax` so the renderer can show either or both without re-querying.
- `PriceLabel` adds a `BOTH` mode that stacks two prices, with sale and range handled per line.

## JIRA
https://bigcommercecloud.atlassian.net/browse/TRAC-188

## Migration
No data migration required. The `Price` type in `vibes/soul/primitives/price-label` has changed shape (added `Money`, `PricePlain`; removed `PriceTaxBoth`). Forks importing `Price` directly will need to update.

# Testing Instructions for TRAC-188

## What's Being Tested

Tax Display setting from BigCommerce Control Panel applies to all product price displays:
- Mode `Inc.` → shows `(Inc. Tax)` label
- Mode `Ex.` → shows `(Ex. Tax)` label  
- Mode `Both` → shows **stacked prices** with both labels

## Test Checklist

### Set CP Tax Display Setting to `Inc.` (Inclusive of Tax)
- [x] PDP product page shows `$X.XX`
<img width="488" height="488" alt="Screenshot 2026-05-30 at 12 33 02 PM" src="https://github.com/user-attachments/assets/ff982e7d-73b5-4816-961e-4016f2215611" />

- [x] Category PLP cards show `$X.XX`
<img width="735" height="727" alt="Screenshot 2026-05-30 at 12 31 48 PM" src="https://github.com/user-attachments/assets/96223b82-f7f3-4702-a782-025baa7f9d35" />

- [x] Search results show `$X.XX`
<img width="733" height="707" alt="Screenshot 2026-05-30 at 12 32 16 PM" src="https://github.com/user-attachments/assets/0f4cf46e-dcf5-4928-8181-cb987740d04d" />

- [x] Home page featured products show `$X.XX`
<img width="454" height="650" alt="Screenshot 2026-05-30 at 12 29 35 PM" src="https://github.com/user-attachments/assets/67ae7234-6187-4cd7-9b54-c0029797d411" />

- [x] Compare page shows `$X.XX` for all products
<img width="523" height="343" alt="Screenshot 2026-05-30 at 12 34 40 PM" src="https://github.com/user-attachments/assets/b46d82d0-599a-4b5b-95a3-c284153bbc55" />

- [x] Wishlist shows `$X.XX`
<img width="245" height="208" alt="Screenshot 2026-05-30 at 12 35 24 PM" src="https://github.com/user-attachments/assets/2e094334-3373-436c-95b9-900e53ec0629" />

- [x] Sale price shows `$SALE.XX` with original price struck through
- [x] Range price shows `From $MIN.XX - $MAX.XX`
- [x] Cart line items are INC and summary language is correct
<img width="736" height="325" alt="Screenshot 2026-05-30 at 3 28 36 PM" src="https://github.com/user-attachments/assets/bdd2f2bb-a6d9-43ec-822e-d9a835bf5a50" />


### Set CP Tax Display Setting to `Ex.` (Exclusive of Tax)
- [x] PDP product page shows `$X.XX`
<img width="480" height="489" alt="Screenshot 2026-05-30 at 12 49 37 PM" src="https://github.com/user-attachments/assets/306e2555-bf21-49f2-82a0-50d61e88a4fc" />

- [x] Category PLP cards show `$X.XX`
<img width="735" height="728" alt="Screenshot 2026-05-30 at 12 50 21 PM" src="https://github.com/user-attachments/assets/75d70a91-c848-43d3-8d03-fc6be8119fd1" />

- [x] Search results show `$X.XX`
<img width="738" height="499" alt="Screenshot 2026-05-30 at 12 53 08 PM" src="https://github.com/user-attachments/assets/4cd1ee84-3398-445c-8320-1205cc0d879c" />

- [x] Home page featured products show `$X.XX`
<img width="730" height="674" alt="Screenshot 2026-05-30 at 12 54 26 PM" src="https://github.com/user-attachments/assets/880c3696-7529-4b81-bd07-795f0f0ab21b" />

- [x] Compare page shows `$X.XX` for all products
<img width="517" height="341" alt="Screenshot 2026-05-30 at 12 55 03 PM" src="https://github.com/user-attachments/assets/6611346e-2ac1-4ee4-9405-45d1e6e58947" />

- [x] Wishlist shows `$X.XX`
<img width="242" height="216" alt="Screenshot 2026-05-30 at 12 55 50 PM" src="https://github.com/user-attachments/assets/78a3494c-20ae-4ef9-a99a-7dd7a5b9293c" />

- [x] Sale price shows `$X.XX` with original price struck through
- [x] Range price shows `$MIN.XX - $MAX.XX'
- [x] Cart line items are EXC and summary language is correct
<img width="731" height="339" alt="Screenshot 2026-05-30 at 3 29 31 PM" src="https://github.com/user-attachments/assets/6fc6ef72-5d7b-43f5-8f6d-9debb527f2db" />


### Set CP PDP Tax Display Setting to `Both` and price INC (Stacked)
- [x] PDP product page shows stacked prices
<img width="480" height="485" alt="Screenshot 2026-05-30 at 1 01 40 PM" src="https://github.com/user-attachments/assets/1f8b546d-1a96-4c26-924b-440aecd78c62" />

### Set CP PLP Tax Display Setting to `Both` and price INC (Stacked)
- [x] Category PLP cards show stacked pricing
<img width="732" height="743" alt="Screenshot 2026-05-30 at 1 02 21 PM" src="https://github.com/user-attachments/assets/7f90fdfd-0e29-48da-9841-4abac007f95f" />

- [x] Search results show stacked pricing
<img width="733" height="521" alt="Screenshot 2026-05-30 at 1 03 08 PM" src="https://github.com/user-attachments/assets/f2380e7b-b986-45c8-b476-fd98df047a7a" />

- [x] Home page shows stacked pricing
<img width="732" height="712" alt="Screenshot 2026-05-30 at 1 00 46 PM" src="https://github.com/user-attachments/assets/62223a12-44db-46de-9633-99d0131bc440" />

- [x] Compare page shows stacked prices aligned in columns
<img width="525" height="310" alt="Screenshot 2026-05-30 at 1 03 45 PM" src="https://github.com/user-attachments/assets/524c08bb-c4b5-426a-88c3-20a7ef1207e8" />

- [x] Wishlist shows stacked pricing
<img width="240" height="238" alt="Screenshot 2026-05-30 at 1 04 29 PM" src="https://github.com/user-attachments/assets/1c1efd39-5836-44fb-8d76-2d483270575e" />

- [x] Sale price: original and current prices both stacked:
- [x] Range price shows stacked min and max:

### Set CP Tax Display Setting to `Both` and 'INC' On Tax Exempt Store
- [x] PDP product page shows EXC prices
<img width="478" height="486" alt="Screenshot 2026-05-30 at 4 28 55 PM" src="https://github.com/user-attachments/assets/49c9f38e-1cda-46a4-a272-016cbf25e69d" />

- [x] Home page shows EXC pricing
<img width="472" height="238" alt="Screenshot 2026-05-30 at 4 28 12 PM" src="https://github.com/user-attachments/assets/e2562c8a-b624-46c5-b35f-11f2d7d9adf5" />

- [x] Cart line items are EXC and summary language is correct
<img width="464" height="56" alt="Screenshot 2026-05-30 at 4 29 22 PM" src="https://github.com/user-attachments/assets/f0187dbb-41a7-4854-8bb6-6472c28690ac" />

### Range Prices On Sale Display
- [x] HOME: CP INC
<img width="155" height="223" alt="Screenshot 2026-05-30 at 4 20 05 PM" src="https://github.com/user-attachments/assets/91f23878-78e8-4337-b688-46547ec2ad32" />

- [x] HOME: CP EXC
<img width="154" height="223" alt="Screenshot 2026-05-30 at 3 59 42 PM" src="https://github.com/user-attachments/assets/7f4a282b-34a7-4611-8dd8-421b4c85a80f" />

- [x] HOME: CP INC PDP/PLP BOTH
<img width="162" height="243" alt="Screenshot 2026-05-30 at 3 53 59 PM" src="https://github.com/user-attachments/assets/9fb975c7-60a7-43cb-8f59-b2254c4856e8" />

- [x] WISHLIST: CP INC
<img width="77" height="114" alt="Screenshot 2026-05-30 at 4 20 30 PM" src="https://github.com/user-attachments/assets/cee56c1c-2e65-4664-a95c-3a7b21caa3c3" />

- [x] WISHLIST: CP EXC
<img width="76" height="113" alt="Screenshot 2026-05-30 at 4 00 15 PM" src="https://github.com/user-attachments/assets/90b36997-af60-40aa-95f7-73ceed921e10" />

- [x] WISHLIST: CP INC PDP/PLP BOTH
<img width="80" height="151" alt="Screenshot 2026-05-30 at 3 54 25 PM" src="https://github.com/user-attachments/assets/89a729ca-2700-47af-85c7-1ce97fa4e008" />

- [x] CART: CP INC
<img width="467" height="53" alt="Screenshot 2026-05-30 at 4 20 53 PM" src="https://github.com/user-attachments/assets/839095d7-3e17-469f-a5ad-b92412f81852" />

- [x] CART: CP EXC
<img width="462" height="55" alt="Screenshot 2026-05-30 at 4 00 38 PM" src="https://github.com/user-attachments/assets/6f0c96bb-b32e-4248-a815-08ec168cbda1" />

- [x] CART: CP INC PDP/PLP BOTH
<img width="464" height="57" alt="Screenshot 2026-05-30 at 3 55 59 PM" src="https://github.com/user-attachments/assets/ad697080-49ec-4b32-9b9b-cab15c3a4447" />

- [x] CART: CP EXC PDP/PLP BOTH
<img width="464" height="56" alt="Screenshot 2026-05-30 at 3 57 45 PM" src="https://github.com/user-attachments/assets/d992ff9a-9410-4d09-a41b-88ee39e3a34a" />

- [x] PDP: CP INC
<img width="487" height="482" alt="Screenshot 2026-05-30 at 4 21 20 PM" src="https://github.com/user-attachments/assets/9ea31721-e6c2-4d6c-8b26-7ac503a32f4d" />

- [x] PDP: CP EXC
<img width="489" height="483" alt="Screenshot 2026-05-30 at 4 01 03 PM" src="https://github.com/user-attachments/assets/f7812f81-4420-421c-ba84-325d5b9b9b62" />

- [x] PDP: CP INC PDP/PLP BOTH
<img width="507" height="488" alt="Screenshot 2026-05-30 at 3 55 21 PM" src="https://github.com/user-attachments/assets/a37f2b55-cfca-4f90-9675-2c84249fd722" />