### PR TITLE
fix(core): LTRAC-829 use exact-path lookup for Makeswift page metadata

### DIFF
--- a/core/lib/makeswift/client.ts
+++ b/core/lib/makeswift/client.ts
@@ -34,20 +34,16 @@ function normalizeLocale(locale: string): string | undefined {
 }
 
 export async function getMakeswiftPageMetadata({ path, locale }: { path: string; locale: string }) {
-  const { data: pages } = await client.getPages({
-    pathPrefix: path,
-    locale: normalizeLocale(locale),
-    siteVersion: await getSiteVersion(),
-  });
+  const snapshot = await getPageSnapshot({ path, locale });
 
-  if (pages.length === 0 || !pages[0]) {
+  if (snapshot == null) {
     return null;
   }
 
-  const { title, description } = pages[0];
+  const { meta } = snapshot.document;
 
   return {
-    ...(title && { title }),
-    ...(description && { description }),
+    ...(meta.title && { title: meta.title }),
+    ...(meta.description && { description: meta.description }),
   };
 }


### PR DESCRIPTION
Linear: [LTRAC-829](https://linear.app/commerce/issue/LTRAC-829/getmakeswiftpagemetadata-returns-wrong-pages-seo-due-to-pathprefix)

## What/Why?

`getMakeswiftPageMetadata()` resolved the Makeswift page with `client.getPages({ pathPrefix: path })` — a **prefix** match — then took `pages[0]`, which could be an unrelated page. Two clear breaks:

- **Home `/`**: `pathPrefix: '/'` matches *every* page, so `pages[0]` (default sort) rendered an arbitrary page's SEO.
- **Nested collisions**: `/product/12` prefix-matches `/product/120`, `/product/123`; a sibling's Makeswift SEO leaked onto the wrong product when no exact page existed.

Fix: switch to an **exact-path** lookup via the existing `getPageSnapshot()` helper (same file), reading `document.meta`. This is the approach the original changeset `5097034e9` documented. BC-default + Makeswift per-page opt-in behavior is preserved — only the page binding becomes exact. The return shape (`{ title?, description? }`) is unchanged, so none of the ~13 callers need changes.

## Testing

- `cd core && pnpm exec tsc --noEmit` and `pnpm exec eslint lib/makeswift/client.ts` — both pass.
- Manual scenarios:
  - BC-backed page with no Makeswift SEO → BC `seo.*` used.
  - BC-backed page with Makeswift SEO set → Makeswift values used (per-page opt-in).
  - Two products where only one has a Makeswift page → the other does **not** inherit its SEO.
  - Home `/` → uses the home Makeswift page's SEO (or BC default), never an arbitrary page.

## Migration

None. Internal behavior change only; no API or file moves.