### PR TITLE
feat(product): display product videos on the PDP

### DIFF
--- a/.changeset/product-videos-pdp.md
+++ b/.changeset/product-videos-pdp.md
@@ -1,0 +1,14 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Display product videos (YouTube) on the PDP in a dedicated section below the primary product content, mirroring the Stencil/Cornerstone layout. The Storefront GraphQL API exposes product videos as a `{ title, url }` pair (`Product.videos`); Catalyst now fetches them and renders a featured player with a thumbnail strip (clicking a thumbnail swaps the featured video) using [`lite-youtube-embed`](https://github.com/paulirish/lite-youtube-embed) — a lightweight facade that loads the YouTube player only when a shopper clicks. A small `getYouTubeId()` helper extracts the video id from the watch URL the API returns.
+
+## Migration
+
+Additive — no breaking changes; existing PDP markup, the image gallery, and image pagination are unchanged. Forks adopting this manually need to:
+
+- add the `lite-youtube-embed` dependency;
+- request `videos(first: 25) { edges { node { title url } } }` on the PDP product query (`product/[slug]/page-data.ts`);
+- stream those videos and render the new `ProductVideos` section below `ProductDetail` (`product/[slug]/page.tsx`);
+- allow `i.ytimg.com/vi/**` in `next.config.ts` `images.remotePatterns` for poster thumbnails.

--- a/core/app/[locale]/(default)/product/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/product/[slug]/page-data.ts
@@ -296,6 +296,18 @@ const StreamableProductQuery = graphql(
             altText
             url: urlTemplate(lossy: true)
           }
+          # Product videos. The Storefront GraphQL API only returns the video
+          # title and url (a YouTube watch URL); the dedicated PDP Videos section
+          # renders them via lite-youtube-embed. 25 covers realistic product
+          # video counts without needing pagination.
+          videos(first: 25) {
+            edges {
+              node {
+                title
+                url
+              }
+            }
+          }
           sku
           weight {
             value

--- a/core/app/[locale]/(default)/product/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { SearchParams } from 'nuqs/server';
 import { Stream, Streamable } from '@/vibes/soul/lib/streamable';
 import { FeaturedProductCarousel } from '@/vibes/soul/sections/featured-product-carousel';
 import { ProductDetail } from '@/vibes/soul/sections/product-detail';
+import { ProductVideos } from '@/vibes/soul/sections/product-detail/product-videos';
 import { auth, getSessionCustomerAccessToken } from '~/auth';
 import { rewriteWysiwygContentUrls } from '~/data-transformers/html-content-transformer';
 import { pricesTransformer } from '~/data-transformers/prices-transformer';
@@ -196,6 +197,18 @@ export default async function Product({ params, searchParams }: Props) {
         : images,
       pageInfo: product.images.pageInfo,
     };
+  });
+
+  // Product videos render in their own section below the primary content, so
+  // they're streamed independently of the gallery images. The Storefront
+  // GraphQL API returns each video as { title, url } (a YouTube watch URL).
+  const streamableVideos = Streamable.from(async () => {
+    const product = await streamableProduct;
+
+    return removeEdgesAndNodes(product.videos).map((video) => ({
+      url: video.url,
+      title: video.title,
+    }));
   });
 
   const streameableCtaLabel = Streamable.from(async () => {
@@ -595,6 +608,10 @@ export default async function Product({ params, searchParams }: Props) {
           user={streamableUser}
         />
       </ProductAnalyticsProvider>
+
+      <Stream fallback={null} value={streamableVideos}>
+        {(videos) => videos.length > 0 && <ProductVideos videos={videos} />}
+      </Stream>
 
       <FeaturedProductCarousel
         cta={{ label: t('RelatedProducts.cta'), href: '/shop-all' }}

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -470,6 +470,11 @@
       "backorderQuantity": "{quantity, number} will be on backorder",
       "loadingMoreImages": "Loading more images",
       "imagesLoaded": "{count, plural, =1 {1 more image loaded} other {# more images loaded}}",
+      "playVideo": "Play video",
+      "viewVideo": "View video",
+      "videosTitle": "Videos",
+      "hideVideos": "Hide videos",
+      "showVideos": "Show videos",
       "Submit": {
         "addToCart": "Add to cart",
         "outOfStock": "Out of stock",

--- a/core/next.config.ts
+++ b/core/next.config.ts
@@ -66,6 +66,10 @@ export default async (): Promise<NextConfig> => {
     experimental: {
       optimizePackageImports: ['@icons-pack/react-simple-icons'],
     },
+    images: {
+      // Allow product-video poster thumbnails (YouTube) through next/image.
+      remotePatterns: [{ protocol: 'https', hostname: 'i.ytimg.com', pathname: '/vi/**' }],
+    },
     typescript: {
       ignoreBuildErrors: !!process.env.CI,
     },

--- a/core/package.json
+++ b/core/package.json
@@ -61,6 +61,7 @@
     "graphql": "^16.11.0",
     "dompurify": "^3.3.1",
     "jose": "^5.10.0",
+    "lite-youtube-embed": "^0.3.4",
     "lodash.debounce": "^4.0.8",
     "lru-cache": "^11.1.0",
     "lucide-react": "^0.474.0",

--- a/core/vibes/soul/sections/product-detail/lite-youtube-embed.d.ts
+++ b/core/vibes/soul/sections/product-detail/lite-youtube-embed.d.ts
@@ -1,0 +1,5 @@
+// `lite-youtube-embed` ships no TypeScript declarations. It is imported only for
+// its side effect — registering the <lite-youtube> custom element — so an ambient
+// module declaration (implicit `any`) is sufficient and keeps the production
+// `next build` / `tsc` typecheck passing.
+declare module 'lite-youtube-embed';

--- a/core/vibes/soul/sections/product-detail/lite-youtube.tsx
+++ b/core/vibes/soul/sections/product-detail/lite-youtube.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+// lite-youtube-embed is a tiny, dependency-free custom element that renders a
+// YouTube facade (poster + play button) and only injects the real iframe on
+// click — the standard "third-party facade" pattern. The CSS styles the element.
+import 'lite-youtube-embed/src/lite-yt-embed.css';
+
+import type { CSSProperties } from 'react';
+
+// Register the <lite-youtube> custom element on the client only: the package
+// subclasses HTMLElement at import time, which isn't defined during SSR. The
+// element still renders as inert markup on the server and upgrades on hydration.
+if (typeof window !== 'undefined') {
+  void import('lite-youtube-embed');
+}
+
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements {
+      'lite-youtube': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
+        videoid: string;
+        playlabel?: string;
+        params?: string;
+      };
+    }
+  }
+}
+
+export interface LiteYouTubeProps {
+  videoId: string;
+  /** Visually-hidden label for the play button (accessibility). */
+  playLabel: string;
+  className?: string;
+  style?: CSSProperties;
+}
+
+export function LiteYouTube({ videoId, playLabel, className, style }: LiteYouTubeProps) {
+  return (
+    <lite-youtube
+      className={className}
+      params="rel=0"
+      playlabel={playLabel}
+      style={style}
+      videoid={videoId}
+    />
+  );
+}

--- a/core/vibes/soul/sections/product-detail/product-videos.tsx
+++ b/core/vibes/soul/sections/product-detail/product-videos.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { clsx } from 'clsx';
+import { useTranslations } from 'next-intl';
+import { useId, useState } from 'react';
+
+import { Image } from '~/components/image';
+
+import { LiteYouTube } from './lite-youtube';
+import { getYouTubeId, getYouTubePosterUrl } from './video-embed';
+
+export interface ProductVideo {
+  url: string;
+  title: string;
+}
+
+export interface ProductVideosProps {
+  videos: ProductVideo[];
+  className?: string;
+}
+
+// eslint-disable-next-line valid-jsdoc
+/**
+ * Renders product videos as a dedicated section below the primary product
+ * content (mirroring the Stencil/Cornerstone `product_below_content` layout)
+ * rather than inside the image gallery. A single featured player is shown with
+ * a horizontal strip of thumbnails; clicking a thumbnail swaps the featured
+ * video. Product videos are YouTube-only, matching BigCommerce's supported
+ * provider, so non-YouTube URLs are dropped.
+ *
+ * Theming CSS variables (shared with the gallery):
+ *
+ * ```css
+ * :root {
+ *   --product-gallery-focus: hsl(var(--primary));
+ *   --product-gallery-image-background: hsl(var(--contrast-100));
+ *   --product-gallery-image-border-active: hsl(var(--foreground));
+ *   --product-detail-primary-text: hsl(var(--foreground));
+ *   --product-detail-title-font-family: var(--font-family-heading);
+ * }
+ * ```
+ */
+export function ProductVideos({ videos, className }: ProductVideosProps) {
+  const t = useTranslations('Product.ProductDetails');
+
+  // Resolve to YouTube ids up front; non-YouTube URLs are skipped (YouTube is
+  // the only supported product-video provider).
+  const youtubeVideos = videos
+    .map((video) => ({ id: getYouTubeId(video.url), title: video.title }))
+    .filter((video): video is { id: string; title: string } => video.id !== null);
+
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [isOpen, setIsOpen] = useState(true);
+  const panelId = useId();
+
+  const featured = youtubeVideos[Math.min(selectedIndex, youtubeVideos.length - 1)];
+
+  // No renderable (YouTube) videos — render nothing. The `!featured` check also
+  // narrows the indexed access to a defined value for the rest of the render.
+  if (!featured) return null;
+
+  return (
+    <section aria-label={t('videosTitle')} className={clsx('@container', className)}>
+      <div className="mx-auto w-full max-w-screen-2xl px-4 py-10 @xl:px-6 @xl:py-14 @4xl:px-8 @4xl:py-20">
+        <div className="mb-6 flex items-center justify-between">
+          <h2 className="font-[family-name:var(--product-detail-title-font-family,var(--font-family-heading))] text-2xl font-medium text-[var(--product-detail-primary-text,hsl(var(--foreground)))] @xl:text-3xl @4xl:text-4xl">
+            {t('videosTitle')}
+          </h2>
+          <button
+            aria-controls={panelId}
+            aria-expanded={isOpen}
+            className="text-sm font-semibold text-[var(--product-detail-primary-text,hsl(var(--foreground)))] underline-offset-4 transition-opacity hover:opacity-80"
+            onClick={() => setIsOpen((open) => !open)}
+            type="button"
+          >
+            {isOpen ? t('hideVideos') : t('showVideos')}
+          </button>
+        </div>
+
+        {isOpen && (
+          <div className="duration-200 animate-in fade-in" id={panelId}>
+            {/* Featured player */}
+            <div className="relative aspect-video w-full overflow-hidden rounded-lg bg-[var(--product-gallery-image-background,hsl(var(--contrast-100)))]">
+              <LiteYouTube
+                className="h-full w-full max-w-none"
+                // Remount when the featured video changes so the previously
+                // playing player stops (and frees its audio).
+                key={featured.id}
+                playLabel={`${t('playVideo')}: ${featured.title}`}
+                videoId={featured.id}
+              />
+            </div>
+            {Boolean(featured.title) && (
+              <p className="mb-4 mt-3 text-sm font-semibold text-[var(--product-detail-primary-text,hsl(var(--foreground)))]">
+                {featured.title}
+              </p>
+            )}
+
+            {/* Thumbnail strip — only when there's more than one video to choose from. */}
+            {youtubeVideos.length > 1 && (
+              <div className="flex gap-3 overflow-x-auto pb-2">
+                {youtubeVideos.map((video, index) => (
+                  <button
+                    aria-label={`${t('viewVideo')}: ${video.title}`}
+                    aria-pressed={index === selectedIndex}
+                    className={clsx(
+                      'group relative w-40 shrink-0 overflow-hidden rounded-lg border transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--product-gallery-focus,hsl(var(--primary)))] focus-visible:ring-offset-2 @md:w-48',
+                      index === selectedIndex
+                        ? 'border-[var(--product-gallery-image-border-active,hsl(var(--foreground)))]'
+                        : 'border-transparent',
+                    )}
+                    key={`${video.id}-${index}`}
+                    onClick={() => setSelectedIndex(index)}
+                    type="button"
+                  >
+                    <div className="relative aspect-video w-full bg-[var(--product-gallery-image-background,hsl(var(--contrast-100)))]">
+                      <Image
+                        alt={video.title}
+                        className={clsx(
+                          'object-cover transition-opacity',
+                          index === selectedIndex
+                            ? 'opacity-100'
+                            : 'opacity-70 group-hover:opacity-100',
+                        )}
+                        fill
+                        sizes="12rem"
+                        src={getYouTubePosterUrl(video.id)}
+                      />
+                      {/* Play badge marks the thumbnail as a video. */}
+                      <span className="absolute inset-0 flex items-center justify-center">
+                        <span className="flex h-8 w-8 items-center justify-center rounded-full bg-black/60 text-white">
+                          <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="14"
+                            viewBox="0 0 24 24"
+                            width="14"
+                          >
+                            <path d="M8 5v14l11-7z" />
+                          </svg>
+                        </span>
+                      </span>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/core/vibes/soul/sections/product-detail/video-embed.ts
+++ b/core/vibes/soul/sections/product-detail/video-embed.ts
@@ -1,0 +1,56 @@
+/**
+ * Product videos come from the Storefront GraphQL API as a YouTube watch URL
+ * (e.g. `https://www.youtube.com/watch?v=...`). The `<lite-youtube>` player
+ * (see ./lite-youtube) needs the bare video id, and the Videos section thumbnail
+ * needs a poster image — both are derived here. The embedding itself (iframe, facade,
+ * autoplay) is handled by the lite-youtube-embed library.
+ *
+ * Product videos are YouTube-only; any other URL yields a null id and is skipped.
+ */
+
+// YouTube ids are short alphanumeric tokens; reject anything else so a malformed
+// path tail or encoded query material can't leak through.
+const YOUTUBE_ID = /^[\w-]{6,}$/;
+const YOUTUBE_HOSTS = new Set(['youtube.com', 'm.youtube.com', 'youtu.be']);
+
+// Extract the YouTube video id from a watch/share URL, or null if it isn't a
+// (safe http/https) YouTube URL.
+export function getYouTubeId(rawUrl: string): string | null {
+  let url: URL;
+
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+
+  const host = url.hostname.replace(/^www\./, '');
+
+  if (!YOUTUBE_HOSTS.has(host)) return null;
+
+  // https://www.youtube.com/watch?v=ID
+  const vParam = url.searchParams.get('v');
+
+  if (vParam && YOUTUBE_ID.test(vParam)) return vParam;
+
+  // https://www.youtube.com/embed/ID, /shorts/ID, /v/ID
+  const match = /\/(?:embed|shorts|v)\/([\w-]+)/.exec(url.pathname);
+
+  if (match?.[1] && YOUTUBE_ID.test(match[1])) return match[1];
+
+  // https://youtu.be/ID — first path segment only, ignoring any tail.
+  if (host === 'youtu.be') {
+    const [, first] = url.pathname.split('/');
+
+    if (first && YOUTUBE_ID.test(first)) return first;
+  }
+
+  return null;
+}
+
+// Poster/thumbnail image URL for a YouTube video id (used by the gallery thumbnail).
+export function getYouTubePosterUrl(videoId: string): string {
+  return `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       jose:
         specifier: ^5.10.0
         version: 5.10.0
+      lite-youtube-embed:
+        specifier: ^0.3.4
+        version: 0.3.4
       lodash.debounce:
         specifier: ^4.0.8
         version: 4.0.8
@@ -7240,6 +7243,9 @@ packages:
   listhen@1.9.0:
     resolution: {integrity: sha512-I8oW2+QL5KJo8zXNWX046M134WchxsXC7SawLPvRQpogCbkyQIaFxPE89A2HiwR7vAK2Dm2ERBAmyjTYGYEpBg==}
     hasBin: true
+
+  lite-youtube-embed@0.3.4:
+    resolution: {integrity: sha512-aXgxpwK7AIW58GEbRzA8EYaY4LWvF3FKak6B9OtSJmuNyLhX2ouD4cMTxz/yR5HFInhknaYd2jLWOTRTvT8oAw==}
 
   load-tsconfig@0.2.5:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
@@ -18397,6 +18403,8 @@ snapshots:
       ufo: 1.6.1
       untun: 0.1.3
       uqr: 0.1.2
+
+  lite-youtube-embed@0.3.4: {}
 
   load-tsconfig@0.2.5: {}
 


### PR DESCRIPTION
> Recreation of #3044, rebased on current `canary` (`c6b3b0713`). Verified with `pnpm -C core typecheck` and `eslint` (clean on all changed files).

## What / Why

Product videos were unsupported on the Catalyst PDP even though the Storefront
GraphQL API already exposes them on `Product.videos`. The API returns a
`{ title, url }` pair (a YouTube *watch* URL — YouTube is BigCommerce's supported
product-video provider), so two pieces were missing: the query never requested
the field, and there was no layer to turn a watch URL into an embeddable player.

This PR adds both and renders videos in a **dedicated section below the primary
product content** — mirroring the Stencil/Cornerstone `product_below_content`
layout — rather than mixing them into the image gallery.

### Layout

A "Videos" section sits directly below `ProductDetail`, before Related Products
and Reviews:

```
ProductDetail (gallery = images only)
→ Videos          ◄── new section
→ Related Products
→ Reviews
```

It renders a **featured player + horizontal thumbnail strip** (clicking a
thumbnail swaps the featured video) with a Hide/Show toggle. This matches the
Cornerstone PDP video structure. The featured player is full section width
(`max-w-screen-2xl`) as a starting point.

## Changes

| File | Change |
|------|--------|
| `core/app/.../product/[slug]/page-data.ts` | Add `videos(first: 25) { edges { node { title url } } }` to the PDP product query |
| `core/app/.../product/[slug]/page.tsx` | Add `streamableVideos` (independent of the gallery image stream); mount `<ProductVideos>` below `ProductDetail` |
| `core/vibes/soul/sections/product-detail/product-videos.tsx` | **New.** Section component — heading + collapsible toggle, featured `lite-youtube` player + title, thumbnail strip that swaps the featured video |
| `core/vibes/soul/sections/product-detail/lite-youtube.tsx` | **New.** Client-only `<lite-youtube>` facade wrapper (poster + play button; injects the iframe only on click) |
| `core/vibes/soul/sections/product-detail/video-embed.ts` | **New.** `getYouTubeId()` (defensive watch-URL parser) + `getYouTubePosterUrl()` |
| `core/vibes/soul/sections/product-detail/lite-youtube-embed.d.ts` | **New.** Ambient module declaration — `lite-youtube-embed` ships no types and is imported only for its custom-element side effect |
| `core/messages/en.json` | i18n keys: `videosTitle`, `hideVideos`, `showVideos`, `playVideo`, `viewVideo` (English source) |
| `core/next.config.ts` | Allow `i.ytimg.com/vi/**` poster thumbnails through `next/image` |
| `core/package.json` | Add `lite-youtube-embed ^0.3.4` |
| `.changeset/product-videos-pdp.md` | `minor` bump to `@bigcommerce/catalyst-core` |

## Design notes

- **Dedicated section, not the gallery:** keeps the gallery purely visual
  (image-only), matches the long-standing Stencil/Cornerstone PDP convention, and
  lets videos scale without competing with image pagination / load-more.
- **`lite-youtube-embed`:** a tiny, dependency-free third-party facade — shows a
  poster + play button and injects the `youtube-nocookie` iframe only on click, so
  no heavy player loads on PDP view. Registered client-side only (it subclasses
  `HTMLElement` at import, which breaks SSR); inert markup server-side, upgrades on
  hydration.
- **YouTube-only:** `getYouTubeId()` validates protocol + host + id shape and
  drops anything that isn't a YouTube URL, matching BC's supported provider. The
  section renders nothing when there are no usable YouTube URLs.
- **Playback hygiene:** the featured `<lite-youtube>` is keyed by video id, so
  swapping videos remounts the player and stops the previous one.

## Accessibility

- Collapsible toggle uses `aria-expanded` + `aria-controls` wired to the panel via
  `useId()`.
- Thumbnails use `aria-pressed` for selected state and labelled `aria-label`s; the
  play control has a visually-hidden label.

## Testing

Verified on current `canary` (base `c6b3b0713`):

```bash
pnpm install                     # lockfile adds only lite-youtube-embed
pnpm -C core typecheck           # 0 errors on changed files
eslint <changed files>           # clean
```

- PDP renders the Videos section: featured player, title, thumbnail strip;
  toggle hides/shows; thumbnails swap the featured video.
- **0** player iframes on initial load (facade); the iframe mounts only on click.

### `getYouTubeId()` verification matrix

`core/` has no unit-test runner today (tests are Playwright e2e), so the parser is
covered by this manual matrix (a unit test is a ready follow-up — the function is
pure):

| Input | Expected |
|-------|----------|
| `https://www.youtube.com/watch?v=dQw4w9WgXcQ` | `dQw4w9WgXcQ` |
| `https://youtu.be/dQw4w9WgXcQ` | `dQw4w9WgXcQ` |
| `https://www.youtube.com/embed/dQw4w9WgXcQ` | `dQw4w9WgXcQ` |
| `https://www.youtube.com/shorts/dQw4w9WgXcQ` | `dQw4w9WgXcQ` |
| `https://m.youtube.com/watch?v=dQw4w9WgXcQ` | `dQw4w9WgXcQ` |
| `https://vimeo.com/123456` | `null` (non-YouTube host) |
| `https://youtube.com.evil.com/watch?v=x` | `null` (host not whitelisted) |
| `javascript:alert(1)` | `null` (non-http(s) protocol) |
| `not a url` | `null` (parse failure) |
| `https://www.youtube.com/watch?v=` | `null` (empty id) |

## Migration / risk

Additive — the gallery, image load-more, and the review-form image consumer are
unchanged. CSP isn't affected (Catalyst sets no `frame-src`, so the YouTube iframe
loads). Branch is based on current `canary` (`c6b3b0713`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)