### PR TITLE
LTRAC-988: Add custom domain command

### DIFF
--- a/packages/catalyst/src/cli/commands/domains.spec.ts
+++ b/packages/catalyst/src/cli/commands/domains.spec.ts
@@ -208,7 +208,9 @@ describe('domain API client', () => {
 
     await expect(
       createDomain(domain, projectUuid, storeHash, accessToken, apiHost),
-    ).rejects.toThrow(/Failed to add domain: 502 Bad Gateway.*Correlation ID:/);
+    ).rejects.toThrow(
+      'Failed to add domain: 502 Bad Gateway. This is a server-side response from the Domains API.',
+    );
   });
 });
 

--- a/packages/catalyst/src/cli/commands/domains.spec.ts
+++ b/packages/catalyst/src/cli/commands/domains.spec.ts
@@ -1,0 +1,302 @@
+import { Command } from 'commander';
+import Conf from 'conf';
+import { http, HttpResponse } from 'msw';
+import { afterAll, afterEach, beforeAll, describe, expect, MockInstance, test, vi } from 'vitest';
+
+import { server } from '../../../tests/mocks/node';
+import { createDomain, getDomain } from '../lib/domains';
+import { consola } from '../lib/logger';
+import { mkTempDir } from '../lib/mk-temp-dir';
+import { getProjectConfig, ProjectConfigSchema } from '../lib/project-config';
+
+import { domains, formatDomain, formatDomainStatus, waitForDomainVerification } from './domains';
+
+let exitMock: MockInstance;
+let tmpDir: string;
+let cleanup: () => Promise<void>;
+let config: Conf<ProjectConfigSchema>;
+
+const projectUuid = '6b202364-10f3-11f1-8bc7-fe9b9d8b14ab';
+const storeHash = 'test-store';
+const accessToken = 'test-token';
+const apiHost = 'api.bigcommerce.com';
+const domain = 'www.example.com';
+
+function writeCredentials() {
+  config.set('storeHash', storeHash);
+  config.set('accessToken', accessToken);
+  config.set('projectUuid', projectUuid);
+}
+
+beforeAll(async () => {
+  process.env.CATALYST_TELEMETRY_DISABLED = '1';
+
+  consola.mockTypes(() => vi.fn());
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  exitMock = vi.spyOn(process, 'exit').mockImplementation(() => null as never);
+
+  [tmpDir, cleanup] = await mkTempDir();
+
+  vi.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+
+  config = getProjectConfig();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  config.delete('storeHash');
+  config.delete('accessToken');
+  config.delete('projectUuid');
+});
+
+afterAll(async () => {
+  delete process.env.CATALYST_TELEMETRY_DISABLED;
+
+  vi.restoreAllMocks();
+  exitMock.mockRestore();
+
+  await cleanup();
+});
+
+describe('command configuration', () => {
+  test('domains has an add subcommand', () => {
+    expect(domains).toBeInstanceOf(Command);
+    expect(domains.name()).toBe('domains');
+    expect(domains.description()).toBe(
+      'Manage custom domains for the current Native Hosting project.',
+    );
+
+    const add = domains.commands.find((command) => command.name() === 'add');
+
+    expect(add).toBeDefined();
+    expect(add?.description()).toBe('Add a custom domain to the current Native Hosting project.');
+    expect(add?.options).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ flags: '--store-hash <hash>' }),
+        expect.objectContaining({ flags: '--access-token <token>' }),
+        expect.objectContaining({ flags: '--api-host <host>' }),
+        expect.objectContaining({ flags: '--project-uuid <uuid>' }),
+        expect.objectContaining({ flags: '--wait' }),
+      ]),
+    );
+  });
+});
+
+describe('formatDomainStatus', () => {
+  test('formats known domain statuses', () => {
+    expect(formatDomainStatus('pending')).toContain('pending');
+    expect(formatDomainStatus('verified')).toContain('active');
+    expect(formatDomainStatus('failed')).toContain('failed');
+    expect(formatDomainStatus('unknown')).toContain('unknown');
+  });
+});
+
+describe('formatDomain', () => {
+  test('formats a domain line with the display status', () => {
+    expect(
+      formatDomain({
+        domain,
+        project_uuid: projectUuid,
+        verification_status: 'verified',
+      }),
+    ).toContain(`${domain} `);
+    expect(
+      formatDomain({
+        domain,
+        project_uuid: projectUuid,
+        verification_status: 'verified',
+      }),
+    ).toContain('active');
+  });
+});
+
+describe('domain API client', () => {
+  test('creates a domain with the expected request body', async () => {
+    let capturedBody: unknown;
+
+    server.use(
+      http.post(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains',
+        async ({ request }) => {
+          capturedBody = await request.json();
+
+          return HttpResponse.json(
+            {
+              data: {
+                domain,
+                project_uuid: projectUuid,
+                verification_status: 'pending',
+              },
+            },
+            { status: 201 },
+          );
+        },
+      ),
+    );
+
+    await expect(
+      createDomain(domain, projectUuid, storeHash, accessToken, apiHost),
+    ).resolves.toEqual({
+      domain,
+      project_uuid: projectUuid,
+      verification_status: 'pending',
+    });
+    expect(capturedBody).toEqual({ domain });
+  });
+
+  test('surfaces disabled API responses', async () => {
+    server.use(
+      http.post(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains',
+        () => new HttpResponse(null, { status: 403 }),
+      ),
+    );
+
+    await expect(
+      createDomain(domain, projectUuid, storeHash, accessToken, apiHost),
+    ).rejects.toThrow('Infrastructure Domains API not enabled');
+  });
+
+  test('surfaces V3 validation errors', async () => {
+    server.use(
+      http.post(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains',
+        () =>
+          HttpResponse.json(
+            {
+              title: 'Domain could not be added.',
+              errors: { domain: 'Enter a valid domain.' },
+            },
+            { status: 422 },
+          ),
+      ),
+    );
+
+    await expect(
+      createDomain(domain, projectUuid, storeHash, accessToken, apiHost),
+    ).rejects.toThrow('Domain could not be added. (domain: Enter a valid domain.)');
+  });
+
+  test('falls back to status text when the error response is not a V3 body', async () => {
+    server.use(
+      http.get(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains/:domain',
+        () => new HttpResponse(null, { status: 500, statusText: 'Internal Server Error' }),
+      ),
+    );
+
+    await expect(getDomain(domain, projectUuid, storeHash, accessToken, apiHost)).rejects.toThrow(
+      'Failed to fetch domain: Internal Server Error',
+    );
+  });
+});
+
+describe('waitForDomainVerification', () => {
+  test('returns immediately when the domain is already verified', async () => {
+    await expect(
+      waitForDomainVerification({
+        domain,
+        projectUuid,
+        storeHash,
+        accessToken,
+        apiHost,
+        intervalMs: 0,
+      }),
+    ).resolves.toEqual({
+      domain,
+      project_uuid: projectUuid,
+      verification_status: 'verified',
+    });
+  });
+
+  test('polls pending domains until they leave pending status', async () => {
+    let requests = 0;
+
+    server.use(
+      http.get(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains/:domain',
+        () => {
+          requests += 1;
+
+          return HttpResponse.json({
+            data: {
+              domain,
+              project_uuid: projectUuid,
+              verification_status: requests === 1 ? 'pending' : 'failed',
+            },
+          });
+        },
+      ),
+    );
+
+    await expect(
+      waitForDomainVerification({
+        domain,
+        projectUuid,
+        storeHash,
+        accessToken,
+        apiHost,
+        intervalMs: 0,
+      }),
+    ).resolves.toEqual({
+      domain,
+      project_uuid: projectUuid,
+      verification_status: 'failed',
+    });
+    expect(requests).toBe(2);
+  });
+
+  test('returns the latest pending status after the timeout expires', async () => {
+    server.use(
+      http.get(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains/:domain',
+        () =>
+          HttpResponse.json({
+            data: {
+              domain,
+              project_uuid: projectUuid,
+              verification_status: 'pending',
+            },
+          }),
+      ),
+    );
+
+    await expect(
+      waitForDomainVerification({
+        domain,
+        projectUuid,
+        storeHash,
+        accessToken,
+        apiHost,
+        timeoutMs: 0,
+      }),
+    ).resolves.toEqual({
+      domain,
+      project_uuid: projectUuid,
+      verification_status: 'pending',
+    });
+  });
+});
+
+describe('add command', () => {
+  test('adds a domain to the linked project', async () => {
+    writeCredentials();
+
+    await domains.parseAsync(['add', domain], { from: 'user' });
+
+    expect(consola.start).toHaveBeenCalledWith(`Adding domain ${domain}...`);
+    expect(consola.success).toHaveBeenCalledWith(`Domain ${domain} added.`);
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining(domain));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining('pending'));
+    expect(exitMock).toHaveBeenCalledWith(0);
+  });
+
+  test('can wait for domain verification after adding', async () => {
+    writeCredentials();
+
+    await domains.parseAsync(['add', domain, '--wait'], { from: 'user' });
+
+    expect(consola.start).toHaveBeenCalledWith(`Waiting for ${domain} to verify...`);
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining('active'));
+  });
+});

--- a/packages/catalyst/src/cli/commands/domains.spec.ts
+++ b/packages/catalyst/src/cli/commands/domains.spec.ts
@@ -177,17 +177,38 @@ describe('domain API client', () => {
     ).rejects.toThrow('Domain could not be added. (domain: Enter a valid domain.)');
   });
 
-  test('falls back to status text when the error response is not a V3 body', async () => {
+  test('falls back to status text when a client error response is not a V3 body', async () => {
     server.use(
       http.get(
         'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains/:domain',
-        () => new HttpResponse(null, { status: 500, statusText: 'Internal Server Error' }),
+        () => new HttpResponse(null, { status: 400, statusText: 'Bad Request' }),
       ),
     );
 
     await expect(getDomain(domain, projectUuid, storeHash, accessToken, apiHost)).rejects.toThrow(
-      'Failed to fetch domain: Internal Server Error',
+      'Failed to fetch domain: Bad Request',
     );
+  });
+
+  test('adds status and correlation details for server errors', async () => {
+    server.use(
+      http.post(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains',
+        () =>
+          HttpResponse.json(
+            {
+              status: 502,
+              title: 'Bad Gateway',
+              errors: {},
+            },
+            { status: 502, statusText: 'Bad Gateway' },
+          ),
+      ),
+    );
+
+    await expect(
+      createDomain(domain, projectUuid, storeHash, accessToken, apiHost),
+    ).rejects.toThrow(/Failed to add domain: 502 Bad Gateway.*Correlation ID:/);
   });
 });
 

--- a/packages/catalyst/src/cli/commands/domains.ts
+++ b/packages/catalyst/src/cli/commands/domains.ts
@@ -1,0 +1,146 @@
+import { Command } from 'commander';
+import { colorize } from 'consola/utils';
+
+import { createDomain, Domain, DomainStatus, getDomain } from '../lib/domains';
+import { consola } from '../lib/logger';
+import { getProjectConfig } from '../lib/project-config';
+import { resolveCredentials } from '../lib/resolve-credentials';
+import {
+  accessTokenOption,
+  apiHostOption,
+  projectUuidOption,
+  resolveProjectUuid,
+  storeHashOption,
+} from '../lib/shared-options';
+import { getTelemetry } from '../lib/telemetry';
+
+const WAIT_INTERVAL_MS = 5000;
+const WAIT_TIMEOUT_MS = 5 * 60 * 1000;
+
+const STATUS_COLORS: Record<DomainStatus, Parameters<typeof colorize>[0]> = {
+  pending: 'yellow',
+  verified: 'green',
+  failed: 'red',
+  unknown: 'gray',
+};
+
+const STATUS_LABELS: Record<DomainStatus, string> = {
+  pending: 'pending',
+  verified: 'active',
+  failed: 'failed',
+  unknown: 'unknown',
+};
+
+interface DomainCommandContext {
+  projectUuid: string;
+  storeHash: string;
+  accessToken: string;
+  apiHost: string;
+}
+
+interface DomainCommandOptions {
+  storeHash?: string;
+  accessToken?: string;
+  apiHost: string;
+  projectUuid?: string;
+}
+
+interface WaitForDomainVerificationOptions extends DomainCommandContext {
+  domain: string;
+  intervalMs?: number;
+  timeoutMs?: number;
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function resolveDomainCommandContext(options: DomainCommandOptions): DomainCommandContext {
+  const config = getProjectConfig();
+  const { storeHash, accessToken } = resolveCredentials(options, config);
+  const projectUuid = resolveProjectUuid(options);
+
+  return {
+    projectUuid,
+    storeHash,
+    accessToken,
+    apiHost: options.apiHost,
+  };
+}
+
+export function formatDomainStatus(status: DomainStatus): string {
+  return colorize(STATUS_COLORS[status], STATUS_LABELS[status]);
+}
+
+export function formatDomain(domain: Domain): string {
+  return `${domain.domain} ${formatDomainStatus(domain.verification_status)}`;
+}
+
+export async function waitForDomainVerification({
+  domain,
+  projectUuid,
+  storeHash,
+  accessToken,
+  apiHost,
+  intervalMs = WAIT_INTERVAL_MS,
+  timeoutMs = WAIT_TIMEOUT_MS,
+}: WaitForDomainVerificationOptions): Promise<Domain> {
+  const startedAt = Date.now();
+  let current = await getDomain(domain, projectUuid, storeHash, accessToken, apiHost);
+
+  while (current.verification_status === 'pending' && Date.now() - startedAt < timeoutMs) {
+    // eslint-disable-next-line no-await-in-loop
+    await sleep(intervalMs);
+    // eslint-disable-next-line no-await-in-loop
+    current = await getDomain(domain, projectUuid, storeHash, accessToken, apiHost);
+  }
+
+  return current;
+}
+
+const add = new Command('add')
+  .configureHelp({ showGlobalOptions: true })
+  .description('Add a custom domain to the current Native Hosting project.')
+  .argument('<domain>', 'Custom domain to add.')
+  .addHelpText(
+    'after',
+    `
+Examples:
+  $ catalyst domains add www.example.com
+
+  # Wait until the domain leaves pending verification
+  $ catalyst domains add www.example.com --wait`,
+  )
+  .addOption(storeHashOption())
+  .addOption(accessTokenOption())
+  .addOption(apiHostOption())
+  .addOption(projectUuidOption())
+  .option('--wait', 'Poll until domain verification completes or times out.')
+  .action(async (domain, options) => {
+    const context = resolveDomainCommandContext(options);
+
+    await getTelemetry().identify(context.storeHash);
+
+    consola.start(`Adding domain ${domain}...`);
+
+    let result = await createDomain(
+      domain,
+      context.projectUuid,
+      context.storeHash,
+      context.accessToken,
+      context.apiHost,
+    );
+
+    consola.success(`Domain ${result.domain} added.`);
+
+    if (options.wait && result.verification_status === 'pending') {
+      consola.start(`Waiting for ${result.domain} to verify...`);
+      result = await waitForDomainVerification({ domain: result.domain, ...context });
+    }
+
+    consola.log(formatDomain(result));
+    process.exit(0);
+  });
+
+export const domains = new Command('domains')
+  .configureHelp({ showGlobalOptions: true })
+  .description('Manage custom domains for the current Native Hosting project.')
+  .addCommand(add);

--- a/packages/catalyst/src/cli/lib/domains.ts
+++ b/packages/catalyst/src/cli/lib/domains.ts
@@ -39,8 +39,8 @@ function authHeaders(accessToken: string) {
   };
 }
 
-function formatResponseStatus(response: Response): string {
-  return [response.status, response.statusText].filter(Boolean).join(' ');
+function formatResponseStatus(response: Response, message?: string): string {
+  return [response.status, response.statusText || message].filter(Boolean).join(' ');
 }
 
 async function getErrorMessage(response: Response, action: string): Promise<string> {
@@ -48,9 +48,9 @@ async function getErrorMessage(response: Response, action: string): Promise<stri
   const message = formatV3Error(body);
 
   if (response.status >= 500) {
-    const status = formatResponseStatus(response);
+    const status = formatResponseStatus(response, message);
 
-    return `${action}: ${status}. This is a server-side response from the Domains API. Correlation ID: ${getTelemetry().correlationId}.`;
+    return `${action}: ${status}. This is a server-side response from the Domains API.`;
   }
 
   return message ?? `${action}: ${response.statusText}`;

--- a/packages/catalyst/src/cli/lib/domains.ts
+++ b/packages/catalyst/src/cli/lib/domains.ts
@@ -39,13 +39,24 @@ function authHeaders(accessToken: string) {
   };
 }
 
-async function getErrorMessage(response: Response, fallback: string): Promise<string> {
-  const body: unknown = await response.json().catch(() => null);
-
-  return formatV3Error(body) ?? fallback;
+function formatResponseStatus(response: Response): string {
+  return [response.status, response.statusText].filter(Boolean).join(' ');
 }
 
-async function assertDomainResponse(response: Response, fallback: string): Promise<void> {
+async function getErrorMessage(response: Response, action: string): Promise<string> {
+  const body: unknown = await response.json().catch(() => null);
+  const message = formatV3Error(body);
+
+  if (response.status >= 500) {
+    const status = formatResponseStatus(response);
+
+    return `${action}: ${status}. This is a server-side response from the Domains API. Correlation ID: ${getTelemetry().correlationId}.`;
+  }
+
+  return message ?? `${action}: ${response.statusText}`;
+}
+
+async function assertDomainResponse(response: Response, action: string): Promise<void> {
   assertAuthorized(response);
 
   if (response.status === 403) {
@@ -53,7 +64,7 @@ async function assertDomainResponse(response: Response, fallback: string): Promi
   }
 
   if (!response.ok) {
-    throw new Error(await getErrorMessage(response, fallback));
+    throw new Error(await getErrorMessage(response, action));
   }
 }
 
@@ -73,7 +84,7 @@ export async function createDomain(
     body: JSON.stringify({ domain }),
   });
 
-  await assertDomainResponse(response, `Failed to add domain: ${response.statusText}`);
+  await assertDomainResponse(response, 'Failed to add domain');
 
   const result: unknown = await response.json();
 
@@ -92,7 +103,7 @@ export async function getDomain(
     headers: authHeaders(accessToken),
   });
 
-  await assertDomainResponse(response, `Failed to fetch domain: ${response.statusText}`);
+  await assertDomainResponse(response, 'Failed to fetch domain');
 
   const result: unknown = await response.json();
 

--- a/packages/catalyst/src/cli/lib/domains.ts
+++ b/packages/catalyst/src/cli/lib/domains.ts
@@ -1,0 +1,100 @@
+import { z } from 'zod';
+
+import { assertAuthorized } from './auth-errors';
+import { formatV3Error } from './observability';
+import { getTelemetry } from './telemetry';
+
+export const domainStatusSchema = z.enum(['pending', 'verified', 'failed', 'unknown']);
+
+export type DomainStatus = z.infer<typeof domainStatusSchema>;
+
+const domainSchema = z.object({
+  domain: z.string(),
+  project_uuid: z.string(),
+  verification_status: domainStatusSchema,
+});
+
+const domainResponseSchema = z.object({
+  data: domainSchema,
+});
+
+export type Domain = z.infer<typeof domainSchema>;
+
+const DOMAINS_API_NOT_ENABLED =
+  'Infrastructure Domains API not enabled. If you are part of the alpha, contact support@bigcommerce.com to enable it.';
+
+function domainsUrl(storeHash: string, projectUuid: string, apiHost: string) {
+  return `https://${apiHost}/stores/${storeHash}/v3/infrastructure/projects/${projectUuid}/domains`;
+}
+
+function domainUrl(storeHash: string, projectUuid: string, domain: string, apiHost: string) {
+  return `${domainsUrl(storeHash, projectUuid, apiHost)}/${encodeURIComponent(domain)}`;
+}
+
+function authHeaders(accessToken: string) {
+  return {
+    Accept: 'application/json',
+    'X-Auth-Token': accessToken,
+    'X-Correlation-Id': getTelemetry().correlationId,
+  };
+}
+
+async function getErrorMessage(response: Response, fallback: string): Promise<string> {
+  const body: unknown = await response.json().catch(() => null);
+
+  return formatV3Error(body) ?? fallback;
+}
+
+async function assertDomainResponse(response: Response, fallback: string): Promise<void> {
+  assertAuthorized(response);
+
+  if (response.status === 403) {
+    throw new Error(DOMAINS_API_NOT_ENABLED);
+  }
+
+  if (!response.ok) {
+    throw new Error(await getErrorMessage(response, fallback));
+  }
+}
+
+export async function createDomain(
+  domain: string,
+  projectUuid: string,
+  storeHash: string,
+  accessToken: string,
+  apiHost: string,
+): Promise<Domain> {
+  const response = await fetch(domainsUrl(storeHash, projectUuid, apiHost), {
+    method: 'POST',
+    headers: {
+      ...authHeaders(accessToken),
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ domain }),
+  });
+
+  await assertDomainResponse(response, `Failed to add domain: ${response.statusText}`);
+
+  const result: unknown = await response.json();
+
+  return domainResponseSchema.parse(result).data;
+}
+
+export async function getDomain(
+  domain: string,
+  projectUuid: string,
+  storeHash: string,
+  accessToken: string,
+  apiHost: string,
+): Promise<Domain> {
+  const response = await fetch(domainUrl(storeHash, projectUuid, domain, apiHost), {
+    method: 'GET',
+    headers: authHeaders(accessToken),
+  });
+
+  await assertDomainResponse(response, `Failed to fetch domain: ${response.statusText}`);
+
+  const result: unknown = await response.json();
+
+  return domainResponseSchema.parse(result).data;
+}

--- a/packages/catalyst/src/cli/program.ts
+++ b/packages/catalyst/src/cli/program.ts
@@ -12,6 +12,7 @@ import { build } from './commands/build';
 import { channel } from './commands/channel';
 import { create } from './commands/create';
 import { deploy } from './commands/deploy';
+import { domains } from './commands/domains';
 import { env } from './commands/env';
 import { logs } from './commands/logs';
 import { project } from './commands/project';
@@ -87,6 +88,7 @@ program
   .addCommand(start)
   .addCommand(build)
   .addCommand(deploy)
+  .addCommand(domains)
   .addCommand(logs)
   .addCommand(project)
   .addCommand(env)

--- a/packages/catalyst/tests/mocks/handlers.ts
+++ b/packages/catalyst/tests/mocks/handlers.ts
@@ -25,6 +25,39 @@ export const handlers = [
     }),
   ),
 
+  // Handler for createDomain
+  http.post(
+    'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains',
+    async ({ request }) => {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      const body = (await request.json()) as { domain: string };
+
+      return HttpResponse.json(
+        {
+          data: {
+            domain: body.domain,
+            project_uuid: '6b202364-10f3-11f1-8bc7-fe9b9d8b14ab',
+            verification_status: 'pending',
+          },
+        },
+        { status: 201 },
+      );
+    },
+  ),
+
+  // Handler for getDomain
+  http.get(
+    'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains/:domain',
+    ({ params }) =>
+      HttpResponse.json({
+        data: {
+          domain: params.domain,
+          project_uuid: params.projectUuid,
+          verification_status: 'verified',
+        },
+      }),
+  ),
+
   // Handler for fetchProjects
   http.get('https://:apiHost/stores/:storeHash/v3/infrastructure/projects', () =>
     HttpResponse.json({


### PR DESCRIPTION
## What/Why?
Refs LTRAC-988

Adds the `catalyst domains add <domain>` workflow and a shared domain API client for the Native Hosting domain endpoints. The command resolves existing CLI credentials/project config, displays the returned verification status, and can poll until a pending domain leaves pending status.

DNS record rendering is intentionally not included because the current API response only exposes domain, project UUID, and verification status.

## Testing
- `node_modules/.bin/vitest run src/cli/commands/domains.spec.ts`
- `node_modules/.bin/tsc --noEmit`
- `node_modules/.bin/eslint src/cli/commands/domains.ts src/cli/commands/domains.spec.ts src/cli/lib/domains.ts tests/mocks/handlers.ts src/cli/program.ts --max-warnings 0`

Attempted full `node_modules/.bin/vitest run --coverage`, but this local environment fails unrelated existing tests that require `api.github.com` network access and npm package env vars.

## Migration
None.