### PR TITLE
ci: TRAC-881 Hook up Linear releases via linear-release-action

### DIFF
--- a/.github/workflows/changesets-release.yml
+++ b/.github/workflows/changesets-release.yml
@@ -21,6 +21,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          # Full history required for linear-release-action to scan commits.
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
@@ -39,6 +42,16 @@ jobs:
         env:
           CLI_SEGMENT_WRITE_KEY: ${{ secrets.CLI_SEGMENT_WRITE_KEY }}
 
+      - name: Sync Linear release
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          command: sync
+          # TODO: one-time bootstrap bound so the first sync doesn't scan this
+          # existing project's full history. Remove once the pipeline has its
+          # own release bookmark.
+          base_ref: ${{ github.ref_name == 'canary' && '@bigcommerce/catalyst-core@1.8.0' || '@bigcommerce/catalyst-makeswift@1.8.0' }}
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
@@ -51,3 +64,34 @@ jobs:
           commit: "Version Packages (`${{ github.ref_name }}`)"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve headline package
+        id: headline
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          PACKAGE_NAME="@bigcommerce/catalyst-core"
+          if [ "${{ github.ref_name }}" = "integrations/makeswift" ]; then
+            PACKAGE_NAME="@bigcommerce/catalyst-makeswift"
+          fi
+          VERSION=$(echo '${{ steps.changesets.outputs.publishedPackages }}' | jq -r --arg name "$PACKAGE_NAME" '.[] | select(.name == $name) | .version')
+          if [ -z "$VERSION" ]; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "tag=$PACKAGE_NAME@$VERSION" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fetch release notes
+        if: steps.headline.outputs.found == 'true'
+        run: gh release view "${{ steps.headline.outputs.tag }}" --json body -q .body > /tmp/release-notes.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Complete Linear release
+        if: steps.headline.outputs.found == 'true'
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          command: complete
+          version: ${{ steps.headline.outputs.tag }}
+          release_notes: /tmp/release-notes.md


### PR DESCRIPTION
Jira: [TRAC-881](https://bigcommercecloud.atlassian.net/browse/TRAC-881)

## What/Why?

Wires up [linear/linear-release-action](https://github.com/linear/linear-release-action) in `changesets-release.yml` so the "Catalyst Release" pipeline in Linear (scheduled, stages `Planned → In Progress → Merged → Released`) can answer "when will this ship" questions (LTRAC-913).

- `sync` runs on every push to `canary`/`integrations/makeswift`, attaching merged issues to whichever release is currently open in the pipeline — this is how Linear expects scheduled pipelines to be fed continuously as PRs merge.
- `complete` only fires when `changesets/action` actually publishes the branch's headline package (`@bigcommerce/catalyst-core` on `canary`, `@bigcommerce/catalyst-makeswift` on `integrations/makeswift`), resolved from the `publishedPackages` output. If a run only bumps a non-headline package (e.g. `@bigcommerce/create-catalyst` or the CLI), it's skipped and those issues stay attached to the still-open release.
- Release notes for `complete` are pulled straight from the GitHub Release body that `changesets/action` already generates for the published tag (`gh release view`), reusing the existing changeset-authored changelog instead of re-parsing `CHANGELOG.md` or relying on Linear's own auto-generated notes (currently off on this pipeline).
- Checkout now uses `fetch-depth: 0` since the Linear CLI needs real commit history to scan.

Explicitly out of scope: the manual `@latest` tag move (drives demo-site deploys in `deploy.yml`) stays untouched — a Linear release is considered shipped when changesets publishes a new version, not when `@latest` moves.

## Testing

Can't fully dry-run this without pushing to a protected branch. Plan is to watch the Action logs on the next few real pushes/publishes to `canary` and `integrations/makeswift`, confirm the `LINEAR_ACCESS_KEY` secret authenticates, `headline` step resolves the right tag, and the release shows up correctly in Linear (https://linear.app/commerce/pipeline/catalyst-release/releases) with attached issues and, after a real publish, the changelog as notes.

## Migration

N/A — CI workflow only, no application code changes.

[TRAC-881]: https://bigcommercecloud.atlassian.net/browse/TRAC-881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ