### PR TITLE
LTRAC-442: feat(cli) - Persist deployment env vars via `catalyst env`

### DIFF
--- a/packages/catalyst/src/cli/commands/deploy.spec.ts
+++ b/packages/catalyst/src/cli/commands/deploy.spec.ts
@@ -550,8 +550,95 @@ test('reads from env options', () => {
   ]);
 
   expect(() => parseEnvironmentVariables(['foo_bar'])).toThrow(
-    'Invalid secret format: foo_bar. Expected format: KEY=VALUE',
+    'Invalid env var format: foo_bar. Expected format: KEY=VALUE',
   );
+});
+
+test('splits secrets on the first = so values containing = survive', () => {
+  const envVariables = parseEnvironmentVariables(['TOKEN=abc=def==']);
+
+  expect(envVariables).toEqual([{ type: 'secret', key: 'TOKEN', value: 'abc=def==' }]);
+});
+
+describe('persisted env vars', () => {
+  interface DeploymentBody {
+    environment_variables?: Array<{ type: string; key: string; value: string }>;
+  }
+
+  test('sends stored env vars and lets inline --secret override the same key', async () => {
+    const config = getProjectConfig();
+
+    config.set('projectUuid', projectUuid);
+    config.set('storeHash', storeHash);
+    config.set('accessToken', accessToken);
+    config.set('env', { PERSISTED_ONLY: 'keep', SHARED: 'stored' });
+
+    let body: DeploymentBody | undefined;
+
+    server.use(
+      http.post(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/deployments',
+        async ({ request }) => {
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+          body = (await request.json()) as DeploymentBody;
+
+          return HttpResponse.json({ data: { deployment_uuid: deploymentUuid } });
+        },
+      ),
+    );
+
+    await program.parseAsync([
+      'node',
+      'catalyst',
+      'deploy',
+      '--api-host',
+      apiHost,
+      '--prebuilt',
+      '--secret',
+      'SHARED=override',
+      '--secret',
+      'FLAG_ONLY=flag',
+    ]);
+
+    expect(body?.environment_variables).toEqual(
+      expect.arrayContaining([
+        { type: 'secret', key: 'PERSISTED_ONLY', value: 'keep' },
+        { type: 'secret', key: 'SHARED', value: 'override' },
+        { type: 'secret', key: 'FLAG_ONLY', value: 'flag' },
+      ]),
+    );
+    // The shared key is sent once, with the inline flag value winning.
+    expect(body?.environment_variables?.filter((e) => e.key === 'SHARED')).toHaveLength(1);
+
+    config.delete('env');
+  });
+
+  test('omits environment_variables when nothing is stored or passed', async () => {
+    const config = getProjectConfig();
+
+    config.set('projectUuid', projectUuid);
+    config.set('storeHash', storeHash);
+    config.set('accessToken', accessToken);
+    config.delete('env');
+
+    let body: DeploymentBody | undefined;
+
+    server.use(
+      http.post(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/deployments',
+        async ({ request }) => {
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+          body = (await request.json()) as DeploymentBody;
+
+          return HttpResponse.json({ data: { deployment_uuid: deploymentUuid } });
+        },
+      ),
+    );
+
+    await program.parseAsync(['node', 'catalyst', 'deploy', '--api-host', apiHost, '--prebuilt']);
+
+    expect(body?.environment_variables).toBeUndefined();
+  });
 });
 
 describe('--prebuilt flag', () => {

--- a/packages/catalyst/src/cli/commands/deploy.ts
+++ b/packages/catalyst/src/cli/commands/deploy.ts
@@ -14,6 +14,12 @@ import {
   setupCommerceHosting,
 } from '../lib/commerce-hosting';
 import { getDeploymentErrorMessage } from '../lib/deployment-errors';
+import {
+  getStoredEnv,
+  mergeDeploymentSecrets,
+  parseEnvAssignment,
+  toDeploymentSecrets,
+} from '../lib/env-config';
 import { installDependencies } from '../lib/install-dependencies';
 import { consola } from '../lib/logger';
 import { getProjectConfig } from '../lib/project-config';
@@ -179,16 +185,12 @@ export const uploadBundleZip = async (uploadUrl: string) => {
 
 export const parseEnvironmentVariables = (secretOption?: string[]) => {
   return secretOption?.map((envVar) => {
-    const [key, value] = envVar.split('=');
-
-    if (!key || !value) {
-      throw new Error(`Invalid secret format: ${envVar}. Expected format: KEY=VALUE`);
-    }
+    const { key, value } = parseEnvAssignment(envVar);
 
     return {
       type: 'secret' as const,
-      key: key.trim(),
-      value: value.trim(),
+      key,
+      value,
     };
   });
 };
@@ -359,6 +361,9 @@ export const deploy = new Command('deploy')
   .addHelpText(
     'after',
     `
+Environment variables saved with \`catalyst env add\` are sent automatically on every deploy.
+Use \`--secret\` to set or override a variable for a single run.
+
 Example:
   $ catalyst deploy --secret BIGCOMMERCE_STORE_HASH=<YOUR_STORE_HASH> --secret BIGCOMMERCE_STOREFRONT_TOKEN=<YOUR_STOREFRONT_TOKEN>`,
   )
@@ -373,7 +378,7 @@ Example:
   .addOption(
     new Option(
       '--secret <value>',
-      'Secret to set for the deployment (repeatable). Format: --secret KEY=VALUE',
+      'Secret to set for this deployment (repeatable). Overrides a stored value for the same key. Format: --secret KEY=VALUE',
     ).argParser((value: string, previous: string[] = []) => {
       return previous.concat([value]);
     }),
@@ -516,7 +521,14 @@ Example:
 
     await uploadBundleZip(uploadSignature.upload_url);
 
-    const environmentVariables = parseEnvironmentVariables(options.secret);
+    // Merge persisted env vars (`catalyst env add`) with any inline `--secret`
+    // flags. Inline flags win on conflict, letting users override a stored
+    // value for a single run. Send `undefined` when there's nothing to set so
+    // we preserve the prior payload shape.
+    const flagSecrets = parseEnvironmentVariables(options.secret) ?? [];
+    const persistedSecrets = toDeploymentSecrets(getStoredEnv(config));
+    const mergedSecrets = mergeDeploymentSecrets(persistedSecrets, flagSecrets);
+    const environmentVariables = mergedSecrets.length > 0 ? mergedSecrets : undefined;
 
     const { deployment_uuid: deploymentUuid } = await createDeployment(
       projectUuid,

--- a/packages/catalyst/src/cli/commands/env.spec.ts
+++ b/packages/catalyst/src/cli/commands/env.spec.ts
@@ -1,0 +1,115 @@
+import { Command } from 'commander';
+import { afterAll, afterEach, beforeAll, beforeEach, expect, MockInstance, test, vi } from 'vitest';
+
+import { consola } from '../lib/logger';
+import { mkTempDir } from '../lib/mk-temp-dir';
+import { getProjectConfig } from '../lib/project-config';
+import { program } from '../program';
+
+import { env } from './env';
+
+let exitMock: MockInstance;
+let tmpDir: string;
+let cleanup: () => Promise<void>;
+
+beforeAll(async () => {
+  consola.mockTypes(() => vi.fn());
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  exitMock = vi.spyOn(process, 'exit').mockImplementation(() => null as never);
+
+  [tmpDir, cleanup] = await mkTempDir();
+});
+
+beforeEach(() => {
+  process.chdir(tmpDir);
+});
+
+afterEach(() => {
+  getProjectConfig().delete('env');
+  vi.clearAllMocks();
+});
+
+afterAll(async () => {
+  await cleanup();
+});
+
+test('properly configured Command instance', () => {
+  expect(env).toBeInstanceOf(Command);
+  expect(env.name()).toBe('env');
+  expect(env.commands.map((c) => c.name()).sort()).toEqual(['add', 'list', 'remove']);
+});
+
+test('add stores variables in .bigcommerce/project.json', async () => {
+  await program.parseAsync(['node', 'catalyst', 'env', 'add', 'FOO=bar', 'BAZ=qux']);
+
+  expect(getProjectConfig().get('env')).toEqual({ FOO: 'bar', BAZ: 'qux' });
+  expect(exitMock).toHaveBeenCalledWith(0);
+});
+
+test('add merges with and overwrites existing variables', async () => {
+  const config = getProjectConfig();
+
+  config.set('env', { FOO: 'old', KEEP: 'me' });
+
+  await program.parseAsync(['node', 'catalyst', 'env', 'add', 'FOO=new']);
+
+  expect(config.get('env')).toEqual({ FOO: 'new', KEEP: 'me' });
+});
+
+test('add never prints the raw value', async () => {
+  await program.parseAsync(['node', 'catalyst', 'env', 'add', 'SECRET=supersecret']);
+
+  const logged = vi.mocked(consola.log).mock.calls.flat().join('\n');
+
+  expect(logged).toContain('SECRET=');
+  expect(logged).not.toContain('supersecret');
+});
+
+test('add rejects an invalid assignment without partially writing', async () => {
+  const config = getProjectConfig();
+
+  config.set('env', { EXISTING: 'value' });
+
+  await expect(
+    program.parseAsync(['node', 'catalyst', 'env', 'add', 'GOOD=ok', 'bad-entry']),
+  ).rejects.toThrow('Invalid env var format: bad-entry');
+
+  // GOOD must not have been persisted since one entry was invalid.
+  expect(config.get('env')).toEqual({ EXISTING: 'value' });
+});
+
+test('remove deletes stored variables', async () => {
+  const config = getProjectConfig();
+
+  config.set('env', { FOO: 'bar', BAZ: 'qux' });
+
+  await program.parseAsync(['node', 'catalyst', 'env', 'remove', 'FOO']);
+
+  expect(config.get('env')).toEqual({ BAZ: 'qux' });
+  expect(exitMock).toHaveBeenCalledWith(0);
+});
+
+test('remove warns for keys that are not stored', async () => {
+  getProjectConfig().set('env', { FOO: 'bar' });
+
+  await program.parseAsync(['node', 'catalyst', 'env', 'remove', 'MISSING']);
+
+  expect(consola.warn).toHaveBeenCalledWith(expect.stringContaining('MISSING'));
+});
+
+test('list shows stored keys with masked values', async () => {
+  getProjectConfig().set('env', { FOO: 'bar' });
+
+  await program.parseAsync(['node', 'catalyst', 'env', 'list']);
+
+  const logged = vi.mocked(consola.log).mock.calls.flat().join('\n');
+
+  expect(logged).toContain('FOO=');
+  expect(logged).not.toContain('bar');
+});
+
+test('list reports when nothing is stored', async () => {
+  await program.parseAsync(['node', 'catalyst', 'env', 'list']);
+
+  expect(consola.info).toHaveBeenCalledWith(expect.stringContaining('No environment variables'));
+});

--- a/packages/catalyst/src/cli/commands/env.ts
+++ b/packages/catalyst/src/cli/commands/env.ts
@@ -1,0 +1,118 @@
+import { Command } from 'commander';
+
+import { getStoredEnv, parseEnvAssignment } from '../lib/env-config';
+import { consola } from '../lib/logger';
+import { getProjectConfig } from '../lib/project-config';
+
+// Values are secrets, so we never print them back. A fixed-width mask avoids
+// leaking the length of the stored value.
+const MASK = '••••••';
+
+const add = new Command('add')
+  .configureHelp({ showGlobalOptions: true })
+  .description(
+    'Add or update one or more deployment environment variables. Stored in .bigcommerce/project.json and sent as secrets on every `catalyst deploy`.',
+  )
+  .argument('<vars...>', 'One or more environment variables in KEY=VALUE format.')
+  .addHelpText(
+    'after',
+    `
+Example:
+  $ catalyst env add BIGCOMMERCE_STORE_HASH=abc123 BIGCOMMERCE_STOREFRONT_TOKEN=ey...`,
+  )
+  .action((vars: string[]) => {
+    const config = getProjectConfig();
+    const stored = { ...getStoredEnv(config) };
+
+    // Parse everything before writing so a single invalid entry doesn't leave a
+    // partial update behind.
+    const parsed = vars.map((entry) => parseEnvAssignment(entry));
+
+    parsed.forEach(({ key, value }) => {
+      stored[key] = value;
+    });
+
+    config.set('env', stored);
+
+    const keys = parsed.map(({ key }) => key);
+
+    consola.success(
+      `Saved ${keys.length} environment variable${keys.length === 1 ? '' : 's'} to .bigcommerce/project.json:`,
+    );
+    keys.forEach((key) => consola.log(`  ${key}=${MASK}`));
+
+    process.exit(0);
+  });
+
+const remove = new Command('remove')
+  .configureHelp({ showGlobalOptions: true })
+  .description('Remove one or more stored deployment environment variables.')
+  .argument('<keys...>', 'One or more environment variable names to remove.')
+  .addHelpText(
+    'after',
+    `
+Example:
+  $ catalyst env remove BIGCOMMERCE_STORE_HASH BIGCOMMERCE_STOREFRONT_TOKEN`,
+  )
+  .action((keys: string[]) => {
+    const config = getProjectConfig();
+    const stored = getStoredEnv(config);
+    const toRemove = new Set<string>();
+
+    keys.forEach((key) => {
+      if (key in stored) {
+        toRemove.add(key);
+      } else {
+        consola.warn(`No stored environment variable named "${key}". Skipping.`);
+      }
+    });
+
+    const next = Object.fromEntries(Object.entries(stored).filter(([key]) => !toRemove.has(key)));
+
+    config.set('env', next);
+
+    const removed = Array.from(toRemove);
+
+    if (removed.length > 0) {
+      consola.success(
+        `Removed ${removed.length} environment variable${removed.length === 1 ? '' : 's'}: ${removed.join(', ')}.`,
+      );
+    }
+
+    process.exit(0);
+  });
+
+const list = new Command('list')
+  .configureHelp({ showGlobalOptions: true })
+  .description('List stored deployment environment variables (values are masked).')
+  .addHelpText(
+    'after',
+    `
+Example:
+  $ catalyst env list`,
+  )
+  .action(() => {
+    const config = getProjectConfig();
+    const stored = getStoredEnv(config);
+    const keys = Object.keys(stored).sort();
+
+    if (keys.length === 0) {
+      consola.info('No environment variables stored. Add one with `catalyst env add KEY=VALUE`.');
+      process.exit(0);
+
+      return;
+    }
+
+    keys.forEach((key) => consola.log(`${key}=${MASK}`));
+
+    process.exit(0);
+  });
+
+export const env = new Command('env')
+  .configureHelp({ showGlobalOptions: true })
+  .description(
+    'Manage persistent deployment environment variables. These are sent as secrets on every `catalyst deploy`, so you no longer need to pass `--secret` each time.',
+  )
+  .addCommand(add)
+  .addCommand(remove)
+  .addCommand(list);

--- a/packages/catalyst/src/cli/lib/env-config.spec.ts
+++ b/packages/catalyst/src/cli/lib/env-config.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'vitest';
+
+import { mergeDeploymentSecrets, parseEnvAssignment, toDeploymentSecrets } from './env-config';
+
+describe('parseEnvAssignment', () => {
+  test('parses a basic KEY=VALUE assignment', () => {
+    expect(parseEnvAssignment('FOO=bar')).toEqual({ key: 'FOO', value: 'bar' });
+  });
+
+  test('splits on the first = so values containing = survive', () => {
+    expect(parseEnvAssignment('TOKEN=abc=def==')).toEqual({ key: 'TOKEN', value: 'abc=def==' });
+  });
+
+  test('trims surrounding whitespace', () => {
+    expect(parseEnvAssignment('  FOO = bar ')).toEqual({ key: 'FOO', value: 'bar' });
+  });
+
+  test('throws when there is no =', () => {
+    expect(() => parseEnvAssignment('FOO')).toThrow(
+      'Invalid env var format: FOO. Expected format: KEY=VALUE',
+    );
+  });
+
+  test('throws when the value is empty', () => {
+    expect(() => parseEnvAssignment('FOO=')).toThrow(
+      'Invalid env var format: FOO=. Expected format: KEY=VALUE',
+    );
+  });
+
+  test('throws when the key is not a valid env var name', () => {
+    expect(() => parseEnvAssignment('1FOO=bar')).toThrow('Invalid env var name: 1FOO');
+    expect(() => parseEnvAssignment('FOO-BAR=baz')).toThrow('Invalid env var name: FOO-BAR');
+  });
+});
+
+describe('toDeploymentSecrets', () => {
+  test('maps an env map into secret payload entries', () => {
+    expect(toDeploymentSecrets({ FOO: 'bar', BAZ: 'qux' })).toEqual([
+      { type: 'secret', key: 'FOO', value: 'bar' },
+      { type: 'secret', key: 'BAZ', value: 'qux' },
+    ]);
+  });
+
+  test('returns an empty array for an empty map', () => {
+    expect(toDeploymentSecrets({})).toEqual([]);
+  });
+});
+
+describe('mergeDeploymentSecrets', () => {
+  test('merges both sets with flag secrets overriding persisted on conflict', () => {
+    const persisted = toDeploymentSecrets({ PERSISTED_ONLY: 'keep', SHARED: 'stored' });
+    const flagSecrets = toDeploymentSecrets({ SHARED: 'override', FLAG_ONLY: 'flag' });
+
+    const merged = mergeDeploymentSecrets(persisted, flagSecrets);
+
+    expect(merged).toEqual([
+      { type: 'secret', key: 'PERSISTED_ONLY', value: 'keep' },
+      { type: 'secret', key: 'SHARED', value: 'override' },
+      { type: 'secret', key: 'FLAG_ONLY', value: 'flag' },
+    ]);
+  });
+
+  test('returns persisted secrets when there are no flag secrets', () => {
+    const persisted = toDeploymentSecrets({ FOO: 'bar' });
+
+    expect(mergeDeploymentSecrets(persisted, [])).toEqual([
+      { type: 'secret', key: 'FOO', value: 'bar' },
+    ]);
+  });
+});

--- a/packages/catalyst/src/cli/lib/env-config.ts
+++ b/packages/catalyst/src/cli/lib/env-config.ts
@@ -1,0 +1,66 @@
+import type Conf from 'conf';
+
+import { ProjectConfigSchema } from './project-config';
+
+// A single deployment environment variable as the infrastructure API expects
+// it. We only persist/send `secret` vars today (see ProjectConfigSchema.env).
+export interface DeploymentSecret {
+  type: 'secret';
+  key: string;
+  value: string;
+}
+
+// Matches POSIX-ish env var names: leading letter/underscore, then
+// letters/digits/underscores. Keeps the stored config (and the deployment
+// payload) free of keys that wouldn't be valid env vars at runtime.
+const ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+// Parse a single `KEY=VALUE` assignment. Splits on the *first* `=` only, so
+// values containing `=` (e.g. base64 or tokens) survive intact. Validates the
+// key shape and rejects empty values.
+export const parseEnvAssignment = (input: string): { key: string; value: string } => {
+  const separatorIndex = input.indexOf('=');
+
+  if (separatorIndex === -1) {
+    throw new Error(`Invalid env var format: ${input}. Expected format: KEY=VALUE`);
+  }
+
+  const key = input.slice(0, separatorIndex).trim();
+  const value = input.slice(separatorIndex + 1).trim();
+
+  if (!key || !value) {
+    throw new Error(`Invalid env var format: ${input}. Expected format: KEY=VALUE`);
+  }
+
+  if (!ENV_KEY_PATTERN.test(key)) {
+    throw new Error(
+      `Invalid env var name: ${key}. Names must start with a letter or underscore and contain only letters, numbers, and underscores.`,
+    );
+  }
+
+  return { key, value };
+};
+
+// Read the persisted env var map (KEY -> VALUE), defaulting to empty.
+export const getStoredEnv = (config: Conf<ProjectConfigSchema>): Record<string, string> => {
+  return config.get('env') ?? {};
+};
+
+// Convert a persisted env var map into the deployment `secret` payload shape.
+export const toDeploymentSecrets = (envVars: Record<string, string>): DeploymentSecret[] => {
+  return Object.entries(envVars).map(([key, value]) => ({ type: 'secret', key, value }));
+};
+
+// Merge persisted secrets with inline `--secret` flag secrets, keyed by name.
+// Inline flags win on conflict so users can override a stored value per-run.
+export const mergeDeploymentSecrets = (
+  persisted: DeploymentSecret[],
+  flagSecrets: DeploymentSecret[],
+): DeploymentSecret[] => {
+  const byKey = new Map<string, DeploymentSecret>();
+
+  persisted.forEach((secret) => byKey.set(secret.key, secret));
+  flagSecrets.forEach((secret) => byKey.set(secret.key, secret));
+
+  return Array.from(byKey.values());
+};

--- a/packages/catalyst/src/cli/lib/project-config.spec.ts
+++ b/packages/catalyst/src/cli/lib/project-config.spec.ts
@@ -50,3 +50,13 @@ test('writes and reads field from .bigcommerce/project.json', async () => {
   expect(config.get('storeHash')).toBe('abc123');
   expect(config.get('accessToken')).toBe('secret-token');
 });
+
+test('env defaults to an empty object and round-trips a map', () => {
+  expect(config.get('env')).toEqual({});
+
+  config.set('env', { FOO: 'bar', BAZ: 'qux' });
+
+  expect(config.get('env')).toEqual({ FOO: 'bar', BAZ: 'qux' });
+
+  config.delete('env');
+});

--- a/packages/catalyst/src/cli/lib/project-config.ts
+++ b/packages/catalyst/src/cli/lib/project-config.ts
@@ -7,6 +7,11 @@ export interface ProjectConfigSchema {
   framework: 'catalyst';
   storeHash?: string;
   accessToken?: string;
+  // Persistent deployment environment variables (KEY -> VALUE). Every entry is
+  // sent to the deployment as a `secret` by `catalyst deploy`. Managed via the
+  // `catalyst env` commands. Lives here (gitignored .bigcommerce/project.json)
+  // so users don't have to re-pass `--secret` on every deploy.
+  env?: Record<string, string>;
 }
 
 export function getProjectConfig() {
@@ -23,6 +28,11 @@ export function getProjectConfig() {
       },
       storeHash: { type: 'string' },
       accessToken: { type: 'string' },
+      env: {
+        type: 'object',
+        additionalProperties: { type: 'string' },
+        default: {},
+      },
     },
   });
 }

--- a/packages/catalyst/src/cli/program.ts
+++ b/packages/catalyst/src/cli/program.ts
@@ -12,6 +12,7 @@ import { build } from './commands/build';
 import { channel } from './commands/channel';
 import { create } from './commands/create';
 import { deploy } from './commands/deploy';
+import { env } from './commands/env';
 import { logs } from './commands/logs';
 import { project } from './commands/project';
 import { start } from './commands/start';
@@ -87,6 +88,7 @@ program
   .addCommand(deploy)
   .addCommand(logs)
   .addCommand(project)
+  .addCommand(env)
   .addCommand(channel)
   .addCommand(auth)
   .addCommand(telemetry)


### PR DESCRIPTION
Jira: [LTRAC-442](https://linear.app/commerce/issue/LTRAC-442)

## What/Why?

Testers expected a way to configure persistent env vars rather than re-typing `--secret KEY=VALUE` on every `catalyst deploy`. This got worse after LTRAC-640 removed the implicit `process.env` secret detection: now nothing reaches a deployment unless every secret is passed inline each time. (Note: the existing global `--env-path` flag only loads vars into `process.env` for the local build — post-LTRAC-640 those values are no longer forwarded to the deployment, so it doesn't solve this.)

This adds a `catalyst env` command group — `add`, `remove`, `list` — that persists deployment secrets to `.bigcommerce/project.json`, which is already gitignored and already stores the access token in plaintext, so this is consistent with current behavior. `catalyst deploy` reads them and sends them automatically as the deployment's `environment_variables`.

Key decisions:
- **Deploy-only**: stored vars are sent as deployment secrets but are *not* injected into the local build (`build` keeps reading `.env.local` / `process.env`), to avoid baking values into the bundle and blurring build vs runtime config.
- **Secrets only**: every stored var is sent with `type: 'secret'`. Values are masked in all command output and never printed back.
- **Inline flags win**: on deploy, persisted vars merge with any `--secret` flags; on a key conflict the inline flag overrides the stored value, allowing per-run overrides.
- A shared `parseEnvAssignment` splits on the *first* `=`, so values containing `=` (base64/tokens) survive intact — a fix over deploy's prior `split('=')`.

Refs LTRAC-442

## Testing

`pnpm --filter @bigcommerce/catalyst test` — full suite passes (302 tests). New/updated coverage:
- `lib/env-config.spec.ts` — first-`=` split, key/value validation, `toDeploymentSecrets`, `mergeDeploymentSecrets` (flag overrides persisted).
- `commands/env.spec.ts` — add/remove/list round-trips through `project.json`, masking, atomic add (one bad entry aborts the whole write), warn on removing a missing key.
- `commands/deploy.spec.ts` — persisted vars are sent, inline `--secret` overrides the same key (sent once), and `environment_variables` is omitted when nothing is set.

Also `pnpm typecheck` and `pnpm lint` pass clean.

Manual: from a scaffolded project's `core/`, `catalyst env add FOO=bar BAZ=qux` → `.bigcommerce/project.json` gains an `env` map; `catalyst env list` shows masked values; `catalyst env remove FOO` drops it; `catalyst deploy --secret BAZ=override` sends the merged set with `BAZ` overridden.

## Migration

None. The `env` field is optional and defaults to `{}`; existing projects are unaffected.