### PR TITLE
LTRAC-467: chore(create-catalyst) - Deprecate the `integration` command

### DIFF
--- a/.changeset/ltrac-467-deprecate-integration.md
+++ b/.changeset/ltrac-467-deprecate-integration.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/create-catalyst": minor
+---
+
+Deprecate the `create-catalyst integration` command. It now prints a deprecation warning when invoked and is hidden from `--help`. The command builds integration patches by diffing git tags, which won't work once Catalyst projects are distributed as tarballs (no git history) — it will be replaced by the forthcoming `catalyst upgrade` command. The command still functions for now; full removal will follow in a future major version.

--- a/packages/create-catalyst/src/commands/integration.ts
+++ b/packages/create-catalyst/src/commands/integration.ts
@@ -1,5 +1,6 @@
 import { Command } from '@commander-js/extra-typings';
 import { exec as execCb } from 'child_process';
+import { colorize } from 'consola/utils';
 import { parse } from 'dotenv';
 import { outputFileSync, writeJsonSync } from 'fs-extra/esm';
 import kebabCase from 'lodash.kebabcase';
@@ -22,6 +23,14 @@ export const integration = new Command('integration')
   .argument('<integration-name>', 'Formatted name of the integration')
   .option('--commit-hash <hash>', 'Override integration source branch with a specific commit hash')
   .action(async (integrationNameRaw, options) => {
+    console.warn(
+      colorize(
+        'yellow',
+        '⚠ `create-catalyst integration` is deprecated and will be replaced by the ' +
+          '`catalyst upgrade` command.',
+      ),
+    );
+
     // @todo check for integration name conflicts
     const integrationName = z.string().transform(kebabCase).parse(integrationNameRaw);
 

--- a/packages/create-catalyst/src/index.ts
+++ b/packages/create-catalyst/src/index.ts
@@ -19,7 +19,9 @@ program
   .description('A command line tool to create a new Catalyst project.')
   .addCommand(create, { isDefault: true })
   .addCommand(init)
-  .addCommand(integration)
+  // Deprecated: hidden from help so new users don't discover it; still runnable
+  // (with a deprecation warning) until it's removed. See LTRAC-467.
+  .addCommand(integration, { hidden: true })
   .addCommand(telemetry)
   .hook('preAction', telemetryPreHook)
   .hook('postAction', telemetryPostHook);


### PR DESCRIPTION
Linear: [LTRAC-467](https://linear.app/commerce/issue/LTRAC-467)

## What/Why?
Deprecates `create-catalyst integration` ahead of its eventual removal. The command builds integration patches by diffing git tags (`@bigcommerce/catalyst-core@*`), which relies on the merchant's project having full git history. Once projects are distributed as **tarballs** instead of git clones ([LTRAC-409](https://linear.app/commerce/issue/LTRAC-409)), that history won't exist and the command can't work. The `catalyst upgrade` command will subsume the use case (integrations publish tags; merchants target them with `catalyst upgrade`).

This ships the **deprecation warning first** on the stable (`canary`) line so we can cut a CLI release that warns users before the command is removed.

- `commands/integration.ts` — prints a yellow deprecation warning when invoked (still runs for now), pointing at the future `catalyst upgrade`.
- `index.ts` — registers the command with `{ hidden: true }` so it no longer appears in `--help` (verified: `--help` now lists only `create`/`init`/`telemetry`).
- Changeset (`minor`).

## Testing
`pnpm build`, `pnpm typecheck`, `pnpm lint`, and `pnpm test` (8 tests) all pass in `packages/create-catalyst`. Verified against the built `dist`: `--help` hides `integration`, and invoking it prints the warning.

## Migration
None for end users — the command still works, just warns and is hidden. Docs referencing `create-catalyst integration` should note the deprecation (follow-up).

## Note
Full **removal** of the command is handled separately as part of the create-catalyst → `catalyst` consolidation ([LTRAC-910](https://linear.app/commerce/issue/LTRAC-910), on the `alpha` line, which reduces create-catalyst to a thin `catalyst create` wrapper). This PR is the canary-line deprecation stopgap.