### PR TITLE
fix(cli): autoreconnect catalyst logs tail when API proxy stalls

### DIFF
--- a/packages/catalyst/src/cli/commands/logs.spec.ts
+++ b/packages/catalyst/src/cli/commands/logs.spec.ts
@@ -453,6 +453,50 @@ describe('retry and reconnect', () => {
     expect(consola.warn).toHaveBeenCalledWith('Log stream closed by server, reconnecting...');
   });
 
+  test(
+    'reconnects when the stream stalls without emitting any data',
+    { timeout: 3000 },
+    async () => {
+      let requestCount = 0;
+      const ttlMs = 200;
+
+      // Stream that stays open but never enqueues — simulates an API proxy
+      // half-closing the socket: bytes stop arriving but no FIN or error is
+      // surfaced, so reader.read() would otherwise block forever.
+      const createStalledStream = () =>
+        new ReadableStream({
+          start() {
+            // intentionally empty
+          },
+        });
+
+      server.use(
+        http.get(
+          'https://:apiHost/stores/:storeHash/v3/infrastructure/logs/:projectUuid/tail',
+          () => {
+            requestCount += 1;
+
+            if (requestCount <= 2) {
+              return new HttpResponse(createStalledStream(), {
+                status: 200,
+                headers: { 'Content-Type': 'text/event-stream' },
+              });
+            }
+
+            return new HttpResponse(null, { status: 404, statusText: 'Not Found' });
+          },
+        ),
+      );
+
+      await expect(
+        tailLogs(projectUuid, storeHash, accessToken, apiHost, 'default', ttlMs),
+      ).rejects.toThrow('Failed to open log stream: 404 Not Found');
+
+      expect(requestCount).toBe(3);
+      expect(consola.warn).toHaveBeenCalledWith('Log stream idle, reconnecting...');
+    },
+  );
+
   test('reconnects when connection TTL is reached', { timeout: 3000 }, async () => {
     let requestCount = 0;
     const ttlMs = 200;

--- a/packages/catalyst/src/cli/commands/logs.ts
+++ b/packages/catalyst/src/cli/commands/logs.ts
@@ -127,6 +127,32 @@ const processLogEvent = (event: string, format: LogFormat) => {
   }
 };
 
+type TimeoutRaceResult<T> = { kind: 'value'; value: T } | { kind: 'timeout' };
+
+// Races a promise against a timer so a hung `reader.read()` doesn't block the
+// reconnect loop. Without this, the connection TTL check below the read() call
+// never runs when the API proxy half-closes the socket — bytes stop arriving
+// but no FIN/error surfaces, so the read promise stays pending forever.
+const raceWithTimeout = async <T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+): Promise<TimeoutRaceResult<T>> => {
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+
+  const timeoutPromise = new Promise<TimeoutRaceResult<T>>((resolve) => {
+    timeoutHandle = setTimeout(() => resolve({ kind: 'timeout' }), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([
+      promise.then((value): TimeoutRaceResult<T> => ({ kind: 'value', value })),
+      timeoutPromise,
+    ]);
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
+  }
+};
+
 const openLogStream = async (
   projectUuid: string,
   storeHash: string,
@@ -181,15 +207,37 @@ export const tailLogs = async (
       const decoder = new TextDecoder();
       const connectTime = Date.now();
       let buffer = '';
+      let receivedData = false;
 
       retries = 0;
 
       // eslint-disable-next-line no-constant-condition, @typescript-eslint/no-unnecessary-condition
       while (true) {
+        const remainingTtlMs = connectionTtlMs - (Date.now() - connectTime);
+
+        if (remainingTtlMs <= 0) {
+          void reader.cancel();
+          break;
+        }
+
         // eslint-disable-next-line no-await-in-loop
-        const { value, done: streamDone } = await reader.read();
+        const readResult = await raceWithTimeout(reader.read(), remainingTtlMs);
+
+        if (readResult.kind === 'timeout') {
+          // No bytes for the whole TTL window — proxy likely half-closed the
+          // socket. Warn the user so they see the reconnect happen.
+          if (!receivedData) {
+            consola.warn('Log stream idle, reconnecting...');
+          }
+
+          void reader.cancel();
+          break;
+        }
+
+        const { value, done: streamDone } = readResult.value;
 
         if (value) {
+          receivedData = true;
           buffer += decoder.decode(value, { stream: true });
 
           const parts = buffer.split('\n\n');
@@ -203,7 +251,7 @@ export const tailLogs = async (
             .forEach((event) => processLogEvent(event, format));
         }
 
-        if (streamDone || Date.now() - connectTime >= connectionTtlMs) {
+        if (streamDone) {
           void reader.cancel();
           break;
         }


### PR DESCRIPTION
Linear: [LTRAC-440](https://linear.app/commerce/issue/LTRAC-440/cli-autoreconnect-log-stream-after-api-proxy-disconnection)
Jira: [TRAC-430](https://bigcommercecloud.atlassian.net/browse/TRAC-430)

## What/Why?

Alpha testers reported `catalyst logs tail` going silent while their storefront was actively being browsed, with no auto-reconnect.

Root cause: the reconnect loop only triggers when `reader.read()` returns (`done: true`, a thrown error like `"terminated"`, or the post-read TTL check). When the API proxy half-closes the socket — bytes stop arriving but no FIN or error surfaces — the read promise hangs forever. The 1-minute connection TTL check sits right below the `await reader.read()` call, so it never runs in that state.

Fix: race `reader.read()` against the remaining TTL so the TTL becomes an absolute deadline. When it fires, we cancel the reader, break out of the inner loop, and the existing outer loop opens a new stream. Healthy rotations stay silent (matches existing behavior); we only warn when the connection completed the window without yielding any data, since that's a real stall.

Retry/backoff semantics are unchanged: stall-triggered reconnects don't bump the retry counter (same as the existing server-disconnect path), so persistent stalls keep retrying as long as `openLogStream` succeeds.

## Rollout/Rollback

Code-only change in `@bigcommerce/catalyst`. Rollback is a revert.

## Testing

`pnpm lint`, `pnpm typecheck`, `pnpm test` are all green (269 tests pass).

New spec: `reconnects when the stream stalls without emitting any data` — opens a `ReadableStream` that never enqueues, asserts that after the TTL fires the CLI reconnects (subsequent request lands), and the "Log stream idle, reconnecting..." warning is emitted.

To verify manually: tail logs against a deployed project and run `sudo pfctl` / `iptables` to drop server→client packets on the relevant connection — the stream should auto-reconnect within ~1 minute instead of hanging.

```
[2026-05-27T15:12:48.611Z] [INFO] [BigCommerce] mutation ProductViewed - 66.00ms - complexity 1002                                                    10:12:49 AM
[2026-05-27T15:12:49.839Z] [INFO] [BigCommerce] query ProductPageMetadataQuery - 1294.00ms - complexity 411                                           10:12:49 AM
[2026-05-27T15:12:49.847Z] [INFO] [BigCommerce] query VanityUrlQuery - 8.00ms - complexity 1003                                                       10:12:49 AM

 WARN  Log stream closed by server, reconnecting...                                                                                                   11:41:51 AM


 WARN  Log stream closed by server, reconnecting...                                                                                                   11:41:56 AM


 WARN  Log stream closed by server, reconnecting...                                                                                                   11:42:01 AM


 WARN  Log stream closed by server, reconnecting...                                                                                                   11:42:06 AM


 WARN  Log stream closed by server, reconnecting...                                                                                                   11:42:11 AM


 WARN  Log stream closed by server, reconnecting...                                                                                                   11:42:16 AM


 WARN  Log stream closed by server, reconnecting...                                                                                                   11:42:21 AM


 WARN  Log stream closed by server, reconnecting...                                                                                                   11:42:26 AM

[2026-05-27T16:42:44.520Z] [WARN] Runtime Cache unavailable in this environment. Falling back to in-memory cache.                                     11:42:45 AM
[2026-05-27T16:42:44.846Z] [INFO] [BigCommerce] query getStoreStatus - 326.00ms - complexity 1002                                                     11:42:45 AM
[2026-05-27T16:42:44.966Z] [INFO] [BigCommerce] mutation VisitStarted - 446.00ms - complexity 1002                                                    11:42:45 AM
[2026-05-27T16:42:45.193Z] [INFO] [BigCommerce] query GetRouteQuery - 347.00ms - complexity 1011                                                      11:42:45 AM
[2026-05-27T16:42:45.193Z] [ERROR] Failed to prepare server Error: An error occurred while loading the instrumentation hook  
```

[TRAC-430]: https://bigcommercecloud.atlassian.net/browse/TRAC-430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ