### PR TITLE
fix(cli): strip @vercel/otel hook in Commerce Hosting setup

### DIFF
--- a/.changeset/cli-strip-instrumentation-hook.md
+++ b/.changeset/cli-strip-instrumentation-hook.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst": patch
+---
+
+Remove `core/instrumentation.ts` and the `@vercel/otel` dependency during Commerce Hosting setup. The hook isn't compatible with the OpenNext + Cloudflare Workers bundling path and caused a "Failed to prepare server" error on every cold start in `catalyst logs tail`. Self-hosted (non-Commerce Hosting) deployments are unaffected.

--- a/packages/catalyst/src/cli/commands/create.ts
+++ b/packages/catalyst/src/cli/commands/create.ts
@@ -478,7 +478,7 @@ Examples:
       setupCoreProject(projectDir);
 
       if (useCommerceHosting && commerceHostingProject && storeHash && accessToken) {
-        setupCommerceHosting({
+        await setupCommerceHosting({
           projectDir,
           projectUuid: commerceHostingProject.uuid,
           storeHash,

--- a/packages/catalyst/src/cli/commands/deploy.ts
+++ b/packages/catalyst/src/cli/commands/deploy.ts
@@ -8,6 +8,7 @@ import { z } from 'zod';
 
 import { runChannelSiteUrlFlow } from '../lib/channel-site-flow';
 import {
+  cleanupCloudflareIncompatibilities,
   NoLinkedProjectError,
   selectOrCreateInfrastructureProject,
   setupCommerceHosting,
@@ -467,6 +468,12 @@ Example:
       consola.success('Commerce Hosting setup complete.');
 
       await installDependencies(projectDir);
+    } else {
+      // Existing Commerce Hosting users may carry artifacts incompatible with
+      // the Cloudflare worker bundle from earlier Catalyst versions
+      // (`core/instrumentation.ts`, `@vercel/otel`). Sweep them on every deploy
+      // so the fix lands without forcing a re-link.
+      cleanupCloudflareIncompatibilities(dirname(process.cwd()));
     }
 
     if (options.prebuilt) {

--- a/packages/catalyst/src/cli/commands/deploy.ts
+++ b/packages/catalyst/src/cli/commands/deploy.ts
@@ -464,7 +464,7 @@ Example:
 
       const projectDir = dirname(process.cwd());
 
-      setupCommerceHosting({ projectDir, projectUuid, storeHash, accessToken });
+      await setupCommerceHosting({ projectDir, projectUuid, storeHash, accessToken });
       consola.success('Commerce Hosting setup complete.');
 
       await installDependencies(projectDir);
@@ -473,7 +473,7 @@ Example:
       // the Cloudflare worker bundle from earlier Catalyst versions
       // (`core/instrumentation.ts`, `@vercel/otel`). Sweep them on every deploy
       // so the fix lands without forcing a re-link.
-      cleanupCloudflareIncompatibilities(dirname(process.cwd()));
+      await cleanupCloudflareIncompatibilities(dirname(process.cwd()));
     }
 
     if (options.prebuilt) {

--- a/packages/catalyst/src/cli/commands/project.ts
+++ b/packages/catalyst/src/cli/commands/project.ts
@@ -3,6 +3,7 @@ import { colorize } from 'consola/utils';
 import { dirname } from 'node:path';
 
 import {
+  cleanupCloudflareIncompatibilities,
   NoLinkedProjectError,
   selectOrCreateInfrastructureProject,
   setupCommerceHosting,
@@ -29,7 +30,17 @@ async function offerCommerceHostingSetup(
   projectUuid: string,
   credentials?: { storeHash: string; accessToken: string },
 ) {
-  if (getProjectState().isTransformed) return;
+  const projectDir = dirname(process.cwd());
+
+  // Already-transformed projects skip the setup prompt below — but they may
+  // still carry artifacts incompatible with the Cloudflare worker bundle
+  // (e.g. `core/instrumentation.ts`, `@vercel/otel`). Run cleanup so existing
+  // Commerce Hosting users pick up these fixes on re-link without prompting.
+  if (getProjectState().isTransformed) {
+    cleanupCloudflareIncompatibilities(projectDir);
+
+    return;
+  }
 
   const shouldSetup = await consola.prompt(
     'Your project has been linked, but is not fully set up for Commerce Hosting deployments yet. Would you like to run the setup now?',
@@ -37,8 +48,6 @@ async function offerCommerceHostingSetup(
   );
 
   if (!shouldSetup) return;
-
-  const projectDir = dirname(process.cwd());
 
   setupCommerceHosting({
     projectDir,

--- a/packages/catalyst/src/cli/commands/project.ts
+++ b/packages/catalyst/src/cli/commands/project.ts
@@ -37,7 +37,7 @@ async function offerCommerceHostingSetup(
   // (e.g. `core/instrumentation.ts`, `@vercel/otel`). Run cleanup so existing
   // Commerce Hosting users pick up these fixes on re-link without prompting.
   if (getProjectState().isTransformed) {
-    cleanupCloudflareIncompatibilities(projectDir);
+    await cleanupCloudflareIncompatibilities(projectDir);
 
     return;
   }
@@ -49,7 +49,7 @@ async function offerCommerceHostingSetup(
 
   if (!shouldSetup) return;
 
-  setupCommerceHosting({
+  await setupCommerceHosting({
     projectDir,
     projectUuid,
     storeHash: credentials?.storeHash,

--- a/packages/catalyst/src/cli/lib/commerce-hosting.spec.ts
+++ b/packages/catalyst/src/cli/lib/commerce-hosting.spec.ts
@@ -20,6 +20,7 @@ import {
   promptForCommerceHostingProject,
   setupCommerceHosting,
 } from './commerce-hosting';
+import { consola } from './logger';
 import * as projectLib from './project';
 import { InfrastructureProjectValidationError } from './project';
 
@@ -576,13 +577,20 @@ describe('setupCommerceHosting', () => {
   });
 
   let projectDir: string;
+  let restoreTty: () => void;
+  let consolaPromptSpy: MockInstance<typeof consola.prompt>;
 
   beforeEach(() => {
     projectDir = mkdtempSync(join(tmpdir(), 'catalyst-create-test-'));
+    restoreTty = withInteractiveTty();
+    consolaPromptSpy = vi.spyOn(consola, 'prompt');
+    consolaPromptSpy.mockResolvedValue(true);
   });
 
   afterEach(() => {
     rmSync(projectDir, { recursive: true, force: true });
+    restoreTty();
+    consolaPromptSpy.mockRestore();
   });
 
   function writeCorePackageJson(contents: unknown) {
@@ -618,13 +626,13 @@ describe('setupCommerceHosting', () => {
     );
   }
 
-  it('adds the OpenNext Cloudflare dep while preserving existing dependencies', () => {
+  it('adds the OpenNext Cloudflare dep while preserving existing dependencies', async () => {
     writeCorePackageJson({
       scripts: { dev: 'next dev' },
       dependencies: { next: '^15.0.0', react: '^18.0.0' },
     });
 
-    setupCommerceHosting({ projectDir, projectUuid: 'u' });
+    await setupCommerceHosting({ projectDir, projectUuid: 'u' });
 
     const pkg = readCorePackageJson();
 
@@ -632,7 +640,7 @@ describe('setupCommerceHosting', () => {
     expect(pkg.dependencies).toHaveProperty('@opennextjs/cloudflare');
   });
 
-  it('drops @vercel/otel from dependencies while preserving other deps', () => {
+  it('drops @vercel/otel from dependencies when the user accepts the instrumentation removal prompt', async () => {
     writeCorePackageJson({
       scripts: { dev: 'next dev' },
       dependencies: {
@@ -642,8 +650,9 @@ describe('setupCommerceHosting', () => {
         '@opentelemetry/api': '^1.9.0',
       },
     });
+    writeCoreInstrumentationFile('export function register() {}\n');
 
-    setupCommerceHosting({ projectDir, projectUuid: 'u' });
+    await setupCommerceHosting({ projectDir, projectUuid: 'u' });
 
     const pkg = readCorePackageJson();
 
@@ -656,21 +665,21 @@ describe('setupCommerceHosting', () => {
     expect(pkg.dependencies).toHaveProperty('@opennextjs/cloudflare');
   });
 
-  it('is a no-op for the @vercel/otel removal when it is not in dependencies', () => {
+  it('keeps @vercel/otel in place when no instrumentation.ts file exists', async () => {
     writeCorePackageJson({
       scripts: { dev: 'next dev' },
-      dependencies: { next: '^15.0.0' },
+      dependencies: { next: '^15.0.0', '@vercel/otel': '^2.1.0' },
     });
 
-    expect(() => setupCommerceHosting({ projectDir, projectUuid: 'u' })).not.toThrow();
+    await setupCommerceHosting({ projectDir, projectUuid: 'u' });
 
     const pkg = readCorePackageJson();
 
-    expect(pkg.dependencies).not.toHaveProperty('@vercel/otel');
-    expect(pkg.dependencies).toMatchObject({ next: '^15.0.0' });
+    expect(pkg.dependencies).toHaveProperty('@vercel/otel', '^2.1.0');
+    expect(consolaPromptSpy).not.toHaveBeenCalled();
   });
 
-  it('does not modify package.json scripts (handled by setupCoreProject)', () => {
+  it('does not modify package.json scripts (handled by setupCoreProject)', async () => {
     writeCorePackageJson({
       scripts: {
         dev: 'npm run generate && next dev',
@@ -679,7 +688,7 @@ describe('setupCommerceHosting', () => {
       },
     });
 
-    setupCommerceHosting({ projectDir, projectUuid: 'u' });
+    await setupCommerceHosting({ projectDir, projectUuid: 'u' });
 
     expect(readCorePackageJson().scripts).toEqual({
       dev: 'npm run generate && next dev',
@@ -688,7 +697,7 @@ describe('setupCommerceHosting', () => {
     });
   });
 
-  it('preserves unrelated top-level package.json fields', () => {
+  it('preserves unrelated top-level package.json fields', async () => {
     writeCorePackageJson({
       name: '@bigcommerce/catalyst-core',
       description: 'test description',
@@ -698,7 +707,7 @@ describe('setupCommerceHosting', () => {
       devDependencies: { jest: '^29.0.0' },
     });
 
-    setupCommerceHosting({ projectDir, projectUuid: 'u' });
+    await setupCommerceHosting({ projectDir, projectUuid: 'u' });
 
     const pkg = readCorePackageJson();
 
@@ -709,18 +718,18 @@ describe('setupCommerceHosting', () => {
     expect(pkg.devDependencies).toEqual({ jest: '^29.0.0' });
   });
 
-  it('writes core/.bigcommerce/project.json with the correct shape', () => {
+  it('writes core/.bigcommerce/project.json with the correct shape', async () => {
     writeCorePackageJson({ scripts: { dev: 'next dev' } });
 
-    setupCommerceHosting({ projectDir, projectUuid: 'uuid-xyz' });
+    await setupCommerceHosting({ projectDir, projectUuid: 'uuid-xyz' });
 
     expect(readProjectJson()).toEqual({ projectUuid: 'uuid-xyz', framework: 'catalyst' });
   });
 
-  it('includes storeHash and accessToken in project.json when provided', () => {
+  it('includes storeHash and accessToken in project.json when provided', async () => {
     writeCorePackageJson({ scripts: { dev: 'next dev' } });
 
-    setupCommerceHosting({
+    await setupCommerceHosting({
       projectDir,
       projectUuid: 'uuid-xyz',
       storeHash: 'abc123',
@@ -735,10 +744,10 @@ describe('setupCommerceHosting', () => {
     });
   });
 
-  it('omits storeHash and accessToken when not provided', () => {
+  it('omits storeHash and accessToken when not provided', async () => {
     writeCorePackageJson({ scripts: { dev: 'next dev' } });
 
-    setupCommerceHosting({ projectDir, projectUuid: 'uuid-xyz' });
+    await setupCommerceHosting({ projectDir, projectUuid: 'uuid-xyz' });
 
     const projectJson = readProjectJson();
 
@@ -746,10 +755,10 @@ describe('setupCommerceHosting', () => {
     expect(projectJson.accessToken).toBeUndefined();
   });
 
-  it('includes only the credentials that are provided', () => {
+  it('includes only the credentials that are provided', async () => {
     writeCorePackageJson({ scripts: { dev: 'next dev' } });
 
-    setupCommerceHosting({
+    await setupCommerceHosting({
       projectDir,
       projectUuid: 'uuid-xyz',
       storeHash: 'abc123',
@@ -761,21 +770,21 @@ describe('setupCommerceHosting', () => {
     expect(projectJson.accessToken).toBeUndefined();
   });
 
-  it('throws when core/package.json is missing', () => {
-    expect(() => setupCommerceHosting({ projectDir, projectUuid: 'u' })).toThrow();
+  it('throws when core/package.json is missing', async () => {
+    await expect(setupCommerceHosting({ projectDir, projectUuid: 'u' })).rejects.toThrow();
   });
 
-  it('throws when core/package.json has an invalid shape', () => {
+  it('throws when core/package.json has an invalid shape', async () => {
     writeCorePackageJson({ dependencies: { next: 42 } });
 
-    expect(() => setupCommerceHosting({ projectDir, projectUuid: 'u' })).toThrow();
+    await expect(setupCommerceHosting({ projectDir, projectUuid: 'u' })).rejects.toThrow();
   });
 
   describe('core/.env.local symlink', () => {
-    it('creates a symlink at core/.env.local pointing to ../.env.local', () => {
+    it('creates a symlink at core/.env.local pointing to ../.env.local', async () => {
       writeCorePackageJson({ scripts: { dev: 'next dev' } });
 
-      setupCommerceHosting({ projectDir, projectUuid: 'u' });
+      await setupCommerceHosting({ projectDir, projectUuid: 'u' });
 
       const coreEnvPath = join(projectDir, 'core', '.env.local');
 
@@ -783,11 +792,11 @@ describe('setupCommerceHosting', () => {
       expect(readlinkSync(coreEnvPath)).toBe(join('..', '.env.local'));
     });
 
-    it('keeps both files in sync via the symlink target', () => {
+    it('keeps both files in sync via the symlink target', async () => {
       writeCorePackageJson({ scripts: { dev: 'next dev' } });
       writeFileSync(join(projectDir, '.env.local'), 'FOO=bar\n');
 
-      setupCommerceHosting({ projectDir, projectUuid: 'u' });
+      await setupCommerceHosting({ projectDir, projectUuid: 'u' });
 
       expect(readFileSync(join(projectDir, 'core', '.env.local'), 'utf-8')).toBe('FOO=bar\n');
 
@@ -796,12 +805,12 @@ describe('setupCommerceHosting', () => {
       expect(readFileSync(join(projectDir, '.env.local'), 'utf-8')).toBe('FOO=baz\n');
     });
 
-    it('does not clobber an existing core/.env.local file', () => {
+    it('does not clobber an existing core/.env.local file', async () => {
       writeCorePackageJson({ scripts: { dev: 'next dev' } });
       mkdirSync(join(projectDir, 'core'), { recursive: true });
       writeFileSync(join(projectDir, 'core', '.env.local'), 'PRESERVE=me\n');
 
-      setupCommerceHosting({ projectDir, projectUuid: 'u' });
+      await setupCommerceHosting({ projectDir, projectUuid: 'u' });
 
       const coreEnvPath = join(projectDir, 'core', '.env.local');
 
@@ -822,11 +831,11 @@ describe('setupCommerceHosting', () => {
       '',
     ].join('\n');
 
-    it('renames proxy.ts to middleware.ts, renames the export, and injects the edge runtime', () => {
+    it('renames proxy.ts to middleware.ts, renames the export, and injects the edge runtime', async () => {
       writeCorePackageJson({ scripts: { dev: 'next dev' } });
       writeCoreProxyFile(proxyFixture);
 
-      setupCommerceHosting({ projectDir, projectUuid: 'u' });
+      await setupCommerceHosting({ projectDir, projectUuid: 'u' });
 
       const middlewarePath = join(projectDir, 'core', 'middleware.ts');
       const proxyPath = join(projectDir, 'core', 'proxy.ts');
@@ -841,11 +850,11 @@ describe('setupCommerceHosting', () => {
       expect(middleware).toContain("runtime: 'experimental-edge'");
     });
 
-    it('preserves the rest of the file contents', () => {
+    it('preserves the rest of the file contents', async () => {
       writeCorePackageJson({ scripts: { dev: 'next dev' } });
       writeCoreProxyFile(proxyFixture);
 
-      setupCommerceHosting({ projectDir, projectUuid: 'u' });
+      await setupCommerceHosting({ projectDir, projectUuid: 'u' });
 
       const middleware = readFileSync(join(projectDir, 'core', 'middleware.ts'), 'utf-8');
 
@@ -853,29 +862,44 @@ describe('setupCommerceHosting', () => {
       expect(middleware).toContain("matcher: ['/((?!api).*)']");
     });
 
-    it('is a no-op when proxy.ts does not exist', () => {
+    it('is a no-op when proxy.ts does not exist', async () => {
       writeCorePackageJson({ scripts: { dev: 'next dev' } });
 
-      expect(() => setupCommerceHosting({ projectDir, projectUuid: 'u' })).not.toThrow();
+      await expect(setupCommerceHosting({ projectDir, projectUuid: 'u' })).resolves.not.toThrow();
       expect(existsSync(join(projectDir, 'core', 'middleware.ts'))).toBe(false);
     });
   });
 
   describe('instrumentation.ts removal', () => {
-    it('deletes core/instrumentation.ts when it exists', () => {
+    it('deletes core/instrumentation.ts when the user accepts the prompt', async () => {
       writeCorePackageJson({ scripts: { dev: 'next dev' } });
       writeCoreInstrumentationFile('export function register() {}\n');
 
-      setupCommerceHosting({ projectDir, projectUuid: 'u' });
+      await setupCommerceHosting({ projectDir, projectUuid: 'u' });
 
       expect(existsSync(join(projectDir, 'core', 'instrumentation.ts'))).toBe(false);
     });
 
-    it('is a no-op when instrumentation.ts does not exist', () => {
+    it('preserves core/instrumentation.ts when the user declines the prompt', async () => {
+      consolaPromptSpy.mockResolvedValueOnce(false);
+
+      writeCorePackageJson({
+        scripts: { dev: 'next dev' },
+        dependencies: { '@vercel/otel': '^2.1.0' },
+      });
+      writeCoreInstrumentationFile('export function register() {}\n');
+
+      await setupCommerceHosting({ projectDir, projectUuid: 'u' });
+
+      expect(existsSync(join(projectDir, 'core', 'instrumentation.ts'))).toBe(true);
+      expect(readCorePackageJson().dependencies).toHaveProperty('@vercel/otel', '^2.1.0');
+    });
+
+    it('does not prompt when instrumentation.ts does not exist', async () => {
       writeCorePackageJson({ scripts: { dev: 'next dev' } });
 
-      expect(() => setupCommerceHosting({ projectDir, projectUuid: 'u' })).not.toThrow();
-      expect(existsSync(join(projectDir, 'core', 'instrumentation.ts'))).toBe(false);
+      await expect(setupCommerceHosting({ projectDir, projectUuid: 'u' })).resolves.not.toThrow();
+      expect(consolaPromptSpy).not.toHaveBeenCalled();
     });
   });
 });
@@ -884,13 +908,20 @@ describe('cleanupCloudflareIncompatibilities', () => {
   const packageJsonSchema = z.record(z.string(), z.unknown());
 
   let projectDir: string;
+  let restoreTty: () => void;
+  let consolaPromptSpy: MockInstance<typeof consola.prompt>;
 
   beforeEach(() => {
     projectDir = mkdtempSync(join(tmpdir(), 'catalyst-cleanup-test-'));
+    restoreTty = withInteractiveTty();
+    consolaPromptSpy = vi.spyOn(consola, 'prompt');
+    consolaPromptSpy.mockResolvedValue(true);
   });
 
   afterEach(() => {
     rmSync(projectDir, { recursive: true, force: true });
+    restoreTty();
+    consolaPromptSpy.mockRestore();
   });
 
   function writeCorePackageJson(contents: unknown) {
@@ -913,56 +944,62 @@ describe('cleanupCloudflareIncompatibilities', () => {
     );
   }
 
-  it('removes core/instrumentation.ts when present', () => {
-    writeCorePackageJson({ dependencies: { next: '^15.0.0' } });
-    writeCoreInstrumentationFile('export function register() {}\n');
-
-    cleanupCloudflareIncompatibilities(projectDir);
-
-    expect(existsSync(join(projectDir, 'core', 'instrumentation.ts'))).toBe(false);
-  });
-
-  it('drops @vercel/otel while preserving every other dependency', () => {
+  it('removes core/instrumentation.ts and drops @vercel/otel when the user accepts (TTY)', async () => {
     writeCorePackageJson({
-      dependencies: {
-        next: '^15.0.0',
-        react: '^18.0.0',
-        '@vercel/otel': '^2.1.0',
-        '@opentelemetry/api': '^1.9.0',
-      },
+      dependencies: { next: '^15.0.0', '@vercel/otel': '^2.1.0' },
     });
-
-    cleanupCloudflareIncompatibilities(projectDir);
-
-    const pkg = readCorePackageJson();
-
-    expect(pkg.dependencies).not.toHaveProperty('@vercel/otel');
-    expect(pkg.dependencies).toMatchObject({
-      next: '^15.0.0',
-      react: '^18.0.0',
-      '@opentelemetry/api': '^1.9.0',
-    });
-  });
-
-  it('is fully idempotent when nothing needs to change', () => {
-    writeCorePackageJson({ dependencies: { next: '^15.0.0' } });
-
-    const before = readFileSync(join(projectDir, 'core', 'package.json'), 'utf-8');
-
-    expect(() => cleanupCloudflareIncompatibilities(projectDir)).not.toThrow();
-
-    expect(existsSync(join(projectDir, 'core', 'instrumentation.ts'))).toBe(false);
-    expect(readFileSync(join(projectDir, 'core', 'package.json'), 'utf-8')).toBe(before);
-  });
-
-  it('skips silently when core/package.json does not exist', () => {
-    expect(() => cleanupCloudflareIncompatibilities(projectDir)).not.toThrow();
-  });
-
-  it('removes the instrumentation file even when no package.json is present', () => {
     writeCoreInstrumentationFile('export function register() {}\n');
 
-    cleanupCloudflareIncompatibilities(projectDir);
+    await cleanupCloudflareIncompatibilities(projectDir);
+
+    expect(existsSync(join(projectDir, 'core', 'instrumentation.ts'))).toBe(false);
+    expect(readCorePackageJson().dependencies).not.toHaveProperty('@vercel/otel');
+    expect(readCorePackageJson().dependencies).toMatchObject({ next: '^15.0.0' });
+  });
+
+  it('leaves the file and the dep alone when the user declines (TTY)', async () => {
+    consolaPromptSpy.mockResolvedValueOnce(false);
+
+    writeCorePackageJson({
+      dependencies: { next: '^15.0.0', '@vercel/otel': '^2.1.0' },
+    });
+    writeCoreInstrumentationFile('// customized\nexport function register() {}\n');
+
+    await cleanupCloudflareIncompatibilities(projectDir);
+
+    expect(existsSync(join(projectDir, 'core', 'instrumentation.ts'))).toBe(true);
+    expect(readCorePackageJson().dependencies).toHaveProperty('@vercel/otel', '^2.1.0');
+  });
+
+  it('skips the cleanup and never prompts in non-interactive contexts', async () => {
+    restoreTty();
+    restoreTty = withNonInteractiveTty();
+
+    writeCorePackageJson({
+      dependencies: { next: '^15.0.0', '@vercel/otel': '^2.1.0' },
+    });
+    writeCoreInstrumentationFile('// customized\nexport function register() {}\n');
+
+    await cleanupCloudflareIncompatibilities(projectDir);
+
+    expect(consolaPromptSpy).not.toHaveBeenCalled();
+    expect(existsSync(join(projectDir, 'core', 'instrumentation.ts'))).toBe(true);
+    expect(readCorePackageJson().dependencies).toHaveProperty('@vercel/otel', '^2.1.0');
+  });
+
+  it('is a silent no-op when instrumentation.ts does not exist', async () => {
+    writeCorePackageJson({ dependencies: { next: '^15.0.0', '@vercel/otel': '^2.1.0' } });
+
+    await cleanupCloudflareIncompatibilities(projectDir);
+
+    expect(consolaPromptSpy).not.toHaveBeenCalled();
+    expect(readCorePackageJson().dependencies).toHaveProperty('@vercel/otel', '^2.1.0');
+  });
+
+  it('removes the instrumentation file even when no package.json is present', async () => {
+    writeCoreInstrumentationFile('export function register() {}\n');
+
+    await cleanupCloudflareIncompatibilities(projectDir);
 
     expect(existsSync(join(projectDir, 'core', 'instrumentation.ts'))).toBe(false);
   });

--- a/packages/catalyst/src/cli/lib/commerce-hosting.spec.ts
+++ b/packages/catalyst/src/cli/lib/commerce-hosting.spec.ts
@@ -15,6 +15,7 @@ import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } fr
 import { z } from 'zod';
 
 import {
+  cleanupCloudflareIncompatibilities,
   promptAndCreateCommerceHostingProject,
   promptForCommerceHostingProject,
   setupCommerceHosting,
@@ -876,5 +877,93 @@ describe('setupCommerceHosting', () => {
       expect(() => setupCommerceHosting({ projectDir, projectUuid: 'u' })).not.toThrow();
       expect(existsSync(join(projectDir, 'core', 'instrumentation.ts'))).toBe(false);
     });
+  });
+});
+
+describe('cleanupCloudflareIncompatibilities', () => {
+  const packageJsonSchema = z.record(z.string(), z.unknown());
+
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), 'catalyst-cleanup-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  function writeCorePackageJson(contents: unknown) {
+    const coreDir = join(projectDir, 'core');
+
+    mkdirSync(coreDir, { recursive: true });
+    writeFileSync(join(coreDir, 'package.json'), JSON.stringify(contents, null, 2));
+  }
+
+  function writeCoreInstrumentationFile(contents: string) {
+    const coreDir = join(projectDir, 'core');
+
+    mkdirSync(coreDir, { recursive: true });
+    writeFileSync(join(coreDir, 'instrumentation.ts'), contents);
+  }
+
+  function readCorePackageJson() {
+    return packageJsonSchema.parse(
+      JSON.parse(readFileSync(join(projectDir, 'core', 'package.json'), 'utf-8')),
+    );
+  }
+
+  it('removes core/instrumentation.ts when present', () => {
+    writeCorePackageJson({ dependencies: { next: '^15.0.0' } });
+    writeCoreInstrumentationFile('export function register() {}\n');
+
+    cleanupCloudflareIncompatibilities(projectDir);
+
+    expect(existsSync(join(projectDir, 'core', 'instrumentation.ts'))).toBe(false);
+  });
+
+  it('drops @vercel/otel while preserving every other dependency', () => {
+    writeCorePackageJson({
+      dependencies: {
+        next: '^15.0.0',
+        react: '^18.0.0',
+        '@vercel/otel': '^2.1.0',
+        '@opentelemetry/api': '^1.9.0',
+      },
+    });
+
+    cleanupCloudflareIncompatibilities(projectDir);
+
+    const pkg = readCorePackageJson();
+
+    expect(pkg.dependencies).not.toHaveProperty('@vercel/otel');
+    expect(pkg.dependencies).toMatchObject({
+      next: '^15.0.0',
+      react: '^18.0.0',
+      '@opentelemetry/api': '^1.9.0',
+    });
+  });
+
+  it('is fully idempotent when nothing needs to change', () => {
+    writeCorePackageJson({ dependencies: { next: '^15.0.0' } });
+
+    const before = readFileSync(join(projectDir, 'core', 'package.json'), 'utf-8');
+
+    expect(() => cleanupCloudflareIncompatibilities(projectDir)).not.toThrow();
+
+    expect(existsSync(join(projectDir, 'core', 'instrumentation.ts'))).toBe(false);
+    expect(readFileSync(join(projectDir, 'core', 'package.json'), 'utf-8')).toBe(before);
+  });
+
+  it('skips silently when core/package.json does not exist', () => {
+    expect(() => cleanupCloudflareIncompatibilities(projectDir)).not.toThrow();
+  });
+
+  it('removes the instrumentation file even when no package.json is present', () => {
+    writeCoreInstrumentationFile('export function register() {}\n');
+
+    cleanupCloudflareIncompatibilities(projectDir);
+
+    expect(existsSync(join(projectDir, 'core', 'instrumentation.ts'))).toBe(false);
   });
 });

--- a/packages/catalyst/src/cli/lib/commerce-hosting.spec.ts
+++ b/packages/catalyst/src/cli/lib/commerce-hosting.spec.ts
@@ -598,6 +598,13 @@ describe('setupCommerceHosting', () => {
     writeFileSync(join(coreDir, 'proxy.ts'), contents);
   }
 
+  function writeCoreInstrumentationFile(contents: string) {
+    const coreDir = join(projectDir, 'core');
+
+    mkdirSync(coreDir, { recursive: true });
+    writeFileSync(join(coreDir, 'instrumentation.ts'), contents);
+  }
+
   function readCorePackageJson() {
     return packageJsonSchema.parse(
       JSON.parse(readFileSync(join(projectDir, 'core', 'package.json'), 'utf-8')),
@@ -622,6 +629,44 @@ describe('setupCommerceHosting', () => {
 
     expect(pkg.dependencies).toMatchObject({ next: '^15.0.0', react: '^18.0.0' });
     expect(pkg.dependencies).toHaveProperty('@opennextjs/cloudflare');
+  });
+
+  it('drops @vercel/otel from dependencies while preserving other deps', () => {
+    writeCorePackageJson({
+      scripts: { dev: 'next dev' },
+      dependencies: {
+        next: '^15.0.0',
+        react: '^18.0.0',
+        '@vercel/otel': '^2.1.0',
+        '@opentelemetry/api': '^1.9.0',
+      },
+    });
+
+    setupCommerceHosting({ projectDir, projectUuid: 'u' });
+
+    const pkg = readCorePackageJson();
+
+    expect(pkg.dependencies).not.toHaveProperty('@vercel/otel');
+    expect(pkg.dependencies).toMatchObject({
+      next: '^15.0.0',
+      react: '^18.0.0',
+      '@opentelemetry/api': '^1.9.0',
+    });
+    expect(pkg.dependencies).toHaveProperty('@opennextjs/cloudflare');
+  });
+
+  it('is a no-op for the @vercel/otel removal when it is not in dependencies', () => {
+    writeCorePackageJson({
+      scripts: { dev: 'next dev' },
+      dependencies: { next: '^15.0.0' },
+    });
+
+    expect(() => setupCommerceHosting({ projectDir, projectUuid: 'u' })).not.toThrow();
+
+    const pkg = readCorePackageJson();
+
+    expect(pkg.dependencies).not.toHaveProperty('@vercel/otel');
+    expect(pkg.dependencies).toMatchObject({ next: '^15.0.0' });
   });
 
   it('does not modify package.json scripts (handled by setupCoreProject)', () => {
@@ -812,6 +857,24 @@ describe('setupCommerceHosting', () => {
 
       expect(() => setupCommerceHosting({ projectDir, projectUuid: 'u' })).not.toThrow();
       expect(existsSync(join(projectDir, 'core', 'middleware.ts'))).toBe(false);
+    });
+  });
+
+  describe('instrumentation.ts removal', () => {
+    it('deletes core/instrumentation.ts when it exists', () => {
+      writeCorePackageJson({ scripts: { dev: 'next dev' } });
+      writeCoreInstrumentationFile('export function register() {}\n');
+
+      setupCommerceHosting({ projectDir, projectUuid: 'u' });
+
+      expect(existsSync(join(projectDir, 'core', 'instrumentation.ts'))).toBe(false);
+    });
+
+    it('is a no-op when instrumentation.ts does not exist', () => {
+      writeCorePackageJson({ scripts: { dev: 'next dev' } });
+
+      expect(() => setupCommerceHosting({ projectDir, projectUuid: 'u' })).not.toThrow();
+      expect(existsSync(join(projectDir, 'core', 'instrumentation.ts'))).toBe(false);
     });
   });
 });

--- a/packages/catalyst/src/cli/lib/commerce-hosting.ts
+++ b/packages/catalyst/src/cli/lib/commerce-hosting.ts
@@ -66,11 +66,48 @@ const convertProxyToMiddleware = (projectDir: string) => {
 
 // The default `core/instrumentation.ts` registers `@vercel/otel`, whose node
 // build OpenNext bundles into the worker chunk; workerd then throws on cold
-// start with "Failed to prepare server". The hook isn't wired to any tracer
-// consumers in /core, so we drop it (and the dep) for Commerce Hosting deploys.
-// Exported because callers run this on already-transformed projects too, where
-// `setupCommerceHosting` would short-circuit.
-export const cleanupCloudflareIncompatibilities = (projectDir: string) => {
+// start with "Failed to prepare server". A Vercel-deploying user may have
+// customized the hook though, so we prompt before removing it (and only drop
+// `@vercel/otel` if the user agrees — their customization probably imports it).
+// In non-TTY contexts (CI deploys, scripts), skip the cleanup with a warning so
+// no customization is silently wiped. Exported because callers run this on
+// already-transformed projects too, where `setupCommerceHosting` would
+// short-circuit.
+export const cleanupCloudflareIncompatibilities = async (projectDir: string) => {
+  const instrumentationPath = join(projectDir, 'core', 'instrumentation.ts');
+
+  if (!existsSync(instrumentationPath)) return;
+
+  if (!process.stdin.isTTY) {
+    consola.warn(
+      'core/instrumentation.ts is present and may be incompatible with the Cloudflare Workers ' +
+        'bundle (the default @vercel/otel scaffolding throws at cold start under workerd). ' +
+        'Skipping automatic cleanup in non-interactive mode — re-run interactively to remove it, ' +
+        'or delete/gate it manually.',
+    );
+
+    return;
+  }
+
+  const shouldRemove = await consola.prompt(
+    'Catalyst found core/instrumentation.ts, which is incompatible with the Cloudflare Workers ' +
+      'bundle when it uses @vercel/otel (causes "Failed to prepare server" at cold start). ' +
+      'Remove it and drop @vercel/otel from core/package.json?',
+    { type: 'confirm', initial: true },
+  );
+
+  if (!shouldRemove) {
+    consola.info(
+      'Leaving core/instrumentation.ts in place. The Cloudflare worker will continue to log ' +
+        '"Failed to prepare server" at cold start until this is resolved manually.',
+    );
+
+    return;
+  }
+
+  unlinkSync(instrumentationPath);
+  consola.info('Removed core/instrumentation.ts (incompatible with Cloudflare Workers).');
+
   const corePackageJsonPath = join(projectDir, 'core', 'package.json');
 
   if (existsSync(corePackageJsonPath)) {
@@ -81,21 +118,12 @@ export const cleanupCloudflareIncompatibilities = (projectDir: string) => {
 
       pkg.dependencies = preservedDeps;
       writeJson(corePackageJsonPath, sortPackageJsonFields(pkg));
-      consola.info(
-        'Dropped @vercel/otel from core/package.json (incompatible with Cloudflare Workers).',
-      );
+      consola.info('Dropped @vercel/otel from core/package.json.');
     }
-  }
-
-  const instrumentationPath = join(projectDir, 'core', 'instrumentation.ts');
-
-  if (existsSync(instrumentationPath)) {
-    unlinkSync(instrumentationPath);
-    consola.info('Removed core/instrumentation.ts (incompatible with Cloudflare Workers).');
   }
 };
 
-export const setupCommerceHosting = ({
+export const setupCommerceHosting = async ({
   projectDir,
   projectUuid,
   storeHash,
@@ -106,7 +134,7 @@ export const setupCommerceHosting = ({
   storeHash?: string;
   accessToken?: string;
 }) => {
-  cleanupCloudflareIncompatibilities(projectDir);
+  await cleanupCloudflareIncompatibilities(projectDir);
 
   const corePackageJsonPath = join(projectDir, 'core', 'package.json');
   const pkg = corePackageJsonSchema.parse(JSON.parse(readFileSync(corePackageJsonPath, 'utf-8')));
@@ -450,7 +478,7 @@ export async function runCommerceHostingSetup({
     useExistingOnCollision,
   );
 
-  setupCommerceHosting({
+  await setupCommerceHosting({
     projectDir,
     projectUuid: project.uuid,
     storeHash: api.storeHash,

--- a/packages/catalyst/src/cli/lib/commerce-hosting.ts
+++ b/packages/catalyst/src/cli/lib/commerce-hosting.ts
@@ -64,6 +64,18 @@ const convertProxyToMiddleware = (projectDir: string) => {
   unlinkSync(proxyPath);
 };
 
+// The default `core/instrumentation.ts` registers `@vercel/otel`, whose node
+// build OpenNext bundles into the worker chunk; workerd then throws on cold
+// start with "Failed to prepare server". The hook isn't wired to any tracer
+// consumers in /core, so we drop it (and the dep) for Commerce Hosting deploys.
+const removeInstrumentationHook = (projectDir: string) => {
+  const instrumentationPath = join(projectDir, 'core', 'instrumentation.ts');
+
+  if (!existsSync(instrumentationPath)) return;
+
+  unlinkSync(instrumentationPath);
+};
+
 export const setupCommerceHosting = ({
   projectDir,
   projectUuid,
@@ -78,8 +90,10 @@ export const setupCommerceHosting = ({
   const corePackageJsonPath = join(projectDir, 'core', 'package.json');
   const pkg = corePackageJsonSchema.parse(JSON.parse(readFileSync(corePackageJsonPath, 'utf-8')));
 
+  const { '@vercel/otel': _removedVercelOtel, ...preservedDeps } = pkg.dependencies ?? {};
+
   pkg.dependencies = {
-    ...pkg.dependencies,
+    ...preservedDeps,
     '@opennextjs/cloudflare': OPENNEXT_CLOUDFLARE_VERSION,
   };
 
@@ -97,6 +111,7 @@ export const setupCommerceHosting = ({
 
   symlinkRootEnvToCore(projectDir);
   convertProxyToMiddleware(projectDir);
+  removeInstrumentationHook(projectDir);
 };
 
 interface CommerceHostingApiContext {

--- a/packages/catalyst/src/cli/lib/commerce-hosting.ts
+++ b/packages/catalyst/src/cli/lib/commerce-hosting.ts
@@ -96,6 +96,8 @@ export const cleanupCloudflareIncompatibilities = async (projectDir: string) => 
     { type: 'confirm', initial: true },
   );
 
+  consola.log('');
+
   if (!shouldRemove) {
     consola.info(
       'Leaving core/instrumentation.ts in place. The Cloudflare worker will continue to log ' +

--- a/packages/catalyst/src/cli/lib/commerce-hosting.ts
+++ b/packages/catalyst/src/cli/lib/commerce-hosting.ts
@@ -68,12 +68,31 @@ const convertProxyToMiddleware = (projectDir: string) => {
 // build OpenNext bundles into the worker chunk; workerd then throws on cold
 // start with "Failed to prepare server". The hook isn't wired to any tracer
 // consumers in /core, so we drop it (and the dep) for Commerce Hosting deploys.
-const removeInstrumentationHook = (projectDir: string) => {
+// Exported because callers run this on already-transformed projects too, where
+// `setupCommerceHosting` would short-circuit.
+export const cleanupCloudflareIncompatibilities = (projectDir: string) => {
+  const corePackageJsonPath = join(projectDir, 'core', 'package.json');
+
+  if (existsSync(corePackageJsonPath)) {
+    const pkg = corePackageJsonSchema.parse(JSON.parse(readFileSync(corePackageJsonPath, 'utf-8')));
+
+    if (pkg.dependencies && '@vercel/otel' in pkg.dependencies) {
+      const { '@vercel/otel': _removedVercelOtel, ...preservedDeps } = pkg.dependencies;
+
+      pkg.dependencies = preservedDeps;
+      writeJson(corePackageJsonPath, sortPackageJsonFields(pkg));
+      consola.info(
+        'Dropped @vercel/otel from core/package.json (incompatible with Cloudflare Workers).',
+      );
+    }
+  }
+
   const instrumentationPath = join(projectDir, 'core', 'instrumentation.ts');
 
-  if (!existsSync(instrumentationPath)) return;
-
-  unlinkSync(instrumentationPath);
+  if (existsSync(instrumentationPath)) {
+    unlinkSync(instrumentationPath);
+    consola.info('Removed core/instrumentation.ts (incompatible with Cloudflare Workers).');
+  }
 };
 
 export const setupCommerceHosting = ({
@@ -87,13 +106,13 @@ export const setupCommerceHosting = ({
   storeHash?: string;
   accessToken?: string;
 }) => {
+  cleanupCloudflareIncompatibilities(projectDir);
+
   const corePackageJsonPath = join(projectDir, 'core', 'package.json');
   const pkg = corePackageJsonSchema.parse(JSON.parse(readFileSync(corePackageJsonPath, 'utf-8')));
 
-  const { '@vercel/otel': _removedVercelOtel, ...preservedDeps } = pkg.dependencies ?? {};
-
   pkg.dependencies = {
-    ...preservedDeps,
+    ...pkg.dependencies,
     '@opennextjs/cloudflare': OPENNEXT_CLOUDFLARE_VERSION,
   };
 
@@ -111,7 +130,6 @@ export const setupCommerceHosting = ({
 
   symlinkRootEnvToCore(projectDir);
   convertProxyToMiddleware(projectDir);
-  removeInstrumentationHook(projectDir);
 };
 
 interface CommerceHostingApiContext {


### PR DESCRIPTION
Linear: [LTRAC-807](https://linear.app/commerce/issue/LTRAC-807) (parent: [LTRAC-615](https://linear.app/commerce/issue/LTRAC-615))

## What/Why?

`catalyst logs tail` against a Cloudflare-hosted Catalyst storefront prints `[ERROR] Failed to prepare server Error: An error occurred while loading the instrumentation hook` on every cold start. Root cause: `core/instrumentation.ts` registers `@vercel/otel`, and because OpenNext builds the worker as a Node-style runtime (`nodejs_compat`), the bundler resolves `@vercel/otel` through its `node` export condition — pulling `@opentelemetry/sdk-node` and its Node-only side-effects into the worker chunk. At cold start, `workerd` evaluates those side-effects, hits an API `nodejs_compat` doesn't cover, throws, and Next.js's instrumentation loader catches it as the generic "Failed to prepare server" line.

The fix lives in a new exported `cleanupCloudflareIncompatibilities(projectDir)` helper called from every Commerce Hosting entry point so both fresh setups and already-transformed projects pick it up:

- `setupCommerceHosting` — fresh users via the regular setup flow
- `offerCommerceHostingSetup` on `catalyst project link` — already-transformed users (the path that gates on `!isTransformed` and otherwise short-circuits)
- `catalyst deploy` — already-transformed users on every deploy, so the fix lands without a re-link

### Behavior — prompt-driven, not silent

A Vercel-deploying Catalyst user may have **customized** `core/instrumentation.ts` (Sentry, custom OTel providers, span enrichment, etc.). Silent deletion would wipe that work the first time they try Cloudflare. So the cleanup asks first:

| State | TTY | What happens |
|---|---|---|
| `core/instrumentation.ts` missing | any | No prompt, no action, no dep change. Silent. |
| File present | TTY | Prompt: "Catalyst found `core/instrumentation.ts` … Remove it and drop `@vercel/otel`?" Default Yes. On accept → delete file + drop dep. On decline → keep both, log a one-line note that the cold-start error will persist until resolved manually. |
| File present | non-TTY | `consola.warn` explaining the incompatibility; skip the cleanup. No file or dep change. Recommend re-running interactively or removing/gating manually. |

The dep removal is tied to the file decision — if the user kept their customized file, `@vercel/otel` stays too (they're probably importing it).

Self-hosted / Vercel deploys never hit any of these Commerce Hosting paths, so they keep the file regardless.

Not in scope: this isn't "OTel can't work on Cloudflare." A real Workers-compatible OTel setup (e.g. `@microlabs/otel-cf-workers`) is a separate workstream if Native Hosting wants storefront instrumentation beyond Cloudflare's built-in observability.

## Testing

- `pnpm vitest run src/cli/lib/commerce-hosting.spec.ts` — 52 passed. New cases cover TTY accept (file deleted + dep dropped), TTY decline (file kept + dep kept), non-TTY skip (no prompt, no change), and the "file missing" no-op.
- `pnpm test` (full `@bigcommerce/catalyst` package) — 279 passed across 23 files.
- `pnpm lint` + `pnpm tsc --noEmit` — clean.

End-to-end on Native Hosting:

1. **Default file path (happy)** — on an already-transformed project that still has the default `core/instrumentation.ts` + `@vercel/otel`: run `catalyst project link` (or `catalyst deploy`) interactively, accept the prompt, see the `[info]` confirmations. Re-deploy → `[ERROR] Failed to prepare server` is gone on cold start.
2. **Customized file path** — edit `core/instrumentation.ts` to add a comment or import, re-run `catalyst project link`, decline the prompt → confirm file and dep are untouched.
3. **CI / non-TTY path** — run `catalyst project link --project-uuid <uuid> < /dev/null` → see the `[warn]` line, confirm nothing was modified.

The `[WARN] env.IMAGES binding is not defined` is intentionally still present — tracked separately in [LTRAC-808](https://linear.app/commerce/issue/LTRAC-808).

```
~/dev/catalyst/core on  jorgemoya/ltrac-807-cli-strip-vercelotel-instrumentation-hook-during-commerce [?]
❯ node ../packages/catalyst/dist/cli.js project link
◢ @bigcommerce/catalyst v1.0.0-alpha.4                                                                                                                10:43:35 AM

◐ Fetching projects...                                                                                                                                10:43:35 AM
✔ Projects fetched.                                                                                                                                  10:43:35 AM

✔ Select a project or create a new project (Press <enter> to select).
catalyst-jm-test [linked]
◐ Writing project UUID to .bigcommerce/project.json...                                                                                                10:43:36 AM
✔ Project UUID written to .bigcommerce/project.json.                                                                                                 10:43:36 AM

✔ Your project has been linked, but is not fully set up for Commerce Hosting deployments yet. Would you like to run the setup now?
Yes

✔ Catalyst found core/instrumentation.ts, which is incompatible with the Cloudflare Workers bundle when it uses @vercel/otel (causes "Failed to prepare server" at
cold start). Remove it and drop @vercel/otel from core/package.json?
Yes
                                                                                                                                                      10:43:40 AM
ℹ Removed core/instrumentation.ts (incompatible with Cloudflare Workers).                                                                            10:43:40 AM
ℹ Dropped @vercel/otel from core/package.json.                                                                                                       10:43:40 AM
✔ Commerce Hosting setup complete.                                                                                                                   10:43:40 AM
✔ Dependencies installed successfully.
```

## Migration

None required. Cleanup is automatic on the next interactive `catalyst project link` or `catalyst deploy` invocation. Customized users see a prompt before any change is made. CI deploys never auto-remove.

Fixes LTRAC-807