### PR TITLE
LTRAC-441: fix(cli) - Surface clear re-auth error on expired token

### DIFF
--- a/packages/catalyst/src/cli/commands/auth.spec.ts
+++ b/packages/catalyst/src/cli/commands/auth.spec.ts
@@ -103,7 +103,7 @@ describe('whoami', () => {
     expect(exitMock).toHaveBeenCalledWith(1);
   });
 
-  test('reports invalid credentials on 401', async () => {
+  test('reports an invalid or expired token on 401', async () => {
     const config = getProjectConfig();
 
     config.set('storeHash', 'test-store');
@@ -119,7 +119,7 @@ describe('whoami', () => {
     await program.parseAsync(['node', 'catalyst', 'auth', 'whoami']);
 
     expect(consola.error).toHaveBeenCalledWith(
-      expect.stringContaining('Not logged in: invalid credentials'),
+      'Not logged in: your access token is invalid or has expired. Run `catalyst auth login`.',
     );
     expect(exitMock).toHaveBeenCalledWith(1);
   });

--- a/packages/catalyst/src/cli/commands/auth.ts
+++ b/packages/catalyst/src/cli/commands/auth.ts
@@ -1,6 +1,7 @@
 import { Command, Option } from 'commander';
 import { z } from 'zod';
 
+import { assertAuthorized, UnauthorizedError } from '../lib/auth-errors';
 import { consola } from '../lib/logger';
 import { LoginAbortedError, login as runInteractiveLogin } from '../lib/login';
 import { fetchProjects } from '../lib/project';
@@ -21,6 +22,8 @@ async function fetchStoreProfile(storeHash: string, accessToken: string, apiHost
       Accept: 'application/json',
     },
   });
+
+  assertAuthorized(response);
 
   if (!response.ok) {
     throw new Error(`${response.status} ${response.statusText}`);
@@ -107,7 +110,11 @@ Example:
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
 
-      if (message.includes('401') || message.includes('403')) {
+      if (error instanceof UnauthorizedError) {
+        consola.error(
+          'Not logged in: your access token is invalid or has expired. Run `catalyst auth login`.',
+        );
+      } else if (message.includes('401') || message.includes('403')) {
         consola.error(`Not logged in: invalid credentials (${message})`);
       } else {
         consola.error(`Failed to verify credentials: ${message}`);

--- a/packages/catalyst/src/cli/commands/deploy.ts
+++ b/packages/catalyst/src/cli/commands/deploy.ts
@@ -6,6 +6,7 @@ import { dirname, join } from 'node:path';
 import yoctoSpinner from 'yocto-spinner';
 import { z } from 'zod';
 
+import { assertAuthorized } from '../lib/auth-errors';
 import { runChannelSiteUrlFlow } from '../lib/channel-site-flow';
 import {
   cleanupCloudflareIncompatibilities,
@@ -146,6 +147,8 @@ export const generateUploadSignature = async (
     },
   );
 
+  assertAuthorized(response);
+
   if (!response.ok) {
     throw new Error(`Failed to fetch upload signature: ${response.status} ${response.statusText}`);
   }
@@ -223,6 +226,8 @@ export const createDeployment = async (
     },
   );
 
+  assertAuthorized(response);
+
   if (!response.ok) {
     throw new Error(`Failed to create deployment: ${response.status} ${response.statusText}`);
   }
@@ -257,6 +262,8 @@ export const getDeploymentStatus = async (
       },
     },
   );
+
+  assertAuthorized(response);
 
   if (!response.ok) {
     throw new Error(`Failed to open event stream: ${response.status} ${response.statusText}`);
@@ -344,6 +351,8 @@ export const fetchProject = async (
       },
     },
   );
+
+  assertAuthorized(response);
 
   if (!response.ok) {
     throw new Error(`Failed to fetch projects: ${response.status} ${response.statusText}`);

--- a/packages/catalyst/src/cli/commands/logs.spec.ts
+++ b/packages/catalyst/src/cli/commands/logs.spec.ts
@@ -392,7 +392,7 @@ describe('error handling', () => {
     );
   });
 
-  test('throws on fatal 401 unauthorized', async () => {
+  test('throws a re-auth error on fatal 401 unauthorized', async () => {
     server.use(
       http.get(
         'https://:apiHost/stores/:storeHash/v3/infrastructure/logs/:projectUuid/tail',
@@ -401,7 +401,7 @@ describe('error handling', () => {
     );
 
     await expect(tailLogs(projectUuid, storeHash, accessToken, apiHost, 'default')).rejects.toThrow(
-      'Failed to open log stream: 401 Unauthorized',
+      'catalyst auth login',
     );
   });
 });

--- a/packages/catalyst/src/cli/commands/logs.ts
+++ b/packages/catalyst/src/cli/commands/logs.ts
@@ -2,6 +2,7 @@ import { Command, Option } from 'commander';
 import { colorize } from 'consola/utils';
 import { z } from 'zod';
 
+import { UnauthorizedError } from '../lib/auth-errors';
 import { consola } from '../lib/logger';
 import { getProjectConfig } from '../lib/project-config';
 import { resolveCredentials } from '../lib/resolve-credentials';
@@ -193,6 +194,12 @@ const openLogStream = async (
       },
     },
   );
+
+  // An invalid/expired token won't recover by reconnecting — surface the
+  // re-auth guidance and stop the loop (fatal) rather than burning retries.
+  if (response.status === 401) {
+    throw new StreamError(new UnauthorizedError().message, true);
+  }
 
   if (!response.ok) {
     throw new StreamError(

--- a/packages/catalyst/src/cli/commands/project.spec.ts
+++ b/packages/catalyst/src/cli/commands/project.spec.ts
@@ -451,6 +451,27 @@ describe('project list', () => {
     );
     expect(exitMock).toHaveBeenCalledWith(1);
   });
+
+  test('surfaces an expired-session error on 401', async () => {
+    server.use(
+      http.get('https://:apiHost/stores/:storeHash/v3/infrastructure/projects', () =>
+        HttpResponse.json({}, { status: 401 }),
+      ),
+    );
+
+    await expect(
+      program.parseAsync([
+        'node',
+        'catalyst',
+        'project',
+        'list',
+        '--store-hash',
+        storeHash,
+        '--access-token',
+        accessToken,
+      ]),
+    ).rejects.toThrow('catalyst auth login');
+  });
 });
 
 describe('project link', () => {

--- a/packages/catalyst/src/cli/index.ts
+++ b/packages/catalyst/src/cli/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { UnauthorizedError } from './lib/auth-errors';
 import { consola } from './lib/logger';
 import { getTelemetry } from './lib/telemetry';
 import { program } from './program';
@@ -19,6 +20,13 @@ const handleFatalError = async (error: unknown) => {
     await telemetry.analytics.closeAndFlush();
   } catch {
     // Don't mask the original error
+  }
+
+  // An invalid/expired token is user-actionable, not a bug to report — print the
+  // re-auth guidance without the "share your Correlation ID with support" noise.
+  if (error instanceof UnauthorizedError) {
+    consola.error(errorMessage);
+    process.exit(1);
   }
 
   consola.error(errorMessage);

--- a/packages/catalyst/src/cli/lib/auth-errors.spec.ts
+++ b/packages/catalyst/src/cli/lib/auth-errors.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'vitest';
+
+import { assertAuthorized, UnauthorizedError } from './auth-errors';
+
+const responseWith = (status: number) => new Response(null, { status });
+
+describe('assertAuthorized', () => {
+  test('throws UnauthorizedError on 401', () => {
+    expect(() => assertAuthorized(responseWith(401))).toThrow(UnauthorizedError);
+  });
+
+  test.each([200, 403, 404, 500])('does not throw on %i', (status) => {
+    expect(() => assertAuthorized(responseWith(status))).not.toThrow();
+  });
+});
+
+describe('UnauthorizedError', () => {
+  test('carries an actionable re-auth message', () => {
+    const error = new UnauthorizedError();
+
+    expect(error.name).toBe('UnauthorizedError');
+    expect(error.message).toContain('catalyst auth login');
+  });
+});

--- a/packages/catalyst/src/cli/lib/auth-errors.ts
+++ b/packages/catalyst/src/cli/lib/auth-errors.ts
@@ -1,0 +1,31 @@
+// Thrown when an authenticated API call comes back 401 Unauthorized — i.e. the
+// access token was sent but rejected. This covers an expired/revoked token as
+// well as a token that was never valid (e.g. a typo'd `--access-token` flag or
+// a stale `CATALYST_ACCESS_TOKEN` env var). It does NOT cover the "no
+// credentials at all" case — that's caught earlier by `resolveCredentials`
+// (and `auth whoami`'s own guard) before any request is made.
+//
+// The CLI can't refresh the token silently (the device-code flow returns no
+// refresh token), so the only recovery is to re-authenticate. Callers should
+// let this propagate to the top-level handler in `index.ts`, which prints the
+// message without the generic "share your Correlation ID with support"
+// bug-report framing.
+export class UnauthorizedError extends Error {
+  constructor() {
+    super(
+      'Your access token is invalid or has expired.\n' +
+        'Run `catalyst auth login` to re-authenticate.',
+    );
+    this.name = 'UnauthorizedError';
+  }
+}
+
+// Call immediately after an authenticated `fetch`, before any other status
+// checks. Only 401 means "invalid/expired token" — 403 is overloaded elsewhere
+// to mean "API not enabled" (scope/feature flag), so it is intentionally not
+// treated as an auth failure here.
+export function assertAuthorized(response: Response): void {
+  if (response.status === 401) {
+    throw new UnauthorizedError();
+  }
+}

--- a/packages/catalyst/src/cli/lib/channels.ts
+++ b/packages/catalyst/src/cli/lib/channels.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { assertAuthorized } from './auth-errors';
 import { getTelemetry } from './telemetry';
 
 // `origin` is the CLI-API gateway (configured via `--cli-api-origin`, default
@@ -174,6 +175,8 @@ export async function fetchAvailableChannels(
       },
     },
   );
+
+  assertAuthorized(response);
 
   if (!response.ok) {
     throw new Error(`GET /v3/channels failed: ${response.status} ${response.statusText}`);

--- a/packages/catalyst/src/cli/lib/localization.ts
+++ b/packages/catalyst/src/cli/lib/localization.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { assertAuthorized } from './auth-errors';
 import { getTelemetry } from './telemetry';
 
 const allowedLocales = [
@@ -51,6 +52,8 @@ export const getAvailableLocales = async (
       },
     },
   );
+
+  assertAuthorized(response);
 
   if (!response.ok) {
     throw new Error(

--- a/packages/catalyst/src/cli/lib/project.ts
+++ b/packages/catalyst/src/cli/lib/project.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { assertAuthorized } from './auth-errors';
 import { getTelemetry } from './telemetry';
 
 export class InfrastructureProjectValidationError extends Error {
@@ -46,6 +47,8 @@ export async function hasProjectsAccess(
     headers: authHeaders(accessToken),
   });
 
+  assertAuthorized(response);
+
   if (response.status === 200) return true;
   if (response.status === 403) return false;
 
@@ -63,6 +66,8 @@ export async function fetchProjects(
     method: 'GET',
     headers: authHeaders(accessToken),
   });
+
+  assertAuthorized(response);
 
   if (response.status === 403) {
     throw new Error(
@@ -133,6 +138,8 @@ export async function createProject(
     body: JSON.stringify({ name }),
   });
 
+  assertAuthorized(response);
+
   if (response.status === 400 || response.status === 422) {
     const body: unknown = await response.json().catch(() => null);
     const fallback =
@@ -176,6 +183,8 @@ export async function deleteProject(
     method: 'DELETE',
     headers: authHeaders(accessToken),
   });
+
+  assertAuthorized(response);
 
   if (response.status === 403) {
     throw new Error(


### PR DESCRIPTION
Jira: [LTRAC-441](https://linear.app/commerce/issue/LTRAC-441) · [TRAC-431](https://bigcommercecloud.atlassian.net/browse/TRAC-431)

## What/Why?

Auth tokens stored in `.bigcommerce/project.json` stop working between sessions. The CLI still believes it's authorized (a token is present), but API calls return **401 Unauthorized** on `project list`, `deploy`, etc. Because every authenticated `fetch` only checked `response.ok` and threw a generic `Failed to ...: Unauthorized`, users had no idea they needed to re-authenticate.

Root cause: credentials come from the device-code OAuth flow (short-lived, **expiring** token) or a manual store-level API account (non-expiring). The device-code success response is parsed for only `access_token`/`store_hash` — any expiry/refresh metadata is discarded — so **silent refresh isn't possible** today. Auto-refresh (refresh token) and longer token lifetimes both require login-service/backend changes outside this repo; this PR implements the self-contained fix: detect 401 consistently and tell the user to re-authenticate.

Key decisions:
- Only **401** is treated as an auth failure. **403** is intentionally left untouched because it's overloaded in this codebase to mean "Infrastructure Projects API not enabled" (scope/feature flag).
- New shared `UnauthorizedError` + `assertAuthorized(response)` (`lib/auth-errors.ts`), called at every authenticated fetch site (`project.ts`, `channels.ts`, `localization.ts`, `deploy.ts`).
- Messaging covers **any rejected token** — expired/revoked *or* never-valid (e.g. a typo'd `--access-token` flag or stale `CATALYST_ACCESS_TOKEN`): _"Your access token is invalid or has expired. Run `catalyst auth login` to re-authenticate."_ The "no credentials at all" case is **not** a 401 — it's caught earlier by `resolveCredentials` (and `auth whoami`'s own guard) with a "Missing credentials" message before any request is made.
- `logs tail` raises a **fatal** stream error on 401 so the reconnect loop stops with the re-auth message instead of burning retries.
- The top-level handler in `index.ts` prints the re-auth guidance without the "share your Correlation ID with support" bug-report framing (telemetry still tracked).
- `lib/login.ts` `manualLogin` is deliberately unchanged — a 401 during interactive login already shows "Could not validate credentials".

Follow-ups (out of scope, backend-dependent): auto-refresh via a persisted `refresh_token`, and proactive expiry warnings via persisted `expires_in`.

## Testing

- `pnpm typecheck`, `pnpm lint` (max-warnings 0), and `pnpm test` (**314 passing**) all green.
- Added/updated specs: `auth-errors.spec.ts` (401 throws, 200/403/500 no-op), a `project list` 401 regression test, and updated `auth.spec.ts` / `logs.spec.ts` to assert the new re-auth messaging.
- Manual smoke: set a bogus `accessToken` in `.bigcommerce/project.json`, then run `catalyst project list`, `catalyst deploy`, `catalyst auth whoami`, `catalyst logs tail` — each prints "Your access token is invalid or has expired ... Run \`catalyst auth login\`" and exits non-zero (logs does not retry-loop). A valid token still works end-to-end.

## Migration

None. No breaking changes or moved files.

[TRAC-431]: https://bigcommercecloud.atlassian.net/browse/TRAC-431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ