### PR TITLE
LTRAC-989: List custom domain statuses

### DIFF
--- a/packages/catalyst/src/cli/commands/domains.spec.ts
+++ b/packages/catalyst/src/cli/commands/domains.spec.ts
@@ -4,7 +4,7 @@ import { http, HttpResponse } from 'msw';
 import { afterAll, afterEach, beforeAll, describe, expect, MockInstance, test, vi } from 'vitest';
 
 import { server } from '../../../tests/mocks/node';
-import { createDomain, getDomain } from '../lib/domains';
+import { createDomain, getDomain, listDomains } from '../lib/domains';
 import { consola } from '../lib/logger';
 import { mkTempDir } from '../lib/mk-temp-dir';
 import { getProjectConfig, ProjectConfigSchema } from '../lib/project-config';
@@ -59,7 +59,7 @@ afterAll(async () => {
 });
 
 describe('command configuration', () => {
-  test('domains has an add subcommand', () => {
+  test('domains has add and list subcommands', () => {
     expect(domains).toBeInstanceOf(Command);
     expect(domains.name()).toBe('domains');
     expect(domains.description()).toBe(
@@ -67,6 +67,7 @@ describe('command configuration', () => {
     );
 
     const add = domains.commands.find((command) => command.name() === 'add');
+    const list = domains.commands.find((command) => command.name() === 'list');
 
     expect(add).toBeDefined();
     expect(add?.description()).toBe('Add a custom domain to the current Native Hosting project.');
@@ -77,6 +78,19 @@ describe('command configuration', () => {
         expect.objectContaining({ flags: '--api-host <host>' }),
         expect.objectContaining({ flags: '--project-uuid <uuid>' }),
         expect.objectContaining({ flags: '--wait' }),
+      ]),
+    );
+
+    expect(list).toBeDefined();
+    expect(list?.description()).toBe('List custom domains for the current Native Hosting project.');
+    expect(list?.options).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ flags: '--store-hash <hash>' }),
+        expect.objectContaining({ flags: '--access-token <token>' }),
+        expect.objectContaining({ flags: '--api-host <host>' }),
+        expect.objectContaining({ flags: '--project-uuid <uuid>' }),
+        expect.objectContaining({ flags: '--domain <domain>' }),
+        expect.objectContaining({ flags: '--status <status>' }),
       ]),
     );
   });
@@ -212,6 +226,59 @@ describe('domain API client', () => {
       'Failed to add domain: 502 Bad Gateway. This is a server-side response from the Domains API.',
     );
   });
+
+  test('lists domains for a project', async () => {
+    await expect(listDomains(projectUuid, storeHash, accessToken, apiHost)).resolves.toEqual([
+      {
+        domain: 'www.example.com',
+        project_uuid: projectUuid,
+        verification_status: 'pending',
+      },
+      {
+        domain: 'shop.example.com',
+        project_uuid: projectUuid,
+        verification_status: 'verified',
+      },
+    ]);
+  });
+
+  test('passes list filters to the API', async () => {
+    let capturedSearchParams: URLSearchParams | undefined;
+
+    server.use(
+      http.get(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains',
+        ({ request }) => {
+          capturedSearchParams = new URL(request.url).searchParams;
+
+          return HttpResponse.json({
+            data: [
+              {
+                domain,
+                project_uuid: projectUuid,
+                verification_status: 'pending',
+              },
+            ],
+          });
+        },
+      ),
+    );
+
+    await expect(
+      listDomains(projectUuid, storeHash, accessToken, apiHost, {
+        domains: [domain],
+        verificationStatus: 'pending',
+      }),
+    ).resolves.toEqual([
+      {
+        domain,
+        project_uuid: projectUuid,
+        verification_status: 'pending',
+      },
+    ]);
+    expect(capturedSearchParams?.get('domain:in')).toBe(domain);
+    expect(capturedSearchParams?.get('verification_status')).toBe('pending');
+  });
 });
 
 describe('waitForDomainVerification', () => {
@@ -321,5 +388,67 @@ describe('add command', () => {
 
     expect(consola.start).toHaveBeenCalledWith(`Waiting for ${domain} to verify...`);
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining('active'));
+  });
+});
+
+describe('list command', () => {
+  test('lists domains for the linked project', async () => {
+    writeCredentials();
+
+    await domains.parseAsync(['list'], { from: 'user' });
+
+    expect(consola.start).toHaveBeenCalledWith('Fetching domains...');
+    expect(consola.success).toHaveBeenCalledWith('Domains fetched.');
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining('www.example.com'));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining('pending'));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining('shop.example.com'));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining('active'));
+    expect(exitMock).toHaveBeenCalledWith(0);
+  });
+
+  test('passes filters from options', async () => {
+    let capturedSearchParams: URLSearchParams | undefined;
+
+    server.use(
+      http.get(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains',
+        ({ request }) => {
+          capturedSearchParams = new URL(request.url).searchParams;
+
+          return HttpResponse.json({
+            data: [
+              {
+                domain,
+                project_uuid: projectUuid,
+                verification_status: 'pending',
+              },
+            ],
+          });
+        },
+      ),
+    );
+
+    writeCredentials();
+
+    await domains.parseAsync(['list', '--domain', domain, '--status', 'pending'], { from: 'user' });
+
+    expect(capturedSearchParams?.get('domain:in')).toBe(domain);
+    expect(capturedSearchParams?.get('verification_status')).toBe('pending');
+  });
+
+  test('reports when no domains are configured', async () => {
+    server.use(
+      http.get(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains',
+        () => HttpResponse.json({ data: [] }),
+      ),
+    );
+
+    writeCredentials();
+
+    await domains.parseAsync(['list'], { from: 'user' });
+
+    expect(consola.info).toHaveBeenCalledWith('No custom domains found.');
+    expect(exitMock).toHaveBeenCalledWith(0);
   });
 });

--- a/packages/catalyst/src/cli/commands/domains.ts
+++ b/packages/catalyst/src/cli/commands/domains.ts
@@ -1,7 +1,14 @@
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import { colorize } from 'consola/utils';
 
-import { createDomain, Domain, DomainStatus, getDomain } from '../lib/domains';
+import {
+  createDomain,
+  Domain,
+  DomainStatus,
+  DomainStatusFilter,
+  getDomain,
+  listDomains,
+} from '../lib/domains';
 import { consola } from '../lib/logger';
 import { getProjectConfig } from '../lib/project-config';
 import { resolveCredentials } from '../lib/resolve-credentials';
@@ -16,6 +23,7 @@ import { getTelemetry } from '../lib/telemetry';
 
 const WAIT_INTERVAL_MS = 5000;
 const WAIT_TIMEOUT_MS = 5 * 60 * 1000;
+const DOMAIN_STATUS_FILTERS: DomainStatusFilter[] = ['pending', 'verified', 'failed'];
 
 const STATUS_COLORS: Record<DomainStatus, Parameters<typeof colorize>[0]> = {
   pending: 'yellow',
@@ -140,7 +148,61 @@ Examples:
     process.exit(0);
   });
 
+const list = new Command('list')
+  .configureHelp({ showGlobalOptions: true })
+  .description('List custom domains for the current Native Hosting project.')
+  .addHelpText(
+    'after',
+    `
+Examples:
+  $ catalyst domains list
+
+  # Show pending domains only
+  $ catalyst domains list --status pending`,
+  )
+  .addOption(storeHashOption())
+  .addOption(accessTokenOption())
+  .addOption(apiHostOption())
+  .addOption(projectUuidOption())
+  .option('--domain <domain>', 'Only show a specific domain.')
+  .addOption(
+    new Option('--status <status>', 'Filter by verification status.').choices(
+      DOMAIN_STATUS_FILTERS,
+    ),
+  )
+  .action(async (options) => {
+    const context = resolveDomainCommandContext(options);
+
+    await getTelemetry().identify(context.storeHash);
+
+    consola.start('Fetching domains...');
+
+    const result = await listDomains(
+      context.projectUuid,
+      context.storeHash,
+      context.accessToken,
+      context.apiHost,
+      {
+        domains: options.domain ? [options.domain] : undefined,
+        verificationStatus: options.status,
+      },
+    );
+
+    consola.success('Domains fetched.');
+
+    if (result.length === 0) {
+      consola.info('No custom domains found.');
+      process.exit(0);
+
+      return;
+    }
+
+    result.forEach((item) => consola.log(formatDomain(item)));
+    process.exit(0);
+  });
+
 export const domains = new Command('domains')
   .configureHelp({ showGlobalOptions: true })
   .description('Manage custom domains for the current Native Hosting project.')
-  .addCommand(add);
+  .addCommand(add)
+  .addCommand(list);

--- a/packages/catalyst/src/cli/lib/domains.ts
+++ b/packages/catalyst/src/cli/lib/domains.ts
@@ -18,7 +18,17 @@ const domainResponseSchema = z.object({
   data: domainSchema,
 });
 
+const domainListResponseSchema = z.object({
+  data: z.array(domainSchema),
+});
+
 export type Domain = z.infer<typeof domainSchema>;
+export type DomainStatusFilter = Exclude<DomainStatus, 'unknown'>;
+
+interface ListDomainsFilters {
+  domains?: string[];
+  verificationStatus?: DomainStatusFilter;
+}
 
 const DOMAINS_API_NOT_ENABLED =
   'Infrastructure Domains API not enabled. If you are part of the alpha, contact support@bigcommerce.com to enable it.';
@@ -108,4 +118,35 @@ export async function getDomain(
   const result: unknown = await response.json();
 
   return domainResponseSchema.parse(result).data;
+}
+
+export async function listDomains(
+  projectUuid: string,
+  storeHash: string,
+  accessToken: string,
+  apiHost: string,
+  filters: ListDomainsFilters = {},
+): Promise<Domain[]> {
+  const search = new URLSearchParams();
+
+  if (filters.domains && filters.domains.length > 0) {
+    search.set('domain:in', filters.domains.join(','));
+  }
+
+  if (filters.verificationStatus) {
+    search.set('verification_status', filters.verificationStatus);
+  }
+
+  const query = search.toString();
+  const url = `${domainsUrl(storeHash, projectUuid, apiHost)}${query ? `?${query}` : ''}`;
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: authHeaders(accessToken),
+  });
+
+  await assertDomainResponse(response, 'Failed to fetch domains');
+
+  const result: unknown = await response.json();
+
+  return domainListResponseSchema.parse(result).data;
 }

--- a/packages/catalyst/tests/mocks/handlers.ts
+++ b/packages/catalyst/tests/mocks/handlers.ts
@@ -45,6 +45,26 @@ export const handlers = [
     },
   ),
 
+  // Handler for listDomains
+  http.get(
+    'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains',
+    ({ params }) =>
+      HttpResponse.json({
+        data: [
+          {
+            domain: 'www.example.com',
+            project_uuid: params.projectUuid,
+            verification_status: 'pending',
+          },
+          {
+            domain: 'shop.example.com',
+            project_uuid: params.projectUuid,
+            verification_status: 'verified',
+          },
+        ],
+      }),
+  ),
+
   // Handler for getDomain
   http.get(
     'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains/:domain',


### PR DESCRIPTION
## What/Why?
Refs LTRAC-989

Adds `catalyst domains list` on top of the shared domain command/API client from #3070. The command resolves existing CLI credentials/project config, supports optional `--domain` and `--status` filters, and renders color-coded domain statuses with an explicit empty state.

This PR is stacked after #3070 and should be reviewed/merged after that PR.

## Testing
- `node_modules/.bin/vitest run src/cli/commands/domains.spec.ts`
- `node_modules/.bin/tsc --noEmit`
- `node_modules/.bin/eslint src/cli/commands/domains.ts src/cli/commands/domains.spec.ts src/cli/lib/domains.ts tests/mocks/handlers.ts --max-warnings 0`

Full `node_modules/.bin/vitest run --coverage` was attempted on #3070, but this local environment fails unrelated existing tests that require `api.github.com` network access and npm package env vars.

## Migration
None.