### PR TITLE
fix(cli): add repository field to @bigcommerce/catalyst package.json

### DIFF
--- a/packages/catalyst/package.json
+++ b/packages/catalyst/package.json
@@ -2,6 +2,11 @@
   "name": "@bigcommerce/catalyst",
   "version": "1.0.0",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bigcommerce/catalyst",
+    "directory": "packages/catalyst"
+  },
   "bin": {
     "catalyst": "dist/cli.js"
   },


### PR DESCRIPTION
## What/Why?

Hotfix for the failed `@bigcommerce/catalyst@1.0.0` publish. When the Version Packages (`canary`) release [#3078](https://github.com/bigcommerce/catalyst/pull/3078) merged, the Changesets Release workflow failed to publish the CLI:

```
E422 Unprocessable Entity — Error verifying sigstore provenance bundle:
Failed to validate repository information: package.json: "repository.url" is "",
expected to match "https://github.com/bigcommerce/catalyst" from provenance
```

The canary release publishes via **npm OIDC trusted publishing**, which enforces provenance and requires `package.json` to declare a `repository.url` matching the source repo. `packages/catalyst/package.json` had no `repository` field, so npm rejected it.

`@bigcommerce/create-catalyst@2.0.0` **did** publish and now depends on `@bigcommerce/catalyst@^1.0.0` — which does not exist on npm — so `npx create-catalyst` / `pnpm create catalyst` is currently broken. This is urgent.

This adds the `repository` field matching the working pattern already used by `@bigcommerce/create-catalyst` and `@bigcommerce/catalyst-client` (both publish fine).

## Testing

- Locally verified the tarball and build are unaffected (`npm pack --dry-run`, `pnpm --filter @bigcommerce/catalyst build`).
- On merge to `canary`, the Changesets Release workflow re-runs and publishes any unpublished package versions. It will publish `@bigcommerce/catalyst@1.0.0` (now passing provenance) and skip `@bigcommerce/create-catalyst@2.0.0` (already published). No version bump / changeset is needed — `1.0.0` is already the version on `canary`.
- Verify after merge: `npm view @bigcommerce/catalyst dist-tags` shows `latest: 1.0.0`, and `npx create-catalyst@latest` resolves.

## Migration

None.