### PR TITLE
fix(cli): clean dist directory before each build

### DIFF
--- a/packages/catalyst/src/cli/commands/build.ts
+++ b/packages/catalyst/src/cli/commands/build.ts
@@ -1,6 +1,6 @@
 import { Command, Option } from 'commander';
 import { execa } from 'execa';
-import { copyFile, cp, writeFile } from 'node:fs/promises';
+import { copyFile, cp, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import { getModuleCliPath } from '../lib/get-module-cli-path';
@@ -17,6 +17,11 @@ export async function buildCatalystProject(projectUuid: string): Promise<void> {
   const bigcommerceDistDir = join(coreDir, '.bigcommerce', 'dist');
 
   const wranglerConfig = getWranglerConfig(projectUuid);
+
+  // Wrangler's --outdir writes alongside existing files instead of replacing
+  // the directory. Stale artifacts (e.g. wasm modules named by an older
+  // Wrangler version) end up in the bundle and break the Cloudflare upload.
+  await rm(bigcommerceDistDir, { recursive: true, force: true });
 
   consola.start('Copying templates...');
 


### PR DESCRIPTION
Jira: [LTRAC-814](https://linear.app/commerce/issue/LTRAC-814)

## What/Why?

Wrangler's `--outdir` writes the deployment bundle alongside whatever is already in `.bigcommerce/dist`, never replacing the directory. When Wrangler is upgraded between builds — or any prior artifact lingers — old files end up in the zip uploaded to the deployer.

In one observed case the dist held both the current Wrangler 4.x plain wasm filenames *and* `?module`-suffixed copies from an older Wrangler:

```
output/77d9faebf...-resvg.wasm           (current build)
output/77d9faebf...-resvg.wasm?module    (4-week-old leftover)
output/ef4866ec...-yoga.wasm             (current build)
output/ef4866ec...-yoga.wasm?module      (4-week-old leftover)
```

The `?` in the filename confused the server-side multipart upload to Cloudflare, and the deploy failed with:

```
Uncaught Error: No such module "77d9faebf...-resvg.wasm".
  imported from "worker.js"
```

`rm -rf .bigcommerce && catalyst deploy` worked. This patch makes that cleanup automatic — `buildCatalystProject` now wipes `.bigcommerce/dist` before the OpenNext build and Wrangler dry-run run.

## Testing

- `pnpm lint` — clean
- `pnpm exec tsc --noEmit` — clean
- `pnpm exec vitest run src/cli/commands/build.spec.ts` — passes
- Manually verified locally: after stale `?module`-suffixed wasm files accumulate, running `catalyst build` with this change produces a clean dist with only the current artifacts.

## Migration

None. Internal CLI change only.