### PR TITLE
fix(cli): remove implicit secret detection from deploy

### DIFF
--- a/packages/catalyst/src/cli/commands/deploy.spec.ts
+++ b/packages/catalyst/src/cli/commands/deploy.spec.ts
@@ -27,7 +27,6 @@ import { program } from '../program';
 
 import { buildCatalystProject } from './build';
 import {
-  autoDetectSecrets,
   createDeployment,
   deploy,
   generateBundleZip,
@@ -553,91 +552,6 @@ test('reads from env options', () => {
   expect(() => parseEnvironmentVariables(['foo_bar'])).toThrow(
     'Invalid secret format: foo_bar. Expected format: KEY=VALUE',
   );
-});
-
-describe('autoDetectSecrets', () => {
-  test('auto-detects env vars from process.env', () => {
-    vi.stubEnv('BIGCOMMERCE_STORE_HASH', 'hash123');
-    vi.stubEnv('BIGCOMMERCE_CHANNEL_ID', '1');
-    vi.stubEnv('BIGCOMMERCE_STOREFRONT_TOKEN', 'token456');
-    vi.stubEnv('BIGCOMMERCE_API_HOST', 'api.bigcommerce.com');
-    vi.stubEnv('BIGCOMMERCE_GRAPHQL_API_DOMAIN', 'graphql.bigcommerce.com');
-    vi.stubEnv('AUTH_SECRET', 'secret789');
-
-    const result = autoDetectSecrets([]);
-
-    expect(result).toEqual([
-      { type: 'secret', key: 'BIGCOMMERCE_STORE_HASH', value: 'hash123' },
-      { type: 'secret', key: 'BIGCOMMERCE_CHANNEL_ID', value: '1' },
-      { type: 'secret', key: 'BIGCOMMERCE_STOREFRONT_TOKEN', value: 'token456' },
-      { type: 'secret', key: 'BIGCOMMERCE_API_HOST', value: 'api.bigcommerce.com' },
-      { type: 'secret', key: 'BIGCOMMERCE_GRAPHQL_API_DOMAIN', value: 'graphql.bigcommerce.com' },
-      { type: 'secret', key: 'AUTH_SECRET', value: 'secret789' },
-    ]);
-
-    vi.unstubAllEnvs();
-  });
-
-  test('skips env vars already provided by user', () => {
-    vi.stubEnv('BIGCOMMERCE_STORE_HASH', 'env-hash');
-    vi.stubEnv('BIGCOMMERCE_CHANNEL_ID', '99');
-
-    const result = autoDetectSecrets([
-      { type: 'secret', key: 'BIGCOMMERCE_STORE_HASH', value: 'user-hash' },
-    ]);
-
-    expect(result).toContainEqual({
-      type: 'secret',
-      key: 'BIGCOMMERCE_STORE_HASH',
-      value: 'user-hash',
-    });
-    expect(result).not.toContainEqual(
-      expect.objectContaining({ key: 'BIGCOMMERCE_STORE_HASH', value: 'env-hash' }),
-    );
-    expect(result).toContainEqual({
-      type: 'secret',
-      key: 'BIGCOMMERCE_CHANNEL_ID',
-      value: '99',
-    });
-
-    vi.unstubAllEnvs();
-  });
-
-  test('warns for required missing env vars', () => {
-    vi.stubEnv('BIGCOMMERCE_STORE_HASH', '');
-    vi.stubEnv('BIGCOMMERCE_CHANNEL_ID', '');
-    vi.stubEnv('BIGCOMMERCE_STOREFRONT_TOKEN', '');
-
-    autoDetectSecrets([]);
-
-    expect(consola.warn).toHaveBeenCalledWith(expect.stringContaining('BIGCOMMERCE_STORE_HASH'));
-    expect(consola.warn).toHaveBeenCalledWith(expect.stringContaining('BIGCOMMERCE_CHANNEL_ID'));
-    expect(consola.warn).toHaveBeenCalledWith(
-      expect.stringContaining('BIGCOMMERCE_STOREFRONT_TOKEN'),
-    );
-
-    vi.unstubAllEnvs();
-  });
-
-  test('silently skips optional missing env vars', () => {
-    vi.stubEnv('BIGCOMMERCE_API_HOST', '');
-    vi.stubEnv('BIGCOMMERCE_GRAPHQL_API_DOMAIN', '');
-
-    autoDetectSecrets([]);
-
-    const warnCalls = vi.mocked(consola.warn).mock.calls.flat().join(' ');
-
-    expect(warnCalls).not.toContain('BIGCOMMERCE_API_HOST');
-    expect(warnCalls).not.toContain('BIGCOMMERCE_GRAPHQL_API_DOMAIN');
-
-    vi.unstubAllEnvs();
-  });
-
-  test('returns empty array when no env vars and no input', () => {
-    const result = autoDetectSecrets(undefined);
-
-    expect(result).toEqual(expect.arrayContaining([]));
-  });
 });
 
 describe('--prebuilt flag', () => {

--- a/packages/catalyst/src/cli/commands/deploy.ts
+++ b/packages/catalyst/src/cli/commands/deploy.ts
@@ -192,38 +192,6 @@ export const parseEnvironmentVariables = (secretOption?: string[]) => {
   });
 };
 
-const AUTO_DETECT_SECRETS = [
-  { key: 'BIGCOMMERCE_STORE_HASH', warnIfMissing: true },
-  { key: 'BIGCOMMERCE_CHANNEL_ID', warnIfMissing: true },
-  { key: 'BIGCOMMERCE_STOREFRONT_TOKEN', warnIfMissing: true },
-  { key: 'BIGCOMMERCE_API_HOST', warnIfMissing: false },
-  { key: 'BIGCOMMERCE_GRAPHQL_API_DOMAIN', warnIfMissing: false },
-  { key: 'AUTH_SECRET', warnIfMissing: false },
-];
-
-export const autoDetectSecrets = (
-  environmentVariables?: Array<{ type: 'secret' | 'plain_text'; key: string; value: string }>,
-) => {
-  const secrets = environmentVariables ?? [];
-  const existingKeys = new Set(secrets.map((s) => s.key));
-
-  AUTO_DETECT_SECRETS.forEach(({ key, warnIfMissing }) => {
-    if (existingKeys.has(key)) {
-      return;
-    }
-
-    const value = process.env[key];
-
-    if (value) {
-      secrets.push({ type: 'secret', key, value });
-    } else if (warnIfMissing) {
-      consola.warn(`${key} is not set in the environment and was not provided via --secret.`);
-    }
-  });
-
-  return secrets;
-};
-
 export const createDeployment = async (
   projectUuid: string,
   uploadUuid: string,
@@ -541,7 +509,7 @@ Example:
 
     await uploadBundleZip(uploadSignature.upload_url);
 
-    const environmentVariables = autoDetectSecrets(parseEnvironmentVariables(options.secret));
+    const environmentVariables = parseEnvironmentVariables(options.secret);
 
     const { deployment_uuid: deploymentUuid } = await createDeployment(
       projectUuid,


### PR DESCRIPTION
Linear: [LTRAC-640](https://linear.app/commerce/issue/LTRAC-640/remove-implicit-secret-detection-to-prevent-deployment-errors) · Jira: [TRAC-626](https://bigcommercecloud.atlassian.net/browse/TRAC-626)

## What/Why?

`catalyst deploy` silently scanned `process.env` for a hardcoded allowlist (`BIGCOMMERCE_STORE_HASH`, `BIGCOMMERCE_CHANNEL_ID`, `BIGCOMMERCE_STOREFRONT_TOKEN`, `BIGCOMMERCE_API_HOST`, `BIGCOMMERCE_GRAPHQL_API_DOMAIN`, `AUTH_SECRET`) and shipped matches as runtime secrets on the deployed Cloudflare worker. A developer with `.env.local` populated for local dev could push those values to production without noticing. Per Miguel's note on LTRAC-442, every other deploy CLI requires explicit env-var declaration at deploy time — this aligns with that model.

Users now declare each secret explicitly via `--secret KEY=VALUE` (repeatable). The `--secret` flag, the `parseEnvironmentVariables` helper, and the help-text example are unchanged.

**Scope is deliberately narrow.** We considered and intentionally left alone:

- `--env-path` (global, defined in `program.ts`) — still loads `.env` files into `process.env` for CLI input resolution; no longer affects the deployment payload.
- The commander `.env('CATALYST_STORE_HASH')` / `.env('CATALYST_ACCESS_TOKEN')` / `.env('BIGCOMMERCE_API_HOST')` / `.env('CATALYST_PROJECT_UUID')` bindings in `shared-options.ts` — 1:1 documented mappings to a `--flag`, equivalent to typing the flag.
- `.env.local` auto-load + the `BIGCOMMERCE_STORE_HASH` → `CATALYST_STORE_HASH` alias in `program.ts` — also CLI input resolution only, never deployment payload.

Improving the bulk-secrets UX (e.g. an `--env-file` for deploy that ships file contents as secrets) is tracked separately under LTRAC-442.

## Testing

- `pnpm test src/cli/commands/deploy.spec.ts` — 29/29 passing locally with the `autoDetectSecrets` describe block removed.
- `pnpm lint` and `pnpm typecheck` — clean; no dangling references to `autoDetectSecrets` / `AUTO_DETECT_SECRETS`.
- Manual smoke:
  - `catalyst deploy --secret BIGCOMMERCE_STORE_HASH=... --secret BIGCOMMERCE_STOREFRONT_TOKEN=... --dry-run` — runs through; full deploy payload contains exactly the declared secrets.
  - `catalyst deploy --dry-run` (no `--secret` flags) — no auto-detect output, no "X is not set in the environment" warnings, payload omits `environment_variables`.

## Migration

Deploys that relied on implicit `process.env` detection must now pass each secret explicitly:

```
catalyst deploy \
  --secret BIGCOMMERCE_STORE_HASH=<hash> \
  --secret BIGCOMMERCE_CHANNEL_ID=<id> \
  --secret BIGCOMMERCE_STOREFRONT_TOKEN=<token> \
  --secret AUTH_SECRET=<secret>
```

[TRAC-626]: https://bigcommercecloud.atlassian.net/browse/TRAC-626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ