### PR TITLE
fix(core): rewrite WYSIWYG /content image URLs to absolute CDN URLs

### DIFF
--- a/.changeset/fix-wysiwyg-content-image-urls.md
+++ b/.changeset/fix-wysiwyg-content-image-urls.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Fix broken images in WYSIWYG content (web pages, blog posts, product description and warranty). Images uploaded through the Control Panel editor are stored as root-relative `/content/...` paths that 404 on the headless storefront domain; they are now rewritten to absolute BigCommerce CDN URLs.

--- a/.changeset/fix-wysiwyg-content-image-urls.md
+++ b/.changeset/fix-wysiwyg-content-image-urls.md
@@ -2,4 +2,4 @@
 "@bigcommerce/catalyst-core": patch
 ---
 
-Fix broken images in WYSIWYG content (web pages, blog posts, product description and warranty). Images uploaded through the Control Panel editor are stored as root-relative `/content/...` paths that 404 on the headless storefront domain; they are now rewritten to absolute BigCommerce CDN URLs.
+Fix broken images in WYSIWYG content (web pages, blog posts, product description and warranty). Images uploaded through the Control Panel editor are stored as store-root-relative WebDAV paths (`/content/...` and `/product_images/...`) that 404 on the headless storefront domain; they are now rewritten to absolute BigCommerce CDN URLs.

--- a/core/app/[locale]/(default)/blog/[blogId]/page.tsx
+++ b/core/app/[locale]/(default)/blog/[blogId]/page.tsx
@@ -5,6 +5,7 @@ import { cache } from 'react';
 
 import { BlogPostContent, BlogPostContentBlogPost } from '@/vibes/soul/sections/blog-post-content';
 import { Breadcrumb } from '@/vibes/soul/sections/breadcrumbs';
+import { rewriteWysiwygContentUrls } from '~/data-transformers/html-content-transformer';
 import { getMetadataAlternates } from '~/lib/seo/canonical';
 
 import { getBlogPageData } from './page-data';
@@ -59,7 +60,7 @@ async function getBlogPost(props: Props): Promise<BlogPostContentBlogPost> {
   return {
     author: blogPost.author ?? undefined,
     title: blogPost.name,
-    content: blogPost.htmlBody,
+    content: rewriteWysiwygContentUrls(blogPost.htmlBody),
     date: format.dateTime(new Date(blogPost.publishedDate.utc)),
     image: blogPost.thumbnailImage
       ? { alt: blogPost.thumbnailImage.altText, src: blogPost.thumbnailImage.url }

--- a/core/app/[locale]/(default)/product/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { Stream, Streamable } from '@/vibes/soul/lib/streamable';
 import { FeaturedProductCarousel } from '@/vibes/soul/sections/featured-product-carousel';
 import { ProductDetail } from '@/vibes/soul/sections/product-detail';
 import { auth, getSessionCustomerAccessToken } from '~/auth';
+import { rewriteWysiwygContentUrls } from '~/data-transformers/html-content-transformer';
 import { pricesTransformer } from '~/data-transformers/prices-transformer';
 import { productCardTransformer } from '~/data-transformers/product-card-transformer';
 import { productOptionsTransformer } from '~/data-transformers/product-options-transformer';
@@ -482,7 +483,12 @@ export default async function Product({ params, searchParams }: Props) {
             {
               title: t('ProductDetails.Accordions.warranty'),
               content: (
-                <div className="prose" dangerouslySetInnerHTML={{ __html: product.warranty }} />
+                <div
+                  className="prose"
+                  dangerouslySetInnerHTML={{
+                    __html: rewriteWysiwygContentUrls(product.warranty),
+                  }}
+                />
               ),
             },
           ]
@@ -569,7 +575,13 @@ export default async function Product({ params, searchParams }: Props) {
           product={{
             id: baseProduct.entityId.toString(),
             title: baseProduct.name,
-            description: <div dangerouslySetInnerHTML={{ __html: baseProduct.description }} />,
+            description: (
+              <div
+                dangerouslySetInnerHTML={{
+                  __html: rewriteWysiwygContentUrls(baseProduct.description),
+                }}
+              />
+            ),
             href: baseProduct.path,
             images: streamableImages,
             price: streamablePrices,

--- a/core/app/[locale]/(default)/webpages/[id]/normal/page.tsx
+++ b/core/app/[locale]/(default)/webpages/[id]/normal/page.tsx
@@ -10,6 +10,7 @@ import {
   breadcrumbsTransformer,
   truncateBreadcrumbs,
 } from '~/data-transformers/breadcrumbs-transformer';
+import { rewriteWysiwygContentUrls } from '~/data-transformers/html-content-transformer';
 import { getMetadataAlternates } from '~/lib/seo/canonical';
 
 import { WebPageContent, WebPage as WebPageData } from '../_components/web-page';
@@ -33,7 +34,7 @@ const getWebPage = cache(async (id: string, customerAccessToken?: string): Promi
   return {
     title: webpage.name,
     breadcrumbs,
-    content: webpage.htmlBody,
+    content: rewriteWysiwygContentUrls(webpage.htmlBody),
     seo: webpage.seo,
   };
 });

--- a/core/data-transformers/html-content-transformer.ts
+++ b/core/data-transformers/html-content-transformer.ts
@@ -1,0 +1,14 @@
+import { contentAssetUrl } from '~/lib/store-assets';
+
+// The Control Panel WYSIWYG editor stores uploaded images/files as root-relative
+// `/content/...` paths. These resolve on a same-domain Stencil storefront but 404 on the
+// headless Catalyst domain. Rewrite them to absolute BigCommerce CDN URLs.
+const CONTENT_URL_REGEX = /(src|href)=("|')\/content\/([^"']*)\2/gi;
+
+export function rewriteWysiwygContentUrls(html: string): string {
+  return html.replace(
+    CONTENT_URL_REGEX,
+    (_match, attr: string, quote: string, path: string) =>
+      `${attr}=${quote}${contentAssetUrl(path)}${quote}`,
+  );
+}

--- a/core/data-transformers/html-content-transformer.ts
+++ b/core/data-transformers/html-content-transformer.ts
@@ -1,14 +1,16 @@
-import { contentAssetUrl } from '~/lib/store-assets';
+import { cdnAssetUrl } from '~/lib/store-assets';
 
-// The Control Panel WYSIWYG editor stores uploaded images/files as root-relative
-// `/content/...` paths. These resolve on a same-domain Stencil storefront but 404 on the
-// headless Catalyst domain. Rewrite them to absolute BigCommerce CDN URLs.
-const CONTENT_URL_REGEX = /(src|href)=("|')\/content\/([^"']*)\2/gi;
+// The Control Panel WYSIWYG editor stores uploaded images/files as store-root-relative WebDAV
+// paths — `/content/...` for content uploads and `/product_images/...` for image-manager
+// uploads. These resolve on a same-domain Stencil storefront but 404 on the headless Catalyst
+// domain. Rewrite them to absolute BigCommerce CDN URLs. Scoped to known WebDAV asset folders
+// so internal page links are left untouched.
+const WEBDAV_ASSET_URL_REGEX = /(src|href)=("|')(\/(?:content|product_images)\/[^"']*)\2/gi;
 
 export function rewriteWysiwygContentUrls(html: string): string {
   return html.replace(
-    CONTENT_URL_REGEX,
+    WEBDAV_ASSET_URL_REGEX,
     (_match, attr: string, quote: string, path: string) =>
-      `${attr}=${quote}${contentAssetUrl(path)}${quote}`,
+      `${attr}=${quote}${cdnAssetUrl(path)}${quote}`,
   );
 }

--- a/core/lib/store-assets.ts
+++ b/core/lib/store-assets.ts
@@ -23,6 +23,19 @@ const cdnImageUrlBuilder = (
 };
 
 /**
+ * Given a store-root-relative WebDAV path (e.g. `/content/foo.png` or
+ * `/product_images/uploaded_images/bar.jpg`), return the absolute CDN URL that
+ * serves it. WebDAV folders are mirrored to the CDN at `/s-{storeHash}{path}`.
+ *
+ * @param {string} rootRelativePath - The store-root-relative path, including its leading slash.
+ * @param {number} cdnIndex - The index of the CDN URL to use. Defaults to 0.
+ * @returns {string} The absolute CDN URL to the asset.
+ */
+export const cdnAssetUrl = (rootRelativePath: string, cdnIndex = 0): string => {
+  return `https://${buildConfig.get('urls').cdnUrls.at(cdnIndex)}/s-${storeHash}${rootRelativePath}`;
+};
+
+/**
  * Given a path, return the full URL to the content asset.
  * These assets are accessible via the /content folder in WebDAV on the store.
  * A query parameter containing the commit SHA is appended to the URL to ensure
@@ -33,7 +46,7 @@ const cdnImageUrlBuilder = (
  * @returns {string} The full URL to the content asset.
  */
 export const contentAssetUrl = (path: string, cdnIndex = 0): string => {
-  return `https://${buildConfig.get('urls').cdnUrls.at(cdnIndex)}/s-${storeHash}/content/${path}`;
+  return cdnAssetUrl(`/content/${path}`, cdnIndex);
 };
 
 /**


### PR DESCRIPTION
Jira: [LTRAC-297](https://bigcommercecloud.atlassian.net/browse/TRAC-297)

## What/Why?
Images added to a Web Page (or blog post, product description/warranty) through the Control Panel WYSIWYG editor render as broken images on the storefront.

The editor stores uploaded assets as **store-root-relative WebDAV paths** — `/content/...` for content uploads and `/product_images/...` for image-manager uploads. On a same-domain Stencil storefront these resolve fine, but on the headless Catalyst domain they resolve against the storefront's own origin (no such route) → 404 → broken image. The HTML is injected verbatim via `dangerouslySetInnerHTML` with no URL rewriting.

This adds a server-side transformer (`rewriteWysiwygContentUrls`) that rewrites `src`/`href` values pointing at those WebDAV folders to absolute BigCommerce CDN URLs (`https://<cdn>/s-<storeHash><path>`), via a new `cdnAssetUrl()` helper in `store-assets.ts` (`contentAssetUrl()` now delegates to it). It is scoped to the known asset folders so internal page links and already-absolute URLs are left untouched. Applied to every raw-HTML surface: web pages, blog posts, and product description + warranty.

## Testing
Verified locally against a Web Page with an image-manager image embedded via the WYSIWYG editor:

- Before: `<img src="/product_images/uploaded_images/...png">` → broken (404 on the storefront origin).
- After: rendered as `<img src="https://cdn11.bigcommerce.com/s-<hash>/product_images/uploaded_images/...png">` → loads correctly.

Steps to reproduce/verify:
1. On a store, add an image to a Web Page via the Control Panel WYSIWYG editor.
2. View the page on the storefront; the image renders (previously broken). Inspect `<img src>` — it points to the CDN.
3. Regression: internal links (sidebar/breadcrumbs like `/shipping-returns/`) still navigate correctly and are not rewritten.
4. Spot-check a product with an image in its description/warranty and a blog post with an embedded asset.

## Migration
None.