### PR TITLE
TRAC-499: feat - implement query logs in catalyst cli

### DIFF
--- a/packages/catalyst/README.md
+++ b/packages/catalyst/README.md
@@ -29,6 +29,7 @@ For example:
 ```bash
 pnpm exec <repo-root>/packages/catalyst/dist/cli.js project list
 pnpm exec <repo-root>/packages/catalyst/dist/cli.js logs tail
+pnpm exec <repo-root>/packages/catalyst/dist/cli.js logs query --start 2026-06-01T00:00:00Z --end 2026-06-02T00:00:00Z
 pnpm exec <repo-root>/packages/catalyst/dist/cli.js deploy
 ```
 

--- a/packages/catalyst/src/cli/commands/logs.spec.ts
+++ b/packages/catalyst/src/cli/commands/logs.spec.ts
@@ -140,6 +140,7 @@ describe('command configuration', () => {
         expect.objectContaining({ flags: '--access-token <token>' }),
         expect.objectContaining({ flags: '--api-host <host>' }),
         expect.objectContaining({ flags: '--project-uuid <uuid>' }),
+        expect.objectContaining({ flags: '--format <format>', defaultValue: 'default' }),
       ]),
     );
   });
@@ -584,7 +585,112 @@ describe('credential resolution', () => {
 });
 
 describe('query subcommand', () => {
-  test('exits with error as not yet implemented', async () => {
+  const start = '2026-06-01T00:00:00Z';
+  const end = '2026-06-02T00:00:00Z';
+
+  const queryArgs = (extra: string[] = []) => [
+    'node',
+    'catalyst',
+    'logs',
+    'query',
+    '--store-hash',
+    storeHash,
+    '--access-token',
+    accessToken,
+    '--project-uuid',
+    projectUuid,
+    '--start',
+    start,
+    '--end',
+    end,
+    ...extra,
+  ];
+
+  test('prints formatted log lines and a count footer', async () => {
+    await program.parseAsync(queryArgs());
+
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining('/cart'));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining('[TypeError]'));
+    expect(consola.info).toHaveBeenCalledWith('1 entry shown (oldest first, times in UTC).');
+    // TODO(TRAC-934): no next-page hint is printed while pagination is removed.
+    expect(consola.info).not.toHaveBeenCalledWith(expect.stringContaining('More available'));
+  });
+
+  test('warns when the result fills --limit exactly', async () => {
+    server.use(
+      http.get('https://:apiHost/stores/:storeHash/v3/infrastructure/logs/:projectUuid', () =>
+        HttpResponse.json({
+          data: [
+            { id: '2', timestamp: '2026-06-01T13:00:00Z', level: 'info', messages: ['newer'] },
+            { id: '1', timestamp: '2026-06-01T12:00:00Z', level: 'info', messages: ['older'] },
+          ],
+        }),
+      ),
+    );
+
+    await program.parseAsync(queryArgs(['--limit', '2']));
+
+    expect(consola.info).toHaveBeenCalledWith(expect.stringContaining('Limit of 2 reached'));
+  });
+
+  test('does not warn when the result is below --limit', async () => {
+    server.use(
+      http.get('https://:apiHost/stores/:storeHash/v3/infrastructure/logs/:projectUuid', () =>
+        HttpResponse.json({
+          data: [{ id: '1', timestamp: '2026-06-01T12:00:00Z', level: 'info', messages: ['only'] }],
+        }),
+      ),
+    );
+
+    await program.parseAsync(queryArgs(['--limit', '5']));
+
+    expect(consola.info).not.toHaveBeenCalledWith(expect.stringContaining('reached'));
+  });
+
+  test('prints entries oldest-first', async () => {
+    server.use(
+      http.get('https://:apiHost/stores/:storeHash/v3/infrastructure/logs/:projectUuid', () =>
+        HttpResponse.json({
+          data: [
+            { id: '2', timestamp: '2026-06-01T13:00:00Z', level: 'info', messages: ['newer'] },
+            { id: '1', timestamp: '2026-06-01T12:00:00Z', level: 'info', messages: ['older'] },
+          ],
+          meta: {
+            cursor_pagination: { count: 2, per_page: 50, start_cursor: null, end_cursor: null },
+          },
+        }),
+      ),
+    );
+
+    await program.parseAsync(queryArgs());
+
+    const logged = vi.mocked(consola.log).mock.calls.map(([line]) => String(line));
+    const olderIndex = logged.findIndex((line) => line.includes('older'));
+    const newerIndex = logged.findIndex((line) => line.includes('newer'));
+
+    expect(olderIndex).toBeGreaterThanOrEqual(0);
+    expect(olderIndex).toBeLessThan(newerIndex);
+  });
+
+  test('--since queries a relative window ending now', async () => {
+    let captured: URLSearchParams | undefined;
+
+    server.use(
+      http.get(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/logs/:projectUuid',
+        ({ request }) => {
+          captured = new URL(request.url).searchParams;
+
+          return HttpResponse.json({
+            data: [],
+            meta: {
+              cursor_pagination: { count: 0, per_page: 50, start_cursor: null, end_cursor: null },
+            },
+          });
+        },
+      ),
+    );
+
     await program.parseAsync([
       'node',
       'catalyst',
@@ -594,9 +700,141 @@ describe('query subcommand', () => {
       storeHash,
       '--access-token',
       accessToken,
+      '--project-uuid',
+      projectUuid,
+      '--since',
+      '1h',
     ]);
 
-    expect(consola.error).toHaveBeenCalledWith('The query command is not yet implemented.');
+    const sentStart = Date.parse(captured?.get('start') ?? '');
+    const sentEnd = Date.parse(captured?.get('end') ?? '');
+
+    expect(sentEnd - sentStart).toBe(60 * 60 * 1000);
+    expect(Math.abs(Date.now() - sentEnd)).toBeLessThan(60 * 1000);
+  });
+
+  test('reads project UUID from project.json when --project-uuid is omitted', async () => {
+    config.set('projectUuid', projectUuid);
+
+    await program.parseAsync([
+      'node',
+      'catalyst',
+      'logs',
+      'query',
+      '--store-hash',
+      storeHash,
+      '--access-token',
+      accessToken,
+      '--start',
+      start,
+      '--end',
+      end,
+    ]);
+
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining('/cart'));
+  });
+
+  test('outputs one raw JSON entry per line with --format json', async () => {
+    await program.parseAsync(queryArgs(['--format', 'json']));
+
+    // NDJSON to stdout (like `tail --format json`), no footer chrome.
+    expect(stdoutWriteMock).toHaveBeenCalledWith(expect.stringContaining('"is_exception":true'));
+    expect(consola.info).not.toHaveBeenCalledWith(expect.stringContaining('entry shown'));
+  });
+
+  test('includes request details with --format request', async () => {
+    await program.parseAsync(queryArgs(['--format', 'request']));
+
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining('GET /cart (500)'));
+  });
+
+  test('reports when no entries are found', async () => {
+    server.use(
+      http.get('https://:apiHost/stores/:storeHash/v3/infrastructure/logs/:projectUuid', () =>
+        HttpResponse.json({
+          data: [],
+          meta: {
+            cursor_pagination: { count: 0, per_page: 50, start_cursor: null, end_cursor: null },
+          },
+        }),
+      ),
+    );
+
+    await program.parseAsync(queryArgs());
+
+    expect(consola.info).toHaveBeenCalledWith(
+      'No log entries found for the given window and filters.',
+    );
+  });
+
+  test('forwards filters as query params', async () => {
+    let captured: URLSearchParams | undefined;
+
+    server.use(
+      http.get(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/logs/:projectUuid',
+        ({ request }) => {
+          captured = new URL(request.url).searchParams;
+
+          return HttpResponse.json({
+            data: [],
+            meta: {
+              cursor_pagination: { count: 0, per_page: 50, start_cursor: null, end_cursor: null },
+            },
+          });
+        },
+      ),
+    );
+
+    await program.parseAsync(
+      queryArgs([
+        '--method',
+        'GET',
+        '--status-code',
+        '500',
+        '--url-like',
+        '/cart',
+        '--level-min',
+        'warn',
+        '--limit',
+        '10',
+      ]),
+    );
+
+    expect(captured?.get('method')).toBe('GET');
+    expect(captured?.get('status_code')).toBe('500');
+    expect(captured?.get('url:like')).toBe('/cart');
+    expect(captured?.get('level:min')).toBe('warn');
+    expect(captured?.get('limit')).toBe('10');
+    expect(captured?.get('after')).toBeNull();
+  });
+
+  test('exits with error when no project UUID can be resolved', async () => {
+    await program.parseAsync([
+      'node',
+      'catalyst',
+      'logs',
+      'query',
+      '--store-hash',
+      storeHash,
+      '--access-token',
+      accessToken,
+      '--start',
+      start,
+      '--end',
+      end,
+    ]);
+
+    expect(consola.error).toHaveBeenCalledWith(expect.stringContaining('Project UUID is required'));
+    expect(exitMock).toHaveBeenCalledWith(1);
+  });
+
+  test('exits with an error on an invalid time window', async () => {
+    await program.parseAsync(queryArgs(['--end', '2026-05-01T00:00:00Z']));
+
+    expect(consola.error).toHaveBeenCalledWith(
+      expect.stringContaining('--start must be before or equal to --end'),
+    );
     expect(exitMock).toHaveBeenCalledWith(1);
   });
 
@@ -607,9 +845,7 @@ describe('query subcommand', () => {
     delete process.env.CATALYST_STORE_HASH;
     delete process.env.CATALYST_ACCESS_TOKEN;
 
-    await expect(program.parseAsync(['node', 'catalyst', 'logs', 'query'])).rejects.toThrow(
-      'Missing credentials',
-    );
+    await program.parseAsync(['node', 'catalyst', 'logs', 'query', '--start', start, '--end', end]);
 
     if (savedStoreHash !== undefined) process.env.CATALYST_STORE_HASH = savedStoreHash;
     if (savedAccessToken !== undefined) process.env.CATALYST_ACCESS_TOKEN = savedAccessToken;

--- a/packages/catalyst/src/cli/commands/logs.ts
+++ b/packages/catalyst/src/cli/commands/logs.ts
@@ -1,9 +1,10 @@
-import { Command, Option } from 'commander';
+import { Command, InvalidArgumentError, Option } from 'commander';
 import { colorize } from 'consola/utils';
 import { z } from 'zod';
 
 import { UnauthorizedError } from '../lib/auth-errors';
 import { consola } from '../lib/logger';
+import { formatLogEntry, LOG_LEVELS, queryLogs, resolveTimeWindow } from '../lib/observability';
 import { getProjectConfig } from '../lib/project-config';
 import { resolveCredentials } from '../lib/resolve-credentials';
 import {
@@ -347,26 +348,142 @@ Examples:
     }
   });
 
+// Validates a numeric flag client-side so typos fail instantly with a clear
+// message instead of sending NaN (or an out-of-range value) to the API.
+const parseIntInRange = (flag: string, min: number, max: number) => (value: string) => {
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed < min || parsed > max) {
+    throw new InvalidArgumentError(`${flag} must be an integer between ${min} and ${max}.`);
+  }
+
+  return parsed;
+};
+
 const query = new Command('query')
   .configureHelp({ showGlobalOptions: true })
   .description('Query historical logs from your deployed application.')
   .addHelpText(
     'after',
     `
-Example:
-  $ catalyst logs query`,
+Specify a time window with \`--since\` (relative to now) or \`--start\`/\`--end\`
+(ISO-8601 timestamps or Unix epoch seconds, UTC). The window may not exceed
+7 days. Entries print oldest-first; timestamps are UTC.
+
+Examples:
+  # Last hour of logs
+  $ catalyst logs query --since 1h
+
+  # Everything from today (UTC)
+  $ catalyst logs query --start 2026-06-11T00:00:00Z
+
+  # Errors only for a specific path
+  $ catalyst logs query --since 24h --level-min error --url-like /cart
+
+  # Errors with request details (method, URL, status)
+  $ catalyst logs query --since 1h --level-min error --format request
+
+  # Raw JSON (NDJSON) for piping to other tools
+  $ catalyst logs query --since 2d --format json`,
   )
   .addOption(storeHashOption())
   .addOption(accessTokenOption())
   .addOption(apiHostOption())
   .addOption(projectUuidOption())
-  .action((options) => {
-    const config = getProjectConfig();
+  .addOption(
+    new Option(
+      '--since <duration>',
+      'Relative window ending at --end (default: now), e.g. 30m, 6h, 2d (units: s, m, h, d).',
+    ).conflicts('start'),
+  )
+  .option('--start <time>', 'Window start: ISO-8601 timestamp or Unix epoch (seconds).')
+  .option(
+    '--end <time>',
+    'Window end: ISO-8601 timestamp or Unix epoch (seconds). Defaults to now. The window must not exceed 7 days.',
+  )
+  .option('--method <method>', 'Filter by request HTTP method (case-insensitive).')
+  .addOption(
+    new Option('--status-code <code>', 'Filter by response status code (100-599).').argParser(
+      parseIntInRange('--status-code', 100, 599),
+    ),
+  )
+  .option('--url-like <substring>', 'Filter by URL substring (case-sensitive).')
+  .addOption(
+    new Option('--level-min <level>', 'Minimum log level.').choices(Array.from(LOG_LEVELS)),
+  )
+  .addOption(
+    new Option('--limit <n>', 'Maximum number of entries to return (1-500).')
+      .argParser(parseIntInRange('--limit', 1, 500))
+      .default(100),
+  )
+  // TODO(TRAC-934): --after (cursor) and --all (follow pagination) were
+  // removed until Cloudflare fixes invocations-view pagination
+  .addOption(
+    new Option('--format <format>', 'Output format for log entries.')
+      .choices(['json', 'pretty', 'default', 'short', 'request'])
+      .default('default'),
+  )
+  .action(async (options) => {
+    try {
+      const config = getProjectConfig();
+      const { storeHash, accessToken } = resolveCredentials(options, config);
 
-    resolveCredentials(options, config);
+      await telemetry.identify(storeHash);
 
-    consola.error('The query command is not yet implemented.');
-    process.exit(1);
+      const projectUuid = resolveProjectUuid(options);
+      const { start, end } = resolveTimeWindow(options);
+
+      const result = await queryLogs(projectUuid, storeHash, accessToken, options.apiHost, {
+        start,
+        end,
+        method: options.method,
+        statusCode: options.statusCode,
+        urlLike: options.urlLike,
+        levelMin: options.levelMin,
+        limit: options.limit,
+      });
+
+      const entries = result.data;
+      const ordered = [...entries].reverse();
+
+      if (options.format === 'json') {
+        ordered.forEach((entry) => process.stdout.write(`${JSON.stringify(entry)}\n`));
+
+        return;
+      }
+
+      if (options.format === 'pretty') {
+        ordered.forEach((entry) => consola.log(JSON.stringify(entry, null, 2)));
+
+        return;
+      }
+
+      if (entries.length === 0) {
+        consola.info('No log entries found for the given window and filters.');
+
+        return;
+      }
+
+      // `json`/`pretty` returned above, leaving the human line formats — capture
+      // the narrowed value so it survives into the forEach closure.
+      const lineFormat = options.format;
+
+      ordered.forEach((entry) => consola.log(formatLogEntry(entry, lineFormat)));
+
+      consola.info(
+        `${entries.length} ${entries.length === 1 ? 'entry' : 'entries'} shown (oldest first, times in UTC).`,
+      );
+
+      if (entries.length === options.limit) {
+        consola.info(
+          `Limit of ${options.limit} reached; older entries may exist. ` +
+            'Narrow the time window or raise --limit (max 500) to see more.',
+        );
+      }
+    } catch (error) {
+      consola.error(error instanceof Error ? error.message : error);
+      process.exit(1);
+    }
   });
 
 export const logs = new Command('logs')

--- a/packages/catalyst/src/cli/lib/observability.spec.ts
+++ b/packages/catalyst/src/cli/lib/observability.spec.ts
@@ -1,0 +1,463 @@
+import { http, HttpResponse } from 'msw';
+import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
+
+import { server } from '../../../tests/mocks/node';
+
+import { consola } from './logger';
+import { formatLogEntry, formatV3Error, queryLogs, resolveTimeWindow } from './observability';
+
+const projectUuid = '6b202364-10f3-11f1-8bc7-fe9b9d8b14ab';
+const storeHash = 'test-store';
+const accessToken = 'test-token';
+const apiHost = 'api.bigcommerce.com';
+
+const logsUrl = 'https://:apiHost/stores/:storeHash/v3/infrastructure/logs/:projectUuid';
+
+beforeAll(() => {
+  consola.mockTypes(() => vi.fn());
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
+describe('resolveTimeWindow', () => {
+  const nowMs = Date.parse('2026-06-11T12:00:00Z');
+
+  test('throws when both since and start are missing', () => {
+    expect(() => resolveTimeWindow({ end: '2026-06-01T00:00:00Z' })).toThrow(
+      'Provide a time window with --since <duration> or --start <time>.',
+    );
+  });
+
+  test('defaults end to now when omitted', () => {
+    expect(resolveTimeWindow({ start: '2026-06-11T00:00:00Z' }, nowMs)).toEqual({
+      start: '2026-06-11T00:00:00Z',
+      end: '2026-06-11T12:00:00.000Z',
+    });
+  });
+
+  test('computes start from since relative to now', () => {
+    expect(resolveTimeWindow({ since: '6h' }, nowMs)).toEqual({
+      start: '2026-06-11T06:00:00.000Z',
+      end: '2026-06-11T12:00:00.000Z',
+    });
+  });
+
+  test('computes start from since relative to an explicit end', () => {
+    expect(resolveTimeWindow({ since: '30m', end: '2026-06-10T12:00:00Z' }, nowMs)).toEqual({
+      start: '2026-06-10T11:30:00.000Z',
+      end: '2026-06-10T12:00:00Z',
+    });
+  });
+
+  test('supports day-unit durations', () => {
+    expect(resolveTimeWindow({ since: '2d' }, nowMs)).toEqual({
+      start: '2026-06-09T12:00:00.000Z',
+      end: '2026-06-11T12:00:00.000Z',
+    });
+  });
+
+  test('throws on an unparseable since value', () => {
+    expect(() => resolveTimeWindow({ since: 'yesterday' })).toThrow('Invalid --since value');
+    expect(() => resolveTimeWindow({ since: '1w' })).toThrow('Invalid --since value');
+  });
+
+  test('throws when since exceeds 7 days', () => {
+    expect(() => resolveTimeWindow({ since: '8d' })).toThrow('must not exceed 7 days');
+  });
+
+  test('throws on an unparseable start value', () => {
+    expect(() => resolveTimeWindow({ start: 'not-a-date', end: '2026-06-01T00:00:00Z' })).toThrow(
+      'Invalid --start value',
+    );
+  });
+
+  test('throws on an unparseable end value', () => {
+    expect(() => resolveTimeWindow({ start: '2026-06-01T00:00:00Z', end: 'nope' })).toThrow(
+      'Invalid --end value',
+    );
+  });
+
+  test('throws when the window is out of order', () => {
+    expect(() =>
+      resolveTimeWindow({ start: '2026-06-02T00:00:00Z', end: '2026-06-01T00:00:00Z' }),
+    ).toThrow('--start must be before or equal to --end');
+  });
+
+  test('throws when the window exceeds 7 days', () => {
+    expect(() =>
+      resolveTimeWindow({ start: '2026-06-01T00:00:00Z', end: '2026-06-09T00:00:01Z' }),
+    ).toThrow('must not exceed 7 days');
+  });
+
+  test('passes ISO-8601 values through unchanged', () => {
+    expect(
+      resolveTimeWindow({ start: '2026-06-01T00:00:00Z', end: '2026-06-02T00:00:00Z' }),
+    ).toEqual({ start: '2026-06-01T00:00:00Z', end: '2026-06-02T00:00:00Z' });
+  });
+
+  test('passes Unix epoch (seconds) values through unchanged', () => {
+    expect(resolveTimeWindow({ start: '1717200000', end: '1717203600' })).toEqual({
+      start: '1717200000',
+      end: '1717203600',
+    });
+  });
+
+  test('accepts an exactly 7-day window', () => {
+    expect(
+      resolveTimeWindow({ start: '2026-06-01T00:00:00Z', end: '2026-06-08T00:00:00Z' }),
+    ).toEqual({ start: '2026-06-01T00:00:00Z', end: '2026-06-08T00:00:00Z' });
+  });
+});
+
+describe('formatLogEntry', () => {
+  test('formats the default line as [timestamp] [LEVEL] message, like tail', () => {
+    const line = formatLogEntry({
+      timestamp: '2026-06-01T12:34:56.789Z',
+      level: 'error',
+      messages: ['boom', 'happened'],
+      request: { method: 'GET', url: '/cart', status_code: 500 },
+    });
+
+    expect(line).toContain('[2026-06-01T12:34:56.789Z]');
+    expect(line).toContain('ERROR');
+    expect(line).toContain('boom happened');
+    // The default format omits request details — those only show in `request`.
+    expect(line).not.toContain('/cart');
+  });
+
+  test('uses the raw UTC ISO-8601 timestamp in brackets', () => {
+    const line = formatLogEntry({
+      timestamp: '2026-06-01T12:34:56.789Z',
+      level: 'info',
+      messages: ['hi'],
+    });
+
+    expect(line).toContain('[2026-06-01T12:34:56.789Z]');
+  });
+
+  test('includes request method, URL, and status in the request format', () => {
+    const line = formatLogEntry(
+      {
+        timestamp: '2026-06-01T12:34:56.789Z',
+        level: 'error',
+        messages: ['boom'],
+        request: { method: 'GET', url: '/cart', status_code: 500 },
+      },
+      'request',
+    );
+
+    expect(line).toContain('GET /cart (500)');
+    expect(line).toContain('boom');
+  });
+
+  test('prints only the message in the short format', () => {
+    const line = formatLogEntry(
+      {
+        timestamp: '2026-06-01T12:34:56.789Z',
+        level: 'error',
+        messages: ['just the message'],
+        request: { method: 'GET', url: '/cart', status_code: 500 },
+      },
+      'short',
+    );
+
+    expect(line).toBe('just the message');
+  });
+
+  test('marks exceptions with the exception name', () => {
+    const line = formatLogEntry({
+      timestamp: '2026-06-01T12:34:56.789Z',
+      level: 'error',
+      messages: ['Unhandled exception'],
+      is_exception: true,
+      exception_name: 'TypeError',
+    });
+
+    expect(line).toContain('[TypeError]');
+  });
+
+  test('skips the exception marker when the message already contains the name', () => {
+    const line = formatLogEntry({
+      timestamp: '2026-06-01T12:34:56.789Z',
+      level: 'error',
+      messages: ['BigCommerceAPIError: \n    BigCommerce API returned 530\n    \n    '],
+      is_exception: true,
+      exception_name: 'BigCommerceAPIError',
+    });
+
+    expect(line).not.toContain('[BigCommerceAPIError]');
+    expect(line).toContain('BigCommerceAPIError: BigCommerce API returned 530');
+  });
+
+  test('treats <*> placeholders in the exception name as wildcards', () => {
+    const line = formatLogEntry({
+      timestamp: '2026-06-01T12:34:56.789Z',
+      level: 'error',
+      messages: ['\n    BigCommerce API returned 530\n    \n    '],
+      is_exception: true,
+      exception_name: 'BigCommerce API returned <*>',
+    });
+
+    expect(line).not.toContain('[BigCommerce API returned <*>]');
+  });
+
+  test('collapses embedded newlines and indentation into single spaces', () => {
+    const line = formatLogEntry({
+      timestamp: '2026-06-01T12:34:56.789Z',
+      level: 'error',
+      messages: ['first\n    second\n    \n    ', 'third'],
+    });
+
+    expect(line).not.toContain('\n');
+    expect(line).toContain('first second third');
+  });
+
+  test('omits the status code when it is the 0 sentinel', () => {
+    const line = formatLogEntry(
+      {
+        timestamp: '2026-06-01T12:34:56.789Z',
+        level: 'error',
+        messages: ['boom'],
+        request: { method: 'GET', url: '', status_code: 0 },
+      },
+      'request',
+    );
+
+    expect(line).toContain('GET');
+    expect(line).not.toContain('(0)');
+  });
+
+  test('stringifies non-string messages', () => {
+    const line = formatLogEntry({
+      timestamp: '2026-06-01T12:34:56.789Z',
+      level: 'info',
+      messages: ['payload', { code: 530 }],
+    });
+
+    expect(line).toContain('payload {"code":530}');
+  });
+
+  test('renders unrecognized levels without color mapping', () => {
+    const line = formatLogEntry({
+      timestamp: '2026-06-01T12:34:56.789Z',
+      level: 'log',
+      messages: ['hi'],
+    });
+
+    expect(line).toContain('LOG');
+  });
+
+  test('renders a placeholder time when the timestamp is missing', () => {
+    const line = formatLogEntry({ level: 'info', messages: ['hi'] });
+
+    expect(line).toContain('[unknown]');
+    expect(line).toContain('INFO');
+  });
+
+  test('handles a null request and missing level gracefully', () => {
+    const line = formatLogEntry({ messages: ['orphan log'], request: null }, 'request');
+
+    expect(line).toContain('UNKNOWN');
+    expect(line).toContain('orphan log');
+  });
+});
+
+describe('formatV3Error', () => {
+  test('combines title and field errors', () => {
+    expect(
+      formatV3Error({
+        title: 'Invalid request.',
+        errors: { timeframe: 'must span at most 7 days' },
+      }),
+    ).toBe('Invalid request. (timeframe: must span at most 7 days)');
+  });
+
+  test('returns the title alone when there are no field errors', () => {
+    expect(formatV3Error({ title: 'Invalid request.', errors: {} })).toBe('Invalid request.');
+  });
+
+  test('returns field errors alone when there is no title', () => {
+    expect(formatV3Error({ errors: { start: 'is required' } })).toBe('start: is required');
+  });
+
+  test('returns undefined for an unrecognizable body', () => {
+    expect(formatV3Error(null)).toBeUndefined();
+    expect(formatV3Error('oops')).toBeUndefined();
+  });
+});
+
+describe('queryLogs', () => {
+  test('returns the parsed page on success', async () => {
+    server.use(
+      http.get(logsUrl, () =>
+        HttpResponse.json({
+          data: [
+            {
+              id: '01HX',
+              timestamp: '2026-06-01T12:34:56.789Z',
+              level: 'error',
+              messages: ['boom'],
+              request: { method: 'GET', url: '/cart', status_code: 500 },
+            },
+          ],
+          meta: {
+            cursor_pagination: {
+              count: 1,
+              per_page: 50,
+              start_cursor: 'cursor_start',
+              end_cursor: 'cursor_end',
+              links: {},
+            },
+          },
+        }),
+      ),
+    );
+
+    const result = await queryLogs(projectUuid, storeHash, accessToken, apiHost, {
+      start: '2026-06-01T00:00:00Z',
+      end: '2026-06-02T00:00:00Z',
+    });
+
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].level).toBe('error');
+    // TODO(TRAC-934): meta.cursor_pagination is no longer parsed; the
+    // fixture keeps it to confirm the schema tolerates (ignores) extra keys.
+  });
+
+  test('accepts levels outside the known set and non-string messages', async () => {
+    server.use(
+      http.get(logsUrl, () =>
+        HttpResponse.json({
+          data: [
+            {
+              id: '01HX',
+              timestamp: '2026-06-01T12:34:56.789Z',
+              level: 'log',
+              messages: ['payload', { code: 530 }],
+            },
+          ],
+          meta: {
+            cursor_pagination: { count: 1, per_page: 50, start_cursor: null, end_cursor: null },
+          },
+        }),
+      ),
+    );
+
+    const result = await queryLogs(projectUuid, storeHash, accessToken, apiHost, {
+      start: '2026-06-01T00:00:00Z',
+      end: '2026-06-02T00:00:00Z',
+    });
+
+    expect(result.data[0].level).toBe('log');
+  });
+
+  test('forwards filters as query params, including colon params', async () => {
+    let captured: URLSearchParams | undefined;
+
+    server.use(
+      http.get(logsUrl, ({ request }) => {
+        captured = new URL(request.url).searchParams;
+
+        return HttpResponse.json({
+          data: [],
+          meta: {
+            cursor_pagination: { count: 0, per_page: 50, start_cursor: null, end_cursor: null },
+          },
+        });
+      }),
+    );
+
+    await queryLogs(projectUuid, storeHash, accessToken, apiHost, {
+      start: '2026-06-01T00:00:00Z',
+      end: '2026-06-02T00:00:00Z',
+      method: 'GET',
+      statusCode: 500,
+      urlLike: '/cart',
+      levelMin: 'warn',
+      limit: 25,
+    });
+
+    expect(captured?.get('start')).toBe('2026-06-01T00:00:00Z');
+    expect(captured?.get('end')).toBe('2026-06-02T00:00:00Z');
+    expect(captured?.get('method')).toBe('GET');
+    expect(captured?.get('status_code')).toBe('500');
+    expect(captured?.get('url:like')).toBe('/cart');
+    expect(captured?.get('level:min')).toBe('warn');
+    expect(captured?.get('limit')).toBe('25');
+    expect(captured?.get('after')).toBeNull();
+  });
+
+  test('maps 401 to a re-auth error', async () => {
+    server.use(http.get(logsUrl, () => new HttpResponse(null, { status: 401 })));
+
+    await expect(
+      queryLogs(projectUuid, storeHash, accessToken, apiHost, {
+        start: '2026-06-01T00:00:00Z',
+        end: '2026-06-02T00:00:00Z',
+      }),
+    ).rejects.toThrow('catalyst auth login');
+  });
+
+  test('maps 403 to an API-not-enabled error', async () => {
+    server.use(http.get(logsUrl, () => new HttpResponse(null, { status: 403 })));
+
+    await expect(
+      queryLogs(projectUuid, storeHash, accessToken, apiHost, {
+        start: '2026-06-01T00:00:00Z',
+        end: '2026-06-02T00:00:00Z',
+      }),
+    ).rejects.toThrow('Infrastructure Logs API not enabled');
+  });
+
+  test('maps 404 to a project-not-found error', async () => {
+    server.use(http.get(logsUrl, () => new HttpResponse(null, { status: 404 })));
+
+    await expect(
+      queryLogs(projectUuid, storeHash, accessToken, apiHost, {
+        start: '2026-06-01T00:00:00Z',
+        end: '2026-06-02T00:00:00Z',
+      }),
+    ).rejects.toThrow('Project not found');
+  });
+
+  test('surfaces the v3 error message on 422', async () => {
+    server.use(
+      http.get(logsUrl, () =>
+        HttpResponse.json(
+          {
+            status: 422,
+            title: 'Invalid request.',
+            errors: { timeframe: 'must span at most 7 days' },
+          },
+          { status: 422 },
+        ),
+      ),
+    );
+
+    await expect(
+      queryLogs(projectUuid, storeHash, accessToken, apiHost, {
+        start: '2026-06-01T00:00:00Z',
+        end: '2026-06-02T00:00:00Z',
+      }),
+    ).rejects.toThrow('Invalid request. (timeframe: must span at most 7 days)');
+  });
+
+  test('throws a generic error on other non-ok responses', async () => {
+    server.use(
+      http.get(logsUrl, () => new HttpResponse(null, { status: 500, statusText: 'Server Error' })),
+    );
+
+    await expect(
+      queryLogs(projectUuid, storeHash, accessToken, apiHost, {
+        start: '2026-06-01T00:00:00Z',
+        end: '2026-06-02T00:00:00Z',
+      }),
+    ).rejects.toThrow('Failed to fetch logs: 500 Server Error');
+  });
+});

--- a/packages/catalyst/src/cli/lib/observability.ts
+++ b/packages/catalyst/src/cli/lib/observability.ts
@@ -1,0 +1,273 @@
+import { colorize } from 'consola/utils';
+import { z } from 'zod';
+
+import { assertAuthorized } from './auth-errors';
+import { getTelemetry } from './telemetry';
+
+export const LOG_LEVELS = ['debug', 'info', 'warn', 'error'] as const;
+export type LogLevel = (typeof LOG_LEVELS)[number];
+
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+const logEntrySchema = z.object({
+  timestamp: z.string().nullable().optional(),
+  level: z.string().optional(),
+  messages: z.array(z.unknown()).optional(),
+  is_exception: z.boolean().optional(),
+  exception_name: z.string().optional(),
+  request: z
+    .object({
+      method: z.string().optional(),
+      url: z.string().optional(),
+      status_code: z.number().optional(),
+    })
+    .nullable()
+    .optional(),
+});
+
+// TODO(TRAC-934): any `meta.cursor_pagination` the backend still returns is ignored (zod strips unknown keys)
+const queryLogsSchema = z.object({
+  data: z.array(logEntrySchema),
+});
+
+export type LogEntry = z.infer<typeof logEntrySchema>;
+export type QueryLogsResult = z.infer<typeof queryLogsSchema>;
+
+export interface QueryLogsParams {
+  start: string;
+  end: string;
+  method?: string;
+  statusCode?: number;
+  urlLike?: string;
+  levelMin?: LogLevel;
+  limit?: number;
+}
+
+const v3ErrorSchema = z.object({
+  title: z.string().optional(),
+  errors: z.record(z.string(), z.string()).optional(),
+});
+
+export function formatV3Error(body: unknown): string | undefined {
+  const parsed = v3ErrorSchema.safeParse(body);
+
+  if (!parsed.success) return undefined;
+
+  const { title, errors } = parsed.data;
+  const fieldErrors =
+    errors && Object.keys(errors).length > 0
+      ? Object.entries(errors)
+          .map(([field, message]) => `${field}: ${message}`)
+          .join('; ')
+      : undefined;
+
+  if (title && fieldErrors) return `${title} (${fieldErrors})`;
+
+  return title ?? fieldErrors;
+}
+
+// Accepts either an ISO-8601 timestamp or a Unix epoch (seconds) and returns
+// milliseconds since epoch, or null when the value can't be parsed.
+function parseTimeInput(value: string): number | null {
+  const trimmed = value.trim();
+
+  if (/^\d+$/.test(trimmed)) {
+    return Number(trimmed) * 1000;
+  }
+
+  const ms = Date.parse(trimmed);
+
+  return Number.isNaN(ms) ? null : ms;
+}
+
+const DURATION_UNIT_MS: Record<string, number> = {
+  s: 1000,
+  m: 60 * 1000,
+  h: 60 * 60 * 1000,
+  d: 24 * 60 * 60 * 1000,
+};
+
+function parseDuration(value: string): number | null {
+  const match = /^(\d+)([smhd])$/.exec(value.trim());
+
+  if (!match) return null;
+
+  return Number(match[1]) * DURATION_UNIT_MS[match[2]];
+}
+
+export function resolveTimeWindow(
+  opts: { start?: string; end?: string; since?: string },
+  nowMs = Date.now(),
+): {
+  start: string;
+  end: string;
+} {
+  const { since } = opts;
+  let { start, end } = opts;
+  let startMs: number | null;
+  let endMs: number | null;
+
+  if (end) {
+    endMs = parseTimeInput(end);
+
+    if (endMs === null) {
+      throw new Error(
+        `Invalid --end value "${end}". Provide an ISO-8601 timestamp or a Unix epoch (seconds).`,
+      );
+    }
+  } else {
+    endMs = nowMs;
+    end = new Date(endMs).toISOString();
+  }
+
+  if (since) {
+    const durationMs = parseDuration(since);
+
+    if (durationMs === null) {
+      throw new Error(
+        `Invalid --since value "${since}". Provide a duration like 30m, 6h, or 2d (units: s, m, h, d).`,
+      );
+    }
+
+    startMs = endMs - durationMs;
+    start = new Date(startMs).toISOString();
+  } else if (start) {
+    startMs = parseTimeInput(start);
+
+    if (startMs === null) {
+      throw new Error(
+        `Invalid --start value "${start}". Provide an ISO-8601 timestamp or a Unix epoch (seconds).`,
+      );
+    }
+  } else {
+    throw new Error('Provide a time window with --since <duration> or --start <time>.');
+  }
+
+  if (startMs > endMs) {
+    throw new Error('Invalid time window: --start must be before or equal to --end.');
+  }
+
+  if (endMs - startMs > SEVEN_DAYS_MS) {
+    throw new Error('Invalid time window: the range must not exceed 7 days.');
+  }
+
+  return { start, end };
+}
+
+const LEVEL_COLORS: Record<string, Parameters<typeof colorize>[0]> = {
+  debug: 'gray',
+  info: 'green',
+  warn: 'yellow',
+  error: 'red',
+};
+
+export type LogLineFormat = 'default' | 'short' | 'request';
+
+const UNKNOWN_TIME = 'unknown';
+
+function isRedundantExceptionName(name: string, message: string): boolean {
+  const parts = name
+    .split('<*>')
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+
+  return parts.length > 0 && parts.every((part) => message.includes(part));
+}
+
+const stringifyMessage = (message: unknown) =>
+  typeof message === 'string' ? message : JSON.stringify(message);
+
+export function formatLogEntry(entry: LogEntry, format: LogLineFormat = 'default'): string {
+  const message = (entry.messages ?? [])
+    .map(stringifyMessage)
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (format === 'short') return message;
+
+  const level = entry.level ?? 'unknown';
+  const coloredLevel = colorize(LEVEL_COLORS[level.toLowerCase()] ?? 'white', level.toUpperCase());
+
+  const exceptionStr =
+    entry.is_exception &&
+    entry.exception_name &&
+    !isRedundantExceptionName(entry.exception_name, message)
+      ? ` ${colorize('red', `[${entry.exception_name}]`)}`
+      : '';
+
+  let requestStr = '';
+
+  if (format === 'request' && entry.request) {
+    const parts: string[] = [];
+
+    if (entry.request.method) parts.push(entry.request.method);
+    if (entry.request.url) parts.push(entry.request.url);
+
+    // status_code 0 is the backend's "unknown" sentinel — omit it.
+    const status = entry.request.status_code ? ` (${entry.request.status_code})` : '';
+
+    if (parts.length > 0) requestStr = ` ${parts.join(' ')}${status}`;
+  }
+
+  return `[${entry.timestamp ?? UNKNOWN_TIME}] [${coloredLevel}]${requestStr}${exceptionStr} ${message}`;
+}
+
+export async function queryLogs(
+  projectUuid: string,
+  storeHash: string,
+  accessToken: string,
+  apiHost: string,
+  params: QueryLogsParams,
+): Promise<QueryLogsResult> {
+  const search = new URLSearchParams();
+
+  search.set('start', params.start);
+  search.set('end', params.end);
+
+  if (params.method) search.set('method', params.method);
+  if (params.statusCode != null) search.set('status_code', String(params.statusCode));
+  if (params.urlLike) search.set('url:like', params.urlLike); // colon param
+  if (params.levelMin) search.set('level:min', params.levelMin); // colon param
+  if (params.limit != null) search.set('limit', String(params.limit));
+
+  const response = await fetch(
+    `https://${apiHost}/stores/${storeHash}/v3/infrastructure/logs/${projectUuid}?${search.toString()}`,
+    {
+      method: 'GET',
+      headers: {
+        'X-Auth-Token': accessToken,
+        'X-Correlation-Id': getTelemetry().correlationId,
+        Accept: 'application/json',
+      },
+    },
+  );
+
+  assertAuthorized(response);
+
+  if (response.status === 403) {
+    throw new Error(
+      'Infrastructure Logs API not enabled. If you are part of the alpha, contact support@bigcommerce.com to enable it.',
+    );
+  }
+
+  if (response.status === 404) {
+    throw new Error('Project not found. Check the project UUID.');
+  }
+
+  // 400 (bad UUID) and 422 (invalid window/filter) both carry the field-keyed
+  // v3 error envelope — surface its message rather than the bare status.
+  if (response.status === 400 || response.status === 422) {
+    const body: unknown = await response.json().catch(() => null);
+
+    throw new Error(formatV3Error(body) ?? 'Invalid log query.');
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch logs: ${response.status} ${response.statusText}`);
+  }
+
+  const res: unknown = await response.json();
+
+  return queryLogsSchema.parse(res);
+}

--- a/packages/catalyst/tests/mocks/handlers.ts
+++ b/packages/catalyst/tests/mocks/handlers.ts
@@ -138,9 +138,6 @@ export const handlers = [
     });
   }),
 
-  // Handler for queryLogs (historical, single page). The cursor_pagination block
-  // is retained to verify the CLI tolerates a backend that still returns it; the
-  // CLI ignores it while pagination is removed (see parth/logs-query-notes.md).
   http.get('https://:apiHost/stores/:storeHash/v3/infrastructure/logs/:projectUuid', () =>
     HttpResponse.json({
       data: [

--- a/packages/catalyst/tests/mocks/handlers.ts
+++ b/packages/catalyst/tests/mocks/handlers.ts
@@ -138,6 +138,35 @@ export const handlers = [
     });
   }),
 
+  // Handler for queryLogs (historical, single page). The cursor_pagination block
+  // is retained to verify the CLI tolerates a backend that still returns it; the
+  // CLI ignores it while pagination is removed (see parth/logs-query-notes.md).
+  http.get('https://:apiHost/stores/:storeHash/v3/infrastructure/logs/:projectUuid', () =>
+    HttpResponse.json({
+      data: [
+        {
+          id: '01HX9Z8K2J4P7Q6R3T5V8W0YN',
+          timestamp: '2026-06-01T12:34:56.789Z',
+          level: 'error',
+          messages: ['Unhandled exception while rendering /cart'],
+          is_exception: true,
+          request_id: '8f1c2d3e4b5a6978',
+          exception_name: 'TypeError',
+          request: { method: 'GET', url: '/cart', status_code: 500 },
+        },
+      ],
+      meta: {
+        cursor_pagination: {
+          count: 1,
+          per_page: 50,
+          start_cursor: 'cursor_start',
+          end_cursor: 'cursor_end',
+          links: {},
+        },
+      },
+    }),
+  ),
+
   // Handle for createProjects
   http.post('https://:apiHost/stores/:storeHash/v3/infrastructure/projects', () =>
     HttpResponse.json({


### PR DESCRIPTION
## What/Why?
<!--- 
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
--->
Implements the `catalyst logs query` command for Catalyst CLI. This command allows users to query historical log data using Cloudflare's `observability` API. 

Log retention is up to 7 days. 

More information can be found in the docs.

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->
Added unit tests, as well as tested end-to-end using the Catalyst CLI. 

## Migration
<!---
  If you have moved any files around, or made any breaking changes,
  please provide a migration guide for the developers to make rebases easier.
--->
N/A