### PR TITLE
ci: TRAC-881 Split Linear pipelines per branch and name releases

### DIFF
--- a/.github/workflows/changesets-release.yml
+++ b/.github/workflows/changesets-release.yml
@@ -45,8 +45,12 @@ jobs:
       - name: Sync Linear release
         uses: linear/linear-release-action@v0
         with:
-          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          # canary and integrations/makeswift are independently-versioned
+          # products with their own release cadence, so each targets its own
+          # Linear pipeline (and access key) rather than sharing one.
+          access_key: ${{ github.ref_name == 'canary' && secrets.LINEAR_ACCESS_KEY || secrets.LINEAR_MAKESWIFT_ACCESS_KEY }}
           command: sync
+          name: ${{ github.ref_name == 'canary' && '@bigcommerce/catalyst-core (unreleased)' || '@bigcommerce/catalyst-makeswift (unreleased)' }}
           # Only the storefront package ships as its own release; changes to
           # other workspace packages (client, create-catalyst, the CLI) are
           # released separately and shouldn't count toward this pipeline.
@@ -91,7 +95,8 @@ jobs:
         if: steps.headline.outputs.found == 'true'
         uses: linear/linear-release-action@v0
         with:
-          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          access_key: ${{ github.ref_name == 'canary' && secrets.LINEAR_ACCESS_KEY || secrets.LINEAR_MAKESWIFT_ACCESS_KEY }}
           command: complete
+          name: ${{ steps.headline.outputs.tag }}
           version: ${{ steps.headline.outputs.tag }}
           release_notes: /tmp/release-notes.md


### PR DESCRIPTION
Jira: [TRAC-881](https://bigcommercecloud.atlassian.net/browse/TRAC-881)

## What/Why?

Fast-follow to #3085/#3086/#3090. `canary` and `integrations/makeswift` were sharing one Linear pipeline ("Catalyst Release") with no `version` pinned on `sync` — `sync` targets "whatever release is currently open," so with no release in progress, whichever branch pushed first would create one and the other branch's `sync` would attach its issues to that same release instead of starting its own. Two independently-versioned products (each with their own npm package, semver cadence, and release cut timing) need two independent release trains, not one shared "current release."

Splits the `access_key` per branch (`LINEAR_ACCESS_KEY` for canary, a new `LINEAR_MAKESWIFT_ACCESS_KEY` for integrations/makeswift) so each targets its own Linear pipeline entirely — no shared state, no collision risk. `integrations/makeswift`'s pipeline/key still needs to be created in Linear before this is meaningful on that branch (tracked separately).

Also sets a descriptive `name` on the in-progress release instead of Linear's default "New release" (e.g. `@bigcommerce/catalyst-core (unreleased)`), and renames it to the real `package@version` tag once `complete` fires.

## Testing

Requires the `LINEAR_MAKESWIFT_ACCESS_KEY` secret to exist before merging, otherwise the `integrations/makeswift` sync/complete steps will fail on missing access key. Watch the next push to canary to confirm the release shows the descriptive name pre-publish and gets renamed to the version tag on completion.


[TRAC-881]: https://bigcommercecloud.atlassian.net/browse/TRAC-881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ