### PR TITLE
fix(ci): TRAC-881 Scope Linear release sync to core/** changes

### DIFF
--- a/.github/workflows/changesets-release.yml
+++ b/.github/workflows/changesets-release.yml
@@ -47,6 +47,10 @@ jobs:
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
           command: sync
+          # Only the storefront package ships as its own release; changes to
+          # other workspace packages (client, create-catalyst, the CLI) are
+          # released separately and shouldn't count toward this pipeline.
+          include_paths: core/**
           # TODO: one-time bootstrap bound so the first sync doesn't scan this
           # existing project's full history. Remove once the pipeline has its
           # own release bookmark.


### PR DESCRIPTION
Jira: [TRAC-881](https://bigcommercecloud.atlassian.net/browse/TRAC-881)

## What/Why?

Fast-follow to #3085. The "Sync Linear release" step scanned every commit on `canary`/`integrations/makeswift` with no path filter, so changes to `packages/client`, `packages/create-catalyst`, and the CLI were getting swept into the "Catalyst Release" Linear pipeline. Those ship as their own independent releases and shouldn't count toward this one.

Adds `include_paths: core/**` to the `sync` call so only commits touching the storefront package are scanned. `include_paths` isn't needed on the `complete` call since that targets a specific version directly rather than scanning commits.

## Testing

No automated tests for this workflow. Will confirm via the next real push to canary/integrations-makeswift that `sync` only picks up `core/**` commits.

[TRAC-881]: https://bigcommercecloud.atlassian.net/browse/TRAC-881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ