### PR TITLE
LTRAC-873: fix(cli) - Derive Wrangler compatibility_date dynamically

### DIFF
--- a/.changeset/cli-dynamic-compat-date.md
+++ b/.changeset/cli-dynamic-compat-date.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst": patch
+---
+
+`catalyst build` now derives the Cloudflare Workers `compatibility_date` dynamically (current date minus one month) instead of using a pinned date, keeping the build-time runtime semantics aligned with what the deployment service applies at deploy time.

--- a/packages/catalyst/src/cli/lib/wrangler-config.spec.ts
+++ b/packages/catalyst/src/cli/lib/wrangler-config.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest';
 
-import { getWranglerConfig } from './wrangler-config';
+import { getCompatibilityDate, getWranglerConfig } from './wrangler-config';
 
 test('returns a config with name identical to worker self reference service', () => {
   const config = getWranglerConfig('uuid');
@@ -9,4 +9,18 @@ test('returns a config with name identical to worker self reference service', ()
   expect(
     config.services.find((service) => service.binding === 'WORKER_SELF_REFERENCE')?.service,
   ).toBe(`project-uuid`);
+});
+
+test('compatibility date is one month before the given date', () => {
+  expect(getCompatibilityDate(new Date('2026-06-11T15:00:00Z'))).toBe('2026-05-11');
+});
+
+test('compatibility date handles month-end normalization', () => {
+  // May 31 minus one month lands in early May (no April 31), still a valid date.
+  expect(getCompatibilityDate(new Date('2026-05-31T12:00:00Z'))).toBe('2026-05-01');
+  expect(getCompatibilityDate(new Date('2026-01-15T00:00:00Z'))).toBe('2025-12-15');
+});
+
+test('config uses a YYYY-MM-DD compatibility date', () => {
+  expect(getWranglerConfig('uuid').compatibility_date).toMatch(/^\d{4}-\d{2}-\d{2}$/u);
 });

--- a/packages/catalyst/src/cli/lib/wrangler-config.ts
+++ b/packages/catalyst/src/cli/lib/wrangler-config.ts
@@ -1,9 +1,27 @@
+// The compatibility date, compatibility flags, Durable Object classes, and
+// migration tag below are mirrored in Ignition, which builds its own Worker
+// metadata at deploy time (pkg/cloudflare/upload/metadata.go and
+// pkg/cloudflare/upload/migrations/migrations.go). Keep both sides in sync
+// when changing any of them.
+export function getCompatibilityDate(now = new Date()): string {
+  const date = new Date(now);
+
+  // One month behind the current date: recent enough to track Cloudflare
+  // runtime behavior (per Cloudflare guidance), buffered enough to avoid
+  // brand-new compatibility-date-gated changes. Ignition applies the same
+  // offset at deploy time, so the bundle is never built against newer
+  // semantics than it runs under.
+  date.setUTCMonth(date.getUTCMonth() - 1);
+
+  return date.toISOString().slice(0, 10);
+}
+
 export function getWranglerConfig(projectUuid: string) {
   return {
     $schema: 'node_modules/wrangler/config-schema.json',
     main: '../.open-next/worker.js',
     name: `project-${projectUuid}`,
-    compatibility_date: '2025-09-15',
+    compatibility_date: getCompatibilityDate(),
     compatibility_flags: ['nodejs_compat', 'global_fetch_strictly_public'],
     observability: {
       enabled: true,


### PR DESCRIPTION
Linear: [LTRAC-873](https://linear.app/commerce/issue/LTRAC-873/keep-cli-generated-wrangler-config-in-lockstep-with-ignition-deploy)

## What/Why?

The CLI pinned `compatibility_date: '2025-09-15'` in the generated `wrangler.jsonc`, while Ignition stamps a dynamic current date at deploy time (made dynamic deliberately in [ignition#245](https://github.com/bigcommerce/ignition/pull/245) per Cloudflare guidance). The result: worker bundles were built against ~9-month-old Cloudflare runtime semantics but deployed under today's — compat-date-gated runtime changes could alter behavior the bundle was never built for.

Per agreement with @chanceaclark, both sides now derive the date as **current UTC date minus one month** — recent enough to track Cloudflare runtime behavior, buffered enough to avoid brand-new date-gated changes. Since the CLI build always precedes the Ignition deploy, the bundle is never built against newer semantics than it runs under.

Companion Ignition PR applies the same offset on the deploy side: [ignition#288](https://github.com/bigcommerce/ignition/pull/288). The compat flags, Durable Object classes, and migration tag remain manually synced by convention — this PR adds cross-referencing comments for them.

Refs LTRAC-873

## Testing

- New unit tests for `getCompatibilityDate()` cover the one-month offset and month-end normalization (`pnpm exec vitest run src/cli/lib/wrangler-config.spec.ts`).
- Full package suite green: 312 tests, typecheck, lint.

## Migration

None — no public API changes. Generated `.bigcommerce/wrangler.jsonc` will show a rolling date instead of `2025-09-15`.
