### PR TITLE
LTRAC-991: Remove custom domain command

### DIFF
--- a/packages/catalyst/src/cli/commands/domains.spec.ts
+++ b/packages/catalyst/src/cli/commands/domains.spec.ts
@@ -1,15 +1,22 @@
+import { confirm } from '@inquirer/prompts';
 import { Command } from 'commander';
 import Conf from 'conf';
 import { http, HttpResponse } from 'msw';
 import { afterAll, afterEach, beforeAll, describe, expect, MockInstance, test, vi } from 'vitest';
 
 import { server } from '../../../tests/mocks/node';
-import { createDomain, getDomain, listDomains } from '../lib/domains';
+import { createDomain, deleteDomain, getDomain, listDomains } from '../lib/domains';
 import { consola } from '../lib/logger';
 import { mkTempDir } from '../lib/mk-temp-dir';
 import { getProjectConfig, ProjectConfigSchema } from '../lib/project-config';
 
 import { domains, formatDomain, formatDomainStatus, waitForDomainVerification } from './domains';
+
+vi.mock('@inquirer/prompts', () => ({
+  confirm: vi.fn(),
+}));
+
+const confirmMock = vi.mocked(confirm);
 
 let exitMock: MockInstance;
 let tmpDir: string;
@@ -59,7 +66,7 @@ afterAll(async () => {
 });
 
 describe('command configuration', () => {
-  test('domains has add, list, and status subcommands', () => {
+  test('domains has add, list, status, and remove subcommands', () => {
     expect(domains).toBeInstanceOf(Command);
     expect(domains.name()).toBe('domains');
     expect(domains.description()).toBe(
@@ -69,6 +76,7 @@ describe('command configuration', () => {
     const add = domains.commands.find((command) => command.name() === 'add');
     const list = domains.commands.find((command) => command.name() === 'list');
     const status = domains.commands.find((command) => command.name() === 'status');
+    const remove = domains.commands.find((command) => command.name() === 'remove');
 
     expect(add).toBeDefined();
     expect(add?.description()).toBe('Add a custom domain to the current Native Hosting project.');
@@ -106,6 +114,20 @@ describe('command configuration', () => {
         expect.objectContaining({ flags: '--api-host <host>' }),
         expect.objectContaining({ flags: '--project-uuid <uuid>' }),
         expect.objectContaining({ flags: '--wait' }),
+      ]),
+    );
+
+    expect(remove).toBeDefined();
+    expect(remove?.description()).toBe(
+      'Remove a custom domain from the current Native Hosting project.',
+    );
+    expect(remove?.options).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ flags: '--store-hash <hash>' }),
+        expect.objectContaining({ flags: '--access-token <token>' }),
+        expect.objectContaining({ flags: '--api-host <host>' }),
+        expect.objectContaining({ flags: '--project-uuid <uuid>' }),
+        expect.objectContaining({ flags: '--force' }),
       ]),
     );
   });
@@ -293,6 +315,26 @@ describe('domain API client', () => {
     ]);
     expect(capturedSearchParams?.get('domain:in')).toBe(domain);
     expect(capturedSearchParams?.get('verification_status')).toBe('pending');
+  });
+
+  test('deletes a domain', async () => {
+    let deletedDomain: string | readonly string[] | undefined;
+
+    server.use(
+      http.delete(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains/:domain',
+        ({ params }) => {
+          deletedDomain = params.domain;
+
+          return new HttpResponse(null, { status: 204 });
+        },
+      ),
+    );
+
+    await expect(
+      deleteDomain(domain, projectUuid, storeHash, accessToken, apiHost),
+    ).resolves.toBeUndefined();
+    expect(deletedDomain).toBe(domain);
   });
 });
 
@@ -508,5 +550,83 @@ describe('status command', () => {
     expect(consola.start).toHaveBeenCalledWith(`Waiting for ${domain} to verify...`);
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining('active'));
     expect(requests).toBe(2);
+  });
+});
+
+describe('remove command', () => {
+  test('confirms before removing an active domain', async () => {
+    confirmMock.mockResolvedValue(true);
+
+    writeCredentials();
+
+    await domains.parseAsync(['remove', domain], { from: 'user' });
+
+    expect(consola.start).toHaveBeenCalledWith(`Fetching status for ${domain}...`);
+    expect(confirmMock).toHaveBeenCalledWith({
+      message: `Remove active domain ${domain}? Traffic may stop routing to this project.`,
+      default: false,
+    });
+    expect(consola.start).toHaveBeenCalledWith(`Removing domain ${domain}...`);
+    expect(consola.success).toHaveBeenCalledWith(`Domain ${domain} removed.`);
+    expect(exitMock).toHaveBeenCalledWith(0);
+  });
+
+  test('does not remove an active domain when confirmation is declined', async () => {
+    let deleteRequests = 0;
+
+    server.use(
+      http.delete(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains/:domain',
+        () => {
+          deleteRequests += 1;
+
+          return new HttpResponse(null, { status: 204 });
+        },
+      ),
+    );
+
+    confirmMock.mockResolvedValue(false);
+
+    writeCredentials();
+
+    await domains.parseAsync(['remove', domain], { from: 'user' });
+
+    expect(consola.info).toHaveBeenCalledWith('Aborted. No domain was removed.');
+    expect(deleteRequests).toBe(0);
+    expect(exitMock).toHaveBeenCalledWith(0);
+  });
+
+  test('skips confirmation with --force', async () => {
+    confirmMock.mockResolvedValue(false);
+
+    writeCredentials();
+
+    await domains.parseAsync(['remove', domain, '--force'], { from: 'user' });
+
+    expect(confirmMock).not.toHaveBeenCalled();
+    expect(consola.success).toHaveBeenCalledWith(`Domain ${domain} removed.`);
+  });
+
+  test('does not prompt before removing a pending domain', async () => {
+    server.use(
+      http.get(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains/:domain',
+        () =>
+          HttpResponse.json({
+            data: {
+              domain,
+              project_uuid: projectUuid,
+              verification_status: 'pending',
+            },
+          }),
+      ),
+    );
+
+    writeCredentials();
+
+    await domains.parseAsync(['remove', domain], { from: 'user' });
+
+    expect(confirmMock).not.toHaveBeenCalled();
+    expect(consola.success).toHaveBeenCalledWith(`Domain ${domain} removed.`);
   });
 });

--- a/packages/catalyst/src/cli/commands/domains.ts
+++ b/packages/catalyst/src/cli/commands/domains.ts
@@ -1,8 +1,10 @@
+import { confirm } from '@inquirer/prompts';
 import { Command, Option } from 'commander';
 import { colorize } from 'consola/utils';
 
 import {
   createDomain,
+  deleteDomain,
   Domain,
   DomainStatus,
   DomainStatusFilter,
@@ -245,9 +247,71 @@ Examples:
     process.exit(0);
   });
 
+const remove = new Command('remove')
+  .configureHelp({ showGlobalOptions: true })
+  .description('Remove a custom domain from the current Native Hosting project.')
+  .argument('<domain>', 'Custom domain to remove.')
+  .addHelpText(
+    'after',
+    `
+Examples:
+  $ catalyst domains remove www.example.com
+
+  # Skip confirmation for an active domain
+  $ catalyst domains remove www.example.com --force`,
+  )
+  .addOption(storeHashOption())
+  .addOption(accessTokenOption())
+  .addOption(apiHostOption())
+  .addOption(projectUuidOption())
+  .option('--force', 'Skip the confirmation prompt before removing an active domain.')
+  .action(async (domain, options) => {
+    const context = resolveDomainCommandContext(options);
+
+    await getTelemetry().identify(context.storeHash);
+
+    consola.start(`Fetching status for ${domain}...`);
+
+    const current = await getDomain(
+      domain,
+      context.projectUuid,
+      context.storeHash,
+      context.accessToken,
+      context.apiHost,
+    );
+
+    if (current.verification_status === 'verified' && !options.force) {
+      const confirmed = await confirm({
+        message: `Remove active domain ${current.domain}? Traffic may stop routing to this project.`,
+        default: false,
+      });
+
+      if (!confirmed) {
+        consola.info('Aborted. No domain was removed.');
+        process.exit(0);
+
+        return;
+      }
+    }
+
+    consola.start(`Removing domain ${current.domain}...`);
+
+    await deleteDomain(
+      current.domain,
+      context.projectUuid,
+      context.storeHash,
+      context.accessToken,
+      context.apiHost,
+    );
+
+    consola.success(`Domain ${current.domain} removed.`);
+    process.exit(0);
+  });
+
 export const domains = new Command('domains')
   .configureHelp({ showGlobalOptions: true })
   .description('Manage custom domains for the current Native Hosting project.')
   .addCommand(add)
   .addCommand(list)
-  .addCommand(showStatus);
+  .addCommand(showStatus)
+  .addCommand(remove);

--- a/packages/catalyst/src/cli/lib/domains.ts
+++ b/packages/catalyst/src/cli/lib/domains.ts
@@ -150,3 +150,18 @@ export async function listDomains(
 
   return domainListResponseSchema.parse(result).data;
 }
+
+export async function deleteDomain(
+  domain: string,
+  projectUuid: string,
+  storeHash: string,
+  accessToken: string,
+  apiHost: string,
+): Promise<void> {
+  const response = await fetch(domainUrl(storeHash, projectUuid, domain, apiHost), {
+    method: 'DELETE',
+    headers: authHeaders(accessToken),
+  });
+
+  await assertDomainResponse(response, `Failed to remove domain: ${response.statusText}`);
+}

--- a/packages/catalyst/tests/mocks/handlers.ts
+++ b/packages/catalyst/tests/mocks/handlers.ts
@@ -78,6 +78,12 @@ export const handlers = [
       }),
   ),
 
+  // Handler for deleteDomain
+  http.delete(
+    'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains/:domain',
+    () => new HttpResponse(null, { status: 204 }),
+  ),
+
   // Handler for fetchProjects
   http.get('https://:apiHost/stores/:storeHash/v3/infrastructure/projects', () =>
     HttpResponse.json({


### PR DESCRIPTION
## What/Why?
Refs LTRAC-991

Adds `catalyst domains remove <domain>` on top of the stacked domain command work. The command fetches the current domain status before deleting, prompts before removing an active domain, supports `--force` to skip the prompt, and calls the Native Hosting domain delete endpoint.

This PR is stacked after #3072 and should be reviewed/merged after that PR.

## Testing
- `node_modules/.bin/vitest run src/cli/commands/domains.spec.ts`
- `node_modules/.bin/tsc --noEmit`
- `node_modules/.bin/eslint src/cli/commands/domains.ts src/cli/commands/domains.spec.ts src/cli/lib/domains.ts tests/mocks/handlers.ts --max-warnings 0`

Full `node_modules/.bin/vitest run --coverage` was attempted on #3070, but this local environment fails unrelated existing tests that require `api.github.com` network access and npm package env vars.

## Migration
None.