### PR TITLE
feat(cli): add domains transfer command for same-store project moves

### DIFF
--- a/.changeset/domains-transfer-command.md
+++ b/.changeset/domains-transfer-command.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst": minor
+---
+
+Add the `catalyst domains transfer` command, which moves a custom domain from one project to another project in the same store (the same-store counterpart to `domains claim`). Pass `--to-project-uuid <uuid>` to target a specific project, or omit it to pick the destination interactively from your store's projects. When `catalyst domains add` fails because the domain is already bound to another project in the store, it now points you at the exact `domains transfer` command to move it instead of surfacing the raw API error.

--- a/packages/catalyst/src/cli/commands/domains.spec.ts
+++ b/packages/catalyst/src/cli/commands/domains.spec.ts
@@ -677,9 +677,8 @@ describe('add command', () => {
     expect(consola.log).toHaveBeenCalledWith(
       expect.stringContaining('bc-verify=019500e2933d70578e81090dd7240795'),
     );
-    expect(consola.info).toHaveBeenCalledWith(
-      `Once the record is live, run: catalyst domains claim ${domain}`,
-    );
+    expect(consola.info).toHaveBeenCalledWith('Once the record is live, claim it with:');
+    expect(consola.log).toHaveBeenCalledWith(`  catalyst domains claim ${domain}`);
     // The raw V3 title/field text isn't echoed — the concise message replaces it.
     expect(consola.warn).not.toHaveBeenCalledWith(
       expect.stringContaining('Verify ownership using the claim endpoint'),
@@ -715,8 +714,9 @@ describe('add command', () => {
     expect(consola.warn).toHaveBeenCalledWith(
       expect.stringContaining('already bound to another project in this store'),
     );
-    expect(consola.info).toHaveBeenCalledWith(
-      `To move it to this project, run: catalyst domains transfer ${domain} --project-uuid ${boundProjectUuid} --to-project-uuid ${projectUuid}`,
+    expect(consola.info).toHaveBeenCalledWith('To move it to this project, run:');
+    expect(consola.log).toHaveBeenCalledWith(
+      `  catalyst domains transfer ${domain} --project-uuid ${boundProjectUuid} --to-project-uuid ${projectUuid}`,
     );
     // The raw V3 title/field text isn't echoed — the concise message + suggestion replace it.
     expect(consola.warn).not.toHaveBeenCalledWith(

--- a/packages/catalyst/src/cli/commands/domains.spec.ts
+++ b/packages/catalyst/src/cli/commands/domains.spec.ts
@@ -1,11 +1,18 @@
-import { confirm } from '@inquirer/prompts';
+import { confirm, select } from '@inquirer/prompts';
 import { Command } from 'commander';
 import Conf from 'conf';
 import { http, HttpResponse } from 'msw';
 import { afterAll, afterEach, beforeAll, describe, expect, MockInstance, test, vi } from 'vitest';
 
 import { server } from '../../../tests/mocks/node';
-import { claimDomain, createDomain, deleteDomain, getDomain, listDomains } from '../lib/domains';
+import {
+  claimDomain,
+  createDomain,
+  deleteDomain,
+  getDomain,
+  listDomains,
+  transferDomain,
+} from '../lib/domains';
 import { UserActionableError } from '../lib/errors';
 import { consola } from '../lib/logger';
 import { mkTempDir } from '../lib/mk-temp-dir';
@@ -15,9 +22,11 @@ import { domains, formatDomain, formatDomainStatus, waitForDomainVerification } 
 
 vi.mock('@inquirer/prompts', () => ({
   confirm: vi.fn(),
+  select: vi.fn(),
 }));
 
 const confirmMock = vi.mocked(confirm);
+const selectMock = vi.mocked(select);
 
 let exitMock: MockInstance;
 let tmpDir: string;
@@ -67,7 +76,7 @@ afterAll(async () => {
 });
 
 describe('command configuration', () => {
-  test('domains has add, list, status, claim, and remove subcommands', () => {
+  test('domains has add, list, status, claim, transfer, and remove subcommands', () => {
     expect(domains).toBeInstanceOf(Command);
     expect(domains.name()).toBe('domains');
     expect(domains.description()).toBe(
@@ -78,6 +87,7 @@ describe('command configuration', () => {
     const list = domains.commands.find((command) => command.name() === 'list');
     const status = domains.commands.find((command) => command.name() === 'status');
     const claim = domains.commands.find((command) => command.name() === 'claim');
+    const transfer = domains.commands.find((command) => command.name() === 'transfer');
     const remove = domains.commands.find((command) => command.name() === 'remove');
 
     expect(add).toBeDefined();
@@ -129,6 +139,21 @@ describe('command configuration', () => {
         expect.objectContaining({ flags: '--access-token <token>' }),
         expect.objectContaining({ flags: '--api-host <host>' }),
         expect.objectContaining({ flags: '--project-uuid <uuid>' }),
+        expect.objectContaining({ flags: '--wait' }),
+      ]),
+    );
+
+    expect(transfer).toBeDefined();
+    expect(transfer?.description()).toBe(
+      'Transfer a custom domain to another project in the same store.',
+    );
+    expect(transfer?.options).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ flags: '--store-hash <hash>' }),
+        expect.objectContaining({ flags: '--access-token <token>' }),
+        expect.objectContaining({ flags: '--api-host <host>' }),
+        expect.objectContaining({ flags: '--project-uuid <uuid>' }),
+        expect.objectContaining({ flags: '--to-project-uuid <uuid>' }),
         expect.objectContaining({ flags: '--wait' }),
       ]),
     );
@@ -410,6 +435,30 @@ describe('domain API client', () => {
     expect(claimedDomain).toBe(domain);
   });
 
+  test('transfers a domain with the destination project in the body', async () => {
+    const newProjectUuid = 'a23f5785-fd99-4a94-9fb3-945551623923';
+    let capturedBody: unknown;
+    let capturedSourceProject: string | readonly string[] | undefined;
+
+    server.use(
+      http.post(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains/:domain/transfer',
+        async ({ request, params }) => {
+          capturedBody = await request.json();
+          capturedSourceProject = params.projectUuid;
+
+          return new HttpResponse(null, { status: 204 });
+        },
+      ),
+    );
+
+    await expect(
+      transferDomain(domain, projectUuid, newProjectUuid, storeHash, accessToken, apiHost),
+    ).resolves.toBeUndefined();
+    expect(capturedSourceProject).toBe(projectUuid);
+    expect(capturedBody).toEqual({ new_project_uuid: newProjectUuid });
+  });
+
   test('surfaces the ownership-verification TXT record when a claim is not yet verified', async () => {
     server.use(
       http.post(
@@ -597,6 +646,44 @@ describe('add command', () => {
     // The raw V3 title/field text isn't echoed — the concise message replaces it.
     expect(consola.warn).not.toHaveBeenCalledWith(
       expect.stringContaining('Verify ownership using the claim endpoint'),
+    );
+    expect(exitMock).toHaveBeenCalledWith(1);
+  });
+
+  test('suggests the transfer command when the domain is bound to another project in the store', async () => {
+    const boundProjectUuid = 'b23f5785-fd99-4a94-9fb3-945551623924';
+
+    server.use(
+      http.post(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains',
+        () =>
+          HttpResponse.json(
+            {
+              title:
+                'The domain is already bound to another project in this store. Use the transfer endpoint to move it.',
+              errors: {
+                domain: `'${domain}' is already bound to another project in this store.`,
+              },
+              meta: { project_uuid: boundProjectUuid },
+            },
+            { status: 409 },
+          ),
+      ),
+    );
+
+    writeCredentials();
+
+    await domains.parseAsync(['add', domain], { from: 'user' });
+
+    expect(consola.warn).toHaveBeenCalledWith(
+      expect.stringContaining('already bound to another project in this store'),
+    );
+    expect(consola.info).toHaveBeenCalledWith(
+      `To move it to this project, run: catalyst domains transfer ${domain} --project-uuid ${boundProjectUuid} --to-project-uuid ${projectUuid}`,
+    );
+    // The raw V3 title/field text isn't echoed — the concise message + suggestion replace it.
+    expect(consola.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('Use the transfer endpoint to move it'),
     );
     expect(exitMock).toHaveBeenCalledWith(1);
   });
@@ -788,6 +875,98 @@ describe('claim command', () => {
     expect(consola.start).toHaveBeenCalledWith(`Waiting for ${domain} to verify...`);
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining('active'));
     expect(getRequests).toBe(2);
+  });
+});
+
+describe('transfer command', () => {
+  const destinationProjectUuid = 'a23f5785-fd99-4a94-9fb3-945551623923';
+
+  test('transfers to the project passed via --to-project-uuid without prompting', async () => {
+    let capturedBody: unknown;
+    let capturedSourceProject: string | readonly string[] | undefined;
+
+    server.use(
+      http.post(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains/:domain/transfer',
+        async ({ request, params }) => {
+          capturedBody = await request.json();
+          capturedSourceProject = params.projectUuid;
+
+          return new HttpResponse(null, { status: 204 });
+        },
+      ),
+    );
+
+    writeCredentials();
+
+    await domains.parseAsync(['transfer', domain, '--to-project-uuid', destinationProjectUuid], {
+      from: 'user',
+    });
+
+    expect(selectMock).not.toHaveBeenCalled();
+    expect(capturedSourceProject).toBe(projectUuid);
+    expect(capturedBody).toEqual({ new_project_uuid: destinationProjectUuid });
+    expect(consola.success).toHaveBeenCalledWith(`Domain ${domain} transferred.`);
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining('active'));
+    expect(exitMock).toHaveBeenCalledWith(0);
+  });
+
+  test('prompts to pick a destination project, excluding the source', async () => {
+    // Default fetchProjects handler returns Project One + Project Two; the
+    // linked (source) project UUID matches neither, so both are offered.
+    selectMock.mockResolvedValue(destinationProjectUuid);
+
+    let capturedBody: unknown;
+
+    server.use(
+      http.post(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains/:domain/transfer',
+        async ({ request }) => {
+          capturedBody = await request.json();
+
+          return new HttpResponse(null, { status: 204 });
+        },
+      ),
+    );
+
+    writeCredentials();
+
+    await domains.parseAsync(['transfer', domain], { from: 'user' });
+
+    expect(selectMock).toHaveBeenCalledTimes(1);
+
+    const choiceValues = selectMock.mock.calls[0][0].choices.map((choice) =>
+      typeof choice === 'object' && 'value' in choice ? choice.value : undefined,
+    );
+
+    expect(choiceValues).not.toContain(projectUuid);
+    expect(capturedBody).toEqual({ new_project_uuid: destinationProjectUuid });
+    expect(consola.success).toHaveBeenCalledWith(`Domain ${domain} transferred.`);
+  });
+
+  test('rejects a destination that matches the source project', async () => {
+    writeCredentials();
+
+    await expect(
+      domains.parseAsync(['transfer', domain, '--to-project-uuid', projectUuid], { from: 'user' }),
+    ).rejects.toThrow('destination project must differ from the source project');
+  });
+
+  test('errors when there are no other projects to transfer to', async () => {
+    server.use(
+      http.get('https://:apiHost/stores/:storeHash/v3/infrastructure/projects', () =>
+        HttpResponse.json({
+          data: [{ uuid: projectUuid, name: 'Only Project', deployment_hostnames: [] }],
+        }),
+      ),
+    );
+
+    writeCredentials();
+
+    await expect(domains.parseAsync(['transfer', domain], { from: 'user' })).rejects.toThrow(
+      'No other projects to transfer to',
+    );
+    expect(selectMock).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/catalyst/src/cli/commands/domains.spec.ts
+++ b/packages/catalyst/src/cli/commands/domains.spec.ts
@@ -981,7 +981,49 @@ describe('transfer command', () => {
     expect(consola.success).toHaveBeenCalledWith(`Domain ${domain} transferred.`);
   });
 
-  test('errors with guidance when the domain is not on the source project', async () => {
+  test('points at the owning project when the domain lives on another one', async () => {
+    // Default fetchProjects returns Project One (a23f…) + Project Two (b23f…).
+    // The domain is on Project One; the linked project and Project Two 404.
+    const ownerUuid = destinationProjectUuid;
+    let transferRequests = 0;
+
+    server.use(
+      http.get(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains/:domain',
+        ({ params }) =>
+          params.projectUuid === ownerUuid
+            ? HttpResponse.json({
+                data: { domain, project_uuid: ownerUuid, verification_status: 'verified' },
+              })
+            : new HttpResponse(null, { status: 404 }),
+      ),
+      http.post(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains/:domain/transfer',
+        () => {
+          transferRequests += 1;
+
+          return new HttpResponse(null, { status: 204 });
+        },
+      ),
+    );
+
+    writeCredentials();
+
+    await domains.parseAsync(['transfer', domain], { from: 'user' });
+
+    expect(consola.warn).toHaveBeenCalledWith(
+      expect.stringContaining(`${domain} is on project "Project One" (${ownerUuid})`),
+    );
+    expect(consola.log).toHaveBeenCalledWith(
+      `  catalyst domains transfer ${domain} --project-uuid ${ownerUuid}`,
+    );
+    // The transfer is never attempted, and the user is never prompted.
+    expect(transferRequests).toBe(0);
+    expect(selectMock).not.toHaveBeenCalled();
+    expect(exitMock).toHaveBeenCalledWith(1);
+  });
+
+  test('errors when the domain is on no project in the store', async () => {
     let transferRequests = 0;
 
     server.use(
@@ -1005,7 +1047,7 @@ describe('transfer command', () => {
       domains.parseAsync(['transfer', domain, '--to-project-uuid', destinationProjectUuid], {
         from: 'user',
       }),
-    ).rejects.toThrow(`${domain} isn't on the current project`);
+    ).rejects.toThrow(`${domain} isn't on any project in this store`);
 
     // The transfer is never attempted, and the user is never prompted.
     expect(transferRequests).toBe(0);

--- a/packages/catalyst/src/cli/commands/domains.spec.ts
+++ b/packages/catalyst/src/cli/commands/domains.spec.ts
@@ -9,6 +9,7 @@ import {
   claimDomain,
   createDomain,
   deleteDomain,
+  findDomain,
   getDomain,
   listDomains,
   transferDomain,
@@ -457,6 +458,42 @@ describe('domain API client', () => {
     ).resolves.toBeUndefined();
     expect(capturedSourceProject).toBe(projectUuid);
     expect(capturedBody).toEqual({ new_project_uuid: newProjectUuid });
+  });
+
+  test('findDomain returns the domain when it exists on the project', async () => {
+    await expect(findDomain(domain, projectUuid, storeHash, accessToken, apiHost)).resolves.toEqual(
+      {
+        domain,
+        project_uuid: projectUuid,
+        verification_status: 'verified',
+      },
+    );
+  });
+
+  test('findDomain returns null when the domain is not on the project', async () => {
+    server.use(
+      http.get(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains/:domain',
+        () => new HttpResponse(null, { status: 404 }),
+      ),
+    );
+
+    await expect(
+      findDomain(domain, projectUuid, storeHash, accessToken, apiHost),
+    ).resolves.toBeNull();
+  });
+
+  test('findDomain still throws on non-404 errors', async () => {
+    server.use(
+      http.get(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains/:domain',
+        () => new HttpResponse(null, { status: 403 }),
+      ),
+    );
+
+    await expect(findDomain(domain, projectUuid, storeHash, accessToken, apiHost)).rejects.toThrow(
+      'Infrastructure Domains API not enabled',
+    );
   });
 
   test('surfaces the ownership-verification TXT record when a claim is not yet verified', async () => {
@@ -942,6 +979,37 @@ describe('transfer command', () => {
     expect(choiceValues).not.toContain(projectUuid);
     expect(capturedBody).toEqual({ new_project_uuid: destinationProjectUuid });
     expect(consola.success).toHaveBeenCalledWith(`Domain ${domain} transferred.`);
+  });
+
+  test('errors with guidance when the domain is not on the source project', async () => {
+    let transferRequests = 0;
+
+    server.use(
+      http.get(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains/:domain',
+        () => new HttpResponse(null, { status: 404 }),
+      ),
+      http.post(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains/:domain/transfer',
+        () => {
+          transferRequests += 1;
+
+          return new HttpResponse(null, { status: 204 });
+        },
+      ),
+    );
+
+    writeCredentials();
+
+    await expect(
+      domains.parseAsync(['transfer', domain, '--to-project-uuid', destinationProjectUuid], {
+        from: 'user',
+      }),
+    ).rejects.toThrow(`${domain} isn't on the current project`);
+
+    // The transfer is never attempted, and the user is never prompted.
+    expect(transferRequests).toBe(0);
+    expect(selectMock).not.toHaveBeenCalled();
   });
 
   test('rejects a destination that matches the source project', async () => {

--- a/packages/catalyst/src/cli/commands/domains.ts
+++ b/packages/catalyst/src/cli/commands/domains.ts
@@ -208,7 +208,8 @@ Examples:
       if (error instanceof DomainOwnershipVerificationError) {
         consola.warn(`${domain} is already in use on another store.`);
         consola.log(formatOwnershipVerification(error.ownershipVerification));
-        consola.info(`Once the record is live, run: catalyst domains claim ${domain}`);
+        consola.info('Once the record is live, claim it with:');
+        consola.log(`  catalyst domains claim ${domain}`);
         process.exit(1);
 
         return;
@@ -216,8 +217,9 @@ Examples:
 
       if (error instanceof DomainBoundToProjectError) {
         consola.warn(`${domain} is already bound to another project in this store.`);
-        consola.info(
-          `To move it to this project, run: catalyst domains transfer ${domain} --project-uuid ${error.projectUuid} --to-project-uuid ${context.projectUuid}`,
+        consola.info('To move it to this project, run:');
+        consola.log(
+          `  catalyst domains transfer ${domain} --project-uuid ${error.projectUuid} --to-project-uuid ${context.projectUuid}`,
         );
         process.exit(1);
 
@@ -376,9 +378,8 @@ Examples:
       if (error instanceof DomainOwnershipVerificationError) {
         consola.warn(`Ownership of ${domain} could not be verified yet.`);
         consola.log(formatOwnershipVerification(error.ownershipVerification));
-        consola.info(
-          `Once the record is live, run the claim again: catalyst domains claim ${domain}`,
-        );
+        consola.info('Once the record is live, run the claim again:');
+        consola.log(`  catalyst domains claim ${domain}`);
         process.exit(1);
 
         return;

--- a/packages/catalyst/src/cli/commands/domains.ts
+++ b/packages/catalyst/src/cli/commands/domains.ts
@@ -1,4 +1,4 @@
-import { confirm } from '@inquirer/prompts';
+import { confirm, select } from '@inquirer/prompts';
 import { Command, Option } from 'commander';
 import { colorize } from 'consola/utils';
 
@@ -7,14 +7,18 @@ import {
   createDomain,
   deleteDomain,
   Domain,
+  DomainBoundToProjectError,
   DomainOwnershipVerificationError,
   DomainStatus,
   DomainStatusFilter,
   getDomain,
   listDomains,
   OwnershipVerification,
+  transferDomain,
 } from '../lib/domains';
+import { UserActionableError } from '../lib/errors';
 import { consola } from '../lib/logger';
+import { fetchProjects } from '../lib/project';
 import { getProjectConfig } from '../lib/project-config';
 import { resolveCredentials } from '../lib/resolve-credentials';
 import {
@@ -77,6 +81,47 @@ function resolveDomainCommandContext(options: DomainCommandOptions): DomainComma
     accessToken,
     apiHost: options.apiHost,
   };
+}
+
+// Resolves the destination project for a transfer. Uses `--to-project-uuid`
+// when given; otherwise fetches the store's projects and prompts the user to
+// pick one, excluding the source project (a domain can't be transferred to the
+// project it already belongs to).
+async function resolveDestinationProject(
+  domain: string,
+  context: DomainCommandContext,
+  toProjectUuid?: string,
+): Promise<string> {
+  if (toProjectUuid) {
+    if (toProjectUuid === context.projectUuid) {
+      throw new UserActionableError('The destination project must differ from the source project.');
+    }
+
+    return toProjectUuid;
+  }
+
+  consola.start('Fetching projects...');
+
+  const projects = await fetchProjects(context.storeHash, context.accessToken, context.apiHost);
+
+  consola.success('Projects fetched.');
+
+  const destinations = projects.filter((project) => project.uuid !== context.projectUuid);
+
+  if (destinations.length === 0) {
+    throw new UserActionableError(
+      'No other projects to transfer to. Create another project with `catalyst project create` first.',
+    );
+  }
+
+  return select({
+    message: `Select the project to transfer ${domain} to (Press <enter> to select).`,
+    choices: destinations.map((project) => ({
+      name: project.name,
+      value: project.uuid,
+      description: project.uuid,
+    })),
+  });
 }
 
 export function formatDomainStatus(status: DomainStatus): string {
@@ -163,6 +208,16 @@ Examples:
         consola.warn(`${domain} is already in use on another store.`);
         consola.log(formatOwnershipVerification(error.ownershipVerification));
         consola.info(`Once the record is live, run: catalyst domains claim ${domain}`);
+        process.exit(1);
+
+        return;
+      }
+
+      if (error instanceof DomainBoundToProjectError) {
+        consola.warn(`${domain} is already bound to another project in this store.`);
+        consola.info(
+          `To move it to this project, run: catalyst domains transfer ${domain} --project-uuid ${error.projectUuid} --to-project-uuid ${context.projectUuid}`,
+        );
         process.exit(1);
 
         return;
@@ -350,6 +405,72 @@ Examples:
     process.exit(0);
   });
 
+const transfer = new Command('transfer')
+  .configureHelp({ showGlobalOptions: true })
+  .description('Transfer a custom domain to another project in the same store.')
+  .argument('<domain>', 'Custom domain to transfer.')
+  .addHelpText(
+    'after',
+    `
+The domain is transferred from the current project to the destination project.
+Omit --to-project-uuid to pick the destination from a list of your projects.
+
+Examples:
+  # Pick the destination project interactively
+  $ catalyst domains transfer www.example.com
+
+  # Transfer to a specific project
+  $ catalyst domains transfer www.example.com --to-project-uuid <uuid>`,
+  )
+  .addOption(storeHashOption())
+  .addOption(accessTokenOption())
+  .addOption(apiHostOption())
+  .addOption(projectUuidOption())
+  .option('--to-project-uuid <uuid>', 'Destination project UUID. Prompts to choose one if omitted.')
+  .option('--wait', 'Poll until domain verification completes or times out.')
+  .action(async (domain, options) => {
+    const context = resolveDomainCommandContext(options);
+
+    await getTelemetry().identify(context.storeHash);
+
+    const newProjectUuid = await resolveDestinationProject(domain, context, options.toProjectUuid);
+
+    consola.start(`Transferring domain ${domain}...`);
+
+    await transferDomain(
+      domain,
+      context.projectUuid,
+      newProjectUuid,
+      context.storeHash,
+      context.accessToken,
+      context.apiHost,
+    );
+
+    consola.success(`Domain ${domain} transferred.`);
+
+    let result = await getDomain(
+      domain,
+      newProjectUuid,
+      context.storeHash,
+      context.accessToken,
+      context.apiHost,
+    );
+
+    if (options.wait && result.verification_status === 'pending') {
+      consola.start(`Waiting for ${result.domain} to verify...`);
+      result = await waitForDomainVerification({
+        domain: result.domain,
+        projectUuid: newProjectUuid,
+        storeHash: context.storeHash,
+        accessToken: context.accessToken,
+        apiHost: context.apiHost,
+      });
+    }
+
+    consola.log(formatDomain(result));
+    process.exit(0);
+  });
+
 const remove = new Command('remove')
   .configureHelp({ showGlobalOptions: true })
   .description('Remove a custom domain from the current Native Hosting project.')
@@ -418,4 +539,5 @@ export const domains = new Command('domains')
   .addCommand(list)
   .addCommand(showStatus)
   .addCommand(claim)
+  .addCommand(transfer)
   .addCommand(remove);

--- a/packages/catalyst/src/cli/commands/domains.ts
+++ b/packages/catalyst/src/cli/commands/domains.ts
@@ -11,6 +11,7 @@ import {
   DomainOwnershipVerificationError,
   DomainStatus,
   DomainStatusFilter,
+  findDomain,
   getDomain,
   listDomains,
   OwnershipVerification,
@@ -432,6 +433,31 @@ Examples:
     const context = resolveDomainCommandContext(options);
 
     await getTelemetry().identify(context.storeHash);
+
+    // Confirm the domain is on the source project before doing anything else.
+    // `transfer` moves a domain *from* the current project, so a domain that
+    // lives elsewhere can't be transferred from here — catch it now instead of
+    // letting the API reject the transfer with an opaque ownership error after
+    // the user has already picked a destination.
+    consola.start(`Checking ${domain} on the current project...`);
+
+    const owned = await findDomain(
+      domain,
+      context.projectUuid,
+      context.storeHash,
+      context.accessToken,
+      context.apiHost,
+    );
+
+    if (!owned) {
+      throw new UserActionableError(
+        `${domain} isn't on the current project (${context.projectUuid}), so there's nothing to transfer from it. ` +
+          `Run this from the project that currently owns ${domain}, or pass its UUID with --project-uuid <uuid>. ` +
+          `Use \`catalyst domains list\` to find which project has it.`,
+      );
+    }
+
+    consola.success(`${domain} found on the current project.`);
 
     const newProjectUuid = await resolveDestinationProject(domain, context, options.toProjectUuid);
 

--- a/packages/catalyst/src/cli/commands/domains.ts
+++ b/packages/catalyst/src/cli/commands/domains.ts
@@ -451,11 +451,45 @@ Examples:
     );
 
     if (!owned) {
-      throw new UserActionableError(
-        `${domain} isn't on the current project (${context.projectUuid}), so there's nothing to transfer from it. ` +
-          `Run this from the project that currently owns ${domain}, or pass its UUID with --project-uuid <uuid>. ` +
-          `Use \`catalyst domains list\` to find which project has it.`,
+      // The domain isn't on the linked project. Scan the store's other projects
+      // so we can point the user at the exact owner — `domains list` only shows
+      // the *current* project's domains, so it can't help them find where the
+      // domain actually lives.
+      consola.start(`Locating the project that owns ${domain}...`);
+
+      const projects = await fetchProjects(context.storeHash, context.accessToken, context.apiHost);
+      const candidates = projects.filter((project) => project.uuid !== context.projectUuid);
+      const matches = await Promise.all(
+        candidates.map(async (project) => ({
+          project,
+          found: await findDomain(
+            domain,
+            project.uuid,
+            context.storeHash,
+            context.accessToken,
+            context.apiHost,
+          ),
+        })),
       );
+      const owner = matches.find((match) => match.found)?.project;
+
+      if (!owner) {
+        throw new UserActionableError(
+          `${domain} isn't on any project in this store. If it's in use on another store, ` +
+            `claim it with \`catalyst domains claim ${domain}\`; otherwise double-check the domain name.`,
+        );
+      }
+
+      const toSuffix = options.toProjectUuid ? ` --to-project-uuid ${options.toProjectUuid}` : '';
+
+      consola.warn(
+        `${domain} is on project "${owner.name}" (${owner.uuid}), not the current project.`,
+      );
+      consola.info('Re-run the transfer from that project:');
+      consola.log(`  catalyst domains transfer ${domain} --project-uuid ${owner.uuid}${toSuffix}`);
+      process.exit(1);
+
+      return;
     }
 
     consola.success(`${domain} found on the current project.`);

--- a/packages/catalyst/src/cli/lib/domains.ts
+++ b/packages/catalyst/src/cli/lib/domains.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-classes-per-file -- the two domain-collision error types are co-located with the response parsing that throws them */
 import { z } from 'zod';
 
 import { assertAuthorized } from './auth-errors';
@@ -49,6 +50,31 @@ function parseOwnershipVerification(body: unknown): OwnershipVerification | unde
   return parsed.success ? parsed.data.meta.ownership_verification : undefined;
 }
 
+const boundProjectMetaSchema = z.object({
+  meta: z.object({
+    project_uuid: z.string(),
+  }),
+});
+
+// Raised when the Domains API rejects an add/claim because the domain is
+// already bound to a different project in the *same* store. Carries the UUID of
+// that project so the caller can point the user at `domains transfer`.
+export class DomainBoundToProjectError extends UserActionableError {
+  readonly projectUuid: string;
+
+  constructor(message: string, projectUuid: string) {
+    super(message);
+    this.name = 'DomainBoundToProjectError';
+    this.projectUuid = projectUuid;
+  }
+}
+
+function parseBoundProjectUuid(body: unknown): string | undefined {
+  const parsed = boundProjectMetaSchema.safeParse(body);
+
+  return parsed.success ? parsed.data.meta.project_uuid : undefined;
+}
+
 const domainResponseSchema = z.object({
   data: domainSchema,
 });
@@ -80,6 +106,15 @@ function domainClaimUrl(storeHash: string, projectUuid: string, domain: string, 
   return `${domainUrl(storeHash, projectUuid, domain, apiHost)}/claim`;
 }
 
+function domainTransferUrl(
+  storeHash: string,
+  projectUuid: string,
+  domain: string,
+  apiHost: string,
+) {
+  return `${domainUrl(storeHash, projectUuid, domain, apiHost)}/transfer`;
+}
+
 function authHeaders(accessToken: string) {
   return {
     Accept: 'application/json',
@@ -104,10 +139,11 @@ function buildErrorMessage(response: Response, body: unknown, action: string): s
   return message ?? `${action}: ${response.statusText}`;
 }
 
-// Throws for any non-OK Domains API response. When the body carries an
-// `meta.ownership_verification` TXT record (a domain bound to another store),
-// surfaces a DomainOwnershipVerificationError so callers can guide the user
-// through the claim flow; otherwise throws a plain formatted error.
+// Throws for any non-OK Domains API response. Surfaces typed errors for the two
+// claimable/movable conflicts so callers can guide the user: a
+// `meta.ownership_verification` TXT record (domain on another store → claim) or
+// a `meta.project_uuid` (domain on another project in this store → transfer).
+// Otherwise throws a plain formatted error.
 async function assertDomainResponse(response: Response, action: string): Promise<void> {
   assertAuthorized(response);
 
@@ -125,6 +161,12 @@ async function assertDomainResponse(response: Response, action: string): Promise
 
   if (ownershipVerification) {
     throw new DomainOwnershipVerificationError(message, ownershipVerification);
+  }
+
+  const boundProjectUuid = parseBoundProjectUuid(body);
+
+  if (boundProjectUuid) {
+    throw new DomainBoundToProjectError(message, boundProjectUuid);
   }
 
   // 5xx responses are server-side failures worth escalating, so keep the
@@ -238,4 +280,27 @@ export async function claimDomain(
   });
 
   await assertDomainResponse(response, 'Failed to claim domain');
+}
+
+// Moves a domain from its current project (`projectUuid`, the source) to
+// `newProjectUuid` (the destination) within the same store. The API rejects a
+// transfer where the destination equals the source.
+export async function transferDomain(
+  domain: string,
+  projectUuid: string,
+  newProjectUuid: string,
+  storeHash: string,
+  accessToken: string,
+  apiHost: string,
+): Promise<void> {
+  const response = await fetch(domainTransferUrl(storeHash, projectUuid, domain, apiHost), {
+    method: 'POST',
+    headers: {
+      ...authHeaders(accessToken),
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ new_project_uuid: newProjectUuid }),
+  });
+
+  await assertDomainResponse(response, 'Failed to transfer domain');
 }

--- a/packages/catalyst/src/cli/lib/domains.ts
+++ b/packages/catalyst/src/cli/lib/domains.ts
@@ -221,6 +221,33 @@ export async function getDomain(
   return domainResponseSchema.parse(result).data;
 }
 
+// Like `getDomain`, but returns null when the domain isn't present on the
+// given project (404) instead of throwing. Used by `transfer` to confirm the
+// source project actually owns the domain before attempting the move, so the
+// user gets clear guidance instead of the API's opaque ownership rejection.
+export async function findDomain(
+  domain: string,
+  projectUuid: string,
+  storeHash: string,
+  accessToken: string,
+  apiHost: string,
+): Promise<Domain | null> {
+  const response = await fetch(domainUrl(storeHash, projectUuid, domain, apiHost), {
+    method: 'GET',
+    headers: authHeaders(accessToken),
+  });
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  await assertDomainResponse(response, 'Failed to fetch domain');
+
+  const result: unknown = await response.json();
+
+  return domainResponseSchema.parse(result).data;
+}
+
 export async function listDomains(
   projectUuid: string,
   storeHash: string,

--- a/packages/catalyst/src/cli/lib/logger.ts
+++ b/packages/catalyst/src/cli/lib/logger.ts
@@ -2,4 +2,8 @@ import { createConsola } from 'consola';
 
 export const consola = createConsola({
   level: process.env.CONSOLA_LEVEL ? parseInt(process.env.CONSOLA_LEVEL, 10) : 3,
+  // Drop the per-line timestamp. It adds noise for a short-lived CLI and, on
+  // long lines, consola can't right-align it so it falls back to an inline
+  // `[time]` prefix that breaks copy-pasteable command suggestions.
+  formatOptions: { date: false },
 });

--- a/packages/catalyst/tests/mocks/handlers.ts
+++ b/packages/catalyst/tests/mocks/handlers.ts
@@ -90,6 +90,12 @@ export const handlers = [
     () => new HttpResponse(null, { status: 204 }),
   ),
 
+  // Handler for transferDomain
+  http.post(
+    'https://:apiHost/stores/:storeHash/v3/infrastructure/projects/:projectUuid/domains/:domain/transfer',
+    () => new HttpResponse(null, { status: 204 }),
+  ),
+
   // Handler for fetchProjects
   http.get('https://:apiHost/stores/:storeHash/v3/infrastructure/projects', () =>
     HttpResponse.json({


### PR DESCRIPTION
Linear: [LTRAC-1117](https://linear.app/commerce/issue/LTRAC-1117/add-catalyst-domains-transfer-command-to-the-cli)

## What/Why?

Adds `catalyst domains transfer <domain>` — moves a custom domain from its current project to **another project in the same store**. This is the same-store counterpart to `domains claim` (cross-store): when you `domains add` a domain already bound to another project in your store, the API tells you to use transfer.

- Source project = the linked project (`--project-uuid`); destination = `--to-project-uuid`.
- **Interactive when `--to-project-uuid` is omitted:** fetches the store's projects and prompts you to pick one, excluding the source (mirrors the project picker used by `project link` / `deploy`). Pass the flag for non-interactive/CI use.
- After a successful transfer it shows the domain's status against the destination project, with `--wait` to poll until it leaves `pending`.

Client: `transferDomain` → `POST /…/projects/{source}/domains/{domain}/transfer` with `{ new_project_uuid }`. Clear errors use `UserActionableError` (from #3088, now merged) so a bad destination or "no other projects" prints plainly without the Correlation ID / support framing; API 4xx errors flow through the shared `assertDomainResponse`.

### Pre-flight ownership check (follow-up)

`transfer` moves a domain *from* the linked (source) project. If the linked project doesn't own the domain, the API rejected the transfer with an opaque `domain is not owned by the specified project` error — and only *after* the user had already picked a destination. Added a `findDomain` client (a `getDomain` that returns `null` on a 404 instead of throwing) and a pre-flight that runs before the destination prompt: it confirms the domain is on the source project.

When the linked project *doesn't* own the domain, the pre-flight now scans the store's other projects and names the one that actually owns it, printing the exact `--project-uuid` command to re-run. (An earlier version pointed users at `domains list`, which is dead-end guidance — `list` only shows the current project's domains, so it can never surface a domain that lives elsewhere.) If no project in the store owns it, it says so and points at `domains claim` for the cross-store case. The transfer is never attempted and the picker never opens on failure.

### Logging polish (follow-up)

- Disabled consola's per-line wall-clock timestamp (`formatOptions: { date: false }`). It added noise, and on long lines consola couldn't right-align it so it fell back to an inline `[time]` prefix that broke copy-pasteable command suggestions. The `logs` command is unaffected — its timestamps come from the log payload, not consola's clock.
- Command suggestions in the `add`/`claim` "already in use" branches now print on their own unprefixed `consola.log` line, so they stay clean to copy at any terminal width.

## Testing

`pnpm typecheck`, `pnpm lint`, `domains.spec.ts` (43 passing, incl. transfer + pre-flight). New tests: request shape; `--to-project-uuid` (no prompt); interactive selection excludes the source; destination==source rejected; no-other-projects error; `findDomain` returns/null/throws; transfer names the owning project (and never calls the API or prompts) when the domain is on a different project; transfer errors when the domain is on no project in the store. Verified `domains transfer --help` and timestamp-free output on the built CLI.

## Migration

None. Docs: documented in docs-v2 #332 (alongside `claim`).