### PR TITLE
feat(cli): make catalyst auth login and project create onboarding interactive

### DIFF
--- a/.changeset/cli-interactive-auth-onboarding.md
+++ b/.changeset/cli-interactive-auth-onboarding.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst": patch
+---
+
+Make `catalyst auth login` and `catalyst project create` walk first-time users through authentication interactively. When the browser-based device-code flow isn't available, the CLI now offers to fall back to a guided store-hash + access-token prompt (with credential validation against the store profile API). `catalyst project create` no longer requires credentials up front — it kicks off the same interactive login when none are stored.

--- a/.changeset/cli-interactive-auth-onboarding.md
+++ b/.changeset/cli-interactive-auth-onboarding.md
@@ -1,5 +1,0 @@
----
-"@bigcommerce/catalyst": patch
----
-
-Make `catalyst auth login` and `catalyst project create` walk first-time users through authentication interactively. When the browser-based device-code flow isn't available, the CLI now offers to fall back to a guided store-hash + access-token prompt (with credential validation against the store profile API). `catalyst project create` no longer requires credentials up front — it kicks off the same interactive login when none are stored.

--- a/packages/catalyst/src/cli/commands/auth.spec.ts
+++ b/packages/catalyst/src/cli/commands/auth.spec.ts
@@ -1,3 +1,4 @@
+import { password } from '@inquirer/prompts';
 import { Command } from 'commander';
 import { http, HttpResponse } from 'msw';
 import { realpath } from 'node:fs/promises';
@@ -25,6 +26,11 @@ import { auth } from './auth';
 // eslint-disable-next-line import/dynamic-import-chunkname
 vi.mock('yocto-spinner', () => import('../../../tests/mocks/spinner'));
 vi.mock('open', () => ({ default: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('@inquirer/prompts', () => ({
+  password: vi.fn(),
+}));
+
+const passwordMock = vi.mocked(password);
 
 let exitMock: MockInstance;
 let tmpDir: string;
@@ -149,18 +155,137 @@ describe('login', () => {
     expect(exitMock).toHaveBeenCalledWith(0);
   });
 
-  test('handles API error during device code request', async () => {
+  test('prompts to fall back to manual login when device code request fails', async () => {
     server.use(
       http.post(
         'https://login.bigcommerce.com/device/token',
-        () => new HttpResponse(null, { status: 500, statusText: 'Internal Server Error' }),
+        () => new HttpResponse(null, { status: 404, statusText: 'Not Found' }),
       ),
     );
 
+    passwordMock.mockResolvedValueOnce('manual-access-token');
+
+    const promptMock = vi
+      .spyOn(consola, 'prompt')
+      .mockImplementationOnce(async (message, opts) => {
+        expect(message).toContain('Try logging in manually');
+        expect(opts).toMatchObject({ type: 'confirm' });
+
+        return Promise.resolve(true);
+      })
+      .mockImplementationOnce(async (message, opts) => {
+        expect(message).toBe('Store hash:');
+        expect(opts).toMatchObject({ type: 'text' });
+
+        return Promise.resolve('manual-store-hash');
+      });
+
     await program.parseAsync(['node', 'catalyst', 'auth', 'login']);
 
-    expect(consola.error).toHaveBeenCalledWith(expect.stringContaining('Login failed'));
+    expect(consola.warn).toHaveBeenCalledWith(expect.stringContaining("Browser login didn't work"));
+    expect(consola.success).toHaveBeenCalledWith('Logged in to store manual-store-hash.');
+    expect(exitMock).toHaveBeenCalledWith(0);
+
+    const config = getProjectConfig();
+
+    expect(config.get('storeHash')).toBe('manual-store-hash');
+    expect(config.get('accessToken')).toBe('manual-access-token');
+
+    promptMock.mockRestore();
+  });
+
+  test('exits cleanly when user declines manual login fallback', async () => {
+    server.use(
+      http.post(
+        'https://login.bigcommerce.com/device/token',
+        () => new HttpResponse(null, { status: 404, statusText: 'Not Found' }),
+      ),
+    );
+
+    const promptMock = vi.spyOn(consola, 'prompt').mockResolvedValueOnce(false);
+
+    await program.parseAsync(['node', 'catalyst', 'auth', 'login']);
+
+    expect(consola.warn).toHaveBeenCalledWith(expect.stringContaining("Browser login didn't work"));
+    expect(consola.info).toHaveBeenCalledWith(
+      'Login aborted. Re-run `catalyst auth login` when you have your credentials ready.',
+    );
+    expect(exitMock).toHaveBeenCalledWith(0);
+
+    promptMock.mockRestore();
+  });
+
+  test('fails when manual credentials cannot be validated', async () => {
+    server.use(
+      http.post(
+        'https://login.bigcommerce.com/device/token',
+        () => new HttpResponse(null, { status: 404, statusText: 'Not Found' }),
+      ),
+      http.get(
+        'https://:apiHost/stores/:storeHash/v3/settings/store/profile',
+        () => new HttpResponse(null, { status: 401, statusText: 'Unauthorized' }),
+      ),
+    );
+
+    passwordMock.mockResolvedValueOnce('bad-token');
+
+    const promptMock = vi
+      .spyOn(consola, 'prompt')
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce('manual-store-hash');
+
+    await program.parseAsync(['node', 'catalyst', 'auth', 'login']);
+
+    expect(consola.error).toHaveBeenCalledWith(
+      expect.stringContaining('Could not validate credentials'),
+    );
     expect(exitMock).toHaveBeenCalledWith(1);
+
+    promptMock.mockRestore();
+  });
+
+  test('rejects empty store hash during manual login', async () => {
+    server.use(
+      http.post(
+        'https://login.bigcommerce.com/device/token',
+        () => new HttpResponse(null, { status: 404, statusText: 'Not Found' }),
+      ),
+    );
+
+    const promptMock = vi
+      .spyOn(consola, 'prompt')
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce('   ');
+
+    await program.parseAsync(['node', 'catalyst', 'auth', 'login']);
+
+    expect(consola.error).toHaveBeenCalledWith(expect.stringContaining('Store hash is required'));
+    expect(exitMock).toHaveBeenCalledWith(1);
+
+    promptMock.mockRestore();
+  });
+
+  test('rejects empty access token during manual login', async () => {
+    server.use(
+      http.post(
+        'https://login.bigcommerce.com/device/token',
+        () => new HttpResponse(null, { status: 404, statusText: 'Not Found' }),
+      ),
+    );
+
+    passwordMock.mockResolvedValueOnce('   ');
+
+    const promptMock = vi
+      .spyOn(consola, 'prompt')
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce('manual-store-hash');
+
+    await program.parseAsync(['node', 'catalyst', 'auth', 'login']);
+
+    expect(consola.error).toHaveBeenCalledWith(expect.stringContaining('Access token is required'));
+    expect(exitMock).toHaveBeenCalledWith(1);
+
+    promptMock.mockRestore();
   });
 
   test('handles browser open failure gracefully', async () => {

--- a/packages/catalyst/src/cli/commands/auth.ts
+++ b/packages/catalyst/src/cli/commands/auth.ts
@@ -1,13 +1,11 @@
 import { Command, Option } from 'commander';
-import { colorize } from 'consola/utils';
-import open from 'open';
-import yoctoSpinner from 'yocto-spinner';
 import { z } from 'zod';
 
-import { DEFAULT_LOGIN_URL, requestDeviceCode, waitForDeviceToken } from '../lib/auth';
 import { consola } from '../lib/logger';
+import { LoginAbortedError, login as runInteractiveLogin } from '../lib/login';
 import { fetchProjects } from '../lib/project';
 import { getProjectConfig } from '../lib/project-config';
+import { loginUrlOption } from '../lib/shared-options';
 
 const StoreProfileSchema = z.object({
   data: z.object({
@@ -122,16 +120,16 @@ Example:
 const login = new Command('login')
   .configureHelp({ showGlobalOptions: true })
   .description(
-    'Authenticate via browser using the OAuth device code flow. If already logged in, displays current credentials and suggests running `catalyst auth logout` to re-authenticate.',
+    'Authenticate via browser using the OAuth device code flow. Falls back to an interactive store hash + access token prompt if the browser flow is unavailable. If already logged in, displays current credentials and suggests running `catalyst auth logout` to re-authenticate.',
   )
   .addHelpText(
     'after',
     `
 Examples:
-  # Login via browser (recommended)
+  # Login interactively (browser, with manual fallback)
   $ catalyst auth login
 
-  # Login with existing credentials (skips browser flow)
+  # Login with existing credentials (skips interactive flow)
   $ catalyst auth login --store-hash <STORE_HASH> --access-token <ACCESS_TOKEN>`,
   )
   .addOption(
@@ -147,11 +145,12 @@ Examples:
     ).env('CATALYST_ACCESS_TOKEN'),
   )
   .addOption(
-    new Option('--login-url <url>', 'BigCommerce login URL.')
-      .env('BIGCOMMERCE_LOGIN_URL')
-      .default(DEFAULT_LOGIN_URL)
+    new Option('--api-host <host>', 'BigCommerce API host. The default is api.bigcommerce.com.')
+      .env('BIGCOMMERCE_API_HOST')
+      .default('api.bigcommerce.com')
       .hideHelp(),
   )
+  .addOption(loginUrlOption())
   .action(async (options) => {
     try {
       const config = getProjectConfig();
@@ -167,37 +166,23 @@ Examples:
         return;
       }
 
-      const deviceCode = await requestDeviceCode(options.loginUrl);
+      const credentials = await runInteractiveLogin(options.loginUrl, options.apiHost);
 
-      consola.info(
-        `${colorize('yellow', 'Your one-time code:')} ${colorize('bold', deviceCode.user_code)}`,
-      );
+      config.set('storeHash', credentials.storeHash);
+      config.set('accessToken', credentials.accessToken);
 
-      try {
-        await open(deviceCode.verification_uri);
-        consola.info(`Opened ${deviceCode.verification_uri} in your browser.`);
-      } catch {
-        consola.info(
-          `Open ${deviceCode.verification_uri} in your browser and enter the code above.`,
-        );
-      }
-
-      const spinner = yoctoSpinner().start('Waiting for authentication...');
-
-      const credentials = await waitForDeviceToken(
-        options.loginUrl,
-        deviceCode.device_code,
-        deviceCode.interval,
-      );
-
-      spinner.success('Authentication complete.');
-
-      config.set('storeHash', credentials.store_hash);
-      config.set('accessToken', credentials.access_token);
-
-      consola.success(`Logged in to store ${credentials.store_hash}.`);
+      consola.success(`Logged in to store ${credentials.storeHash}.`);
       process.exit(0);
     } catch (error) {
+      if (error instanceof LoginAbortedError) {
+        consola.info(
+          'Login aborted. Re-run `catalyst auth login` when you have your credentials ready.',
+        );
+        process.exit(0);
+
+        return;
+      }
+
       const message = error instanceof Error ? error.message : String(error);
 
       consola.error(`Login failed: ${message}`);

--- a/packages/catalyst/src/cli/commands/create.spec.ts
+++ b/packages/catalyst/src/cli/commands/create.spec.ts
@@ -8,7 +8,7 @@ import { cloneCatalyst } from '../lib/clone-catalyst';
 import { promptForCommerceHostingProject, setupCommerceHosting } from '../lib/commerce-hosting';
 import { installDependencies } from '../lib/install-dependencies';
 import { consola } from '../lib/logger';
-import { login } from '../lib/login';
+import { login, LoginAbortedError } from '../lib/login';
 import { mkTempDir } from '../lib/mk-temp-dir';
 import { hasProjectsAccess } from '../lib/project';
 import { setupCoreProject } from '../lib/setup-core-project';
@@ -26,11 +26,21 @@ vi.mock('@inquirer/prompts', () => ({
   select: vi.fn(),
 }));
 
+const { MockLoginAbortedError } = vi.hoisted(() => ({
+  MockLoginAbortedError: class extends Error {
+    constructor() {
+      super('Login aborted by user.');
+      this.name = 'LoginAbortedError';
+    }
+  },
+}));
+
 vi.mock('../lib/login', () => ({
   login: vi.fn().mockResolvedValue({
     storeHash: 'login-store-hash',
     accessToken: 'login-access-token',
   }),
+  LoginAbortedError: MockLoginAbortedError,
 }));
 
 vi.mock('../lib/clone-catalyst', () => ({ cloneCatalyst: vi.fn() }));
@@ -427,6 +437,44 @@ describe('failure handling', () => {
     ).rejects.toThrow('clone failed before creating directory');
 
     expect(consola.warn).not.toHaveBeenCalledWith(expect.stringContaining('partial state'));
+  });
+
+  test('exits cleanly when the user aborts the interactive login', async () => {
+    vi.mocked(login).mockRejectedValueOnce(new LoginAbortedError());
+
+    await program.parseAsync([
+      'node',
+      'catalyst',
+      'create',
+      '--project-name',
+      uniqueProjectName(),
+      '--project-dir',
+      tmpDir,
+    ]);
+
+    expect(consola.info).toHaveBeenCalledWith(
+      'Login aborted. Re-run `catalyst create` when you have your credentials ready.',
+    );
+    expect(exitMock).toHaveBeenCalledWith(0);
+    expect(cloneCatalyst).not.toHaveBeenCalled();
+  });
+
+  test('propagates non-LoginAbortedError login failures', async () => {
+    vi.mocked(login).mockRejectedValueOnce(new Error('network down'));
+
+    await expect(
+      program.parseAsync([
+        'node',
+        'catalyst',
+        'create',
+        '--project-name',
+        uniqueProjectName(),
+        '--project-dir',
+        tmpDir,
+      ]),
+    ).rejects.toThrow('network down');
+
+    expect(cloneCatalyst).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/catalyst/src/cli/commands/create.ts
+++ b/packages/catalyst/src/cli/commands/create.ts
@@ -19,7 +19,7 @@ import { promptForCommerceHostingProject, setupCommerceHosting } from '../lib/co
 import { installDependencies } from '../lib/install-dependencies';
 import { getAvailableLocales } from '../lib/localization';
 import { consola } from '../lib/logger';
-import { login } from '../lib/login';
+import { login, LoginAbortedError } from '../lib/login';
 import { hasProjectsAccess, type ProjectListItem } from '../lib/project';
 import { setupCoreProject } from '../lib/setup-core-project';
 import { accessTokenOption, storeHashOption } from '../lib/shared-options';
@@ -333,10 +333,25 @@ Examples:
     // access token. Device login covers the missing pieces; the user picks the
     // store during the OAuth flow regardless of any partial flags they passed.
     if (!storeHash || !accessToken) {
-      const credentials = await login(options.loginUrl);
+      const apiHost = `api.${options.bigcommerceHostname}`;
 
-      storeHash = credentials.storeHash;
-      accessToken = credentials.accessToken;
+      try {
+        const credentials = await login(options.loginUrl, apiHost);
+
+        storeHash = credentials.storeHash;
+        accessToken = credentials.accessToken;
+      } catch (error) {
+        if (error instanceof LoginAbortedError) {
+          consola.info(
+            'Login aborted. Re-run `catalyst create` when you have your credentials ready.',
+          );
+          process.exit(0);
+
+          return;
+        }
+
+        throw error;
+      }
     }
 
     const useCommerceHosting = options.hosting === 'commerce';

--- a/packages/catalyst/src/cli/commands/project.spec.ts
+++ b/packages/catalyst/src/cli/commands/project.spec.ts
@@ -1,3 +1,4 @@
+import { password } from '@inquirer/prompts';
 import { Command } from 'commander';
 import Conf from 'conf';
 import { http, HttpResponse } from 'msw';
@@ -24,6 +25,13 @@ import { program } from '../program';
 
 import { link, project } from './project';
 
+// eslint-disable-next-line import/dynamic-import-chunkname
+vi.mock('yocto-spinner', () => import('../../../tests/mocks/spinner'));
+vi.mock('open', () => ({ default: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('@inquirer/prompts', () => ({
+  password: vi.fn(),
+}));
+
 vi.mock('../lib/project-state', () => ({
   getProjectState: vi.fn(),
 }));
@@ -31,6 +39,8 @@ vi.mock('../lib/project-state', () => ({
 vi.mock('../lib/install-dependencies', () => ({
   installDependencies: vi.fn().mockResolvedValue(undefined),
 }));
+
+const passwordMock = vi.mocked(password);
 
 vi.mock('../lib/commerce-hosting', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../lib/commerce-hosting')>();
@@ -204,26 +214,100 @@ describe('project create', () => {
     consolaPromptMock.mockRestore();
   });
 
-  test('with insufficient credentials exits with error', async () => {
-    // Unset env so Commander doesn't pick up CATALYST_* and trigger the create flow (which would prompt for name)
+  test('runs interactive login when no credentials are provided', async () => {
     const savedStoreHash = process.env.CATALYST_STORE_HASH;
     const savedAccessToken = process.env.CATALYST_ACCESS_TOKEN;
 
     delete process.env.CATALYST_STORE_HASH;
     delete process.env.CATALYST_ACCESS_TOKEN;
 
-    await expect(program.parseAsync(['node', 'catalyst', 'project', 'create'])).rejects.toThrow(
-      'Missing credentials',
-    );
+    const consolaPromptMock = vi.spyOn(consola, 'prompt').mockResolvedValueOnce('My New Project');
+
+    await program.parseAsync(['node', 'catalyst', 'project', 'create']);
 
     if (savedStoreHash !== undefined) process.env.CATALYST_STORE_HASH = savedStoreHash;
     if (savedAccessToken !== undefined) process.env.CATALYST_ACCESS_TOKEN = savedAccessToken;
 
-    expect(consola.error).toHaveBeenCalledWith('Missing credentials.');
     expect(consola.info).toHaveBeenCalledWith(
-      'Run `catalyst auth login`, or provide --store-hash and --access-token flags (or set CATALYST_STORE_HASH and CATALYST_ACCESS_TOKEN environment variables).',
+      "You're not logged in yet. Let's get you authenticated before creating a project.",
     );
-    expect(exitMock).toHaveBeenCalledWith(1);
+    expect(consola.success).toHaveBeenCalledWith('Logged in to store mock-store-hash.');
+    expect(consola.success).toHaveBeenCalledWith('Project "New Project" created successfully.');
+    expect(exitMock).toHaveBeenCalledWith(0);
+
+    expect(config.get('storeHash')).toBe('mock-store-hash');
+    expect(config.get('accessToken')).toBe('mock-access-token');
+    expect(config.get('projectUuid')).toBe(projectUuid3);
+
+    consolaPromptMock.mockRestore();
+  });
+
+  test('falls back to manual login when the device flow fails', async () => {
+    const savedStoreHash = process.env.CATALYST_STORE_HASH;
+    const savedAccessToken = process.env.CATALYST_ACCESS_TOKEN;
+
+    delete process.env.CATALYST_STORE_HASH;
+    delete process.env.CATALYST_ACCESS_TOKEN;
+
+    server.use(
+      http.post(
+        'https://login.bigcommerce.com/device/token',
+        () => new HttpResponse(null, { status: 404, statusText: 'Not Found' }),
+      ),
+    );
+
+    passwordMock.mockResolvedValueOnce(accessToken);
+
+    const consolaPromptMock = vi
+      .spyOn(consola, 'prompt')
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(storeHash)
+      .mockResolvedValueOnce('My New Project');
+
+    await program.parseAsync(['node', 'catalyst', 'project', 'create']);
+
+    if (savedStoreHash !== undefined) process.env.CATALYST_STORE_HASH = savedStoreHash;
+    if (savedAccessToken !== undefined) process.env.CATALYST_ACCESS_TOKEN = savedAccessToken;
+
+    expect(consola.warn).toHaveBeenCalledWith(expect.stringContaining("Browser login didn't work"));
+    expect(consola.success).toHaveBeenCalledWith(`Logged in to store ${storeHash}.`);
+    expect(consola.success).toHaveBeenCalledWith('Project "New Project" created successfully.');
+    expect(exitMock).toHaveBeenCalledWith(0);
+
+    expect(config.get('storeHash')).toBe(storeHash);
+    expect(config.get('accessToken')).toBe(accessToken);
+
+    consolaPromptMock.mockRestore();
+  });
+
+  test('exits cleanly when the user aborts the manual login fallback', async () => {
+    const savedStoreHash = process.env.CATALYST_STORE_HASH;
+    const savedAccessToken = process.env.CATALYST_ACCESS_TOKEN;
+
+    delete process.env.CATALYST_STORE_HASH;
+    delete process.env.CATALYST_ACCESS_TOKEN;
+
+    server.use(
+      http.post(
+        'https://login.bigcommerce.com/device/token',
+        () => new HttpResponse(null, { status: 404, statusText: 'Not Found' }),
+      ),
+    );
+
+    const consolaPromptMock = vi.spyOn(consola, 'prompt').mockResolvedValueOnce(false);
+
+    await program.parseAsync(['node', 'catalyst', 'project', 'create']);
+
+    if (savedStoreHash !== undefined) process.env.CATALYST_STORE_HASH = savedStoreHash;
+    if (savedAccessToken !== undefined) process.env.CATALYST_ACCESS_TOKEN = savedAccessToken;
+
+    expect(consola.info).toHaveBeenCalledWith(
+      'Login aborted. Re-run `catalyst project create` when you have your credentials ready.',
+    );
+    expect(exitMock).toHaveBeenCalledWith(0);
+    expect(config.get('projectUuid')).toBeUndefined();
+
+    consolaPromptMock.mockRestore();
   });
 
   test('propagates create project API errors', async () => {

--- a/packages/catalyst/src/cli/commands/project.ts
+++ b/packages/catalyst/src/cli/commands/project.ts
@@ -9,6 +9,7 @@ import {
 } from '../lib/commerce-hosting';
 import { installDependencies } from '../lib/install-dependencies';
 import { consola } from '../lib/logger';
+import { LoginAbortedError, login as runInteractiveLogin } from '../lib/login';
 import { createProject, deleteProject, fetchProjects } from '../lib/project';
 import { getProjectConfig } from '../lib/project-config';
 import { getProjectState } from '../lib/project-state';
@@ -16,6 +17,7 @@ import { resolveCredentials } from '../lib/resolve-credentials';
 import {
   accessTokenOption,
   apiHostOption,
+  loginUrlOption,
   projectUuidOption,
   storeHashOption,
 } from '../lib/shared-options';
@@ -105,7 +107,7 @@ Example:
 const create = new Command('create')
   .configureHelp({ showGlobalOptions: true })
   .description(
-    'Create a new BigCommerce infrastructure project and link it to your local Catalyst project.',
+    'Create a new BigCommerce infrastructure project and link it to your local Catalyst project. Walks you through logging in if you are not authenticated yet.',
   )
   .addHelpText(
     'after',
@@ -116,9 +118,41 @@ Example:
   .addOption(storeHashOption())
   .addOption(accessTokenOption())
   .addOption(apiHostOption())
+  .addOption(loginUrlOption())
   .action(async (options) => {
     const config = getProjectConfig();
-    const { storeHash, accessToken } = resolveCredentials(options, config);
+
+    let storeHash = options.storeHash ?? config.get('storeHash');
+    let accessToken = options.accessToken ?? config.get('accessToken');
+
+    if (!storeHash || !accessToken) {
+      consola.info(
+        "You're not logged in yet. Let's get you authenticated before creating a project.",
+      );
+
+      try {
+        const credentials = await runInteractiveLogin(options.loginUrl, options.apiHost);
+
+        storeHash = credentials.storeHash;
+        accessToken = credentials.accessToken;
+
+        config.set('storeHash', storeHash);
+        config.set('accessToken', accessToken);
+
+        consola.success(`Logged in to store ${storeHash}.`);
+      } catch (error) {
+        if (error instanceof LoginAbortedError) {
+          consola.info(
+            'Login aborted. Re-run `catalyst project create` when you have your credentials ready.',
+          );
+          process.exit(0);
+
+          return;
+        }
+
+        throw error;
+      }
+    }
 
     await getTelemetry().identify(storeHash);
 

--- a/packages/catalyst/src/cli/lib/login.ts
+++ b/packages/catalyst/src/cli/lib/login.ts
@@ -1,8 +1,10 @@
+import { password } from '@inquirer/prompts';
 import { colorize } from 'consola/utils';
 import open from 'open';
 import yoctoSpinner from 'yocto-spinner';
+import { z } from 'zod';
 
-import { requestDeviceCode, waitForDeviceToken } from './auth';
+import { DEVICE_OAUTH_SCOPES, requestDeviceCode, waitForDeviceToken } from './auth';
 import { consola } from './logger';
 
 export interface LoginResult {
@@ -10,7 +12,46 @@ export interface LoginResult {
   accessToken: string;
 }
 
-export async function login(loginUrl: string): Promise<LoginResult> {
+// Thrown when the user declines the manual-login fallback after the browser
+// (device-code) flow has failed. Callers should treat this as a clean exit,
+// not an error — the user explicitly chose to abort.
+export class LoginAbortedError extends Error {
+  constructor() {
+    super('Login aborted by user.');
+    this.name = 'LoginAbortedError';
+  }
+}
+
+const StoreProfileSchema = z.object({
+  data: z.object({
+    store_name: z.string(),
+  }),
+});
+
+async function fetchStoreProfile(storeHash: string, accessToken: string, apiHost: string) {
+  const response = await fetch(`https://${apiHost}/stores/${storeHash}/v3/settings/store/profile`, {
+    method: 'GET',
+    headers: {
+      'X-Auth-Token': accessToken,
+      Accept: 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`);
+  }
+
+  const res: unknown = await response.json();
+  const result = StoreProfileSchema.safeParse(res);
+
+  if (!result.success) {
+    throw new Error('Unexpected response from store profile API');
+  }
+
+  return result.data.data;
+}
+
+async function deviceCodeLogin(loginUrl: string): Promise<LoginResult> {
   const deviceCode = await requestDeviceCode(loginUrl);
 
   consola.info(
@@ -38,4 +79,74 @@ export async function login(loginUrl: string): Promise<LoginResult> {
     storeHash: credentials.store_hash,
     accessToken: credentials.access_token,
   };
+}
+
+async function manualLogin(apiHost: string): Promise<LoginResult> {
+  consola.info(
+    'Create a store-level API account from your BigCommerce Control Panel:\n' +
+      '  Settings → API → Store-level API accounts → Create API account\n' +
+      `Grant these OAuth scopes: ${DEVICE_OAUTH_SCOPES}`,
+  );
+
+  const storeHashInput = await consola.prompt('Store hash:', { type: 'text' });
+  const storeHash = String(storeHashInput).trim();
+
+  if (!storeHash) {
+    throw new Error('Store hash is required.');
+  }
+
+  const accessTokenInput = await password({ message: 'Access token:', mask: true });
+  const accessToken = accessTokenInput.trim();
+
+  if (!accessToken) {
+    throw new Error('Access token is required.');
+  }
+
+  const spinner = yoctoSpinner().start('Validating credentials...');
+
+  try {
+    const profile = await fetchStoreProfile(storeHash, accessToken, apiHost);
+
+    spinner.success(`Validated credentials for ${profile.store_name} (${storeHash}).`);
+  } catch (error) {
+    spinner.error('Failed to validate credentials.');
+
+    const message = error instanceof Error ? error.message : String(error);
+
+    throw new Error(
+      `Could not validate credentials (${message}). Double-check your store hash and access token, then try again.`,
+    );
+  }
+
+  return { storeHash, accessToken };
+}
+
+// Interactive login orchestrator. Used by `catalyst create`, `catalyst auth
+// login`, and `catalyst project create` to gather credentials when none are
+// supplied via flags/env/config.
+//
+// Happy path: opens the browser device-code flow. When that fails (e.g. the
+// device-code endpoint returns 404 because the OAuth client isn't yet
+// provisioned for the user's environment), we ask the user if they'd like to
+// fall back to pasting a store-level API account's credentials instead, then
+// validate them via the store profile API before returning.
+export async function login(loginUrl: string, apiHost: string): Promise<LoginResult> {
+  try {
+    return await deviceCodeLogin(loginUrl);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    consola.warn(`Browser login didn't work (${message}).`);
+
+    const shouldFallback = await consola.prompt(
+      'Try logging in manually with a store hash and access token instead?',
+      { type: 'confirm', initial: true },
+    );
+
+    if (!shouldFallback) {
+      throw new LoginAbortedError();
+    }
+
+    return manualLogin(apiHost);
+  }
 }

--- a/packages/catalyst/src/cli/lib/shared-options.ts
+++ b/packages/catalyst/src/cli/lib/shared-options.ts
@@ -1,5 +1,6 @@
 import { Option } from 'commander';
 
+import { DEFAULT_LOGIN_URL } from './auth';
 import { getProjectConfig } from './project-config';
 
 export const storeHashOption = () =>
@@ -18,6 +19,12 @@ export const apiHostOption = () =>
   new Option('--api-host <host>', 'BigCommerce API host. The default is api.bigcommerce.com.')
     .env('BIGCOMMERCE_API_HOST')
     .default('api.bigcommerce.com')
+    .hideHelp();
+
+export const loginUrlOption = () =>
+  new Option('--login-url <url>', 'BigCommerce login URL.')
+    .env('BIGCOMMERCE_LOGIN_URL')
+    .default(DEFAULT_LOGIN_URL)
     .hideHelp();
 
 export const projectUuidOption = () =>


### PR DESCRIPTION
Linear: [LTRAC-613](https://linear.app/commerce/issue/LTRAC-613/cli-make-auth-login-and-project-create-onboarding-interactive)
Jira: [TRAC-601](https://bigcommercecloud.atlassian.net/browse/TRAC-601)

## What/Why?

First-time users hit `failed to request device code: 404 Not Found` when running `catalyst project create` before  `catalyst auth login`, with no obvious recovery path. The required ordering also wasn't discoverable, and `project create` itself required `--store-hash`/`--access-token` as CLI args before any creds were stored.

This makes both commands walk the user through authentication interactively:

- **`catalyst auth login`** — still tries the browser device-code flow first. If that fails (404, network error, whatever), it warns with the underlying reason and asks: "Try logging in manually with a store hash and access token instead?" If yes, it prompts for the store hash (text) and access token (masked via `@inquirer/prompts` `password`), then validates the pair against `/v3/settings/store/profile` before persisting. If the user declines, it exits 0 with re-run guidance.
- **`catalyst project create`** — no longer fails fast on missing creds. It runs the same interactive login flow inline ("You're not logged in yet…"), persists creds, and continues with project creation.
- **`catalyst create`** (scaffolding) — picks up the manual fallback automatically since it now shares the orchestrator in `lib/login.ts`. Also handles `LoginAbortedError` cleanly so an aborted login doesn't surface as an unhandled rejection.

A new `LoginAbortedError` distinguishes "user explicitly bailed out of the manual fallback" from "login genuinely failed", so each caller can map it to a clean exit instead of an error.

## Rollout/Rollback

No flags, no infra. Plain code change in `@bigcommerce/catalyst`. Rollback is a revert.

## Testing

`pnpm lint`, `pnpm typecheck`, `pnpm test` are all green (268 tests pass).

New spec coverage:
- `auth.spec.ts` — manual fallback success, user declines fallback, validation failure, empty store hash, empty access token.
- `project.spec.ts` — `project create` runs interactive login when no creds; falls back to manual on device-code failure; exits cleanly on user abort.
- `create.spec.ts` — `LoginAbortedError` exits cleanly; non-abort login errors propagate.

To test manually:
1. Wipe `.bigcommerce/project.json` and any `CATALYST_*` env vars.
2. Run `catalyst auth login` against an env where the device-code endpoint 404s — confirm you get the warn + confirm prompt + manual prompts + successful login with validation.
3. Re-wipe creds and run `catalyst project create` directly — confirm it triggers the same interactive flow before prompting for the project name.

```
~/dev/catalyst/core on  jorgemoya/ltrac-613-cli-make-auth-login-and-project-create-onboarding [?] took 2s
❯ node ../packages/catalyst/dist/cli.js project create --api-host api.staging.zone
◢ @bigcommerce/catalyst v1.0.0-alpha.4                                                                                                                 1:44:35 PM

ℹ You're not logged in yet. Let's get you authenticated before creating a project.                                                                    1:44:35 PM
ℹ Your one-time code: cke6268k                                                                                                                        1:44:35 PM
ℹ Opened https://login.bigcommerce.com/device/connect in your browser.                                                                                1:44:35 PM
⠧ Waiting for authentication...
```

```
~/dev/catalyst/core on  jorgemoya/ltrac-613-cli-make-auth-login-and-project-create-onboarding [!?] took 13s
❯ node ../packages/catalyst/dist/cli.js auth login --api-host api.staging.zone
◢ @bigcommerce/catalyst v1.0.0-alpha.4                                                                                                                 1:50:55 PM


 WARN  Browser login didn't work (Failed to request device code: 404 Not Found).                                                                       1:50:55 PM


✔ Try logging in manually with a store hash and access token instead?
Yes
ℹ Create a store-level API account from your BigCommerce Control Panel:                                                                               1:50:57 PM
  Settings → API → Store-level API accounts → Create API account
Grant these OAuth scopes: store_v2_information store_infrastructure_deployments_manage store_infrastructure_logs_read_only store_infrastructure_projects_manage store_channel_settings

✔ Store hash:
c49n252gsy
✔ Access token: *******************************
✔ Validated credentials for Test Store (c49n252gsy).
✔ Logged in to store c49n252gsy.      
```

## Migration

None.

[TRAC-601]: https://bigcommercecloud.atlassian.net/browse/TRAC-601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ