### PR TITLE
TRAC-640: fix(core) - Scope consent cookie to host instead of root domain

### DIFF
--- a/.changeset/ltrac-657-consent-cookie-subdomain.md
+++ b/.changeset/ltrac-657-consent-cookie-subdomain.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Scope the consent manager cookie (`c15t-consent`) to the current host instead of the top-level domain. Previously `crossSubdomain: true` caused the cookie to be set on the root domain (e.g. `.example.com`) for stores running on a sub-domain, so it appeared on both the root domain and the sub-domain. Removing it makes the cookie host-only, so it now exists only on the sub-domain the store runs on.

--- a/core/components/consent-manager/consent-providers.tsx
+++ b/core/components/consent-manager/consent-providers.tsx
@@ -23,7 +23,6 @@ export function ConsentManagerProvider({
         mode: 'offline',
         storageConfig: {
           storageKey: CONSENT_COOKIE_NAME,
-          crossSubdomain: true,
         },
         consentCategories: ['necessary', 'functionality', 'marketing', 'measurement'],
         enabled: isCookieConsentEnabled,


### PR DESCRIPTION
Jira: [TRAC-640](https://bigcommercecloud.atlassian.net/browse/TRAC-640)
Linear: [LTRAC-657](https://linear.app/commerce/issue/LTRAC-657)

## What/Why?

The consent manager (`@c15t/nextjs`) was configured with `crossSubdomain: true`. When set, the library resolves the cookie domain via `getRootDomain()` and writes the `c15t-consent` cookie with `domain=.<root-domain>` (e.g. `.dmgmori.com`). For stores running on a sub-domain (e.g. `shop-us.dmgmori.com`), this scoped the cookie to the root domain and all sub-domains, so it appeared on both the root domain and the sub-domain — which broke the reporting merchant.

Removing `crossSubdomain: true` (the library default is `false`, with no `defaultDomain`) means no `domain=` attribute is emitted, so the cookie is host-only and exists only on the sub-domain the store runs on. This matches the expected behavior in the ticket.

Note: this drops cross-subdomain consent sharing. A merchant intentionally sharing consent across multiple sub-domains can opt back in explicitly via the `defaultDomain` storage option.

## Testing

A faithful repro requires a sub-domain host (locally `getRootDomain()` returns `localhost` unchanged). On a preview/integration deploy on a sub-domain:

1. Load the storefront and accept/save consent to trigger the cookie write.
2. DevTools → Application → Cookies: confirm `c15t-consent` shows the exact host (e.g. `shop-us.dmgmori.com`) in the Domain column, **not** `.dmgmori.com`, and no longer appears under the root domain.
3. Confirm consent state still persists across reloads on the sub-domain (server/client cookie reads use the same cookie name and are unaffected).

## Migration

None. Behavior-only change controlled by a single storage config option; no API or file changes for consumers.

[TRAC-640]: https://bigcommercecloud.atlassian.net/browse/TRAC-640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ