### PR TITLE
LTRAC-808: fix(cli) - Suppress OpenNext IMAGES binding warning in logs tail

### DIFF
--- a/.changeset/cli-suppress-images-binding-warning.md
+++ b/.changeset/cli-suppress-images-binding-warning.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst": patch
+---
+
+Suppress the OpenNext `env.IMAGES binding is not defined` warning in `catalyst logs tail`. OpenNext's Cloudflare image handler logs this on every `/_next/image` request when no IMAGES binding is configured, then falls back to serving the original bytes. Native Hosting intentionally runs without that binding, so the warning is expected noise — it's now filtered out of the human-readable log formats (it remains in `--format json` for raw passthrough).

--- a/.changeset/cli-suppress-images-binding-warning.md
+++ b/.changeset/cli-suppress-images-binding-warning.md
@@ -1,5 +1,0 @@
----
-"@bigcommerce/catalyst": patch
----
-
-Suppress the OpenNext `env.IMAGES binding is not defined` warning in `catalyst logs tail`. OpenNext's Cloudflare image handler logs this on every `/_next/image` request when no IMAGES binding is configured, then falls back to serving the original bytes. Native Hosting intentionally runs without that binding, so the warning is expected noise — it's now filtered out of the human-readable log formats (it remains in `--format json` for raw passthrough).

--- a/packages/catalyst/src/cli/commands/logs.spec.ts
+++ b/packages/catalyst/src/cli/commands/logs.spec.ts
@@ -290,6 +290,75 @@ describe('log event processing', () => {
   });
 });
 
+describe('suppressed log noise', () => {
+  const imagesWarning = 'env.IMAGES binding is not defined';
+
+  test('drops the OpenNext IMAGES binding warning from default format', async () => {
+    const event = {
+      ...validLogEvent,
+      logs: [{ ...validLogEvent.logs[0], level: 'warn', messages: [imagesWarning] }],
+    };
+
+    await callTailLogs('default', [`data: ${JSON.stringify(event)}\n\n`]);
+
+    expect(consola.log).not.toHaveBeenCalledWith(expect.stringContaining(imagesWarning));
+  });
+
+  test('keeps other log entries when only the IMAGES warning is suppressed', async () => {
+    const event = {
+      ...validLogEvent,
+      logs: [
+        { ...validLogEvent.logs[0], level: 'warn', messages: [imagesWarning] },
+        { ...validLogEvent.logs[0], messages: ['hello world'] },
+      ],
+    };
+
+    await callTailLogs('default', [`data: ${JSON.stringify(event)}\n\n`]);
+
+    expect(consola.log).not.toHaveBeenCalledWith(expect.stringContaining(imagesWarning));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining('hello world'));
+  });
+
+  test('emits nothing for an event that is only suppressed noise', async () => {
+    const event = {
+      ...validLogEvent,
+      logs: [{ ...validLogEvent.logs[0], level: 'warn', messages: [imagesWarning] }],
+    };
+
+    await callTailLogs('default', [`data: ${JSON.stringify(event)}\n\n`]);
+
+    expect(consola.log).not.toHaveBeenCalled();
+    expect(consola.error).not.toHaveBeenCalled();
+  });
+
+  test('still emits exceptions even when all log entries are suppressed', async () => {
+    const event = {
+      ...validLogEvent,
+      logs: [{ ...validLogEvent.logs[0], level: 'warn', messages: [imagesWarning] }],
+      exceptions: [{ message: 'something broke' }],
+    };
+
+    await callTailLogs('default', [`data: ${JSON.stringify(event)}\n\n`]);
+
+    expect(consola.log).not.toHaveBeenCalledWith(expect.stringContaining(imagesWarning));
+    expect(consola.error).toHaveBeenCalledWith(
+      expect.stringContaining('EXCEPTION'),
+      expect.objectContaining({ message: 'something broke' }),
+    );
+  });
+
+  test('does not filter the IMAGES warning out of raw json output', async () => {
+    const event = {
+      ...validLogEvent,
+      logs: [{ ...validLogEvent.logs[0], level: 'warn', messages: [imagesWarning] }],
+    };
+
+    await callTailLogs('json', [`data: ${JSON.stringify(event)}\n\n`]);
+
+    expect(stdoutWriteMock).toHaveBeenCalledWith(expect.stringContaining(imagesWarning));
+  });
+});
+
 describe('error handling', () => {
   test('silently ignores heartbeat events', async () => {
     await callTailLogs('default', [`data: \n\ndata: ${JSON.stringify(validLogEvent)}\n\n`]);

--- a/packages/catalyst/src/cli/commands/logs.ts
+++ b/packages/catalyst/src/cli/commands/logs.ts
@@ -63,6 +63,17 @@ class StreamError extends Error {
 const formatMessages = (messages: unknown[]) =>
   messages.map((m) => (typeof m === 'string' ? m : JSON.stringify(m))).join(' ');
 
+// Known framework noise to drop from the human-readable log formats. OpenNext's
+// Cloudflare image handler logs `env.IMAGES binding is not defined` on every
+// `/_next/image` request when no IMAGES binding is configured, then falls back
+// to serving the original bytes. Native Hosting intentionally runs without that
+// binding (see LTRAC-808), so the warning is expected — suppress it so testers
+// aren't flooded with a benign message on every image request.
+const SUPPRESSED_LOG_PATTERNS = [/env\.IMAGES binding is not defined/];
+
+const isSuppressedMessage = (message: string) =>
+  SUPPRESSED_LOG_PATTERNS.some((pattern) => pattern.test(message));
+
 const formatLogEvent = (
   event: z.infer<typeof LogEventSchema>,
   format: 'default' | 'short' | 'request',
@@ -117,10 +128,22 @@ const processLogEvent = (event: string, format: LogFormat) => {
     const parsed: unknown = JSON.parse(event);
     const logEvent = LogEventSchema.parse(parsed);
 
+    const visibleLogs = logEvent.logs.filter(
+      (entry) => !isSuppressedMessage(formatMessages(entry.messages)),
+    );
+
+    // Skip events that contained nothing but suppressed noise so we don't emit
+    // an empty request envelope.
+    if (visibleLogs.length === 0 && logEvent.exceptions.length === 0) {
+      return;
+    }
+
+    const filteredEvent = { ...logEvent, logs: visibleLogs };
+
     if (format === 'pretty') {
-      consola.log(JSON.stringify(logEvent, null, 2));
+      consola.log(JSON.stringify(filteredEvent, null, 2));
     } else {
-      formatLogEvent(logEvent, format);
+      formatLogEvent(filteredEvent, format);
     }
   } catch {
     consola.warn(`Failed to parse log event: ${event}`);


### PR DESCRIPTION
Jira: [LTRAC-808](https://linear.app/commerce/issue/LTRAC-808)

## What/Why?

`catalyst logs tail` was flooding testers with a `[WARN] env.IMAGES binding is not defined` line on every image request. OpenNext's Cloudflare image handler emits this on each `/_next/image` request for a JPEG/PNG/WEBP/AVIF/GIF when `env.IMAGES` is missing, then falls back to serving the original unoptimized bytes.

LTRAC-808 weighed two options: provision an IMAGES Transformations binding in ignition (enables edge image optimization but needs Image Transformations enabled at the BC Cloudflare account level + has per-transformation cost), or leave optimization off and suppress the noise. We chose the latter — closest to the parent ticket's "if not required, remove the code path" framing and unblocked without infra/product dependencies.

This filters the known warning out of the human-readable log formats (`default`, `short`, `request`, `pretty`) and drops events that contain nothing but suppressed noise so we don't print an empty request envelope. Raw `--format json` output is intentionally left untouched so piped/tooling consumers still see the complete stream and can do their own filtering. The suppression is driven by a `SUPPRESSED_LOG_PATTERNS` array, so adding future framework-noise patterns is a one-line change.

Fixes LTRAC-808

## Testing

`pnpm vitest run src/cli/commands/logs.spec.ts` — 44 passing, including new cases covering: the IMAGES warning is dropped, sibling log entries in the same event survive, an event of pure noise emits nothing, exceptions still surface when all logs are suppressed, and `--format json` is not filtered.

To verify manually: run `catalyst logs tail` against a deployed Native Hosting storefront and load a page with images — the `env.IMAGES binding is not defined` lines should no longer appear, while `catalyst logs tail --format json` still includes them.

## Migration

None.