### PR TITLE
fix(core): support required custom customer fields in Account Settings

### DIFF
--- a/.changeset/account-settings-custom-fields-3074.md
+++ b/.changeset/account-settings-custom-fields-3074.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Fix Account Settings failing to save for customers when a merchant-defined required custom customer field exists. BigCommerce revalidates required custom fields on every `updateCustomer` call, so Account Settings now renders and resubmits those fields (mirroring the existing Register/Address form-field support) instead of only supporting first name, last name, email, and company.

--- a/core/app/[locale]/(default)/account/settings/_actions/update-customer.ts
+++ b/core/app/[locale]/(default)/account/settings/_actions/update-customer.ts
@@ -5,11 +5,12 @@ import { parseWithZod } from '@conform-to/zod';
 import { revalidateTag } from 'next/cache';
 import { getTranslations } from 'next-intl/server';
 
+import { Field, FieldGroup } from '@/vibes/soul/form/dynamic-form/schema';
 import { updateAccountSchema } from '@/vibes/soul/sections/account-settings/schema';
-import { UpdateAccountAction } from '@/vibes/soul/sections/account-settings/update-account-form';
+import { State } from '@/vibes/soul/sections/account-settings/update-account-form';
 import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
-import { graphql } from '~/client/graphql';
+import { graphql, VariablesOf } from '~/client/graphql';
 import { TAGS } from '~/client/tags';
 
 const UpdateCustomerMutation = graphql(`
@@ -19,6 +20,8 @@ const UpdateCustomerMutation = graphql(`
         customer {
           firstName
           lastName
+          email
+          company
         }
         errors {
           __typename
@@ -43,11 +46,81 @@ const UpdateCustomerMutation = graphql(`
   }
 `);
 
-export const updateCustomer: UpdateAccountAction = async (prevState, formData) => {
+type FormFieldsInput = NonNullable<
+  VariablesOf<typeof UpdateCustomerMutation>['input']['formFields']
+>;
+
+/*
+ * BigCommerce re-validates every required custom customer field on every updateCustomer call,
+ * even ones already satisfied by a prior save (see issue #3074) - so any required custom field
+ * rendered in the form must always be resent here, not just the ones the user actually changed.
+ */
+function buildFormFieldsInput(
+  fields: Array<Field | FieldGroup<Field>>,
+  value: Record<string, unknown>,
+): FormFieldsInput {
+  const flatFields = fields.flatMap((field) => (Array.isArray(field) ? field : [field]));
+
+  return {
+    checkboxes: flatFields
+      .filter((field) => field.type === 'checkbox-group')
+      .filter((field) => Boolean(value[field.name]))
+      .map((field) => {
+        const rawValue = value[field.name];
+        const rawValues = Array.isArray(rawValue) ? rawValue : [rawValue];
+
+        return {
+          fieldEntityId: Number(field.id),
+          fieldValueEntityIds: rawValues.map(Number),
+        };
+      }),
+    multipleChoices: flatFields
+      .filter((field) => ['radio-group', 'button-radio-group', 'select'].includes(field.type))
+      .filter((field) => Boolean(value[field.name]))
+      .map((field) => ({
+        fieldEntityId: Number(field.id),
+        fieldValueEntityId: Number(value[field.name]),
+      })),
+    numbers: flatFields
+      .filter((field) => field.type === 'number')
+      .filter((field) => Boolean(value[field.name]))
+      .map((field) => ({
+        fieldEntityId: Number(field.id),
+        number: Number(value[field.name]),
+      })),
+    dates: flatFields
+      .filter((field) => field.type === 'date')
+      .filter((field) => Boolean(value[field.name]))
+      .map((field) => ({
+        fieldEntityId: Number(field.id),
+        date: new Date(String(value[field.name])).toISOString(),
+      })),
+    multilineTexts: flatFields
+      .filter((field) => field.type === 'textarea')
+      .filter((field) => Boolean(value[field.name]))
+      .map((field) => ({
+        fieldEntityId: Number(field.id),
+        multilineText: String(value[field.name]),
+      })),
+    texts: flatFields
+      .filter((field) => field.type === 'text' || field.type === 'email')
+      .filter((field) => Boolean(value[field.name]))
+      .map((field) => ({
+        fieldEntityId: Number(field.id),
+        text: String(value[field.name]),
+      })),
+  };
+}
+
+export async function updateCustomer(
+  { fields }: { fields: Array<Field | FieldGroup<Field>> },
+  prevState: Awaited<State>,
+  formData: FormData,
+): Promise<State> {
   const t = await getTranslations('Account.Settings');
   const customerAccessToken = await getSessionCustomerAccessToken();
 
-  const submission = parseWithZod(formData, { schema: updateAccountSchema });
+  const submission = parseWithZod(formData, { schema: updateAccountSchema(fields) });
 
   if (submission.status !== 'success') {
     return {
@@ -56,12 +129,20 @@ export const updateCustomer: UpdateAccountAction = async (prevState, formData) =
     };
   }
 
+  const { firstName, lastName, email, company, ...customFieldValues } = submission.value;
+
   try {
     const response = await client.fetch({
       document: UpdateCustomerMutation,
       customerAccessToken,
       variables: {
-        input: submission.value,
+        input: {
+          firstName,
+          lastName,
+          email,
+          company,
+          formFields: buildFormFieldsInput(fields, customFieldValues),
+        },
       },
       fetchOptions: { cache: 'no-store' },
     });
@@ -107,4 +188,4 @@ export const updateCustomer: UpdateAccountAction = async (prevState, formData) =
       lastResult: submission.reply({ formErrors: [t('somethingWentWrong')] }),
     };
   }
-};
+}

--- a/core/app/[locale]/(default)/account/settings/page-data.tsx
+++ b/core/app/[locale]/(default)/account/settings/page-data.tsx
@@ -4,7 +4,10 @@ import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
 import { graphql, VariablesOf } from '~/client/graphql';
 import { TAGS } from '~/client/tags';
-import { FormFieldsFragment } from '~/data-transformers/form-field-transformer/fragment';
+import {
+  FormFieldsFragment,
+  FormFieldValuesFragment,
+} from '~/data-transformers/form-field-transformer/fragment';
 
 const AccountSettingsQuery = graphql(
   `
@@ -21,6 +24,9 @@ const AccountSettingsQuery = graphql(
         lastName
         company
         isSubscribedToNewsletter
+        formFields {
+          ...FormFieldValuesFragment
+        }
       }
       site {
         settings {
@@ -50,7 +56,7 @@ const AccountSettingsQuery = graphql(
       }
     }
   `,
-  [FormFieldsFragment],
+  [FormFieldsFragment, FormFieldValuesFragment],
 );
 
 type Variables = VariablesOf<typeof AccountSettingsQuery>;
@@ -96,6 +102,7 @@ export const getAccountSettingsQuery = cache(async ({ address, customer }: Props
   return {
     addressFields,
     customerFields,
+    customerFormFieldValues: customerInfo.formFields,
     customerInfo,
     newsletterSettings,
     passwordComplexitySettings,

--- a/core/app/[locale]/(default)/account/settings/page.tsx
+++ b/core/app/[locale]/(default)/account/settings/page.tsx
@@ -3,12 +3,48 @@ import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 
+import { Field } from '@/vibes/soul/form/dynamic-form/schema';
 import { AccountSettingsSection } from '@/vibes/soul/sections/account-settings';
+import { formFieldTransformer } from '~/data-transformers/form-field-transformer';
+import {
+  ACCOUNT_SETTINGS_FIELDS_TO_EXCLUDE,
+  mapFormFieldValueToName,
+} from '~/data-transformers/form-field-transformer/utils';
+import { exists } from '~/lib/utils';
 
 import { changePassword } from './_actions/change-password';
 import { updateCustomer } from './_actions/update-customer';
 import { updateNewsletterSubscription } from './_actions/update-newsletter-subscription';
 import { getAccountSettingsQuery } from './page-data';
+
+function withDefaultValue(field: Field, value: unknown): Field {
+  if (field.type === 'checkbox-group') {
+    return { ...field, defaultValue: Array.isArray(value) ? value.map(String) : undefined };
+  }
+
+  if (typeof value !== 'string') {
+    return field;
+  }
+
+  switch (field.type) {
+    case 'radio-group':
+    case 'select':
+    case 'swatch-radio-group':
+    case 'card-radio-group':
+    case 'button-radio-group':
+    case 'checkbox':
+    case 'number':
+    case 'text':
+    case 'textarea':
+    case 'date':
+    case 'email':
+    case 'hidden':
+      return { ...field, defaultValue: value };
+
+    default:
+      return field;
+  }
+}
 
 interface Props {
   params: Promise<{ locale: string }>;
@@ -47,6 +83,21 @@ export default async function Settings({ params }: Props) {
     },
   );
 
+  const customFieldValues = accountSettings.customerFormFieldValues.reduce<Record<string, unknown>>(
+    (acc, field) => ({ ...acc, ...mapFormFieldValueToName(field) }),
+    {},
+  );
+
+  const updateAccountCustomFields = accountSettings.customerFields
+    .filter((field) => !ACCOUNT_SETTINGS_FIELDS_TO_EXCLUDE.includes(field.entityId))
+    .map(formFieldTransformer)
+    .filter(exists)
+    .map((field) => withDefaultValue(field, customFieldValues[field.name]));
+
+  const updateCustomerWithFields = updateCustomer.bind(null, {
+    fields: updateAccountCustomFields,
+  });
+
   return (
     <AccountSettingsSection
       account={accountSettings.customerInfo}
@@ -63,7 +114,8 @@ export default async function Settings({ params }: Props) {
       newsletterSubscriptionTitle={t('NewsletterSubscription.title')}
       passwordComplexitySettings={accountSettings.passwordComplexitySettings}
       title={t('title')}
-      updateAccountAction={updateCustomer}
+      updateAccountAction={updateCustomerWithFields}
+      updateAccountCustomFields={updateAccountCustomFields}
       updateAccountSubmitLabel={t('cta')}
       updateNewsletterSubscriptionAction={updateNewsletterSubscriptionActionWithCustomerInfo}
     />

--- a/core/data-transformers/form-field-transformer/utils.ts
+++ b/core/data-transformers/form-field-transformer/utils.ts
@@ -25,6 +25,20 @@ export enum FieldNameToFieldId {
 
 export const CUSTOMER_FIELDS_TO_EXCLUDE = [FieldNameToFieldId.currentPassword];
 
+/* Account Settings only manages the fields below directly; anything else returned by
+ site.settings.formFields.customer is a genuinely merchant-defined custom field. */
+export const ACCOUNT_SETTINGS_FIELDS_TO_EXCLUDE = [
+  FieldNameToFieldId.email,
+  FieldNameToFieldId.password,
+  FieldNameToFieldId.confirmPassword,
+  FieldNameToFieldId.currentPassword,
+  FieldNameToFieldId.firstName,
+  FieldNameToFieldId.lastName,
+  FieldNameToFieldId.company,
+  FieldNameToFieldId.phone,
+  FieldNameToFieldId.exclusiveOffers,
+];
+
 export const REGISTER_CUSTOMER_FORM_LAYOUT = [
   [FieldNameToFieldId.firstName, FieldNameToFieldId.lastName],
   FieldNameToFieldId.email,

--- a/core/vibes/soul/form/dynamic-form/index.tsx
+++ b/core/vibes/soul/form/dynamic-form/index.tsx
@@ -241,7 +241,7 @@ function SubmitButton({
   );
 }
 
-function DynamicFormField({
+export function DynamicFormField({
   field,
   formField,
 }: {

--- a/core/vibes/soul/form/dynamic-form/schema.ts
+++ b/core/vibes/soul/form/dynamic-form/schema.ts
@@ -328,30 +328,35 @@ function getFieldSchema(
   return fieldSchema;
 }
 
-export function schema(
+export function getFieldsShape(
   fields: Array<Field | FieldGroup<Field>>,
   passwordComplexity?: PasswordComplexitySettings | null,
   errorTranslations?: FormErrorTranslationMap,
-) {
+): SchemaRawShape {
   const shape: SchemaRawShape = {};
-  let passwordFieldName: string | undefined;
-  let confirmPasswordFieldName: string | undefined;
 
   fields.forEach((field) => {
     if (Array.isArray(field)) {
       field.forEach((f) => {
         shape[f.name] = getFieldSchema(f, passwordComplexity, errorTranslations);
-
-        if (f.type === 'password') passwordFieldName = f.name;
-        if (f.type === 'confirm-password') confirmPasswordFieldName = f.name;
       });
     } else {
       shape[field.name] = getFieldSchema(field, passwordComplexity, errorTranslations);
-
-      if (field.type === 'password') passwordFieldName = field.name;
-      if (field.type === 'confirm-password') confirmPasswordFieldName = field.name;
     }
   });
+
+  return shape;
+}
+
+export function schema(
+  fields: Array<Field | FieldGroup<Field>>,
+  passwordComplexity?: PasswordComplexitySettings | null,
+  errorTranslations?: FormErrorTranslationMap,
+) {
+  const shape = getFieldsShape(fields, passwordComplexity, errorTranslations);
+  const flatFields = fields.flatMap((field) => (Array.isArray(field) ? field : [field]));
+  const passwordFieldName = flatFields.find((f) => f.type === 'password')?.name;
+  const confirmPasswordFieldName = flatFields.find((f) => f.type === 'confirm-password')?.name;
 
   return z.object(shape).superRefine((data, ctx) => {
     if (

--- a/core/vibes/soul/sections/account-settings/index.tsx
+++ b/core/vibes/soul/sections/account-settings/index.tsx
@@ -1,4 +1,8 @@
-import { PasswordComplexitySettings } from '@/vibes/soul/form/dynamic-form/schema';
+import {
+  Field,
+  FieldGroup,
+  PasswordComplexitySettings,
+} from '@/vibes/soul/form/dynamic-form/schema';
 
 import { ChangePasswordAction, ChangePasswordForm } from './change-password-form';
 import {
@@ -11,6 +15,7 @@ export interface AccountSettingsSectionProps {
   title?: string;
   account: Account;
   updateAccountAction: UpdateAccountAction;
+  updateAccountCustomFields?: Array<Field | FieldGroup<Field>>;
   updateAccountSubmitLabel?: string;
   changePasswordTitle?: string;
   changePasswordAction: ChangePasswordAction;
@@ -45,6 +50,7 @@ export function AccountSettingsSection({
   title = 'Account Settings',
   account,
   updateAccountAction,
+  updateAccountCustomFields,
   updateAccountSubmitLabel,
   changePasswordTitle = 'Change Password',
   changePasswordAction,
@@ -73,6 +79,7 @@ export function AccountSettingsSection({
             <UpdateAccountForm
               account={account}
               action={updateAccountAction}
+              customFields={updateAccountCustomFields}
               submitLabel={updateAccountSubmitLabel}
             />
           </div>

--- a/core/vibes/soul/sections/account-settings/schema.ts
+++ b/core/vibes/soul/sections/account-settings/schema.ts
@@ -2,18 +2,23 @@ import { getTranslations } from 'next-intl/server';
 import { z } from 'zod';
 
 import {
+  Field,
+  FieldGroup,
   FormErrorTranslationMap,
+  getFieldsShape,
   getPasswordSchema,
   PasswordComplexitySettings,
 } from '@/vibes/soul/form/dynamic-form/schema';
 import { ExistingResultType } from '~/client/util';
 
-export const updateAccountSchema = z.object({
-  firstName: z.string().min(2).trim(),
-  lastName: z.string().min(2).trim(),
-  email: z.string().email().trim(),
-  company: z.string().trim().optional(),
-});
+export const updateAccountSchema = (customFields: Array<Field | FieldGroup<Field>> = []) =>
+  z.object({
+    firstName: z.string().min(2).trim(),
+    lastName: z.string().min(2).trim(),
+    email: z.string().email().trim(),
+    company: z.string().trim().optional(),
+    ...getFieldsShape(customFields),
+  });
 
 export const updateAccountErrorTranslations = (
   t: ExistingResultType<typeof getTranslations<'Account.Settings'>>,

--- a/core/vibes/soul/sections/account-settings/update-account-form.tsx
+++ b/core/vibes/soul/sections/account-settings/update-account-form.tsx
@@ -1,11 +1,20 @@
 'use client';
 
-import { getFormProps, getInputProps, SubmissionResult, useForm } from '@conform-to/react';
+import {
+  FieldMetadata,
+  FormProvider,
+  getFormProps,
+  getInputProps,
+  SubmissionResult,
+  useForm,
+} from '@conform-to/react';
 import { getZodConstraint } from '@conform-to/zod';
 import { useTranslations } from 'next-intl';
 import { useActionState, useEffect, useOptimistic, useTransition } from 'react';
 import { z } from 'zod';
 
+import { DynamicFormField } from '@/vibes/soul/form/dynamic-form';
+import { Field, FieldGroup } from '@/vibes/soul/form/dynamic-form/schema';
 import { Input } from '@/vibes/soul/form/input';
 import { Button } from '@/vibes/soul/primitives/button';
 import { toast } from '@/vibes/soul/primitives/toaster';
@@ -17,17 +26,31 @@ type Action<S, P> = (state: Awaited<S>, payload: P) => S | Promise<S>;
 
 export type UpdateAccountAction = Action<State, FormData>;
 
-export type Account = z.infer<typeof updateAccountSchema>;
+export type Account = z.infer<ReturnType<typeof updateAccountSchema>>;
 
-interface State {
+export interface State {
   account: Account;
   successMessage?: string;
   lastResult: SubmissionResult | null;
 }
 
+function getDynamicFormField(
+  fields: object,
+  name: string,
+): FieldMetadata<string | string[] | number | boolean | Date | undefined> | undefined {
+  // `fields` is conform's static, schema-derived shape; custom fields are looked up dynamically
+  // by name, which has no static index signature to type against.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return Reflect.get(fields, name);
+}
+
 export interface UpdateAccountFormProps {
   action: UpdateAccountAction;
   account: Account;
+  /* Merchant-defined required/custom customer fields (e.g. a "Terms and Conditions" checkbox
+   added after this account existed). BigCommerce re-validates these on every updateCustomer
+   call, so they must be rendered and submitted in this same form, not a separate one. */
+  customFields?: Array<Field | FieldGroup<Field>>;
   firstNameLabel?: string;
   lastNameLabel?: string;
   emailLabel?: string;
@@ -38,6 +61,7 @@ export interface UpdateAccountFormProps {
 export function UpdateAccountForm({
   action,
   account,
+  customFields = [],
   firstNameLabel = 'First name',
   lastNameLabel = 'Last name',
   emailLabel = 'Email',
@@ -46,6 +70,7 @@ export function UpdateAccountForm({
 }: UpdateAccountFormProps) {
   const t = useTranslations('Account.Settings');
   const errorTranslations = updateAccountErrorTranslations(t);
+  const schema = updateAccountSchema(customFields);
   const [state, formAction] = useActionState(action, { account, lastResult: null });
   const [pending, startTransition] = useTransition();
 
@@ -54,7 +79,7 @@ export function UpdateAccountForm({
     (prevState, formData) => {
       const intent = formData.get('intent');
       const submission = parseWithZodTranslatedErrors(formData, {
-        schema: updateAccountSchema,
+        schema,
         errorTranslations,
       });
 
@@ -74,15 +99,21 @@ export function UpdateAccountForm({
     },
   );
 
+  const customFieldsDefaultValue = customFields
+    .flatMap((f) => (Array.isArray(f) ? f : [f]))
+    .reduce<
+      Record<string, unknown>
+    >((acc, f) => ({ ...acc, [f.name]: 'defaultValue' in f ? f.defaultValue : '' }), {});
+
   const [form, fields] = useForm({
     lastResult: state.lastResult,
-    defaultValue: optimisticState.account,
-    constraint: getZodConstraint(updateAccountSchema),
+    defaultValue: { ...optimisticState.account, ...customFieldsDefaultValue },
+    constraint: getZodConstraint(schema),
     shouldValidate: 'onBlur',
     shouldRevalidate: 'onInput',
     onValidate({ formData }) {
       return parseWithZodTranslatedErrors(formData, {
-        schema: updateAccountSchema,
+        schema,
         errorTranslations,
       });
     },
@@ -95,52 +126,81 @@ export function UpdateAccountForm({
   }, [state]);
 
   return (
-    <form
-      {...getFormProps(form)}
-      action={(formData) => {
-        startTransition(() => {
-          formAction(formData);
-          setOptimisticState(formData);
-        });
-      }}
-      className="space-y-5"
-    >
-      <div className="flex gap-5">
-        <Input
-          {...getInputProps(fields.firstName, { type: 'text' })}
-          errors={fields.firstName.errors}
-          key={fields.firstName.id}
-          label={firstNameLabel}
-        />
-        <Input
-          {...getInputProps(fields.lastName, { type: 'text' })}
-          errors={fields.lastName.errors}
-          key={fields.lastName.id}
-          label={lastNameLabel}
-        />
-      </div>
-      <Input
-        {...getInputProps(fields.email, { type: 'text' })}
-        errors={fields.email.errors}
-        key={fields.email.id}
-        label={emailLabel}
-      />
-      <Input
-        {...getInputProps(fields.company, { type: 'text' })}
-        errors={fields.company.errors}
-        key={fields.company.id}
-        label={companyLabel}
-      />
-      <Button
-        loading={pending}
-        name="intent"
-        size="small"
-        type="submit"
-        value="update"
-        variant="secondary"
+    <FormProvider context={form.context}>
+      <form
+        {...getFormProps(form)}
+        action={(formData) => {
+          startTransition(() => {
+            formAction(formData);
+            setOptimisticState(formData);
+          });
+        }}
+        className="space-y-5"
       >
-        {submitLabel}
-      </Button>
-    </form>
+        <div className="flex gap-5">
+          <Input
+            {...getInputProps(fields.firstName, { type: 'text' })}
+            errors={fields.firstName.errors}
+            key={fields.firstName.id}
+            label={firstNameLabel}
+          />
+          <Input
+            {...getInputProps(fields.lastName, { type: 'text' })}
+            errors={fields.lastName.errors}
+            key={fields.lastName.id}
+            label={lastNameLabel}
+          />
+        </div>
+        <Input
+          {...getInputProps(fields.email, { type: 'text' })}
+          errors={fields.email.errors}
+          key={fields.email.id}
+          label={emailLabel}
+        />
+        <Input
+          {...getInputProps(fields.company, { type: 'text' })}
+          errors={fields.company.errors}
+          key={fields.company.id}
+          label={companyLabel}
+        />
+        {customFields.map((field, index) => {
+          if (Array.isArray(field)) {
+            return (
+              <div className="flex gap-5" key={index}>
+                {field.map((f) => {
+                  const groupFormField = getDynamicFormField(fields, f.name);
+
+                  if (!groupFormField) return null;
+
+                  return (
+                    <DynamicFormField
+                      field={f}
+                      formField={groupFormField}
+                      key={groupFormField.id}
+                    />
+                  );
+                })}
+              </div>
+            );
+          }
+
+          const formField = getDynamicFormField(fields, field.name);
+
+          if (!formField) return null;
+
+          return <DynamicFormField field={field} formField={formField} key={formField.id} />;
+        })}
+        <Button
+          loading={pending}
+          name="intent"
+          size="small"
+          type="submit"
+          value="update"
+          variant="secondary"
+        >
+          {submitLabel}
+        </Button>
+      </form>
+    </FormProvider>
   );
 }


### PR DESCRIPTION
## What/Why?
Fixes #3074.

The issue reports two problems with Account Settings' update-customer flow:

1. Claimed the mutation only sends `firstName`/`lastName`, dropping `email`/`company`. This turned out to be a misread of the code — the lines cited are the mutation's *response selection*, not the input. `submission.value` (validated against `updateAccountSchema`) already includes `email`/`company`, and I confirmed via direct GraphQL calls against a test store that both persist correctly today. No fix needed for this part.
2. Claimed that once a merchant adds a new **required** custom customer field, existing accounts have no way to satisfy it. This is real, and worse than described: I confirmed against a live store that BigCommerce revalidates *every* required custom customer field on *every* `updateCustomer` call — even fields that already have a stored value. A customer with a `firstName`-only edit gets `ValidationError: Required account form field ID X is missing` if that field isn't resent, regardless of whether it was previously set. Account Settings only ever submitted `firstName`/`lastName`/`email`/`company`, so any store with a required custom customer field (e.g. a "Terms and Conditions" checkbox added after accounts already existed) locked customers out of saving *any* change at all.

This is a regression: custom/dynamic form-field support existed in Account Settings since #1257 (Aug 2024) but was dropped during the Vibes migration (`b14180c4`, Dec 2024) and never restored, while Register and Address kept it via the newer `DynamicForm`/`formFieldTransformer` pattern.

This PR restores that support in Account Settings by reusing the same `DynamicForm`/`formFieldTransformer` pattern already used by Register and Address:
- `page-data.tsx` now fetches the customer's existing custom form field values (`customer.formFields`) alongside the field *definitions* it already fetched but never used.
- `page.tsx` filters out fields already covered by the fixed inputs (email, password, name, company, phone, newsletter checkbox) and transforms the rest into `Field`s, pre-filled with the customer's current values.
- `update-account-form.tsx` renders those fields in the *same* form as the existing firstName/lastName/email/company inputs (via the shared `DynamicFormField` renderer), so a single save always resubmits the full required-field state — required given BigCommerce's per-call revalidation.
- `update-customer.ts` builds the mutation's `formFields` input from whatever fields are present, following the same per-type mapping already used by `registerCustomer`/`updateAddress`.
- Small supporting extraction in `dynamic-form/schema.ts` (`getFieldsShape`) so Account Settings' schema can merge the fixed fields with the dynamic ones without duplicating per-field-type zod logic.

## Testing
- Set up a test store with a required "Terms and Conditions" checkbox custom customer field, added *after* a test customer already existed.
- Verified directly against the Storefront GraphQL API (bypassing the app) that:
  - `email`/`company` already persist correctly via the existing mutation input.
  - Omitting the required custom field from `updateCustomer` fails with `ValidationError`, even when the customer already has a stored value for it — confirming the bug and that the fix must always resend it.
- Ran the app locally and rendered `/account/settings` with an authenticated session: confirmed the custom checkbox renders alongside the fixed fields, correctly prefilled from the customer's stored value (checked), and that email/company also prefill from live data.
- `pnpm run typecheck` and `pnpm run lint` pass.
- Not verified: an actual form submission through the browser (no browser automation available in this environment). The submit-side mutation shape was verified directly against the API in isolation and matches what the form now produces.

## Migration
N/A — no breaking changes. `updateAccountSchema` changed from a `ZodObject` to a factory function; only relevant to direct importers of `@/vibes/soul/sections/account-settings/schema`.