### PR TITLE
ci: TRAC-881 Drop the canary base_ref bootstrap for Linear sync

### DIFF
--- a/.github/workflows/changesets-release.yml
+++ b/.github/workflows/changesets-release.yml
@@ -51,10 +51,6 @@ jobs:
           # other workspace packages (client, create-catalyst, the CLI) are
           # released separately and shouldn't count toward this pipeline.
           include_paths: core/**
-          # TODO: one-time bootstrap bound so the first sync doesn't scan this
-          # existing project's full history. Remove once the pipeline has its
-          # own release bookmark.
-          base_ref: ${{ github.ref_name == 'canary' && '@bigcommerce/catalyst-core@1.8.0' || '@bigcommerce/catalyst-makeswift@1.8.0' }}
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets


### PR DESCRIPTION
Jira: [TRAC-881](https://bigcommercecloud.atlassian.net/browse/TRAC-881)

## What/Why?

Fast-follow to #3085/#3086. The bootstrap `base_ref` (`@bigcommerce/catalyst-core@1.8.0`) was meant to be a one-time seed so the first sync didn't scan this existing project's full history, but it was left hardcoded permanently. `linear-release`'s own log makes the consequence explicit: passing `--base-ref` makes it "skip automatic baseline selection" every single run, so every push kept re-scanning the full `1.8.0..HEAD` range instead of narrowing to just new commits.

That range included `a45ab434` ("Release: Catalyst CLI 1.0.0... merge alpha → canary"), a squash-merge whose commit body is hundreds of lines of already-shipped `alpha`-branch history — which kept re-attaching ~23 unrelated old issues to the in-progress release on every run.

Verified locally with the standalone CLI (`--dry-run`) that with no `base_ref` and no stored baseline, it correctly finds 0 matching commits and skips release creation, rather than falling back to scanning full history. A real (non-dry-run) manual sync was run separately with an explicit `--base-ref` pointing just past the alpha-merge noise to seed a correctly-scoped release by hand before this PR lands, so the automatic baseline it establishes is clean.

Drops `base_ref` for both branches down to a single unconditional sync step (no per-branch conditional needed). `integrations/makeswift`'s baseline will be seeded manually the same way, before merging in whatever brings this workflow into that branch — its copy doesn't have these Linear steps yet.

## Testing

Watch the next push to canary: the log should show it using its own stored baseline (no "skipping automatic baseline selection" message) and only pick up genuinely new `core/**` commits.


[TRAC-881]: https://bigcommercecloud.atlassian.net/browse/TRAC-881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ