### PR TITLE
B2B-5056 Fix B2B company registration for catalyst stores

### DIFF
--- a/core/b2b/loader.tsx
+++ b/core/b2b/loader.tsx
@@ -10,6 +10,7 @@ const EnvironmentSchema = z.object({
   BIGCOMMERCE_CHANNEL_ID: z.string({ message: 'BIGCOMMERCE_CHANNEL_ID is required' }),
   LOCAL_BUYER_PORTAL_HOST: z.string().url().optional(),
   BUYER_PORTAL_ENVIRONMENT: z.enum(['production', 'staging', 'integration']).optional().default('production'),
+  BIGCOMMERCE_GRAPHQL_API_DOMAIN: z.string().optional().default('mybigcommerce.com'),
 });
 
 export async function B2BLoader() {
@@ -18,6 +19,7 @@ export async function B2BLoader() {
     BIGCOMMERCE_CHANNEL_ID,
     LOCAL_BUYER_PORTAL_HOST,
     BUYER_PORTAL_ENVIRONMENT,
+    BIGCOMMERCE_GRAPHQL_API_DOMAIN,
   } = EnvironmentSchema.parse(process.env);
 
   const session = await auth();
@@ -25,6 +27,7 @@ export async function B2BLoader() {
   if (LOCAL_BUYER_PORTAL_HOST) {
     return (
       <ScriptDev
+        bcGraphqlDomain={BIGCOMMERCE_GRAPHQL_API_DOMAIN}
         cartId={session?.user?.cartId ?? undefined}
         channelId={BIGCOMMERCE_CHANNEL_ID}
         hostname={LOCAL_BUYER_PORTAL_HOST}
@@ -36,6 +39,7 @@ export async function B2BLoader() {
 
   return (
     <ScriptProduction
+      bcGraphqlDomain={BIGCOMMERCE_GRAPHQL_API_DOMAIN}
       cartId={session?.user?.cartId}
       channelId={BIGCOMMERCE_CHANNEL_ID}
       environment={BUYER_PORTAL_ENVIRONMENT}

--- a/core/b2b/script-dev.tsx
+++ b/core/b2b/script-dev.tsx
@@ -12,9 +12,10 @@ interface DevProps {
   hostname: string;
   token?: string;
   cartId?: string;
+  bcGraphqlDomain?: string;
 }
 
-export function ScriptDev({ cartId, hostname, storeHash, channelId, token }: DevProps) {
+export function ScriptDev({ cartId, hostname, storeHash, channelId, token, bcGraphqlDomain }: DevProps) {
   useB2BAuth(token);
   useB2BCart(cartId);
 
@@ -46,11 +47,12 @@ export function ScriptDev({ cartId, hostname, storeHash, channelId, token }: Dev
                   channel_id: ${channelId},
                   platform: 'catalyst',
                   cart_url: '/cart',
+                  bc_graphql_domain: '${bcGraphqlDomain ?? 'mybigcommerce.com'}',
                 },
               };
           `}
       </Script>
-      <Script data-channelid={storeHash} data-storehash={channelId} src={src} type="module" />
+      <Script data-channelid={channelId} data-storehash={storeHash} src={src} type="module" />
     </>
   );
 }

--- a/core/b2b/script-production.tsx
+++ b/core/b2b/script-production.tsx
@@ -11,6 +11,7 @@ interface Props {
   token?: string;
   environment: 'staging' | 'production' | 'integration';
   cartId?: string | null;
+  bcGraphqlDomain?: string;
 }
 
 const CDN_BY_ENV: Record<Props['environment'], string> = {
@@ -19,7 +20,7 @@ const CDN_BY_ENV: Record<Props['environment'], string> = {
   integration: 'https://microapps.integration.zone',
 };
 
-export function ScriptProduction({ cartId, storeHash, channelId, token, environment }: Props) {
+export function ScriptProduction({ cartId, storeHash, channelId, token, environment, bcGraphqlDomain }: Props) {
   useB2BAuth(token);
   useB2BCart(cartId);
 
@@ -35,6 +36,7 @@ export function ScriptProduction({ cartId, storeHash, channelId, token, environm
                 channel_id: ${channelId},
                 platform: 'catalyst',
                 cart_url: '/cart',
+                bc_graphql_domain: '${bcGraphqlDomain ?? 'mybigcommerce.com'}',
               }
             }
         `}


### PR DESCRIPTION
## What/Why?

While investigating an issue related to company registration from catalyst store front, I found that local catalyst (b2b-integration) setup doesn't work properly. Making these changes to fix local setup.

loader.tsx — reads BIGCOMMERCE_GRAPHQL_API_DOMAIN from env (defaults to mybigcommerce.com) and passes it down as bcGraphqlDomain to both script components
script-dev.tsx — injects bc_graphql_domain into window.B3.setting so the buyer portal can build the correct BC Storefront API URL; also fixes a pre-existing bug where data-channelid and data-storehash attributes were swapped
script-production.tsx — same bc_graphql_domain injection as the dev script

## Testing
Manually tested the company registration 

https://github.com/user-attachments/assets/49c43a42-fd86-450d-8586-999fdf1c9101

## Migration

N/A
