### PR TITLE
LTRAC-908: feat(cli) - Add `catalyst channel link` command

### DIFF
--- a/packages/catalyst/src/cli/commands/channel.spec.ts
+++ b/packages/catalyst/src/cli/commands/channel.spec.ts
@@ -315,7 +315,7 @@ describe('channel connect', () => {
 
     expect(envLocal).toContain(`BIGCOMMERCE_STORE_HASH=${storeHash}`);
     expect(envLocal).toContain('BIGCOMMERCE_STOREFRONT_TOKEN=sft-token');
-    expect(consola.success).toHaveBeenCalledWith(expect.stringContaining('Connected channel 2'));
+    expect(consola.success).toHaveBeenCalledWith(expect.stringContaining('Connected to channel 2'));
     expect(exitMock).toHaveBeenCalledWith(0);
   });
 
@@ -349,7 +349,7 @@ describe('channel connect', () => {
     expect(initChannelId).toBe('2');
     // id 2 in the default channels handler is "Catalyst Storefront".
     expect(consola.success).toHaveBeenCalledWith(
-      expect.stringContaining('Connected channel "Catalyst Storefront" (2)'),
+      expect.stringContaining('Connected to channel "Catalyst Storefront" (2)'),
     );
   });
 

--- a/packages/catalyst/src/cli/commands/channel.spec.ts
+++ b/packages/catalyst/src/cli/commands/channel.spec.ts
@@ -13,7 +13,7 @@ import { program } from '../program';
 
 import { channel } from './channel';
 
-// `channel connect` can trigger the interactive device-code login (browser +
+// `channel link` can trigger the interactive device-code login (browser +
 // spinner); stub both so the no-credentials path runs headless in tests.
 vi.mock('open', () => ({ default: vi.fn().mockResolvedValue(undefined) }));
 // eslint-disable-next-line import/dynamic-import-chunkname
@@ -91,13 +91,11 @@ describe('channel', () => {
     expect(update?.description()).toContain('Update a BigCommerce channel');
   });
 
-  test('has the connect subcommand', () => {
-    const connect = channel.commands.find((cmd) => cmd.name() === 'connect');
+  test('has the link subcommand', () => {
+    const link = channel.commands.find((cmd) => cmd.name() === 'link');
 
-    expect(connect).toBeDefined();
-    expect(connect?.description()).toContain(
-      'Connect this Catalyst project to a BigCommerce channel',
-    );
+    expect(link).toBeDefined();
+    expect(link?.description()).toContain('Link this Catalyst project to a BigCommerce channel');
   });
 });
 
@@ -271,11 +269,11 @@ describe('channel update', () => {
   });
 });
 
-describe('channel connect', () => {
+describe('channel link', () => {
   const initUrl =
     'https://cxm-prd.bigcommerceapp.com/stores/:storeHash/cli-api/v3/channels/:channelId/init';
 
-  test('connects a channel by id and writes .env.local', async () => {
+  test('links a channel by id and writes .env.local', async () => {
     let initChannelId: string | undefined;
 
     server.use(
@@ -299,7 +297,7 @@ describe('channel connect', () => {
       'node',
       'catalyst',
       'channel',
-      'connect',
+      'link',
       '--store-hash',
       storeHash,
       '--access-token',
@@ -315,7 +313,7 @@ describe('channel connect', () => {
 
     expect(envLocal).toContain(`BIGCOMMERCE_STORE_HASH=${storeHash}`);
     expect(envLocal).toContain('BIGCOMMERCE_STOREFRONT_TOKEN=sft-token');
-    expect(consola.success).toHaveBeenCalledWith(expect.stringContaining('Connected to channel 2'));
+    expect(consola.success).toHaveBeenCalledWith(expect.stringContaining('Linked to channel 2'));
     expect(exitMock).toHaveBeenCalledWith(0);
   });
 
@@ -338,7 +336,7 @@ describe('channel connect', () => {
       'node',
       'catalyst',
       'channel',
-      'connect',
+      'link',
       '--store-hash',
       storeHash,
       '--access-token',
@@ -349,7 +347,7 @@ describe('channel connect', () => {
     expect(initChannelId).toBe('2');
     // id 2 in the default channels handler is "Catalyst Storefront".
     expect(consola.success).toHaveBeenCalledWith(
-      expect.stringContaining('Connected to channel "Catalyst Storefront" (2)'),
+      expect.stringContaining('Linked to channel "Catalyst Storefront" (2)'),
     );
   });
 
@@ -369,7 +367,7 @@ describe('channel connect', () => {
       'node',
       'catalyst',
       'channel',
-      'connect',
+      'link',
       '--store-hash',
       storeHash,
       '--access-token',
@@ -399,7 +397,7 @@ describe('channel connect', () => {
       'node',
       'catalyst',
       'channel',
-      'connect',
+      'link',
       '--store-hash',
       storeHash,
       '--access-token',
@@ -421,7 +419,7 @@ describe('channel connect', () => {
       ),
     );
 
-    await program.parseAsync(['node', 'catalyst', 'channel', 'connect', '--channel-id', '2']);
+    await program.parseAsync(['node', 'catalyst', 'channel', 'link', '--channel-id', '2']);
 
     expect(config.get('storeHash')).toBe('mock-store-hash');
     expect(config.get('accessToken')).toBe('mock-access-token');

--- a/packages/catalyst/src/cli/commands/channel.spec.ts
+++ b/packages/catalyst/src/cli/commands/channel.spec.ts
@@ -1,6 +1,8 @@
 import { Command } from 'commander';
 import Conf from 'conf';
 import { http, HttpResponse } from 'msw';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { afterAll, afterEach, beforeAll, describe, expect, MockInstance, test, vi } from 'vitest';
 
 import { server } from '../../../tests/mocks/node';
@@ -10,6 +12,12 @@ import { getProjectConfig, ProjectConfigSchema } from '../lib/project-config';
 import { program } from '../program';
 
 import { channel } from './channel';
+
+// `channel connect` can trigger the interactive device-code login (browser +
+// spinner); stub both so the no-credentials path runs headless in tests.
+vi.mock('open', () => ({ default: vi.fn().mockResolvedValue(undefined) }));
+// eslint-disable-next-line import/dynamic-import-chunkname
+vi.mock('yocto-spinner', () => import('../../../tests/mocks/spinner'));
 
 let exitMock: MockInstance;
 
@@ -81,6 +89,15 @@ describe('channel', () => {
 
     expect(update).toBeDefined();
     expect(update?.description()).toContain('Update a BigCommerce channel');
+  });
+
+  test('has the connect subcommand', () => {
+    const connect = channel.commands.find((cmd) => cmd.name() === 'connect');
+
+    expect(connect).toBeDefined();
+    expect(connect?.description()).toContain(
+      'Connect this Catalyst project to a BigCommerce channel',
+    );
   });
 });
 
@@ -251,5 +268,163 @@ describe('channel update', () => {
         linkedProjectUuid,
       ]),
     ).rejects.toThrow('Re-run `catalyst auth login`');
+  });
+});
+
+describe('channel connect', () => {
+  const initUrl =
+    'https://cxm-prd.bigcommerceapp.com/stores/:storeHash/cli-api/v3/channels/:channelId/init';
+
+  test('connects a channel by id and writes .env.local', async () => {
+    let initChannelId: string | undefined;
+
+    server.use(
+      http.get(initUrl, ({ params }) => {
+        initChannelId = String(params.channelId);
+
+        return HttpResponse.json({
+          data: {
+            storefront_api_token: 'sft-token',
+            envVars: {
+              BIGCOMMERCE_STORE_HASH: storeHash,
+              BIGCOMMERCE_CHANNEL_ID: '2',
+              BIGCOMMERCE_STOREFRONT_TOKEN: 'sft-token',
+            },
+          },
+        });
+      }),
+    );
+
+    await program.parseAsync([
+      'node',
+      'catalyst',
+      'channel',
+      'connect',
+      '--store-hash',
+      storeHash,
+      '--access-token',
+      accessToken,
+      '--channel-id',
+      '2',
+    ]);
+
+    expect(initChannelId).toBe('2');
+    expect(mockIdentify).toHaveBeenCalledWith(storeHash);
+
+    const envLocal = readFileSync(join(tmpDir, '.env.local'), 'utf8');
+
+    expect(envLocal).toContain(`BIGCOMMERCE_STORE_HASH=${storeHash}`);
+    expect(envLocal).toContain('BIGCOMMERCE_STOREFRONT_TOKEN=sft-token');
+    expect(consola.success).toHaveBeenCalledWith(expect.stringContaining('Connected channel 2'));
+    expect(exitMock).toHaveBeenCalledWith(0);
+  });
+
+  test('prompts for a channel when --channel-id is omitted', async () => {
+    let initChannelId: string | undefined;
+
+    server.use(
+      http.get(initUrl, ({ params }) => {
+        initChannelId = String(params.channelId);
+
+        return HttpResponse.json({
+          data: { storefront_api_token: 'sft-token', envVars: { BIGCOMMERCE_CHANNEL_ID: '2' } },
+        });
+      }),
+    );
+
+    const promptMock = vi.spyOn(consola, 'prompt').mockResolvedValueOnce('2');
+
+    await program.parseAsync([
+      'node',
+      'catalyst',
+      'channel',
+      'connect',
+      '--store-hash',
+      storeHash,
+      '--access-token',
+      accessToken,
+    ]);
+
+    expect(promptMock).toHaveBeenCalledTimes(1);
+    expect(initChannelId).toBe('2');
+    // id 2 in the default channels handler is "Catalyst Storefront".
+    expect(consola.success).toHaveBeenCalledWith(
+      expect.stringContaining('Connected channel "Catalyst Storefront" (2)'),
+    );
+  });
+
+  test('merges --env overrides into .env.local', async () => {
+    server.use(
+      http.get(initUrl, () =>
+        HttpResponse.json({
+          data: {
+            storefront_api_token: 'sft-token',
+            envVars: { BIGCOMMERCE_STORE_HASH: storeHash },
+          },
+        }),
+      ),
+    );
+
+    await program.parseAsync([
+      'node',
+      'catalyst',
+      'channel',
+      'connect',
+      '--store-hash',
+      storeHash,
+      '--access-token',
+      accessToken,
+      '--channel-id',
+      '2',
+      '--env',
+      'EXTRA_FLAG=on',
+      '--env',
+      'BIGCOMMERCE_STORE_HASH=overridden',
+    ]);
+
+    const envLocal = readFileSync(join(tmpDir, '.env.local'), 'utf8');
+
+    expect(envLocal).toContain('EXTRA_FLAG=on');
+    expect(envLocal).toContain('BIGCOMMERCE_STORE_HASH=overridden');
+  });
+
+  test('exits when the store has no storefront channels', async () => {
+    server.use(
+      http.get('https://:apiHost/stores/:storeHash/v3/channels', () =>
+        HttpResponse.json({ data: [] }),
+      ),
+    );
+
+    await program.parseAsync([
+      'node',
+      'catalyst',
+      'channel',
+      'connect',
+      '--store-hash',
+      storeHash,
+      '--access-token',
+      accessToken,
+    ]);
+
+    expect(consola.info).toHaveBeenCalledWith(
+      expect.stringContaining('No storefront channels found'),
+    );
+    expect(exitMock).toHaveBeenCalledWith(0);
+  });
+
+  test('logs in and persists credentials when none are available', async () => {
+    server.use(
+      http.get(initUrl, () =>
+        HttpResponse.json({
+          data: { storefront_api_token: 'sft-token', envVars: { BIGCOMMERCE_CHANNEL_ID: '2' } },
+        }),
+      ),
+    );
+
+    await program.parseAsync(['node', 'catalyst', 'channel', 'connect', '--channel-id', '2']);
+
+    expect(config.get('storeHash')).toBe('mock-store-hash');
+    expect(config.get('accessToken')).toBe('mock-access-token');
+    expect(mockIdentify).toHaveBeenCalledWith('mock-store-hash');
   });
 });

--- a/packages/catalyst/src/cli/commands/channel.ts
+++ b/packages/catalyst/src/cli/commands/channel.ts
@@ -40,7 +40,7 @@ const parseChannelId = (value: string): number => {
 
 // Resolve credentials from flags/env → persisted project config → interactive
 // login (persisting on success). Returns null when the user aborts login.
-// `channel connect` is an onboarding command — a fresh clone has neither
+// `channel link` is an onboarding command — a fresh clone has neither
 // .env.local nor .bigcommerce/project.json — so it logs the user in like
 // `catalyst project create`, rather than erroring like the operational commands.
 async function resolveCredentialsWithLogin(
@@ -133,33 +133,32 @@ Examples:
     process.exit(0);
   });
 
-const connect = new Command('connect')
+const link = new Command('link')
   .configureHelp({ showGlobalOptions: true })
   .description(
-    'Connect this Catalyst project to a BigCommerce channel and write its credentials to .env.local.',
+    'Link this Catalyst project to a BigCommerce channel and write its credentials to .env.local.',
   )
   .addHelpText(
     'after',
     `
 Examples:
   # Pick a channel interactively (logs you in if needed)
-  $ catalyst channel connect
+  $ catalyst channel link
 
   # Non-interactive
-  $ catalyst channel connect --store-hash <hash> --access-token <token> --channel-id 123
+  $ catalyst channel link --store-hash <hash> --access-token <token> --channel-id 123
 
   # Append extra environment variables to .env.local
-  $ catalyst channel connect --channel-id 123 --env MY_FLAG=1`,
+  $ catalyst channel link --channel-id 123 --env MY_FLAG=1`,
   )
   .addOption(storeHashOption())
   .addOption(accessTokenOption())
   .addOption(apiHostOption())
   .addOption(loginUrlOption())
   .addOption(
-    new Option(
-      '--channel-id <id>',
-      'Connect this channel directly, skipping the picker.',
-    ).argParser(parseChannelId),
+    new Option('--channel-id <id>', 'Link this channel directly, skipping the picker.').argParser(
+      parseChannelId,
+    ),
   )
   .option(
     '--env <vars...>',
@@ -177,7 +176,7 @@ Examples:
 
     if (!credentials) {
       consola.info(
-        'Login aborted. Re-run `catalyst channel connect` when you have your credentials ready.',
+        'Login aborted. Re-run `catalyst channel link` when you have your credentials ready.',
       );
       process.exit(0);
 
@@ -214,7 +213,7 @@ Examples:
         return aIndex - bIndex;
       });
 
-      const selected = await consola.prompt('Which channel would you like to connect?', {
+      const selected = await consola.prompt('Which channel would you like to link?', {
         type: 'select',
         options: sorted.map((c) => ({
           label: c.name,
@@ -241,7 +240,7 @@ Examples:
       });
     }
 
-    // Writes .env.local in the current working directory — `channel connect`
+    // Writes .env.local in the current working directory — `channel link`
     // runs from inside `core/`, the same place `dev`/`build`/`deploy` run.
     outputFileSync(
       join(process.cwd(), '.env.local'),
@@ -253,7 +252,7 @@ Examples:
     const label = channelName ? `"${channelName}" (${channelId})` : `${channelId}`;
 
     consola.success(
-      `Connected to channel ${label} and wrote ${colorize('cyanBright', '.env.local')}.`,
+      `Linked to channel ${label} and wrote ${colorize('cyanBright', '.env.local')}.`,
     );
     consola.log(`\nStart your storefront:\n\n  ${colorize('yellow', 'pnpm run dev')}\n`);
 
@@ -263,5 +262,5 @@ Examples:
 export const channel = new Command('channel')
   .configureHelp({ showGlobalOptions: true })
   .description('Manage BigCommerce channels.')
-  .addCommand(connect)
+  .addCommand(link)
   .addCommand(update);

--- a/packages/catalyst/src/cli/commands/channel.ts
+++ b/packages/catalyst/src/cli/commands/channel.ts
@@ -1,17 +1,74 @@
-import { Command, Option } from 'commander';
+import { Command, InvalidArgumentError, Option } from 'commander';
+import type Conf from 'conf';
+import { colorize } from 'consola/utils';
+import { outputFileSync } from 'fs-extra/esm';
+import { join } from 'node:path';
 
 import { runChannelSiteUrlFlow } from '../lib/channel-site-flow';
+import { fetchAvailableChannels, getChannelInit } from '../lib/channels';
 import { NoLinkedProjectError } from '../lib/commerce-hosting';
+import { parseEnvAssignment } from '../lib/env-config';
 import { consola } from '../lib/logger';
-import { getProjectConfig } from '../lib/project-config';
+import { LoginAbortedError, login as runInteractiveLogin } from '../lib/login';
+import { getProjectConfig, type ProjectConfigSchema } from '../lib/project-config';
 import { resolveCredentials } from '../lib/resolve-credentials';
 import {
   accessTokenOption,
   apiHostOption,
+  loginUrlOption,
   projectUuidOption,
   storeHashOption,
 } from '../lib/shared-options';
 import { getTelemetry } from '../lib/telemetry';
+
+// Surface Catalyst channels first, then Next, then Stencil (`bigcommerce`),
+// then anything else — same ordering `catalyst create` uses.
+const CHANNEL_SORT_ORDER = ['catalyst', 'next', 'bigcommerce'];
+
+const platformLabel = (platform: string) =>
+  platform === 'bigcommerce' ? 'Stencil' : platform.charAt(0).toUpperCase() + platform.slice(1);
+
+const parseChannelId = (value: string): number => {
+  const parsed = Number.parseInt(value, 10);
+
+  if (Number.isNaN(parsed)) {
+    throw new InvalidArgumentError(`"${value}" is not a valid channel ID (expected a number).`);
+  }
+
+  return parsed;
+};
+
+// Resolve credentials from flags/env → persisted project config → interactive
+// login (persisting on success). Returns null when the user aborts login.
+// `channel connect` is an onboarding command — a fresh clone has neither
+// .env.local nor .bigcommerce/project.json — so it logs the user in like
+// `catalyst project create`, rather than erroring like the operational commands.
+async function resolveCredentialsWithLogin(
+  options: { storeHash?: string; accessToken?: string; loginUrl: string; apiHost: string },
+  config: Conf<ProjectConfigSchema>,
+): Promise<{ storeHash: string; accessToken: string } | null> {
+  const storeHash = options.storeHash ?? config.get('storeHash');
+  const accessToken = options.accessToken ?? config.get('accessToken');
+
+  if (storeHash && accessToken) {
+    return { storeHash, accessToken };
+  }
+
+  try {
+    const credentials = await runInteractiveLogin(options.loginUrl, options.apiHost);
+
+    config.set('storeHash', credentials.storeHash);
+    config.set('accessToken', credentials.accessToken);
+
+    return credentials;
+  } catch (error) {
+    if (error instanceof LoginAbortedError) {
+      return null;
+    }
+
+    throw error;
+  }
+}
 
 const update = new Command('update')
   .configureHelp({ showGlobalOptions: true })
@@ -76,7 +133,134 @@ Examples:
     process.exit(0);
   });
 
+const connect = new Command('connect')
+  .configureHelp({ showGlobalOptions: true })
+  .description(
+    'Connect this Catalyst project to a BigCommerce channel and write its credentials to .env.local.',
+  )
+  .addHelpText(
+    'after',
+    `
+Examples:
+  # Pick a channel interactively (logs you in if needed)
+  $ catalyst channel connect
+
+  # Non-interactive
+  $ catalyst channel connect --store-hash <hash> --access-token <token> --channel-id 123
+
+  # Append extra environment variables to .env.local
+  $ catalyst channel connect --channel-id 123 --env MY_FLAG=1`,
+  )
+  .addOption(storeHashOption())
+  .addOption(accessTokenOption())
+  .addOption(apiHostOption())
+  .addOption(loginUrlOption())
+  .addOption(
+    new Option(
+      '--channel-id <id>',
+      'Connect this channel directly, skipping the picker.',
+    ).argParser(parseChannelId),
+  )
+  .option(
+    '--env <vars...>',
+    'Arbitrary environment variables to set in .env.local. Format: KEY=VALUE (repeatable).',
+  )
+  .addOption(
+    new Option('--cli-api-origin <origin>', 'Catalyst CLI API origin')
+      .default('https://cxm-prd.bigcommerceapp.com')
+      .hideHelp(),
+  )
+  .action(async (options) => {
+    const config = getProjectConfig();
+
+    const credentials = await resolveCredentialsWithLogin(options, config);
+
+    if (!credentials) {
+      consola.info(
+        'Login aborted. Re-run `catalyst channel connect` when you have your credentials ready.',
+      );
+      process.exit(0);
+
+      return;
+    }
+
+    const { storeHash, accessToken } = credentials;
+
+    await getTelemetry().identify(storeHash);
+
+    let channelId = options.channelId;
+    let channelName: string | undefined;
+
+    if (channelId === undefined) {
+      const channels = await fetchAvailableChannels(storeHash, accessToken, options.apiHost);
+
+      if (channels.length === 0) {
+        consola.info(
+          'No storefront channels found on this store. Create one with `catalyst create` and try again.',
+        );
+        process.exit(0);
+
+        return;
+      }
+
+      const sorted = [...channels].sort((a, b) => {
+        const aIndex = CHANNEL_SORT_ORDER.indexOf(a.platform);
+        const bIndex = CHANNEL_SORT_ORDER.indexOf(b.platform);
+
+        if (aIndex === -1 && bIndex === -1) return 0;
+        if (aIndex === -1) return 1;
+        if (bIndex === -1) return -1;
+
+        return aIndex - bIndex;
+      });
+
+      const selected = await consola.prompt('Which channel would you like to connect?', {
+        type: 'select',
+        options: sorted.map((c) => ({
+          label: c.name,
+          value: String(c.id),
+          hint: platformLabel(c.platform),
+        })),
+        cancel: 'reject',
+      });
+
+      channelId = Number(selected);
+      channelName = channels.find((c) => c.id === channelId)?.name;
+    }
+
+    const initData = await getChannelInit(channelId, storeHash, accessToken, options.cliApiOrigin);
+
+    const envVars: Record<string, string> = { ...initData.envVars };
+
+    // Inline `--env KEY=VALUE` overrides win over the channel-provided values.
+    if (options.env) {
+      options.env.forEach((entry) => {
+        const { key, value } = parseEnvAssignment(entry);
+
+        envVars[key] = value;
+      });
+    }
+
+    // Writes .env.local in the current working directory — `channel connect`
+    // runs from inside `core/`, the same place `dev`/`build`/`deploy` run.
+    outputFileSync(
+      join(process.cwd(), '.env.local'),
+      `${Object.entries(envVars)
+        .map(([key, value]) => `${key}=${value}`)
+        .join('\n')}\n`,
+    );
+
+    const label = channelName ? `channel "${channelName}" (${channelId})` : `channel ${channelId}`;
+
+    consola.success(`Connected ${label} — wrote .env.local.`);
+    consola.info('Next steps:');
+    consola.info(colorize('yellow', '  pnpm run dev'));
+
+    process.exit(0);
+  });
+
 export const channel = new Command('channel')
   .configureHelp({ showGlobalOptions: true })
   .description('Manage BigCommerce channels.')
+  .addCommand(connect)
   .addCommand(update);

--- a/packages/catalyst/src/cli/commands/channel.ts
+++ b/packages/catalyst/src/cli/commands/channel.ts
@@ -250,11 +250,12 @@ Examples:
         .join('\n')}\n`,
     );
 
-    const label = channelName ? `channel "${channelName}" (${channelId})` : `channel ${channelId}`;
+    const label = channelName ? `"${channelName}" (${channelId})` : `${channelId}`;
 
-    consola.success(`Connected ${label} — wrote .env.local.`);
-    consola.info('Next steps:');
-    consola.info(colorize('yellow', '  pnpm run dev'));
+    consola.success(
+      `Connected to channel ${label} and wrote ${colorize('cyanBright', '.env.local')}.`,
+    );
+    consola.log(`\nStart your storefront:\n\n  ${colorize('yellow', 'pnpm run dev')}\n`);
 
     process.exit(0);
   });

--- a/packages/catalyst/src/cli/commands/channel.ts
+++ b/packages/catalyst/src/cli/commands/channel.ts
@@ -5,7 +5,12 @@ import { outputFileSync } from 'fs-extra/esm';
 import { join } from 'node:path';
 
 import { runChannelSiteUrlFlow } from '../lib/channel-site-flow';
-import { fetchAvailableChannels, getChannelInit } from '../lib/channels';
+import {
+  channelPlatformLabel,
+  fetchAvailableChannels,
+  getChannelInit,
+  sortChannelsByPlatform,
+} from '../lib/channels';
 import { NoLinkedProjectError } from '../lib/commerce-hosting';
 import { parseEnvAssignment } from '../lib/env-config';
 import { consola } from '../lib/logger';
@@ -20,13 +25,6 @@ import {
   storeHashOption,
 } from '../lib/shared-options';
 import { getTelemetry } from '../lib/telemetry';
-
-// Surface Catalyst channels first, then Next, then Stencil (`bigcommerce`),
-// then anything else — same ordering `catalyst create` uses.
-const CHANNEL_SORT_ORDER = ['catalyst', 'next', 'bigcommerce'];
-
-const platformLabel = (platform: string) =>
-  platform === 'bigcommerce' ? 'Stencil' : platform.charAt(0).toUpperCase() + platform.slice(1);
 
 const parseChannelId = (value: string): number => {
   const parsed = Number.parseInt(value, 10);
@@ -202,23 +200,12 @@ Examples:
         return;
       }
 
-      const sorted = [...channels].sort((a, b) => {
-        const aIndex = CHANNEL_SORT_ORDER.indexOf(a.platform);
-        const bIndex = CHANNEL_SORT_ORDER.indexOf(b.platform);
-
-        if (aIndex === -1 && bIndex === -1) return 0;
-        if (aIndex === -1) return 1;
-        if (bIndex === -1) return -1;
-
-        return aIndex - bIndex;
-      });
-
       const selected = await consola.prompt('Which channel would you like to link?', {
         type: 'select',
-        options: sorted.map((c) => ({
+        options: sortChannelsByPlatform(channels).map((c) => ({
           label: c.name,
           value: String(c.id),
-          hint: platformLabel(c.platform),
+          hint: channelPlatformLabel(c.platform),
         })),
         cancel: 'reject',
       });

--- a/packages/catalyst/src/cli/commands/create.ts
+++ b/packages/catalyst/src/cli/commands/create.ts
@@ -9,10 +9,12 @@ import { join } from 'path';
 import { DEFAULT_LOGIN_URL } from '../lib/auth';
 import { buildWorkspacePackages } from '../lib/build-workspace-packages';
 import {
+  channelPlatformLabel,
   checkChannelEligibility,
   createChannel,
   fetchAvailableChannels,
   getChannelInit,
+  sortChannelsByPlatform,
 } from '../lib/channels';
 import { cloneCatalyst } from '../lib/clone-catalyst';
 import { promptForCommerceHostingProject, setupCommerceHosting } from '../lib/commerce-hosting';
@@ -144,34 +146,15 @@ async function handleChannelCreation(
 }
 
 async function handleChannelSelection(storeHash: string, accessToken: string, apiHost: string) {
-  const channelSortOrder = ['catalyst', 'next', 'bigcommerce'];
   const channels = await fetchAvailableChannels(storeHash, accessToken, apiHost);
 
   const existingChannel = await select({
     message: 'Which channel would you like to use?',
-    choices: channels
-      .sort((a, b) => {
-        const aIndex = channelSortOrder.indexOf(a.platform);
-        const bIndex = channelSortOrder.indexOf(b.platform);
-
-        if (aIndex === -1 && bIndex === -1) {
-          return 0;
-        }
-
-        if (aIndex === -1) return 1;
-        if (bIndex === -1) return -1;
-
-        return aIndex - bIndex;
-      })
-      .map((ch) => ({
-        name: ch.name,
-        value: ch,
-        description: `Channel Platform: ${
-          ch.platform === 'bigcommerce'
-            ? 'Stencil'
-            : ch.platform.charAt(0).toUpperCase() + ch.platform.slice(1)
-        }`,
-      })),
+    choices: sortChannelsByPlatform(channels).map((ch) => ({
+      name: ch.name,
+      value: ch,
+      description: `Channel Platform: ${channelPlatformLabel(ch.platform)}`,
+    })),
   });
 
   return existingChannel.id;

--- a/packages/catalyst/src/cli/lib/channels.spec.ts
+++ b/packages/catalyst/src/cli/lib/channels.spec.ts
@@ -3,7 +3,12 @@ import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
 
 import { server } from '../../../tests/mocks/node';
 
-import { updateChannelSiteUrl } from './channels';
+import {
+  type Channel,
+  channelPlatformLabel,
+  sortChannelsByPlatform,
+  updateChannelSiteUrl,
+} from './channels';
 
 const storeHash = 'test-store';
 const accessToken = 'test-token';
@@ -103,5 +108,26 @@ describe('updateChannelSiteUrl', () => {
     await expect(
       updateChannelSiteUrl(channelId, 'https://x.example', storeHash, accessToken, apiHost),
     ).rejects.toThrow('Failed to update channel site: 500');
+  });
+});
+
+describe('sortChannelsByPlatform', () => {
+  const ch = (id: number, platform: string): Channel => ({ id, name: `ch-${id}`, platform });
+
+  test('orders catalyst → next → bigcommerce → unknown, without mutating the input', () => {
+    const input = [ch(1, 'wordpress'), ch(2, 'bigcommerce'), ch(3, 'next'), ch(4, 'catalyst')];
+    const sorted = sortChannelsByPlatform(input);
+
+    expect(sorted.map((c) => c.platform)).toEqual(['catalyst', 'next', 'bigcommerce', 'wordpress']);
+    // Original array is untouched.
+    expect(input.map((c) => c.platform)).toEqual(['wordpress', 'bigcommerce', 'next', 'catalyst']);
+  });
+});
+
+describe('channelPlatformLabel', () => {
+  test('maps bigcommerce to Stencil and title-cases the rest', () => {
+    expect(channelPlatformLabel('bigcommerce')).toBe('Stencil');
+    expect(channelPlatformLabel('catalyst')).toBe('Catalyst');
+    expect(channelPlatformLabel('next')).toBe('Next');
   });
 });

--- a/packages/catalyst/src/cli/lib/channels.ts
+++ b/packages/catalyst/src/cli/lib/channels.ts
@@ -37,6 +37,32 @@ const channelsResponseSchema = z.object({
   data: z.array(channelSchema),
 });
 
+// Channels are surfaced Catalyst-first, then Next, then Stencil
+// (`bigcommerce`), then anything else — the order the `create` and
+// `channel link` pickers both present. Returns a sorted copy.
+const CHANNEL_PLATFORM_ORDER = ['catalyst', 'next', 'bigcommerce'];
+
+export function sortChannelsByPlatform(channels: Channel[]): Channel[] {
+  return [...channels].sort((a, b) => {
+    const aIndex = CHANNEL_PLATFORM_ORDER.indexOf(a.platform);
+    const bIndex = CHANNEL_PLATFORM_ORDER.indexOf(b.platform);
+
+    if (aIndex === -1 && bIndex === -1) return 0;
+    if (aIndex === -1) return 1;
+    if (bIndex === -1) return -1;
+
+    return aIndex - bIndex;
+  });
+}
+
+// Human-friendly platform name for channel pickers. `bigcommerce` is the
+// Stencil storefront platform; everything else is title-cased.
+export function channelPlatformLabel(platform: string): string {
+  return platform === 'bigcommerce'
+    ? 'Stencil'
+    : platform.charAt(0).toUpperCase() + platform.slice(1);
+}
+
 const initResponseSchema = z.object({
   data: z.object({
     storefront_api_token: z.string(),


### PR DESCRIPTION
Linear: [LTRAC-908](https://linear.app/commerce/issue/LTRAC-908)
Part of [LTRAC-138](https://linear.app/commerce/issue/LTRAC-138) — consolidating `create-catalyst` into the `catalyst` CLI.

## What/Why?
We decided **not** to port `create-catalyst`'s standalone `init` command. It was conceived for "download the Catalyst core repo → connect → run on Vercel", which doesn't apply to a native-hosting-only CLI, and `catalyst create` already connects a channel + writes `.env.local` for new projects.

The one residual need is real: **regenerating `.env.local` from a channel for an existing checkout** — e.g. a teammate who `git clone`d a Catalyst repo where `.env.local` (and `.bigcommerce/project.json`) are gitignored. That's a *channel* concern, distinct from `project link` (the native-hosting deploy target), so it lands as **`catalyst channel link`** — a sibling to `channel update`, and named to parallel the existing `project link` (the CLI's verb for linking a local checkout to a remote BigCommerce resource).

The command:
- Resolves credentials from flags/env → persisted `.bigcommerce/project.json` → interactive device-code `login()` (persisting on success), since a fresh clone has no stored creds — same pattern as `catalyst project create`.
- Selects a storefront channel (Catalyst-first ordering) or takes `--channel-id` to skip the picker.
- Fetches the channel's init data (`getChannelInit`) and writes `.env.local` to the **cwd** (where `dev`/`build`/`deploy` run), with repeatable `--env KEY=VALUE` overrides.

Reuses existing libs (`channels`, `login`, `project-config`, `env-config`, `telemetry`); no new dependencies. `program.ts` is untouched — `channel` is already registered.

## Testing
`pnpm test`, `pnpm typecheck`, and `pnpm lint` all pass in `packages/catalyst`. New `channel link` tests (in `channel.spec.ts`) cover: link by `--channel-id`, the interactive picker, `--env` overrides, the empty-channels exit, and the no-credentials login-and-persist path.

## Migration
None. Purely additive — adds a `channel link` subcommand. `create-catalyst init` is unaffected (the create-catalyst shim removal is tracked in LTRAC-910).