### PR TITLE
fix: TRAC-814 Make session token cookies expire with the session

### DIFF
--- a/.changeset/trac-814-session-cookie-compliance.md
+++ b/.changeset/trac-814-session-cookie-compliance.md
@@ -1,0 +1,33 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Make `authjs.session-token` and `authjs.anonymous-session-token` browser-session cookies (no `Expires` attribute) to satisfy Essential cookie classification requirements.
+
+## What changed
+
+**Anonymous session token:** `anonymousSignIn` no longer sets `maxAge` on the cookie. Without it, Next.js omits `Max-Age`/`Expires` and the cookie becomes a session cookie that the browser drops when it closes.
+
+**Auth session token:** Auth.js v5 unconditionally writes `Expires` on the session token cookie and provides no config option to suppress it. Two post-processing steps strip the attribute:
+
+- `proxies/with-auth.ts` — strips `Expires` from `Set-Cookie` response headers on every page request.
+- `auth/index.ts` — wraps `signIn` and `updateSession` to re-set the cookie via `cookies().set()` without `Expires` immediately after Auth.js writes it, covering the sign-in and session-update paths that middleware cannot reach.
+
+`Max-Age=0` (used by Auth.js for cookie deletion on sign-out) is intentionally left intact.
+
+## Migration
+
+**If you have a custom `maxAge` on `anonymousSignIn`:** The default 7-day `maxAge` has been removed. If your app relies on anonymous sessions persisting across browser restarts, add it back in your own `anonymousSignIn` call:
+
+```ts
+cookieJar.set(anonymousCookieName, jwt, {
+  httpOnly: true,
+  sameSite: 'lax',
+  secure: useSecureCookies,
+  maxAge: 60 * 60 * 24 * 7, // restore 7-day persistence if needed
+});
+```
+
+**If you already have your own `Expires`-stripping workaround:** Remove it. The middleware regex in `with-auth.ts` and the `patchSessionTokenCookies` wrapper in `auth/index.ts` now handle this centrally. Leaving both in place will cause redundant cookie writes.
+
+**If you import `signIn` or `updateSession` directly from `auth/index.ts`:** No change needed — the signatures are identical. The exports are now thin async wrappers that call the Auth.js originals and then patch any session token cookies written during the call.

--- a/core/auth/anonymous-session.ts
+++ b/core/auth/anonymous-session.ts
@@ -31,9 +31,6 @@ export const anonymousSignIn = async (user: Partial<AnonymousUser> = { cartId: n
   cookieJar.set(`${cookiePrefix}${anonymousCookieName}`, jwt, {
     secure: useSecureCookies,
     sameSite: 'lax',
-    // We set the maxAge to 7 days as a good default for anonymous sessions.
-    // This can be adjusted based on your application's needs.
-    maxAge: 60 * 60 * 24 * 7, // 7 days
     httpOnly: true,
   });
 };

--- a/core/auth/index.ts
+++ b/core/auth/index.ts
@@ -1,4 +1,5 @@
 import { decodeJwt } from 'jose';
+import { cookies } from 'next/headers';
 import NextAuth, { type NextAuthConfig, User } from 'next-auth';
 import 'next-auth/jwt';
 import CredentialsProvider from 'next-auth/providers/credentials';
@@ -184,6 +185,7 @@ const config = {
   session: {
     strategy: 'jwt',
   },
+  cookies: {},
   pages: {
     signIn: '/login',
     signOut: '/logout',
@@ -318,7 +320,52 @@ const config = {
   ],
 } satisfies NextAuthConfig;
 
-export const { handlers, auth, signIn, signOut, unstable_update: updateSession } = NextAuth(config);
+const SESSION_TOKEN_NAME_RE = /^(__Secure-)?authjs\.session-token(\.\d+)?$/;
+
+// Auth.js sets Expires on session token cookies via cookies().set() when signIn/updateSession
+// are called from server actions. Re-set those cookies without Expires so they comply with
+// Essential classification (session cookies that expire when the browser closes).
+async function patchSessionTokenCookies() {
+  const cookieJar = await cookies();
+
+  cookieJar.getAll().forEach(({ name, value }) => {
+    if (SESSION_TOKEN_NAME_RE.test(name) && value) {
+      cookieJar.set(name, value, {
+        httpOnly: true,
+        sameSite: 'lax' as const,
+        path: '/',
+        secure: name.startsWith('__Secure-'),
+      });
+    }
+  });
+}
+
+const {
+  handlers,
+  auth,
+  signIn: authSignIn,
+  signOut,
+  unstable_update: authUpdateSession,
+} = NextAuth(config);
+
+export { handlers, auth, signOut };
+
+export const signIn = async (...args: Parameters<typeof authSignIn>) => {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return await authSignIn(...args);
+  } finally {
+    await patchSessionTokenCookies();
+  }
+};
+
+export const updateSession = async (...args: Parameters<typeof authUpdateSession>) => {
+  try {
+    return await authUpdateSession(...args);
+  } finally {
+    await patchSessionTokenCookies();
+  }
+};
 
 export const getSessionCustomerAccessToken = async () => {
   try {

--- a/core/proxies/with-auth.ts
+++ b/core/proxies/with-auth.ts
@@ -6,14 +6,36 @@ import { type ProxyFactory } from './compose-proxies';
 
 // Path matcher for any routes that require authentication
 const protectedPathPattern = new URLPattern({ pathname: `{/:locale}?/(account)/*` });
+const SESSION_TOKEN_COOKIE_RE = /^(__Secure-)?authjs\.session-token(\.\d+)?=/;
 
 function redirectToLogin(url: string) {
   return NextResponse.redirect(new URL('/login', url), { status: 302 });
 }
 
+// Auth.js always sets Expires on session cookies based on session.maxAge. We strip it here
+// so the cookie becomes a session cookie (expires when the browser closes), which is required
+// for Essential cookie classification compliance.
+function stripSessionCookieExpiry(response: Response): Response {
+  const setCookies = response.headers.getSetCookie();
+  const stripped = setCookies.map((cookie) =>
+    SESSION_TOKEN_COOKIE_RE.test(cookie)
+      ? cookie.replace(/;\s*(?:expires|max-age)=[^;]+/gi, '')
+      : cookie,
+  );
+
+  if (stripped.every((c, i) => c === setCookies[i])) return response;
+
+  const modified = new Response(response.body, response);
+
+  modified.headers.delete('set-cookie');
+  stripped.forEach((cookie) => modified.headers.append('set-cookie', cookie));
+
+  return modified;
+}
+
 export const withAuth: ProxyFactory = (next) => {
   return async (request, event) => {
-    return auth(async (req) => {
+    const response = await auth(async (req) => {
       const anonymousSession = await getAnonymousSession();
       const isProtectedRoute = protectedPathPattern.test(req.nextUrl.toString().toLowerCase());
       const isGetRequest = req.method === 'GET';
@@ -45,5 +67,7 @@ export const withAuth: ProxyFactory = (next) => {
       // Continue the proxy chain
       return next(req, event);
     })(request, event);
+
+    return response ? stripSessionCookieExpiry(response) : response;
   };
 };


### PR DESCRIPTION
Jira: [TRAC-814](https://bigcommercecloud.atlassian.net/browse/TRAC-814)

## What/Why?

`authjs.session-token` and `authjs.anonymous-session-token` must be session cookies (no `Expires` attribute) to comply with Essential cookie classification requirements.

**Anonymous session token:** removed `maxAge` from `anonymousSignIn` — without it, Next.js omits the `Max-Age`/`Expires` attribute and the cookie becomes a session cookie.

**Auth session token:** Auth.js v5 unconditionally sets `Expires` on the session cookie based on `session.maxAge` — there is no config option to disable this. The fix post-processes `Set-Cookie` headers to strip the `Expires` attribute from matching cookies. This is applied in two places:

- `proxies/with-auth.ts` — covers session refreshes on every page request (the middleware matcher excludes `/api/*`)
- `app/api/auth/[...nextauth]/route.ts` — covers sign-in, where Auth.js sets the initial session cookie (not reachable by middleware)

The regex matches `authjs.session-token`, `__Secure-authjs.session-token` (HTTPS prefix), and chunked variants (`authjs.session-token.0`, etc.). Only `Expires` is stripped — `Max-Age=0` (used by Auth.js for cookie deletion) is left intact.

This workaround is tracked upstream in [nextauthjs/next-auth#13457](https://github.com/nextauthjs/next-auth/discussions/13457), where we've proposed a first-class config option so this kind of post-processing isn't necessary.

## Testing

1. Start the dev server and open DevTools → Application → Cookies
2. Navigate to any page — verify `authjs.anonymous-session-token` has no `Expires` column value (session cookie)
3. Sign in — verify `authjs.session-token` has no `Expires` column value
4. Sign out and back in — verify the cookie is still a session cookie after the refresh cycle
5. Close the browser and reopen — both cookies should be gone

## Migration

No migrations required.

[TRAC-814]: https://bigcommercecloud.atlassian.net/browse/TRAC-814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ