### PR TITLE
fix(core): keep cart quantity column fixed-width so backorder message wraps

### DIFF
--- a/.changeset/back-684-cart-backorder-column-width.md
+++ b/.changeset/back-684-cart-backorder-column-width.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Keep the cart quantity column at a fixed width so long backorder/inventory messages wrap to the next line instead of stretching the column.

--- a/core/vibes/soul/sections/cart/client.tsx
+++ b/core/vibes/soul/sections/cart/client.tsx
@@ -579,7 +579,7 @@ function CounterForm({
       <input {...getInputProps(fields.id, { type: 'hidden' })} key={fields.id.id} />
       <div className="flex w-full flex-wrap items-center gap-x-5 gap-y-2">
         <PriceLabel className="mt-3 self-start @xl:ml-auto" price={lineItem.price} />
-        <div className="flex size-min flex-col gap-y-0">
+        <div className="flex size-min flex-col gap-y-0 [&>span]:[overflow-wrap:anywhere]">
           <div className="mb-1 mt-1 flex items-center gap-x-5">
             {/* Counter */}
             <div


### PR DESCRIPTION
## What/Why

[BACK-684](https://bigcommercecloud.atlassian.net/browse/BACK-684)

In the cart, a backorder/inventory message could extend the width of the quantity column. When a message contained a long unbreakable token, the column (sized with `size-min` → CSS `min-content`) grew to fit it, dragging the +/− counter out of its fixed right-aligned position and stretching the message across the row.

### Expected behaviour (per ticket)
- Quantity column should have a fixed width in a fixed position.
- Backorder message should wrap to the next row when its length exceeds the column width.

## How

Apply `overflow-wrap: anywhere` to the inventory-message `<span>`s via a direct-child selector on the column container:

```diff
- <div className="flex size-min flex-col gap-y-0">
+ <div className="flex size-min flex-col gap-y-0 [&>span]:[overflow-wrap:anywhere]">
```

Unlike `break-words` (`overflow-wrap: break-word`), `overflow-wrap: anywhere` **is** counted when computing `min-content`. This collapses the messages' min-content contribution, so the column width is driven solely by the constant-width counter row — keeping the column fixed in place while long messages wrap onto the next line. The counter's quantity `<span>` is a grandchild of the container, so it is unaffected by the selector.

## Testing

- `eslint` passes on the changed file.
- Rendered a faithful before/after reproduction in headless Chromium: the counter stays anchored in a fixed position and the long token wraps within the column, while normal messages (e.g. "13 will be backordered") remain on single lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BACK-684]: https://bigcommercecloud.atlassian.net/browse/BACK-684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ