### PR TITLE
fix: TRAC-296: Respect blog visibility setting in footer nav

### DIFF
--- a/.changeset/trac-296-footer-blog-visibility.md
+++ b/.changeset/trac-296-footer-blog-visibility.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Respect the Blog visibility setting (Control Panel > Storefront > Blogs) in the footer navigation. The Blog link no longer appears in the footer's "Navigate" section when Blog visibility is turned off.

--- a/core/components/footer/fragment.ts
+++ b/core/components/footer/fragment.ts
@@ -42,6 +42,7 @@ export const FooterSectionsFragment = graphql(`
           node {
             __typename
             name
+            isVisibleInNavigation
             ... on RawHtmlPage {
               path
             }

--- a/core/components/footer/index.tsx
+++ b/core/components/footer/index.tsx
@@ -124,10 +124,12 @@ export const Footer = async () => {
                 },
               ]
             : []),
-          ...removeEdgesAndNodes(sectionsData.content.pages).map((page) => ({
-            label: page.name,
-            href: page.__typename === 'ExternalLinkPage' ? page.link : page.path,
-          })),
+          ...removeEdgesAndNodes(sectionsData.content.pages)
+            .filter((page) => page.isVisibleInNavigation)
+            .map((page) => ({
+              label: page.name,
+              href: page.__typename === 'ExternalLinkPage' ? page.link : page.path,
+            })),
         ],
       },
     ];


### PR DESCRIPTION
## What/Why?

Jira: [TRAC-296](https://bigcommercecloud.atlassian.net/browse/TRAC-296)

Blog visibility toggle in Control Panel (Storefront > Blogs) was not respected — the Blog link
always appeared in the storefront footer's "Navigate" section regardless of the setting.

Root cause: `FooterSectionsFragment` queries `content.pages` to build the footer's Navigate
links, but never requested `isVisibleInNavigation`, and `Footer` mapped every returned page
into a link unconditionally. Since `isVisibleInNavigation` is exposed per-page on the `WebPage`
interface (including `BlogIndexPage`), we now fetch it and filter hidden pages out before
rendering.

## Testing

Before:
<img width="972" height="344" alt="Screenshot 2026-07-08 at 13 06 22" src="https://github.com/user-attachments/assets/501441b8-704c-4611-be13-e82796e413e7" />

After:
<img width="400" height="217" alt="Screenshot 2026-07-08 at 13 13 55" src="https://github.com/user-attachments/assets/258f721e-fa09-40ee-95fb-c6e84fcdcbdf" />

<img width="1165" height="610" alt="Screenshot 2026-07-08 at 13 06 07" src="https://github.com/user-attachments/assets/9380da96-2d13-4acf-a81b-9b16ddbcb0e9" />


## Migration

None.

[TRAC-296]: https://bigcommercecloud.atlassian.net/browse/TRAC-296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ