### PR TITLE
LTRAC-990: Show custom domain status

### DIFF
--- a/packages/catalyst/src/cli/commands/domains.spec.ts
+++ b/packages/catalyst/src/cli/commands/domains.spec.ts
@@ -59,7 +59,7 @@ afterAll(async () => {
 });
 
 describe('command configuration', () => {
-  test('domains has add and list subcommands', () => {
+  test('domains has add, list, and status subcommands', () => {
     expect(domains).toBeInstanceOf(Command);
     expect(domains.name()).toBe('domains');
     expect(domains.description()).toBe(
@@ -68,6 +68,7 @@ describe('command configuration', () => {
 
     const add = domains.commands.find((command) => command.name() === 'add');
     const list = domains.commands.find((command) => command.name() === 'list');
+    const status = domains.commands.find((command) => command.name() === 'status');
 
     expect(add).toBeDefined();
     expect(add?.description()).toBe('Add a custom domain to the current Native Hosting project.');
@@ -91,6 +92,20 @@ describe('command configuration', () => {
         expect.objectContaining({ flags: '--project-uuid <uuid>' }),
         expect.objectContaining({ flags: '--domain <domain>' }),
         expect.objectContaining({ flags: '--status <status>' }),
+      ]),
+    );
+
+    expect(status).toBeDefined();
+    expect(status?.description()).toBe(
+      'Show the status of a custom domain on the current Native Hosting project.',
+    );
+    expect(status?.options).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ flags: '--store-hash <hash>' }),
+        expect.objectContaining({ flags: '--access-token <token>' }),
+        expect.objectContaining({ flags: '--api-host <host>' }),
+        expect.objectContaining({ flags: '--project-uuid <uuid>' }),
+        expect.objectContaining({ flags: '--wait' }),
       ]),
     );
   });
@@ -450,5 +465,48 @@ describe('list command', () => {
 
     expect(consola.info).toHaveBeenCalledWith('No custom domains found.');
     expect(exitMock).toHaveBeenCalledWith(0);
+  });
+});
+
+describe('status command', () => {
+  test('shows a domain status for the linked project', async () => {
+    writeCredentials();
+
+    await domains.parseAsync(['status', domain], { from: 'user' });
+
+    expect(consola.start).toHaveBeenCalledWith(`Fetching status for ${domain}...`);
+    expect(consola.success).toHaveBeenCalledWith('Domain status fetched.');
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining(domain));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining('active'));
+    expect(exitMock).toHaveBeenCalledWith(0);
+  });
+
+  test('can wait for a pending domain to leave pending status', async () => {
+    let requests = 0;
+
+    server.use(
+      http.get(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains/:domain',
+        () => {
+          requests += 1;
+
+          return HttpResponse.json({
+            data: {
+              domain,
+              project_uuid: projectUuid,
+              verification_status: requests === 1 ? 'pending' : 'verified',
+            },
+          });
+        },
+      ),
+    );
+
+    writeCredentials();
+
+    await domains.parseAsync(['status', domain, '--wait'], { from: 'user' });
+
+    expect(consola.start).toHaveBeenCalledWith(`Waiting for ${domain} to verify...`);
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining('active'));
+    expect(requests).toBe(2);
   });
 });

--- a/packages/catalyst/src/cli/commands/domains.ts
+++ b/packages/catalyst/src/cli/commands/domains.ts
@@ -201,8 +201,53 @@ Examples:
     process.exit(0);
   });
 
+const showStatus = new Command('status')
+  .configureHelp({ showGlobalOptions: true })
+  .description('Show the status of a custom domain on the current Native Hosting project.')
+  .argument('<domain>', 'Custom domain to check.')
+  .addHelpText(
+    'after',
+    `
+Examples:
+  $ catalyst domains status www.example.com
+
+  # Wait until the domain leaves pending verification
+  $ catalyst domains status www.example.com --wait`,
+  )
+  .addOption(storeHashOption())
+  .addOption(accessTokenOption())
+  .addOption(apiHostOption())
+  .addOption(projectUuidOption())
+  .option('--wait', 'Poll until domain verification completes or times out.')
+  .action(async (domain, options) => {
+    const context = resolveDomainCommandContext(options);
+
+    await getTelemetry().identify(context.storeHash);
+
+    consola.start(`Fetching status for ${domain}...`);
+
+    let result = await getDomain(
+      domain,
+      context.projectUuid,
+      context.storeHash,
+      context.accessToken,
+      context.apiHost,
+    );
+
+    consola.success('Domain status fetched.');
+
+    if (options.wait && result.verification_status === 'pending') {
+      consola.start(`Waiting for ${result.domain} to verify...`);
+      result = await waitForDomainVerification({ domain: result.domain, ...context });
+    }
+
+    consola.log(formatDomain(result));
+    process.exit(0);
+  });
+
 export const domains = new Command('domains')
   .configureHelp({ showGlobalOptions: true })
   .description('Manage custom domains for the current Native Hosting project.')
   .addCommand(add)
-  .addCommand(list);
+  .addCommand(list)
+  .addCommand(showStatus);


### PR DESCRIPTION
## What/Why?
Refs LTRAC-990

Adds `catalyst domains status <domain>` on top of the domain command work from #3070 and #3071. The command fetches one domain, renders the color-coded status, and supports `--wait` for pending verification.

This PR is stacked after #3071 and should be reviewed/merged after that PR.

## Testing
- `node_modules/.bin/vitest run src/cli/commands/domains.spec.ts`
- `node_modules/.bin/tsc --noEmit`
- `node_modules/.bin/eslint src/cli/commands/domains.ts src/cli/commands/domains.spec.ts --max-warnings 0`

Full `node_modules/.bin/vitest run --coverage` was attempted on #3070, but this local environment fails unrelated existing tests that require `api.github.com` network access and npm package env vars.

## Migration
None.