### PR TITLE
LTRAC-909: feat(cli) - Add `catalyst integration` command

### DIFF
--- a/packages/catalyst/package.json
+++ b/packages/catalyst/package.json
@@ -36,6 +36,7 @@
     "lodash.kebabcase": "^4.1.1",
     "nypm": "^0.5.4",
     "open": "^10.1.0",
+    "semver": "^7.7.2",
     "std-env": "^3.9.0",
     "yocto-spinner": "^1.0.0",
     "zod": "^4.0.5"
@@ -48,6 +49,7 @@
     "@types/fs-extra": "^11.0.4",
     "@types/lodash.kebabcase": "^4.1.9",
     "@types/node": "^22.15.30",
+    "@types/semver": "^7.7.0",
     "@vitest/coverage-v8": "^3.2.4",
     "@vitest/ui": "^3.2.4",
     "eslint": "^8.57.1",

--- a/packages/catalyst/src/cli/commands/create.spec.ts
+++ b/packages/catalyst/src/cli/commands/create.spec.ts
@@ -19,7 +19,10 @@ import { create } from './create';
 
 // Mock all side-effecting modules so the action runs end-to-end without
 // actually cloning, installing, writing files, or hitting the network.
-vi.mock('child_process', () => ({ execSync: vi.fn() }));
+// `exec` is needed because `program.ts` also imports the `integration` command,
+// which reads `child_process.exec` at module load; an incomplete mock would
+// throw when this suite loads the program graph.
+vi.mock('child_process', () => ({ execSync: vi.fn(), exec: vi.fn() }));
 
 vi.mock('@inquirer/prompts', () => ({
   input: vi.fn(),

--- a/packages/catalyst/src/cli/commands/integration.spec.ts
+++ b/packages/catalyst/src/cli/commands/integration.spec.ts
@@ -1,0 +1,149 @@
+import { exec } from 'child_process';
+import { Command } from 'commander';
+import { outputFileSync, writeJsonSync } from 'fs-extra/esm';
+import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
+
+import { consola } from '../lib/logger';
+import { program } from '../program';
+
+import { integration } from './integration';
+
+// Mock git: reply with canned output keyed off the command string. The source
+// ref resolves to `feature-branch` (from `git rev-parse`) and the latest core
+// tag to `@bigcommerce/catalyst-core@2.0.0`. The integration ref adds `new-dep`,
+// `new-dev`, and `NEW_ENV` on top of the base tag.
+vi.mock('child_process', () => ({
+  exec: vi.fn(
+    (cmd: string, cb: (err: Error | null, res: { stdout: string; stderr: string }) => void) => {
+      const reply = (stdout: string) => cb(null, { stdout, stderr: '' });
+
+      if (cmd.includes('rev-parse')) {
+        reply('feature-branch\n');
+
+        return;
+      }
+
+      if (cmd.includes('tag --list')) {
+        reply('@bigcommerce/catalyst-core@1.0.0\n@bigcommerce/catalyst-core@2.0.0\n');
+
+        return;
+      }
+
+      if (cmd.includes('git diff')) {
+        reply('PATCH_CONTENTS\n');
+
+        return;
+      }
+
+      if (cmd.includes(':core/package.json')) {
+        if (cmd.includes('feature-branch')) {
+          reply(
+            JSON.stringify({
+              dependencies: { shared: '1.0.0', 'new-dep': '1.0.0' },
+              devDependencies: { 'shared-dev': '1.0.0', 'new-dev': '1.0.0' },
+            }),
+          );
+
+          return;
+        }
+
+        reply(
+          JSON.stringify({
+            dependencies: { shared: '1.0.0' },
+            devDependencies: { 'shared-dev': '1.0.0' },
+          }),
+        );
+
+        return;
+      }
+
+      if (cmd.includes(':core/.env.example')) {
+        if (cmd.includes('feature-branch')) {
+          reply('SHARED=1\nNEW_ENV=2\n');
+
+          return;
+        }
+
+        reply('SHARED=1\n');
+
+        return;
+      }
+
+      // `git fetch --tags` and anything else.
+      reply('');
+    },
+  ),
+}));
+
+vi.mock('fs-extra/esm', () => ({
+  outputFileSync: vi.fn(),
+  writeJsonSync: vi.fn(),
+}));
+
+beforeAll(() => {
+  consola.mockTypes(() => vi.fn());
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
+test('properly configured Command instance', () => {
+  expect(integration).toBeInstanceOf(Command);
+  expect(integration.name()).toBe('integration');
+  expect(integration.description()).toContain('Generate an integration patch and manifest');
+});
+
+describe('integration', () => {
+  test('writes a manifest and patch from the diff against the latest core release', async () => {
+    await program.parseAsync(['node', 'catalyst', 'integration', 'My Integration']);
+
+    expect(writeJsonSync).toHaveBeenCalledWith(
+      'integrations/my-integration/manifest.json',
+      {
+        name: 'my-integration',
+        dependencies: { add: ['new-dep'] },
+        devDependencies: { add: ['new-dev'] },
+        environmentVariables: ['NEW_ENV'],
+      },
+      { spaces: 2 },
+    );
+
+    expect(outputFileSync).toHaveBeenCalledWith(
+      'integrations/my-integration/integration.patch',
+      'PATCH_CONTENTS\n',
+    );
+
+    expect(consola.success).toHaveBeenCalledWith('Integration created successfully.');
+  });
+
+  test('diffs against the latest core tag and the resolved source ref', async () => {
+    await program.parseAsync(['node', 'catalyst', 'integration', 'my-integration']);
+
+    expect(vi.mocked(exec)).toHaveBeenCalledWith(
+      "git diff @bigcommerce/catalyst-core@2.0.0...feature-branch -- ':(exclude)core/package.json' ':(exclude)pnpm-lock.yaml'",
+      expect.any(Function),
+    );
+  });
+
+  test('--commit-hash overrides the source ref', async () => {
+    await program.parseAsync([
+      'node',
+      'catalyst',
+      'integration',
+      'my-integration',
+      '--commit-hash',
+      'abc1234',
+    ]);
+
+    const diffCall = vi
+      .mocked(exec)
+      .mock.calls.find(([cmd]) => typeof cmd === 'string' && cmd.startsWith('git diff'));
+
+    expect(diffCall?.[0]).toContain('@bigcommerce/catalyst-core@2.0.0...abc1234');
+  });
+});

--- a/packages/catalyst/src/cli/commands/integration.ts
+++ b/packages/catalyst/src/cli/commands/integration.ts
@@ -1,0 +1,115 @@
+import { Command } from '@commander-js/extra-typings';
+import { exec as execCb } from 'child_process';
+import { parse } from 'dotenv';
+import { outputFileSync, writeJsonSync } from 'fs-extra/esm';
+import kebabCase from 'lodash.kebabcase';
+import { coerce, compare } from 'semver';
+import { promisify } from 'util';
+import { z } from 'zod';
+
+import { consola } from '../lib/logger';
+
+const exec = promisify(execCb);
+
+export const ManifestSchema = z.object({
+  name: z.string(),
+  dependencies: z.object({ add: z.array(z.string()) }),
+  devDependencies: z.object({ add: z.array(z.string()) }),
+  environmentVariables: z.array(z.string()),
+});
+
+type Manifest = z.infer<typeof ManifestSchema>;
+
+export const integration = new Command('integration')
+  .configureHelp({ showGlobalOptions: true })
+  .description(
+    'Generate an integration patch and manifest by diffing the current ref against the latest Catalyst core release.',
+  )
+  .addHelpText(
+    'after',
+    `
+Examples:
+  # Generate from the current branch
+  $ catalyst integration my-integration
+
+  # Generate from a specific commit
+  $ catalyst integration my-integration --commit-hash <hash>`,
+  )
+  .argument('<integration-name>', 'Formatted name of the integration')
+  .option('--commit-hash <hash>', 'Override integration source branch with a specific commit hash')
+  .action(async (integrationNameRaw, options) => {
+    // @todo check for integration name conflicts
+    const integrationName = z.string().transform(kebabCase).parse(integrationNameRaw);
+
+    const manifest: Manifest = {
+      name: integrationName,
+      dependencies: { add: [] },
+      devDependencies: { add: [] },
+      environmentVariables: [],
+    };
+
+    await exec('git fetch --tags');
+
+    const { stdout: headRefStdOut } = await exec('git rev-parse --abbrev-ref HEAD');
+    const [headRef] = headRefStdOut.split('\n');
+    const sourceRef = options.commitHash ?? headRef;
+
+    const { stdout: catalystTags } = await exec('git tag --list @bigcommerce/catalyst-core@\\*');
+    const [latestCoreTag] = catalystTags
+      .split('\n')
+      .filter(Boolean)
+      .sort((a, b) => {
+        const versionA = coerce(a.replace('@bigcommerce/catalyst-core@', ''));
+        const versionB = coerce(b.replace('@bigcommerce/catalyst-core@', ''));
+
+        if (versionA && versionB) {
+          return compare(versionA, versionB);
+        }
+
+        return 0;
+      })
+      .reverse();
+
+    const PackageDependenciesSchema = z.object({
+      dependencies: z.looseObject({}),
+      devDependencies: z.looseObject({}),
+    });
+
+    const getPackageDeps = async (ref: string) => {
+      const { stdout } = await exec(`git show ${ref}:core/package.json`);
+
+      return PackageDependenciesSchema.parse(JSON.parse(stdout));
+    };
+
+    const integrationJson = await getPackageDeps(sourceRef);
+    const latestCoreTagJson = await getPackageDeps(latestCoreTag);
+
+    const diffObjectKeys = (a: Record<string, unknown>, b: Record<string, unknown>) => {
+      return Object.keys(a).filter((key) => !Object.keys(b).includes(key));
+    };
+
+    manifest.dependencies.add = diffObjectKeys(
+      integrationJson.dependencies,
+      latestCoreTagJson.dependencies,
+    );
+    manifest.devDependencies.add = diffObjectKeys(
+      integrationJson.devDependencies,
+      latestCoreTagJson.devDependencies,
+    );
+
+    const { stdout: latestCoreEnv } = await exec(`git show ${latestCoreTag}:core/.env.example`);
+    const { stdout: integrationEnv } = await exec(`git show ${sourceRef}:core/.env.example`);
+
+    manifest.environmentVariables = diffObjectKeys(parse(integrationEnv), parse(latestCoreEnv));
+
+    const { stdout: integrationDiff } = await exec(
+      `git diff ${latestCoreTag}...${sourceRef} -- ':(exclude)core/package.json' ':(exclude)pnpm-lock.yaml'`,
+    );
+
+    outputFileSync(`integrations/${integrationName}/integration.patch`, integrationDiff);
+    writeJsonSync(`integrations/${integrationName}/manifest.json`, manifest, {
+      spaces: 2,
+    });
+
+    consola.success('Integration created successfully.');
+  });

--- a/packages/catalyst/src/cli/program.ts
+++ b/packages/catalyst/src/cli/program.ts
@@ -13,6 +13,7 @@ import { channel } from './commands/channel';
 import { create } from './commands/create';
 import { deploy } from './commands/deploy';
 import { env } from './commands/env';
+import { integration } from './commands/integration';
 import { logs } from './commands/logs';
 import { project } from './commands/project';
 import { start } from './commands/start';
@@ -83,6 +84,7 @@ program
   )
   .addCommand(version)
   .addCommand(create)
+  .addCommand(integration)
   .addCommand(start)
   .addCommand(build)
   .addCommand(deploy)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -351,6 +351,9 @@ importers:
       open:
         specifier: ^10.1.0
         version: 10.1.2
+      semver:
+        specifier: ^7.7.2
+        version: 7.7.4
       std-env:
         specifier: ^3.9.0
         version: 3.9.0
@@ -382,6 +385,9 @@ importers:
       '@types/node':
         specifier: ^22.15.30
         version: 22.15.30
+      '@types/semver':
+        specifier: ^7.7.0
+        version: 7.7.0
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4)
@@ -11218,7 +11224,7 @@ snapshots:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.7.2
+      semver: 7.7.4
 
   '@changesets/assemble-release-plan@6.0.8':
     dependencies:
@@ -11227,7 +11233,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.7.2
+      semver: 7.7.4
 
   '@changesets/changelog-git@0.2.1':
     dependencies:
@@ -11291,7 +11297,7 @@ snapshots:
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
-      semver: 7.7.2
+      semver: 7.7.4
 
   '@changesets/get-github-info@0.6.0(encoding@0.1.13)':
     dependencies:
@@ -13292,7 +13298,7 @@ snapshots:
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
-      semver: 7.7.2
+      semver: 7.7.4
       tar-fs: 3.0.9
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -14831,7 +14837,7 @@ snapshots:
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
-      semver: 7.7.2
+      semver: 7.7.4
       ts-api-utils: 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -15935,7 +15941,7 @@ snapshots:
       dot-prop: 9.0.0
       env-paths: 3.0.0
       json-schema-typed: 8.0.1
-      semver: 7.7.2
+      semver: 7.7.4
       uint8array-extras: 1.4.0
 
   confbox@0.1.8: {}
@@ -16745,7 +16751,7 @@ snapshots:
       espree: 10.3.0
       esquery: 1.6.0
       parse-imports: 2.2.1
-      semver: 7.7.2
+      semver: 7.7.4
       spdx-expression-parse: 4.0.0
       synckit: 0.9.2
     transitivePeerDependencies:
@@ -17672,7 +17678,7 @@ snapshots:
 
   is-bun-module@1.3.0:
     dependencies:
-      semver: 7.7.2
+      semver: 7.7.4
 
   is-callable@1.2.7: {}
 


### PR DESCRIPTION
Linear: [LTRAC-909](https://linear.app/commerce/issue/LTRAC-909)
Part of [LTRAC-138](https://linear.app/commerce/issue/LTRAC-138) — consolidating `create-catalyst` into the `catalyst` CLI.

## What/Why?
Ports the `integration` command from `@bigcommerce/create-catalyst` into the `catalyst` CLI — another gap in the CLI consolidation. It generates an integration patch and manifest by diffing a source ref against the latest Catalyst core release:

- Resolves the source ref from the current branch, or `--commit-hash <hash>` when provided.
- Picks the latest `@bigcommerce/catalyst-core@*` git tag (sorted with `semver`).
- Diffs `core/package.json` and `core/.env.example` to compute added `dependencies`, `devDependencies`, and `environmentVariables`.
- Writes `integrations/<name>/integration.patch` and `integrations/<name>/manifest.json`.

Logic is a faithful port of the original; `console.log` was swapped for `consola`, and `z.object({}).passthrough()` updated to `z.looseObject({})` for zod 4.

Adds the `semver`/`@types/semver` dependency the command relies on.

## Testing
`pnpm test`, `pnpm typecheck`, and `pnpm lint` all pass in `packages/catalyst`. New `integration.spec.ts` mocks `child_process`/`fs-extra` to verify the manifest/patch output and `--commit-hash` override.

Note: `create.spec.ts`'s `child_process` mock gained an `exec` entry — the `integration` command reads `child_process.exec` at module load, and it's now part of the program graph that suite imports.

## Migration
None. Purely additive — registers a new `integration` subcommand; `create-catalyst integration` is unaffected (shim removal tracked in LTRAC-910).