### PR TITLE
feat: TRAC-925 upgrade: whole-tree merge engine and index staging

### DIFF
--- a/packages/catalyst/src/cli/commands/upgrade.spec.ts
+++ b/packages/catalyst/src/cli/commands/upgrade.spec.ts
@@ -1,9 +1,18 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { execa } from 'execa';
+import { execSync } from 'node:child_process';
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { afterEach, describe, expect, test } from 'vitest';
 
-import { computeBaseSimilarity, parseRef } from './upgrade';
+import {
+  applyIndexState,
+  computeBaseSimilarity,
+  mergeCorePerFile,
+  mergeCoreTree,
+  parseRef,
+  resolveStrategy,
+} from './upgrade';
 
 const createdDirs: string[] = [];
 
@@ -19,6 +28,11 @@ async function write(file: string, content: string | Buffer): Promise<void> {
   await mkdir(dirname(file), { recursive: true });
   await writeFile(file, content);
 }
+
+const exists = (p: string) =>
+  access(p)
+    .then(() => true)
+    .catch(() => false);
 
 afterEach(async () => {
   await Promise.all(createdDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
@@ -104,5 +118,278 @@ describe('computeBaseSimilarity', () => {
 
     // 1 base file, 1 match → 1.0 regardless of extra dest files
     expect(await computeBaseSimilarity(join(root, 'base'), join(root, 'dest'))).toBe(1.0);
+  });
+});
+
+// merge-tree --write-tree (the whole-tree engine) needs git >= 2.38. Gate its
+// tests so they're skipped rather than failing on an older git.
+const SUPPORTS_TREE = (() => {
+  try {
+    const match = /(\d+)\.(\d+)/.exec(execSync('git --version').toString());
+
+    return !!match && (Number(match[1]) > 2 || (Number(match[1]) === 2 && Number(match[2]) >= 38));
+  } catch {
+    return false;
+  }
+})();
+
+const engines: Array<'per-file' | 'tree'> = SUPPORTS_TREE ? ['per-file', 'tree'] : ['per-file'];
+
+describe('resolveStrategy', () => {
+  test('passes explicit engines through unchanged', async () => {
+    expect(await resolveStrategy('per-file')).toBe('per-file');
+    expect(await resolveStrategy('tree')).toBe('tree');
+  });
+
+  test('auto resolves to a concrete engine', async () => {
+    expect(['tree', 'per-file']).toContain(await resolveStrategy('auto'));
+  });
+});
+
+describe('applyIndexState', () => {
+  test('pre-stages clean changes and marks conflicts as unmerged', async () => {
+    const root = await mkTmp();
+    const gitRoot = join(root, 'repo');
+    const baseDir = join(root, 'base');
+    const theirsDir = join(root, 'theirs');
+
+    await Promise.all([
+      mkdir(gitRoot, { recursive: true }),
+      mkdir(baseDir, { recursive: true }),
+      mkdir(theirsDir, { recursive: true }),
+    ]);
+    await execa('git', ['init', '-q'], { cwd: gitRoot });
+    await execa('git', ['config', 'user.email', 't@t.com'], { cwd: gitRoot });
+    await execa('git', ['config', 'user.name', 't'], { cwd: gitRoot });
+    await execa('git', ['config', 'commit.gpgsign', 'false'], { cwd: gitRoot });
+
+    // Committed (ours) state. `cf-added` is added by the merchant (add/add);
+    // `cf-deleted` is absent (merchant deleted it → modify/delete).
+    await Promise.all([
+      write(join(gitRoot, 'applied.txt'), 'base\n'),
+      write(join(gitRoot, 'conflict.txt'), 'ours\n'),
+      write(join(gitRoot, 'cf-added.txt'), 'ours-added\n'),
+      write(join(gitRoot, 'todelete.txt'), 'base\n'),
+      write(join(gitRoot, 'package.json'), '{}\n'),
+    ]);
+    await execa('git', ['add', '-A'], { cwd: gitRoot });
+    await execa('git', ['commit', '-qm', 'ours'], { cwd: gitRoot });
+
+    // base + theirs trees the merge ran against.
+    await Promise.all([
+      write(join(baseDir, 'applied.txt'), 'base\n'),
+      write(join(baseDir, 'conflict.txt'), 'base\n'),
+      write(join(baseDir, 'cf-deleted.txt'), 'base\n'),
+      write(join(baseDir, 'todelete.txt'), 'base\n'),
+      write(join(theirsDir, 'applied.txt'), 'upstream\n'),
+      write(join(theirsDir, 'conflict.txt'), 'theirs\n'),
+      write(join(theirsDir, 'cf-added.txt'), 'theirs-added\n'),
+      write(join(theirsDir, 'cf-deleted.txt'), 'theirs\n'),
+      write(join(theirsDir, 'added.txt'), 'new\n'),
+    ]);
+
+    // Worktree as the engine + ref-stamp would have left it.
+    await Promise.all([
+      write(join(gitRoot, 'applied.txt'), 'upstream\n'),
+      write(join(gitRoot, 'conflict.txt'), '<<<<<<< ours\nours\n=======\ntheirs\n>>>>>>> theirs\n'),
+      write(
+        join(gitRoot, 'cf-added.txt'),
+        '<<<<<<< ours\nours-added\n=======\ntheirs-added\n>>>>>>> theirs\n',
+      ),
+      write(join(gitRoot, 'cf-deleted.txt'), 'theirs\n'),
+      write(join(gitRoot, 'added.txt'), 'new\n'),
+      write(join(gitRoot, 'package.json'), '{ "catalyst": {} }\n'),
+      rm(join(gitRoot, 'todelete.txt'), { force: true }),
+    ]);
+
+    await applyIndexState(
+      gitRoot,
+      '.',
+      baseDir,
+      theirsDir,
+      {
+        applied: ['applied.txt'],
+        added: ['added.txt'],
+        deleted: ['todelete.txt'],
+        conflicted: ['conflict.txt', 'cf-added.txt', 'cf-deleted.txt'],
+      },
+      true,
+    );
+
+    const status = (await execa('git', ['status', '--porcelain'], { cwd: gitRoot })).stdout;
+    const line = (file: string) => status.split('\n').find((l) => l.endsWith(file)) ?? '';
+
+    expect(line('applied.txt').startsWith('M')).toBe(true); // staged modify
+    expect(line('added.txt').startsWith('A')).toBe(true); // staged add
+    expect(line('todelete.txt').startsWith('D')).toBe(true); // staged delete
+    expect(line('package.json').startsWith('M')).toBe(true); // stamped ref, staged
+    expect(line('conflict.txt').startsWith('UU')).toBe(true); // both modified
+    expect(line('cf-added.txt').startsWith('AA')).toBe(true); // both added
+    expect(line('cf-deleted.txt').startsWith('DU')).toBe(true); // deleted by us
+  }, 15_000);
+});
+
+// Both engines must satisfy the same MergeResult contract.
+describe.each(engines)('mergeCore engine: %s', (engine) => {
+  interface Fixture {
+    base?: Record<string, string | Buffer>;
+    theirs?: Record<string, string | Buffer>;
+    ours?: Record<string, string | Buffer>;
+  }
+
+  async function setup(fixture: Fixture) {
+    const root = await mkTmp();
+    const baseDir = join(root, 'base');
+    const theirsDir = join(root, 'theirs');
+    const oursDir = join(root, 'ours');
+    const emptyFile = join(root, '.empty');
+
+    await Promise.all([
+      mkdir(baseDir, { recursive: true }),
+      mkdir(theirsDir, { recursive: true }),
+      mkdir(oursDir, { recursive: true }),
+    ]);
+    await write(emptyFile, '');
+    await Promise.all([
+      ...Object.entries(fixture.base ?? {}).map(([k, v]) => write(join(baseDir, k), v)),
+      ...Object.entries(fixture.theirs ?? {}).map(([k, v]) => write(join(theirsDir, k), v)),
+      ...Object.entries(fixture.ours ?? {}).map(([k, v]) => write(join(oursDir, k), v)),
+    ]);
+
+    return { baseDir, theirsDir, oursDir, emptyFile };
+  }
+
+  const run = (baseDir: string, theirsDir: string, oursDir: string, emptyFile: string) =>
+    engine === 'tree'
+      ? mergeCoreTree(baseDir, theirsDir, oursDir)
+      : mergeCorePerFile(baseDir, theirsDir, oursDir, emptyFile);
+
+  test('clean modify: upstream change applies when ours == base', async () => {
+    const { baseDir, theirsDir, oursDir, emptyFile } = await setup({
+      base: { 'a.txt': 'one\ntwo\n' },
+      theirs: { 'a.txt': 'one\ntwo-upstream\n' },
+      ours: { 'a.txt': 'one\ntwo\n' },
+    });
+
+    const result = await run(baseDir, theirsDir, oursDir, emptyFile);
+
+    expect(result.applied).toContain('a.txt');
+    expect(result.conflicted).toHaveLength(0);
+    expect(await readFile(join(oursDir, 'a.txt'), 'utf-8')).toBe('one\ntwo-upstream\n');
+  });
+
+  test('overlapping modify: writes conflict markers, never throws', async () => {
+    const { baseDir, theirsDir, oursDir, emptyFile } = await setup({
+      base: { 'a.txt': 'line\n' },
+      theirs: { 'a.txt': 'line-upstream\n' },
+      ours: { 'a.txt': 'line-merchant\n' },
+    });
+
+    const result = await run(baseDir, theirsDir, oursDir, emptyFile);
+
+    expect(result.conflicted).toContain('a.txt');
+
+    const merged = await readFile(join(oursDir, 'a.txt'), 'utf-8');
+
+    expect(merged).toContain('<<<<<<< ours');
+    expect(merged).toContain('>>>>>>> theirs');
+  });
+
+  test('added file is copied in', async () => {
+    const { baseDir, theirsDir, oursDir, emptyFile } = await setup({
+      theirs: { 'new.ts': 'export const x = 1;\n' },
+    });
+
+    const result = await run(baseDir, theirsDir, oursDir, emptyFile);
+
+    expect(result.added).toContain('new.ts');
+    expect(await readFile(join(oursDir, 'new.ts'), 'utf-8')).toBe('export const x = 1;\n');
+  });
+
+  test('deleted upstream + unmodified locally is removed', async () => {
+    const { baseDir, theirsDir, oursDir, emptyFile } = await setup({
+      base: { 'gone.ts': 'old\n' },
+      ours: { 'gone.ts': 'old\n' },
+    });
+
+    const result = await run(baseDir, theirsDir, oursDir, emptyFile);
+
+    expect(result.deleted).toContain('gone.ts');
+    expect(await exists(join(oursDir, 'gone.ts'))).toBe(false);
+  });
+
+  test('modify/delete: merchant-deleted file upstream modified is restored + flagged', async () => {
+    const { baseDir, theirsDir, oursDir, emptyFile } = await setup({
+      base: { 'keep.ts': 'v1\n' },
+      theirs: { 'keep.ts': 'v2\n' },
+      // ours is missing keep.ts (merchant deleted it)
+    });
+
+    const result = await run(baseDir, theirsDir, oursDir, emptyFile);
+
+    expect(result.conflicted).toContain('keep.ts');
+    expect(await readFile(join(oursDir, 'keep.ts'), 'utf-8')).toBe('v2\n');
+  });
+
+  test('binary change applies when ours == base (no corruption)', async () => {
+    const baseBin = Buffer.from([0x89, 0x50, 0x00, 0x01]);
+    const theirsBin = Buffer.from([0x89, 0x50, 0x00, 0x02, 0x03]);
+    const { baseDir, theirsDir, oursDir, emptyFile } = await setup({
+      base: { 'img.png': baseBin },
+      theirs: { 'img.png': theirsBin },
+      ours: { 'img.png': baseBin },
+    });
+
+    const result = await run(baseDir, theirsDir, oursDir, emptyFile);
+
+    expect(result.applied).toContain('img.png');
+    expect(await readFile(join(oursDir, 'img.png'))).toEqual(theirsBin);
+  });
+
+  test('identical versions produce no changes', async () => {
+    const { baseDir, theirsDir, oursDir, emptyFile } = await setup({
+      base: { 'a.txt': 'same\n' },
+      theirs: { 'a.txt': 'same\n' },
+      ours: { 'a.txt': 'same\n' },
+    });
+
+    const result = await run(baseDir, theirsDir, oursDir, emptyFile);
+
+    expect(result.applied).toHaveLength(0);
+    expect(result.added).toHaveLength(0);
+    expect(result.deleted).toHaveLength(0);
+    expect(result.conflicted).toHaveLength(0);
+  });
+});
+
+// The whole-tree engine's headline advantage over per-file: it follows renames
+// and merges local edits across them (per-file would see delete + add instead).
+describe.skipIf(!SUPPORTS_TREE)('mergeCoreTree rename fidelity', () => {
+  test('follows a rename and carries a local edit across it', async () => {
+    const root = await mkTmp();
+    const baseDir = join(root, 'base');
+    const theirsDir = join(root, 'theirs');
+    const oursDir = join(root, 'ours');
+
+    await Promise.all([
+      mkdir(baseDir, { recursive: true }),
+      mkdir(theirsDir, { recursive: true }),
+      mkdir(oursDir, { recursive: true }),
+    ]);
+
+    // theirs renames old.ts → new.ts; ours edits old.ts in place. A rename-aware
+    // merge lands the edit in new.ts; per-file would hit a modify/delete conflict.
+    await Promise.all([
+      write(join(baseDir, 'old.ts'), 'a\nb\nc\nd\ne\nf\n'),
+      write(join(oursDir, 'old.ts'), 'a\nb\nc\nd\ne-merchant\nf\n'),
+      write(join(theirsDir, 'new.ts'), 'a\nb\nc\nd\ne\nf\n'),
+    ]);
+
+    const result = await mergeCoreTree(baseDir, theirsDir, oursDir);
+
+    expect(await exists(join(oursDir, 'new.ts'))).toBe(true);
+    expect(await exists(join(oursDir, 'old.ts'))).toBe(false);
+    expect(result.conflicted).toHaveLength(0);
+    expect(await readFile(join(oursDir, 'new.ts'), 'utf-8')).toBe('a\nb\nc\nd\ne-merchant\nf\n');
   });
 });

--- a/packages/catalyst/src/cli/commands/upgrade.ts
+++ b/packages/catalyst/src/cli/commands/upgrade.ts
@@ -1,7 +1,19 @@
 import { execa } from 'execa';
-import { access, copyFile, mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import {
+  access,
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { z } from 'zod';
+
+import { consola } from '../lib/logger';
 
 const CorePackageJson = z.object({
   name: z.string().optional(),
@@ -239,6 +251,274 @@ export async function mergeCorePerFile(
   await Promise.all([...new Set([...baseFiles, ...theirsFiles])].map(decide));
 
   return result;
+}
+
+// ── merge strategy selection ───────────────────────────────────────────────────
+export type MergeStrategy = 'auto' | 'tree' | 'per-file';
+
+// `git merge-tree --write-tree` (the whole-tree engine) landed in git 2.38.
+export async function gitSupportsMergeTree(): Promise<boolean> {
+  try {
+    const { stdout } = await execa('git', ['--version']);
+    const match = /(\d+)\.(\d+)/.exec(stdout);
+
+    if (!match) return false;
+
+    const [major, minor] = [Number(match[1]), Number(match[2])];
+
+    return major > 2 || (major === 2 && minor >= 38);
+  } catch {
+    return false;
+  }
+}
+
+// 'auto' resolves to the whole-tree engine when git supports it, else per-file.
+export async function resolveStrategy(strategy: MergeStrategy): Promise<'tree' | 'per-file'> {
+  if (strategy !== 'auto') return strategy;
+
+  if (await gitSupportsMergeTree()) return 'tree';
+
+  consola.warn('git < 2.38 — using the per-file merge engine (no `git merge-tree`).');
+
+  return 'per-file';
+}
+
+// ── whole-tree 3-way merge engine (git merge-tree, 2.38+) ──────────────────────
+// Builds base/ours/theirs as commits in a throwaway object store, runs a real
+// recursive merge (rename detection, modify/delete, mode changes, binary — all
+// native to git), then materialises the merged tree into the catalyst root.
+// Conflicts come back as in-blob <<<ours/===/theirs>>> markers; like per-file it
+// never aborts. Branch names `ours`/`theirs` make the markers match the per-file
+// engine's labels.
+export async function mergeCoreTree(
+  baseDir: string,
+  theirsDir: string,
+  catalystRoot: string,
+): Promise<MergeResult> {
+  const scratch = await mkdtemp(join(tmpdir(), 'catalyst-merge-'));
+
+  try {
+    await execa('git', ['init', '-q', scratch]);
+    // Disable line-ending conversion so checkout-index writes LF on all platforms.
+    await execa('git', ['config', 'core.autocrlf', 'false'], {
+      env: { ...process.env, GIT_DIR: join(scratch, '.git') },
+    });
+
+    const env = {
+      ...process.env,
+      GIT_DIR: join(scratch, '.git'),
+      GIT_AUTHOR_NAME: 'catalyst',
+      GIT_AUTHOR_EMAIL: 'catalyst@bigcommerce.com',
+      GIT_COMMITTER_NAME: 'catalyst',
+      GIT_COMMITTER_EMAIL: 'catalyst@bigcommerce.com',
+    };
+
+    // Snapshot a directory as a tree object (own index per side; .gitignore is
+    // honoured, so build artifacts like node_modules never enter the tree).
+    const writeTree = async (workTree: string, tag: string): Promise<string> => {
+      const sideEnv = {
+        ...env,
+        GIT_WORK_TREE: workTree,
+        GIT_INDEX_FILE: join(scratch, `index.${tag}`),
+      };
+
+      await execa('git', ['add', '-A'], { env: sideEnv });
+
+      return (await execa('git', ['write-tree'], { env: sideEnv })).stdout.trim();
+    };
+
+    const commitTree = (tree: string, parent?: string) =>
+      execa('git', ['commit-tree', tree, '-m', 'x', ...(parent ? ['-p', parent] : [])], {
+        env,
+      }).then((r) => r.stdout.trim());
+
+    const [baseTree, oursTree, theirsTree] = await Promise.all([
+      writeTree(baseDir, 'base'),
+      writeTree(catalystRoot, 'ours'),
+      writeTree(theirsDir, 'theirs'),
+    ]);
+
+    const baseCommit = await commitTree(baseTree);
+    const [oursCommit, theirsCommit] = await Promise.all([
+      commitTree(oursTree, baseCommit),
+      commitTree(theirsTree, baseCommit),
+    ]);
+
+    await Promise.all([
+      execa('git', ['branch', 'ours', oursCommit], { env }),
+      execa('git', ['branch', 'theirs', theirsCommit], { env }),
+    ]);
+
+    // -z --name-only output: <merged-tree-oid> NUL, then conflicted paths each
+    // NUL-terminated, then an empty field marks the end of the conflicted set
+    // (everything after is informational messages we don't need).
+    const merge = await execa(
+      'git',
+      [
+        'merge-tree',
+        '--write-tree',
+        '-z',
+        '--name-only',
+        `--merge-base=${baseCommit}`,
+        'ours',
+        'theirs',
+      ],
+      { env, reject: false },
+    );
+
+    if ((merge.exitCode ?? 0) > 1)
+      throw new Error(merge.stderr || merge.stdout.slice(0, 500) || 'git merge-tree failed');
+
+    // -z --name-only emits <merged-tree-oid>, then conflicted paths, then an
+    // empty field; everything after that is informational and ignored.
+    const fields = merge.stdout.split('\0');
+    const mergedTree = fields[0];
+    const afterOid = fields.slice(1);
+    const emptyAt = afterOid.indexOf('');
+    const conflicted = afterOid.slice(0, emptyAt === -1 ? afterOid.length : emptyAt);
+    const conflictedSet = new Set(conflicted);
+
+    // Materialise the merged tree into the catalyst root (conflict markers are
+    // already baked into the conflicted blobs).
+    const outEnv = {
+      ...env,
+      GIT_WORK_TREE: catalystRoot,
+      GIT_INDEX_FILE: join(scratch, 'index.out'),
+    };
+
+    await execa('git', ['read-tree', mergedTree], { env: outEnv });
+    await execa('git', ['checkout-index', '-a', '-f'], { env: outEnv });
+
+    // Classify ours → merged. -z --name-status emits [status, path, status, …].
+    const diff = await execa(
+      'git',
+      ['diff', '-z', '--no-renames', '--name-status', oursTree, mergedTree],
+      { env },
+    );
+
+    const tokens = diff.stdout.split('\0');
+    const changes: Array<{ status: string; path: string }> = [];
+
+    for (let i = 0; i + 1 < tokens.length; i += 2) {
+      const status = tokens[i];
+      const path = tokens[i + 1];
+
+      if (status && path && !conflictedSet.has(path)) {
+        changes.push({ status, path });
+      }
+    }
+
+    // checkout-index only writes; it won't remove paths the merge dropped.
+    const deleted = changes.filter((change) => change.status === 'D').map((change) => change.path);
+
+    await Promise.all(deleted.map((path) => rm(join(catalystRoot, path), { force: true })));
+
+    return {
+      applied: changes
+        .filter((change) => change.status !== 'A' && change.status !== 'D')
+        .map((change) => change.path),
+      added: changes.filter((change) => change.status === 'A').map((change) => change.path),
+      deleted,
+      conflicted,
+    };
+  } finally {
+    await rm(scratch, { recursive: true, force: true });
+  }
+}
+
+// ── index staging ──────────────────────────────────────────────────────────────
+// After the merge, stage everything that merged cleanly (so the merchant only
+// reviews what needs attention) and register conflicted files as real unmerged
+// index entries: stage 1 = base, 2 = ours (the committed pre-upgrade blob),
+// 3 = theirs. `git status` then reports them as conflicts (UU / AA / DU), which
+// lights up editors' merge UIs. No MERGE_HEAD — the target tag isn't an ancestor,
+// so resolving is a normal `git add` + commit, not a merge commit.
+export async function applyIndexState(
+  gitRoot: string,
+  relDir: string,
+  baseDir: string,
+  theirsDir: string,
+  result: MergeResult,
+  stampedPkg: boolean,
+): Promise<void> {
+  const toRepoPath = (rel: string) => (relDir === '.' ? rel : `${relDir}/${rel}`);
+  const pkgRel = 'package.json';
+
+  // If the stamp resolved package.json (stripped its conflict markers and wrote
+  // clean JSON), treat it as a clean file rather than a conflict — it should be
+  // staged normally so it shows up in `git diff --cached`, not registered as UU.
+  const stillConflicted = result.conflicted.filter((rel) => !(stampedPkg && rel === pkgRel));
+  const conflictedRepoPaths = new Set(stillConflicted.map(toRepoPath));
+
+  // 1. Pre-stage the clean changes (+ the resolved package.json when stamped).
+  const clean = [...result.applied, ...result.added, ...result.deleted].map(toRepoPath);
+
+  if (stampedPkg) clean.push(toRepoPath(pkgRel));
+
+  const toStage = [...new Set(clean)].filter((path) => !conflictedRepoPaths.has(path));
+
+  if (toStage.length) {
+    await execa('git', ['add', '-A', '--', ...toStage], { cwd: gitRoot });
+  }
+
+  if (stillConflicted.length === 0) return;
+
+  // 2. Conflicts → unmerged index entries. ours = the committed blob (the
+  //    clean-tree precondition guarantees the worktree matched HEAD before the
+  //    merge); base/theirs blobs get written into the repo's object store.
+  const OID = /^[0-9a-f]{40,64}$/;
+  // Detect SHA-256 repos (git 2.29+). SHA-1 uses a 40-zero null OID; SHA-256 uses 64.
+  const gitFormat = (
+    await execa('git', ['rev-parse', '--show-object-format'], { cwd: gitRoot, reject: false })
+  ).stdout.trim();
+  const NULL_OID = gitFormat === 'sha256' ? '0'.repeat(64) : '0'.repeat(40);
+
+  // Write a file's content as a blob; null if the file is absent or the OID
+  // comes back malformed (guards against shell wrappers polluting stdout).
+  const hashBlob = async (file: string): Promise<string | null> => {
+    if (!(await pathExists(file))) return null;
+
+    const oid = (
+      await execa('git', ['hash-object', '-w', '--', file], { cwd: gitRoot })
+    ).stdout.trim();
+
+    return OID.test(oid) ? oid : null;
+  };
+
+  // ours mode + blob via `ls-tree`. Unlike `rev-parse HEAD:<path>`, ls-tree
+  // never echoes a missing path back as if it were an object name.
+  const headEntry = async (repoPath: string): Promise<{ mode: string; oid: string } | null> => {
+    const { stdout } = await execa('git', ['ls-tree', 'HEAD', '--', repoPath], {
+      cwd: gitRoot,
+      reject: false,
+    });
+    const match = /^(\d{6}) blob ([0-9a-f]+)\t/.exec(stdout);
+
+    return match ? { mode: match[1], oid: match[2] } : null;
+  };
+
+  const records = await Promise.all(
+    stillConflicted.map(async (rel) => {
+      const repoPath = toRepoPath(rel);
+      const [base, ours, theirs] = await Promise.all([
+        hashBlob(join(baseDir, rel)),
+        headEntry(repoPath),
+        hashBlob(join(theirsDir, rel)),
+      ]);
+
+      return [
+        `0 ${NULL_OID}\t${repoPath}`,
+        ...(base ? [`100644 ${base} 1\t${repoPath}`] : []),
+        ...(ours ? [`${ours.mode} ${ours.oid} 2\t${repoPath}`] : []),
+        ...(theirs ? [`100644 ${theirs} 3\t${repoPath}`] : []),
+      ].join('\n');
+    }),
+  );
+
+  await execa('git', ['update-index', '--index-info'], {
+    cwd: gitRoot,
+    input: `${records.join('\n')}\n`,
+  });
 }
 
 // Re-export readResolvedVersion so later PRs can use it without re-importing.


### PR DESCRIPTION
Jira: [TRAC-925](https://bigcommercecloud.atlassian.net/browse/TRAC-925)

**PR 2 of 4** for `catalyst upgrade` (LTRAC-956). Stacks on TRAC-924 (#3063).

## What/Why?

Adds the whole-tree merge engine (`git merge-tree --write-tree`) and the index staging layer (`applyIndexState`).

The whole-tree engine is the default (used when git >= 2.38). Key design decisions:

- Three sides (base/ours/theirs) are snapshotted as commits in a throwaway object store with **separate `GIT_INDEX_FILE` per side** — this lets all three `git add -A` calls run in parallel without index races, while still sharing the object store for blob dedup
- `git merge-tree -z --name-only` output is NUL-delimited: `<tree-oid>\0<conflicted-path>\0...\0\0<messages>`. The empty field after the last conflicted path is the terminator; everything after is informational and ignored
- `checkout-index` only writes, never removes — deleted paths are identified via `git diff --no-renames --name-status oursTree mergedTree` and removed separately
- `NULL_OID` is detected via `git rev-parse --show-object-format` to support SHA-256 repos (OID = 64 hex vs 40). The `OID` regex already accepts 40–64; NULL_OID now matches

`applyIndexState` registers conflicted files as real unmerged index entries (stages 1/2/3) so VS Code's merge UI activates. `MERGE_HEAD` is intentionally absent — resolving is a normal `git add` + commit, not a merge commit.

## Testing

```bash
pnpm test upgrade.spec
```

Covers: `resolveStrategy`, `applyIndexState`, `mergeCore engine: tree` × 7 (same contract as per-file — both must agree), `mergeCoreTree rename fidelity`.

## Migration

No user-visible changes yet.

[TRAC-925]: https://bigcommercecloud.atlassian.net/browse/TRAC-925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ