### PR TITLE
feat(cli): add domains claim command for cross-store domain ownership

### DIFF
--- a/.changeset/domains-claim-command.md
+++ b/.changeset/domains-claim-command.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst": minor
+---
+
+Add the `catalyst domains claim` command, which claims ownership of a custom domain that is already in use on another store. When you try to add a domain bound to a different store, `catalyst domains add` now prints the ownership-verification TXT record to publish; after publishing it, run `catalyst domains claim <domain>` to release the domain from the other store and bind it to your project.

--- a/packages/catalyst/src/cli/commands/domains.spec.ts
+++ b/packages/catalyst/src/cli/commands/domains.spec.ts
@@ -548,12 +548,18 @@ describe('add command', () => {
     await domains.parseAsync(['add', domain], { from: 'user' });
 
     expect(consola.warn).toHaveBeenCalledWith(
-      expect.stringContaining('already bound to a different store'),
+      expect.stringContaining('already in use on another store'),
     );
     expect(consola.log).toHaveBeenCalledWith(
       expect.stringContaining('bc-verify=019500e2933d70578e81090dd7240795'),
     );
-    expect(consola.info).toHaveBeenCalledWith(`Then run: catalyst domains claim ${domain}`);
+    expect(consola.info).toHaveBeenCalledWith(
+      `Once the record is live, run: catalyst domains claim ${domain}`,
+    );
+    // The raw V3 title/field text isn't echoed — the concise message replaces it.
+    expect(consola.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('Verify ownership using the claim endpoint'),
+    );
     expect(exitMock).toHaveBeenCalledWith(1);
   });
 });
@@ -704,9 +710,7 @@ describe('claim command', () => {
 
     await domains.parseAsync(['claim', domain], { from: 'user' });
 
-    expect(consola.warn).toHaveBeenCalledWith(
-      expect.stringContaining('ownership could not be verified'),
-    );
+    expect(consola.warn).toHaveBeenCalledWith(expect.stringContaining('could not be verified'));
     expect(consola.log).toHaveBeenCalledWith(
       expect.stringContaining('bc-verify=019500e2933d70578e81090dd7240795'),
     );

--- a/packages/catalyst/src/cli/commands/domains.spec.ts
+++ b/packages/catalyst/src/cli/commands/domains.spec.ts
@@ -5,7 +5,7 @@ import { http, HttpResponse } from 'msw';
 import { afterAll, afterEach, beforeAll, describe, expect, MockInstance, test, vi } from 'vitest';
 
 import { server } from '../../../tests/mocks/node';
-import { createDomain, deleteDomain, getDomain, listDomains } from '../lib/domains';
+import { claimDomain, createDomain, deleteDomain, getDomain, listDomains } from '../lib/domains';
 import { consola } from '../lib/logger';
 import { mkTempDir } from '../lib/mk-temp-dir';
 import { getProjectConfig, ProjectConfigSchema } from '../lib/project-config';
@@ -66,7 +66,7 @@ afterAll(async () => {
 });
 
 describe('command configuration', () => {
-  test('domains has add, list, status, and remove subcommands', () => {
+  test('domains has add, list, status, claim, and remove subcommands', () => {
     expect(domains).toBeInstanceOf(Command);
     expect(domains.name()).toBe('domains');
     expect(domains.description()).toBe(
@@ -76,6 +76,7 @@ describe('command configuration', () => {
     const add = domains.commands.find((command) => command.name() === 'add');
     const list = domains.commands.find((command) => command.name() === 'list');
     const status = domains.commands.find((command) => command.name() === 'status');
+    const claim = domains.commands.find((command) => command.name() === 'claim');
     const remove = domains.commands.find((command) => command.name() === 'remove');
 
     expect(add).toBeDefined();
@@ -108,6 +109,20 @@ describe('command configuration', () => {
       'Show the status of a custom domain on the current Native Hosting project.',
     );
     expect(status?.options).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ flags: '--store-hash <hash>' }),
+        expect.objectContaining({ flags: '--access-token <token>' }),
+        expect.objectContaining({ flags: '--api-host <host>' }),
+        expect.objectContaining({ flags: '--project-uuid <uuid>' }),
+        expect.objectContaining({ flags: '--wait' }),
+      ]),
+    );
+
+    expect(claim).toBeDefined();
+    expect(claim?.description()).toBe(
+      'Claim a custom domain that is currently in use on another store.',
+    );
+    expect(claim?.options).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ flags: '--store-hash <hash>' }),
         expect.objectContaining({ flags: '--access-token <token>' }),
@@ -336,6 +351,62 @@ describe('domain API client', () => {
     ).resolves.toBeUndefined();
     expect(deletedDomain).toBe(domain);
   });
+
+  test('claims a domain', async () => {
+    let claimedDomain: string | readonly string[] | undefined;
+
+    server.use(
+      http.post(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains/:domain/claim',
+        ({ params }) => {
+          claimedDomain = params.domain;
+
+          return new HttpResponse(null, { status: 204 });
+        },
+      ),
+    );
+
+    await expect(
+      claimDomain(domain, projectUuid, storeHash, accessToken, apiHost),
+    ).resolves.toBeUndefined();
+    expect(claimedDomain).toBe(domain);
+  });
+
+  test('surfaces the ownership-verification TXT record when a claim is not yet verified', async () => {
+    server.use(
+      http.post(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains/:domain/claim',
+        () =>
+          HttpResponse.json(
+            {
+              title: 'Domain ownership could not be verified.',
+              errors: {
+                domain: `No ownership verification TXT record was found at '_bigcommerce-verification.${domain}'. Add the record, then try again.`,
+              },
+              meta: {
+                ownership_verification: {
+                  type: 'TXT',
+                  name: `_bigcommerce-verification.${domain}`,
+                  value: 'bc-verify=019500e2933d70578e81090dd7240795',
+                },
+              },
+            },
+            { status: 422 },
+          ),
+      ),
+    );
+
+    await expect(
+      claimDomain(domain, projectUuid, storeHash, accessToken, apiHost),
+    ).rejects.toMatchObject({
+      name: 'DomainOwnershipVerificationError',
+      ownershipVerification: {
+        type: 'TXT',
+        name: `_bigcommerce-verification.${domain}`,
+        value: 'bc-verify=019500e2933d70578e81090dd7240795',
+      },
+    });
+  });
 });
 
 describe('waitForDomainVerification', () => {
@@ -446,6 +517,45 @@ describe('add command', () => {
     expect(consola.start).toHaveBeenCalledWith(`Waiting for ${domain} to verify...`);
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining('active'));
   });
+
+  test('surfaces the ownership TXT record and claim guidance on a cross-store collision', async () => {
+    server.use(
+      http.post(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains',
+        () =>
+          HttpResponse.json(
+            {
+              title:
+                'The domain is already bound to a different store. Verify ownership using the claim endpoint, then try again.',
+              errors: {
+                domain: `'${domain}' is already bound to a different store; verify ownership, then try again.`,
+              },
+              meta: {
+                ownership_verification: {
+                  type: 'TXT',
+                  name: `_bigcommerce-verification.${domain}`,
+                  value: 'bc-verify=019500e2933d70578e81090dd7240795',
+                },
+              },
+            },
+            { status: 409 },
+          ),
+      ),
+    );
+
+    writeCredentials();
+
+    await domains.parseAsync(['add', domain], { from: 'user' });
+
+    expect(consola.warn).toHaveBeenCalledWith(
+      expect.stringContaining('already bound to a different store'),
+    );
+    expect(consola.log).toHaveBeenCalledWith(
+      expect.stringContaining('bc-verify=019500e2933d70578e81090dd7240795'),
+    );
+    expect(consola.info).toHaveBeenCalledWith(`Then run: catalyst domains claim ${domain}`);
+    expect(exitMock).toHaveBeenCalledWith(1);
+  });
 });
 
 describe('list command', () => {
@@ -550,6 +660,92 @@ describe('status command', () => {
     expect(consola.start).toHaveBeenCalledWith(`Waiting for ${domain} to verify...`);
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining('active'));
     expect(requests).toBe(2);
+  });
+});
+
+describe('claim command', () => {
+  test('claims a domain for the linked project', async () => {
+    writeCredentials();
+
+    await domains.parseAsync(['claim', domain], { from: 'user' });
+
+    expect(consola.start).toHaveBeenCalledWith(`Claiming domain ${domain}...`);
+    expect(consola.success).toHaveBeenCalledWith(`Domain ${domain} claimed.`);
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining(domain));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining('active'));
+    expect(exitMock).toHaveBeenCalledWith(0);
+  });
+
+  test('prints the ownership TXT record when verification has not completed', async () => {
+    server.use(
+      http.post(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains/:domain/claim',
+        () =>
+          HttpResponse.json(
+            {
+              title: 'Domain ownership could not be verified.',
+              errors: {
+                domain: `No ownership verification TXT record was found at '_bigcommerce-verification.${domain}'. Add the record, then try again.`,
+              },
+              meta: {
+                ownership_verification: {
+                  type: 'TXT',
+                  name: `_bigcommerce-verification.${domain}`,
+                  value: 'bc-verify=019500e2933d70578e81090dd7240795',
+                },
+              },
+            },
+            { status: 422 },
+          ),
+      ),
+    );
+
+    writeCredentials();
+
+    await domains.parseAsync(['claim', domain], { from: 'user' });
+
+    expect(consola.warn).toHaveBeenCalledWith(
+      expect.stringContaining('ownership could not be verified'),
+    );
+    expect(consola.log).toHaveBeenCalledWith(
+      expect.stringContaining('bc-verify=019500e2933d70578e81090dd7240795'),
+    );
+    expect(consola.success).not.toHaveBeenCalled();
+    expect(exitMock).toHaveBeenCalledWith(1);
+  });
+
+  test('can wait for a claimed domain to leave pending status', async () => {
+    let getRequests = 0;
+
+    server.use(
+      http.post(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains/:domain/claim',
+        () => new HttpResponse(null, { status: 204 }),
+      ),
+      http.get(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains/:domain',
+        () => {
+          getRequests += 1;
+
+          return HttpResponse.json({
+            data: {
+              domain,
+              project_uuid: projectUuid,
+              verification_status: getRequests === 1 ? 'pending' : 'verified',
+            },
+          });
+        },
+      ),
+    );
+
+    writeCredentials();
+
+    await domains.parseAsync(['claim', domain, '--wait'], { from: 'user' });
+
+    expect(consola.success).toHaveBeenCalledWith(`Domain ${domain} claimed.`);
+    expect(consola.start).toHaveBeenCalledWith(`Waiting for ${domain} to verify...`);
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining('active'));
+    expect(getRequests).toBe(2);
   });
 });
 

--- a/packages/catalyst/src/cli/commands/domains.ts
+++ b/packages/catalyst/src/cli/commands/domains.ts
@@ -89,7 +89,7 @@ export function formatDomain(domain: Domain): string {
 
 export function formatOwnershipVerification(record: OwnershipVerification): string {
   const lines = [
-    'Publish this DNS record to verify ownership, then run the claim again:',
+    'Add this DNS record to verify ownership:',
     `  Type:  ${record.type}`,
     `  Name:  ${record.name}`,
   ];
@@ -160,9 +160,9 @@ Examples:
       );
     } catch (error) {
       if (error instanceof DomainOwnershipVerificationError) {
-        consola.warn(error.message);
+        consola.warn(`${domain} is already in use on another store.`);
         consola.log(formatOwnershipVerification(error.ownershipVerification));
-        consola.info(`Then run: catalyst domains claim ${domain}`);
+        consola.info(`Once the record is live, run: catalyst domains claim ${domain}`);
         process.exit(1);
 
         return;
@@ -318,8 +318,11 @@ Examples:
       );
     } catch (error) {
       if (error instanceof DomainOwnershipVerificationError) {
-        consola.warn(error.message);
+        consola.warn(`Ownership of ${domain} could not be verified yet.`);
         consola.log(formatOwnershipVerification(error.ownershipVerification));
+        consola.info(
+          `Once the record is live, run the claim again: catalyst domains claim ${domain}`,
+        );
         process.exit(1);
 
         return;

--- a/packages/catalyst/src/cli/commands/domains.ts
+++ b/packages/catalyst/src/cli/commands/domains.ts
@@ -3,13 +3,16 @@ import { Command, Option } from 'commander';
 import { colorize } from 'consola/utils';
 
 import {
+  claimDomain,
   createDomain,
   deleteDomain,
   Domain,
+  DomainOwnershipVerificationError,
   DomainStatus,
   DomainStatusFilter,
   getDomain,
   listDomains,
+  OwnershipVerification,
 } from '../lib/domains';
 import { consola } from '../lib/logger';
 import { getProjectConfig } from '../lib/project-config';
@@ -84,6 +87,20 @@ export function formatDomain(domain: Domain): string {
   return `${domain.domain} ${formatDomainStatus(domain.verification_status)}`;
 }
 
+export function formatOwnershipVerification(record: OwnershipVerification): string {
+  const lines = [
+    'Publish this DNS record to verify ownership, then run the claim again:',
+    `  Type:  ${record.type}`,
+    `  Name:  ${record.name}`,
+  ];
+
+  if (record.value) {
+    lines.push(`  Value: ${record.value}`);
+  }
+
+  return lines.join('\n');
+}
+
 export async function waitForDomainVerification({
   domain,
   projectUuid,
@@ -131,13 +148,28 @@ Examples:
 
     consola.start(`Adding domain ${domain}...`);
 
-    let result = await createDomain(
-      domain,
-      context.projectUuid,
-      context.storeHash,
-      context.accessToken,
-      context.apiHost,
-    );
+    let result: Domain;
+
+    try {
+      result = await createDomain(
+        domain,
+        context.projectUuid,
+        context.storeHash,
+        context.accessToken,
+        context.apiHost,
+      );
+    } catch (error) {
+      if (error instanceof DomainOwnershipVerificationError) {
+        consola.warn(error.message);
+        consola.log(formatOwnershipVerification(error.ownershipVerification));
+        consola.info(`Then run: catalyst domains claim ${domain}`);
+        process.exit(1);
+
+        return;
+      }
+
+      throw error;
+    }
 
     consola.success(`Domain ${result.domain} added.`);
 
@@ -247,6 +279,74 @@ Examples:
     process.exit(0);
   });
 
+const claim = new Command('claim')
+  .configureHelp({ showGlobalOptions: true })
+  .description('Claim a custom domain that is currently in use on another store.')
+  .argument('<domain>', 'Custom domain to claim.')
+  .addHelpText(
+    'after',
+    `
+Claiming requires publishing the ownership-verification TXT record returned when
+you try to add a domain that is already in use on another store. Publish the
+record with your DNS provider, then run this command to complete the claim.
+
+Examples:
+  $ catalyst domains claim www.example.com
+
+  # Wait until the claimed domain leaves pending verification
+  $ catalyst domains claim www.example.com --wait`,
+  )
+  .addOption(storeHashOption())
+  .addOption(accessTokenOption())
+  .addOption(apiHostOption())
+  .addOption(projectUuidOption())
+  .option('--wait', 'Poll until domain verification completes or times out.')
+  .action(async (domain, options) => {
+    const context = resolveDomainCommandContext(options);
+
+    await getTelemetry().identify(context.storeHash);
+
+    consola.start(`Claiming domain ${domain}...`);
+
+    try {
+      await claimDomain(
+        domain,
+        context.projectUuid,
+        context.storeHash,
+        context.accessToken,
+        context.apiHost,
+      );
+    } catch (error) {
+      if (error instanceof DomainOwnershipVerificationError) {
+        consola.warn(error.message);
+        consola.log(formatOwnershipVerification(error.ownershipVerification));
+        process.exit(1);
+
+        return;
+      }
+
+      throw error;
+    }
+
+    consola.success(`Domain ${domain} claimed.`);
+
+    let result = await getDomain(
+      domain,
+      context.projectUuid,
+      context.storeHash,
+      context.accessToken,
+      context.apiHost,
+    );
+
+    if (options.wait && result.verification_status === 'pending') {
+      consola.start(`Waiting for ${result.domain} to verify...`);
+      result = await waitForDomainVerification({ domain: result.domain, ...context });
+    }
+
+    consola.log(formatDomain(result));
+    process.exit(0);
+  });
+
 const remove = new Command('remove')
   .configureHelp({ showGlobalOptions: true })
   .description('Remove a custom domain from the current Native Hosting project.')
@@ -314,4 +414,5 @@ export const domains = new Command('domains')
   .addCommand(add)
   .addCommand(list)
   .addCommand(showStatus)
+  .addCommand(claim)
   .addCommand(remove);

--- a/packages/catalyst/src/cli/lib/domains.ts
+++ b/packages/catalyst/src/cli/lib/domains.ts
@@ -14,6 +14,40 @@ const domainSchema = z.object({
   verification_status: domainStatusSchema,
 });
 
+const ownershipVerificationSchema = z.object({
+  type: z.string(),
+  name: z.string(),
+  value: z.string().optional(),
+});
+
+export type OwnershipVerification = z.infer<typeof ownershipVerificationSchema>;
+
+const ownershipVerificationMetaSchema = z.object({
+  meta: z.object({
+    ownership_verification: ownershipVerificationSchema,
+  }),
+});
+
+// Raised when the Domains API rejects an add/claim because ownership of a
+// domain bound to another store has not been verified. Carries the TXT record
+// the caller must publish so the command can render actionable next steps
+// instead of an opaque error.
+export class DomainOwnershipVerificationError extends Error {
+  readonly ownershipVerification: OwnershipVerification;
+
+  constructor(message: string, ownershipVerification: OwnershipVerification) {
+    super(message);
+    this.name = 'DomainOwnershipVerificationError';
+    this.ownershipVerification = ownershipVerification;
+  }
+}
+
+function parseOwnershipVerification(body: unknown): OwnershipVerification | undefined {
+  const parsed = ownershipVerificationMetaSchema.safeParse(body);
+
+  return parsed.success ? parsed.data.meta.ownership_verification : undefined;
+}
+
 const domainResponseSchema = z.object({
   data: domainSchema,
 });
@@ -41,6 +75,10 @@ function domainUrl(storeHash: string, projectUuid: string, domain: string, apiHo
   return `${domainsUrl(storeHash, projectUuid, apiHost)}/${encodeURIComponent(domain)}`;
 }
 
+function domainClaimUrl(storeHash: string, projectUuid: string, domain: string, apiHost: string) {
+  return `${domainUrl(storeHash, projectUuid, domain, apiHost)}/claim`;
+}
+
 function authHeaders(accessToken: string) {
   return {
     Accept: 'application/json',
@@ -53,8 +91,7 @@ function formatResponseStatus(response: Response, message?: string): string {
   return [response.status, response.statusText || message].filter(Boolean).join(' ');
 }
 
-async function getErrorMessage(response: Response, action: string): Promise<string> {
-  const body: unknown = await response.json().catch(() => null);
+function buildErrorMessage(response: Response, body: unknown, action: string): string {
   const message = formatV3Error(body);
 
   if (response.status >= 500) {
@@ -66,6 +103,10 @@ async function getErrorMessage(response: Response, action: string): Promise<stri
   return message ?? `${action}: ${response.statusText}`;
 }
 
+// Throws for any non-OK Domains API response. When the body carries an
+// `meta.ownership_verification` TXT record (a domain bound to another store),
+// surfaces a DomainOwnershipVerificationError so callers can guide the user
+// through the claim flow; otherwise throws a plain formatted error.
 async function assertDomainResponse(response: Response, action: string): Promise<void> {
   assertAuthorized(response);
 
@@ -73,9 +114,19 @@ async function assertDomainResponse(response: Response, action: string): Promise
     throw new Error(DOMAINS_API_NOT_ENABLED);
   }
 
-  if (!response.ok) {
-    throw new Error(await getErrorMessage(response, action));
+  if (response.ok) {
+    return;
   }
+
+  const body: unknown = await response.json().catch(() => null);
+  const message = buildErrorMessage(response, body, action);
+  const ownershipVerification = parseOwnershipVerification(body);
+
+  if (ownershipVerification) {
+    throw new DomainOwnershipVerificationError(message, ownershipVerification);
+  }
+
+  throw new Error(message);
 }
 
 export async function createDomain(
@@ -164,4 +215,19 @@ export async function deleteDomain(
   });
 
   await assertDomainResponse(response, `Failed to remove domain: ${response.statusText}`);
+}
+
+export async function claimDomain(
+  domain: string,
+  projectUuid: string,
+  storeHash: string,
+  accessToken: string,
+  apiHost: string,
+): Promise<void> {
+  const response = await fetch(domainClaimUrl(storeHash, projectUuid, domain, apiHost), {
+    method: 'POST',
+    headers: authHeaders(accessToken),
+  });
+
+  await assertDomainResponse(response, 'Failed to claim domain');
 }

--- a/packages/catalyst/tests/mocks/handlers.ts
+++ b/packages/catalyst/tests/mocks/handlers.ts
@@ -84,6 +84,12 @@ export const handlers = [
     () => new HttpResponse(null, { status: 204 }),
   ),
 
+  // Handler for claimDomain
+  http.post(
+    'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains/:domain/claim',
+    () => new HttpResponse(null, { status: 204 }),
+  ),
+
   // Handler for fetchProjects
   http.get('https://:apiHost/stores/:storeHash/v3/infrastructure/projects', () =>
     HttpResponse.json({


### PR DESCRIPTION
Linear: [LTRAC-1106](https://linear.app/commerce/issue/LTRAC-1106/implement-domain-claiming-functionality-in-the-cli)

## What/Why?

The `catalyst domains claim` command was missed from the initial Native Hosting CLI work. It lets a user claim ownership of a custom domain that is already in use on another store/project — publish the ownership-verification TXT record, then run `claim` to release the domain from the other store and bind it to the current project (`POST .../projects/{project_uuid}/domains/{domain}/claim`).

The Domains API returns the TXT record to publish in the `meta.ownership_verification` field of a cross-store collision. Rather than let it surface as an opaque error, it's parsed into a typed `DomainOwnershipVerificationError` so:

- `domains add` — on a `409` cross-store collision, prints the TXT record plus `Then run: catalyst domains claim <domain>`.
- `domains claim` — on a `422` not-yet-verified claim, reprints the TXT record so the user can publish it and retry.

`claim` mirrors `add`/`status`: after a successful claim it shows the domain status, and `--wait` polls until the domain leaves `pending` verification.

Docs (CLI reference + native-hosting getting-started) are updated in a separate `docs-v2` change.

## Testing

`pnpm --filter @bigcommerce/catalyst test src/cli/commands/domains.spec.ts` (31 passing), plus `pnpm typecheck` and `pnpm lint`. New coverage: `claimDomain` success + `422` verification error, the `claim` command (success, unverified TXT reprint, `--wait`), and the `add` cross-store collision path. Verified `catalyst domains claim --help` on the built CLI.

## Migration

None.