### PR TITLE
PROJECT-6074 Vault instruments in my accounts page POC

### DIFF
--- a/PROJECT-6074-STRIPE-PLAN.md
+++ b/PROJECT-6074-STRIPE-PLAN.md
@@ -1,0 +1,99 @@
+# PROJECT-6074 · catalyst · Stripe OCS credit card vaulting in My Account
+
+**Repo:** `bigcommerce/catalyst` — `/Volumes/proj/bc/catalyst`
+**Branch:** `poc/PROJECT-6074-account-payments-microapp` (continue on the existing POC branch)
+**Effort:** medium
+**Builds on:**
+- The ECP render POC already on this branch (the `account/payment-methods` route, the microapp loader).
+- The storefront mutations `createVaultToken` (`PROJECT-6074-PLAN.md`) and `createVaultInitialization` (`PROJECT-6074-STRIPE-PLAN.md`).
+
+## Goal
+
+End to end on Catalyst `/account/payment-methods`: a shopper adds a Stripe credit card, it is set up with Stripe (`confirmSetup`) and vaulted in BigPay (`stored_instruments` POST authorized by the VAT), and it then appears via `customer.storedPaymentInstruments`.
+
+**Broader context:** `/Volumes/proj/mine/kb/bc/payments/vaulting/storefront/catalyst/vault-PROJECT-6074/index.html` (§2 two tokens, §3 flow, §9 catalyst, §11.4 the POST proxy).
+
+## Verified facts (from the microapp source — these shape the whole plan)
+
+- The microapp renders the OCS **credit card** form entirely from `storeContextData` **when `paymentProviderInitializationData.setupIntentToken` is present**. That presence selects the Stripe Payment Element path, which reads the publishable key and client secret from init data, mounts the Element, and calls `confirmSetup` itself. It **never** calls the runtime `/initialize` endpoint on the card path. So **no microapp change is required** (see the microapp `PROJECT-6074-STRIPE-PLAN.md`). Catalyst must therefore mint the setup token server-side and pass it in init data.
+- The microapp sends `storeContextData.vaultToken` **verbatim** as the `Authorization` header, with no scheme added. BigPay expects `VAT <jwt>`. So Catalyst must set `vaultToken` to the full `"VAT <token>"` string.
+- The vault write goes to `` `${paymentsUrl}/stores/${storeHash}/customers/${shopperId}/stored_instruments` ``. `paymentsUrl` is host-configurable, so point it at a same-origin Catalyst proxy to avoid a cross-origin POST (doc §11.4).
+- Stripe.js is loaded from `js.stripe.com`, and on success the microapp does `window.location.href = paymentMethodsUrl` (a full-page navigation).
+
+## Current state
+
+- `core/app/[locale]/(default)/account/payment-methods/page.tsx` — fake list page, one ECP section.
+- `.../add/page.tsx` + `.../add/page-data.ts` — server component; `getMicroappAssets()` reads the CDN manifest, `getMicroappCountries()` queries `geography.countries` with the customer access token.
+- `.../add/_components/account-payments-microapp.tsx` — `'use client'`; loads the bundle and calls `renderAccountPayments` with **hardcoded ECP** `storeContextData`.
+
+## The change
+
+1. **GraphQL documents (gql.tada).** Add both mutations, requested in one document so the client makes one round-trip. `createVaultInitialization` returns a **typed union**, so query the Stripe arm with an inline fragment:
+   ```graphql
+   mutation AddCardVaultContext($providerId: ID!) {
+     payment { storedInstrument {
+       createVaultToken { vaultToken expiresIn }
+       createVaultInitialization(providerId: $providerId) {
+         data {
+           ... on StripeOcsVaultInit { publishableKey setupIntentClientSecret connectedAccount }
+         }
+       }
+     } }
+   }
+   ```
+   - gql.tada types the result, so `data` is a discriminated union and the Stripe fields are checked at compile time. Catalyst maps `StripeOcsVaultInit` into the microapp's `paymentProviderInitializationData` shape (step 4). That small mapper is the client-side deserializer, and the rename into the microapp's fixed field names is the one intentional mapping in the pipeline. If `data` resolves to a union member Catalyst did not request (a provider added server-side but not yet wired here), treat it as unsupported and show a clear error rather than rendering.
+   - Run it **server-side** in `page-data.ts` with `getSessionCustomerAccessToken()` (same pattern as `getMicroappCountries`). The VAT and setup token only ever reach the browser inside `storeContextData` at render.
+
+2. **`page-data.ts`:** add `getVaultContext(providerId: string)` that runs the mutation and returns `{ vaultToken, init }`, where `init` is the typed union member. Keep the signature provider-generic; the caller passes `"stripeocs"` and narrows `init` on `__typename`.
+
+3. **The add page (`page.tsx`):** branch on `provider` / `method_type` from the route. For `stripeocs` card, fetch assets + countries + `getVaultContext("stripeocs")` and pass a fully-assembled `storeContextData` to the client component. Keep the existing ECP branch working.
+
+4. **`account-payments-microapp.tsx` (client):** parametrize it to accept `storeContextData` from props instead of hardcoding ECP. For Stripe card, pass:
+   ```ts
+   storeContextData: {
+     providerId: 'stripeocs',
+     // map the typed StripeOcsVaultInit union member into the microapp's StripeOCSInitializationData shape
+     paymentProviderInitializationData: {
+       stripePublishableKey: init.publishableKey,
+       setupIntentToken: init.setupIntentClientSecret,
+       ...(init.connectedAccount ? { stripeConnectedAccount: init.connectedAccount } : {}),
+     },
+     vaultToken: `VAT ${vaultToken}`,     // microapp sends this verbatim as Authorization; include the scheme
+     paymentsUrl: '/api/payments-proxy',  // same-origin proxy base (step 5)
+     storeHash: process.env.BIGCOMMERCE_STORE_HASH,
+     shopperId,          // customer entityId
+     customerEmail,      // used in confirmSetup billing_details
+     currencyCode,
+     storeLocale,        // active locale
+     countries,          // billing-address dropdown
+     paymentMethodsUrl: '/account/payment-methods', // post-success redirect target
+     // methodType is not needed on the card path
+   }
+   ```
+   Wire `errorHandler` to a Catalyst toast. The `<div id="bc-account-payments">` mount node already exists in the POC.
+
+5. **Same-origin `stored_instruments` proxy (doc §11.4).** Add a Catalyst route handler, for example `core/app/api/payments-proxy/[...path]/route.ts`, that forwards `POST` (and any method) to `` `${process.env.PAYMENTS_HOST}/${path.join('/')}` `` server-to-server, preserving the request body and the `Authorization` header, and relaying the response. Set `storeContextData.paymentsUrl` to `/api/payments-proxy` so the microapp's `` `${paymentsUrl}/stores/.../stored_instruments` `` resolves same-origin. This removes the CORS problem and keeps the VAT on a same-origin request.
+   - Env: add `PAYMENTS_HOST` (the BigPay/payments host for the environment). `NODE_TLS_REJECT_UNAUTHORIZED="0"` is already set for local bcdev.
+
+6. **CSP (only if Catalyst enforces one).** Allow Stripe: `script-src https://js.stripe.com`, `frame-src https://js.stripe.com https://hooks.stripe.com`, `connect-src https://api.stripe.com`.
+
+7. **List page:** link per provider to `/account/payment-methods/add?provider=stripeocs&method_type=card`. Keep the ECP link. The real provider list is a later Storefront GraphQL surface (doc §11.6); the POC list stays fake.
+
+## Provider-generic, Stripe-first
+
+The mutation, the `getVaultContext` fetch, and the proxy are all provider-agnostic: a `providerId` argument, a typed `VaultInitializationData` union, and a generic pass-through proxy. The only Stripe-aware code is the inline fragment plus the small mapper from `StripeOcsVaultInit` into the microapp's `StripeOCSInitializationData` shape. Adding the next provider is: pass its `providerId`, add its union arm and fragment, add its mapper, link to its add route. No new Catalyst API.
+
+## Out of scope / follow-ups
+
+- **Stripe ACH** and any provider that mints its own setup token at runtime will hit the microapp's hardcoded `POST /api/storefront/payments/stored-instruments/initialize` (ACH branch only). When needed, add a same-origin Catalyst proxy at that exact path forwarding to `createVaultInitialization` / BigPay, or take the microapp base-URL change (see the microapp plan). Not needed for card.
+- Real provider list and stored-instruments list come from new Storefront GraphQL surfaces (doc §11.2, §11.6).
+
+## Dependencies
+
+- storefront: `createVaultToken` + `createVaultInitialization`. Develop against a storefront running those (which in turn need the interfaces + bigpay changes and the PROJECT-7909 flag enabled for the store).
+- No microapp change.
+
+## Done when
+
+- On Catalyst `/account/payment-methods`, adding a Stripe test card mounts the Stripe Payment Element, `confirmSetup` succeeds, the instrument POSTs through `/api/payments-proxy` with `Authorization: VAT <token>`, and the saved card then appears via `customer.storedPaymentInstruments`.
+- No microapp code change was required.

--- a/core/app/[locale]/(default)/account/layout.tsx
+++ b/core/app/[locale]/(default)/account/layout.tsx
@@ -22,6 +22,7 @@ export default async function Layout({ children, params }: Props) {
           links={[
             { href: '/account/orders/', label: t('orders') },
             { href: '/account/addresses/', label: t('addresses') },
+            { href: '/account/payment-methods/', label: t('paymentMethods') },
             { href: '/account/settings/', label: t('settings') },
             { href: '/account/wishlists/', label: t('wishlists') },
             { href: '/logout', label: t('logout'), prefetch: 'none' },

--- a/core/app/[locale]/(default)/account/payment-methods/add/_components/account-payments-microapp.tsx
+++ b/core/app/[locale]/(default)/account/payment-methods/add/_components/account-payments-microapp.tsx
@@ -46,7 +46,20 @@ export function AccountPaymentsMicroapp({
       return;
     }
 
-    const toUrl = (path: string) => new URL(path, assets.base).toString();
+    // Local dev servers serve stable filenames (no content hash), so append a
+    // per-load cache-buster to defeat any stale browser cache entry. The CDN uses
+    // hashed names, so it needs none.
+    const isLocalBase = assets.base.startsWith('http://');
+    const cacheBust = Date.now();
+    const toUrl = (path: string) => {
+      const url = new URL(path, assets.base);
+
+      if (isLocalBase) {
+        url.searchParams.set('t', String(cacheBust));
+      }
+
+      return url.toString();
+    };
 
     const loadScript = (src: string) =>
       new Promise<void>((resolve, reject) => {

--- a/core/app/[locale]/(default)/account/payment-methods/add/_components/account-payments-microapp.tsx
+++ b/core/app/[locale]/(default)/account/payment-methods/add/_components/account-payments-microapp.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+import { type MicroappAssets, type MicroappCountry } from '../page-data';
+
+interface RenderConfig {
+  styles: Record<string, unknown>;
+  errorHandler: (message: string) => void;
+  storeContextData: Record<string, unknown>;
+}
+
+declare global {
+  interface Window {
+    BigCommerce?: {
+      renderAccountPayments?: (config: RenderConfig) => void;
+    };
+  }
+}
+
+// Loads the storefront-account-payments microapp bundle from the CDN and calls
+// renderAccountPayments for a single provider.
+//
+// POC scope: renders the ECP (ACH) form. Per the source, vaultToken is submit-only
+// and the ECP form needs no init data, so placeholder values are enough to render.
+export function AccountPaymentsMicroapp({
+  assets,
+  countries,
+}: {
+  assets: MicroappAssets;
+  countries: MicroappCountry[];
+}) {
+  const started = useRef(false);
+  const [status, setStatus] = useState('Loading microapp…');
+
+  useEffect(() => {
+    if (started.current) {
+      return;
+    }
+
+    started.current = true;
+
+    if (assets.js.length === 0) {
+      setStatus(`No microapp assets found. ${assets.error ?? ''}`);
+
+      return;
+    }
+
+    const toUrl = (path: string) => new URL(path, assets.base).toString();
+
+    const loadScript = (src: string) =>
+      new Promise<void>((resolve, reject) => {
+        const script = document.createElement('script');
+
+        script.src = src;
+        // Dynamically inserted scripts still execute in insertion order when async is false.
+        script.async = false;
+        script.crossOrigin = 'anonymous';
+        script.onload = () => resolve();
+        script.onerror = () => reject(new Error(`Failed to load ${src}`));
+        document.body.appendChild(script);
+      });
+
+    const run = async () => {
+      // Load in manifest order (runtime, vendors, main); async=false preserves execution order.
+      await Promise.all(assets.js.map((js) => loadScript(toUrl(js))));
+
+      const render = window.BigCommerce?.renderAccountPayments;
+
+      if (typeof render !== 'function') {
+        setStatus('window.BigCommerce.renderAccountPayments is not defined after loading assets.');
+
+        return;
+      }
+
+      render({
+        styles: {},
+        errorHandler: (message: string) => {
+          // eslint-disable-next-line no-console
+          console.error('[account-payments]', message);
+        },
+        storeContextData: {
+          // ECP (ACH): routes to the plain bank-account form (needs no init data).
+          providerId: 'test',
+          methodType: 'ecp',
+          storeLocale: 'en',
+          countries,
+          paymentsUrl: '',
+          paymentMethodsUrl: '/account/payment-methods',
+          // Submit-only fields. Placeholders are fine for a render-only POC.
+          vaultToken: '',
+          shopperId: '',
+          storeHash: '',
+          currencyCode: 'USD',
+          customerEmail: '',
+          paymentProviderInitializationData: {},
+        },
+      });
+
+      setStatus('Microapp rendered.');
+    };
+
+    run().catch((error: unknown) => setStatus(`Error: ${String(error)}`));
+  }, [assets, countries]);
+
+  return (
+    <div>
+      <p className="mb-4 text-sm text-[hsl(var(--contrast-400))]">{status}</p>
+      {/* The microapp mounts its own React tree into this fixed node id. */}
+      <div id="bc-account-payments" />
+    </div>
+  );
+}

--- a/core/app/[locale]/(default)/account/payment-methods/add/_components/account-payments-microapp.tsx
+++ b/core/app/[locale]/(default)/account/payment-methods/add/_components/account-payments-microapp.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 
-import { type MicroappAssets, type MicroappCountry } from '../page-data';
+import { type MicroappAssets } from '../page-data';
 
 interface RenderConfig {
   styles: Record<string, unknown>;
@@ -18,17 +18,15 @@ declare global {
   }
 }
 
-// Loads the storefront-account-payments microapp bundle from the CDN and calls
-// renderAccountPayments for a single provider.
-//
-// POC scope: renders the ECP (ACH) form. Per the source, vaultToken is submit-only
-// and the ECP form needs no init data, so placeholder values are enough to render.
+// Loads the storefront-account-payments microapp bundle from the CDN and calls renderAccountPayments with the
+// storeContextData assembled server-side by the page (provider config, VAT, and — for token providers — the minted
+// setup token). The microapp itself needs no change; the provider path it renders is driven entirely by this data.
 export function AccountPaymentsMicroapp({
   assets,
-  countries,
+  storeContextData,
 }: {
   assets: MicroappAssets;
-  countries: MicroappCountry[];
+  storeContextData: Record<string, unknown>;
 }) {
   const started = useRef(false);
   const [status, setStatus] = useState('Loading microapp…');
@@ -92,29 +90,14 @@ export function AccountPaymentsMicroapp({
           // eslint-disable-next-line no-console
           console.error('[account-payments]', message);
         },
-        storeContextData: {
-          // ECP (ACH): routes to the plain bank-account form (needs no init data).
-          providerId: 'test',
-          methodType: 'ecp',
-          storeLocale: 'en',
-          countries,
-          paymentsUrl: '',
-          paymentMethodsUrl: '/account/payment-methods',
-          // Submit-only fields. Placeholders are fine for a render-only POC.
-          vaultToken: '',
-          shopperId: '',
-          storeHash: '',
-          currencyCode: 'USD',
-          customerEmail: '',
-          paymentProviderInitializationData: {},
-        },
+        storeContextData,
       });
 
       setStatus('Microapp rendered.');
     };
 
     run().catch((error: unknown) => setStatus(`Error: ${String(error)}`));
-  }, [assets, countries]);
+  }, [assets, storeContextData]);
 
   return (
     <div>

--- a/core/app/[locale]/(default)/account/payment-methods/add/page-data.ts
+++ b/core/app/[locale]/(default)/account/payment-methods/add/page-data.ts
@@ -5,13 +5,15 @@ import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
 
-/**
- * Which microapp CDN to load. Prod is public and works for a render-only POC,
- * since the ECP form needs no BigCommerce backend to render. For a bcdev store
- * you can switch to the integration base:
- *   https://microapps.integration.zone/storefront-account-payments/
- */
-const MICROAPP_BASE = 'https://microapps.bigcommerce.com/storefront-account-payments/';
+// Where to load the microapp bundle from. Defaults to the prod CDN.
+// Override with ACCOUNT_PAYMENTS_MICROAPP_BASE in .env.local, for example a
+// local build served over a CORS-enabled static server:
+//   ACCOUNT_PAYMENTS_MICROAPP_BASE=http://localhost:4000/
+// or the integration CDN:
+//   ACCOUNT_PAYMENTS_MICROAPP_BASE=https://microapps.integration.zone/storefront-account-payments/
+const MICROAPP_BASE =
+  process.env.ACCOUNT_PAYMENTS_MICROAPP_BASE ??
+  'https://microapps.bigcommerce.com/storefront-account-payments/';
 
 export interface MicroappAssets {
   base: string;

--- a/core/app/[locale]/(default)/account/payment-methods/add/page-data.ts
+++ b/core/app/[locale]/(default)/account/payment-methods/add/page-data.ts
@@ -97,3 +97,105 @@ export const getMicroappCountries = cache(async (): Promise<MicroappCountry[]> =
     };
   });
 });
+
+// --- Stripe OCS card vaulting (PROJECT-6074) ---
+
+export interface StripeOcsVaultInit {
+  publishableKey: string;
+  setupIntentClientSecret: string;
+  connectedAccount?: string | null;
+}
+
+export interface VaultContext {
+  vaultToken: string;
+  init: StripeOcsVaultInit;
+}
+
+// Mints the VAT and the provider vault initialization in one round-trip. The two are separate operations (a credential
+// vs the SDK render data) but ride the same request. The VAT and setup token only ever reach the browser inside the
+// microapp's storeContextData at render.
+const AddCardVaultContextMutation = graphql(`
+  mutation AddCardVaultContext($providerId: ID!, $currencyCode: String!) {
+    payment {
+      storedInstrument {
+        createVaultToken {
+          vaultToken
+          expiresIn
+        }
+        createVaultInitialization(providerId: $providerId, currencyCode: $currencyCode) {
+          data {
+            __typename
+            ... on StripeOcsVaultInit {
+              publishableKey
+              setupIntentClientSecret
+              connectedAccount
+            }
+          }
+        }
+      }
+    }
+  }
+`);
+
+export const getVaultContext = cache(
+  async (providerId: string, currencyCode: string): Promise<VaultContext> => {
+    const customerAccessToken = await getSessionCustomerAccessToken();
+
+    const response = await client.fetch({
+      document: AddCardVaultContextMutation,
+      variables: { providerId, currencyCode },
+      customerAccessToken,
+      fetchOptions: { cache: 'no-store' },
+    });
+
+    const storedInstrument = response.data.payment.storedInstrument;
+    const vaultToken = storedInstrument.createVaultToken?.vaultToken;
+    const init = storedInstrument.createVaultInitialization?.data;
+
+    if (!vaultToken) {
+      throw new Error('createVaultToken returned no vault token');
+    }
+
+    // The union arm the storefront returned must be one we know how to render; otherwise fail rather than guess.
+    if (init?.__typename !== 'StripeOcsVaultInit') {
+      throw new Error(`Unsupported vault initialization provider: ${init?.__typename ?? 'none'}`);
+    }
+
+    return {
+      vaultToken,
+      init: {
+        publishableKey: init.publishableKey,
+        setupIntentClientSecret: init.setupIntentClientSecret,
+        connectedAccount: init.connectedAccount,
+      },
+    };
+  },
+);
+
+export interface CustomerVaultInfo {
+  entityId: number;
+  email: string;
+}
+
+const GetCustomerForVaultQuery = graphql(`
+  query GetCustomerForVault {
+    customer {
+      entityId
+      email
+    }
+  }
+`);
+
+export const getCustomerForVault = cache(async (): Promise<CustomerVaultInfo | null> => {
+  const customerAccessToken = await getSessionCustomerAccessToken();
+
+  const response = await client.fetch({
+    document: GetCustomerForVaultQuery,
+    customerAccessToken,
+    fetchOptions: { cache: 'no-store' },
+  });
+
+  const customer = response.data.customer;
+
+  return customer ? { entityId: customer.entityId, email: customer.email } : null;
+});

--- a/core/app/[locale]/(default)/account/payment-methods/add/page-data.ts
+++ b/core/app/[locale]/(default)/account/payment-methods/add/page-data.ts
@@ -1,0 +1,97 @@
+import { cache } from 'react';
+import { z } from 'zod';
+
+import { getSessionCustomerAccessToken } from '~/auth';
+import { client } from '~/client';
+import { graphql } from '~/client/graphql';
+
+/**
+ * Which microapp CDN to load. Prod is public and works for a render-only POC,
+ * since the ECP form needs no BigCommerce backend to render. For a bcdev store
+ * you can switch to the integration base:
+ *   https://microapps.integration.zone/storefront-account-payments/
+ */
+const MICROAPP_BASE = 'https://microapps.bigcommerce.com/storefront-account-payments/';
+
+export interface MicroappAssets {
+  base: string;
+  js: string[];
+  css: string[];
+  error?: string;
+}
+
+const ManifestSchema = z.object({
+  js: z.array(z.string()).optional(),
+  css: z.array(z.string()).optional(),
+});
+
+export async function getMicroappAssets(): Promise<MicroappAssets> {
+  try {
+    const res = await fetch(new URL('manifest.json', MICROAPP_BASE), { cache: 'no-store' });
+
+    if (!res.ok) {
+      return { base: MICROAPP_BASE, js: [], css: [], error: `manifest HTTP ${res.status}` };
+    }
+
+    const manifest = ManifestSchema.parse(await res.json());
+
+    return { base: MICROAPP_BASE, js: manifest.js ?? [], css: manifest.css ?? [] };
+  } catch (error) {
+    return { base: MICROAPP_BASE, js: [], css: [], error: String(error) };
+  }
+}
+
+// The shapes the microapp expects for its billing-address country/state selectors.
+export interface MicroappState {
+  code: string;
+  name: string;
+  value: string;
+}
+
+export interface MicroappCountry {
+  code: string;
+  value: string;
+  label: string;
+  states?: MicroappState[];
+}
+
+const GetCountriesQuery = graphql(`
+  query GetCountriesQuery {
+    geography {
+      countries {
+        code
+        name
+        statesOrProvinces {
+          name
+          abbreviation
+        }
+      }
+    }
+  }
+`);
+
+export const getMicroappCountries = cache(async (): Promise<MicroappCountry[]> => {
+  const customerAccessToken = await getSessionCustomerAccessToken();
+
+  const response = await client.fetch({
+    document: GetCountriesQuery,
+    customerAccessToken,
+    fetchOptions: { next: { revalidate: 3600 } },
+  });
+
+  return response.data.geography.countries.map((country) => {
+    const states = country.statesOrProvinces.map((state) => ({
+      code: state.abbreviation,
+      name: state.name,
+      value: state.abbreviation,
+    }));
+
+    return {
+      code: country.code,
+      value: country.code,
+      label: country.name,
+      // Omit when empty so the microapp renders a free-text field, not an empty dropdown.
+      ...(states.length > 0 && { states }),
+    };
+  });
+});

--- a/core/app/[locale]/(default)/account/payment-methods/add/page.tsx
+++ b/core/app/[locale]/(default)/account/payment-methods/add/page.tsx
@@ -1,20 +1,82 @@
 import { setRequestLocale } from 'next-intl/server';
 
 import { Link } from '~/components/link';
+import { getPreferredCurrencyCode } from '~/lib/currency';
 
 import { AccountPaymentsMicroapp } from './_components/account-payments-microapp';
-import { getMicroappAssets, getMicroappCountries } from './page-data';
+import {
+  getCustomerForVault,
+  getMicroappAssets,
+  getMicroappCountries,
+  getVaultContext,
+} from './page-data';
 
 interface Props {
   params: Promise<{ locale: string }>;
+  searchParams: Promise<{ provider?: string; method_type?: string }>;
 }
 
-export default async function AddPaymentMethodPage({ params }: Props) {
+export default async function AddPaymentMethodPage({ params, searchParams }: Props) {
   const { locale } = await params;
+  const { provider, method_type: methodType } = await searchParams;
 
   setRequestLocale(locale);
 
   const [assets, countries] = await Promise.all([getMicroappAssets(), getMicroappCountries()]);
+
+  const isStripeCard = provider === 'stripeocs' && methodType === 'card';
+
+  let storeContextData: Record<string, unknown>;
+
+  if (isStripeCard) {
+    // Currency selects the merchant's provider profile (not an amount), mirroring how the Stencil vault init passes it.
+    const currencyCode = (await getPreferredCurrencyCode()) ?? 'USD';
+    const [vaultContext, customer] = await Promise.all([
+      getVaultContext('stripeocs', currencyCode),
+      getCustomerForVault(),
+    ]);
+
+    storeContextData = {
+      providerId: 'stripeocs',
+      methodType: 'card',
+      storeLocale: locale,
+      countries,
+      // Same-origin proxy so the browser -> BigPay submit stays a first-party request (no CORS) and keeps the VAT off
+      // any third-party origin.
+      paymentsUrl: '/api/payments-proxy',
+      paymentMethodsUrl: '/account/payment-methods',
+      // The microapp sends this verbatim as the Authorization header. BigPay's GenerateVaultToken already returns the
+      // token with its "VAT " scheme prefix, so pass it through as-is; adding another prefix double-prefixes it.
+      vaultToken: vaultContext.vaultToken,
+      shopperId: String(customer?.entityId ?? ''),
+      storeHash: process.env.BIGCOMMERCE_STORE_HASH ?? '',
+      currencyCode,
+      customerEmail: customer?.email ?? '',
+      paymentProviderInitializationData: {
+        stripePublishableKey: vaultContext.init.publishableKey,
+        setupIntentToken: vaultContext.init.setupIntentClientSecret,
+        ...(vaultContext.init.connectedAccount
+          ? { stripeConnectedAccount: vaultContext.init.connectedAccount }
+          : {}),
+      },
+    };
+  } else {
+    // ECP (ACH) render POC: routes to the plain bank-account form, which needs no init data.
+    storeContextData = {
+      providerId: 'test',
+      methodType: 'ecp',
+      storeLocale: locale,
+      countries,
+      paymentsUrl: '',
+      paymentMethodsUrl: '/account/payment-methods',
+      vaultToken: '',
+      shopperId: '',
+      storeHash: '',
+      currencyCode: 'USD',
+      customerEmail: '',
+      paymentProviderInitializationData: {},
+    };
+  }
 
   return (
     <div>
@@ -29,7 +91,7 @@ export default async function AddPaymentMethodPage({ params }: Props) {
         Add payment method
       </h1>
 
-      <AccountPaymentsMicroapp assets={assets} countries={countries} />
+      <AccountPaymentsMicroapp assets={assets} storeContextData={storeContextData} />
     </div>
   );
 }

--- a/core/app/[locale]/(default)/account/payment-methods/add/page.tsx
+++ b/core/app/[locale]/(default)/account/payment-methods/add/page.tsx
@@ -1,0 +1,35 @@
+import { setRequestLocale } from 'next-intl/server';
+
+import { Link } from '~/components/link';
+
+import { AccountPaymentsMicroapp } from './_components/account-payments-microapp';
+import { getMicroappAssets, getMicroappCountries } from './page-data';
+
+interface Props {
+  params: Promise<{ locale: string }>;
+}
+
+export default async function AddPaymentMethodPage({ params }: Props) {
+  const { locale } = await params;
+
+  setRequestLocale(locale);
+
+  const [assets, countries] = await Promise.all([getMicroappAssets(), getMicroappCountries()]);
+
+  return (
+    <div>
+      <Link
+        className="mb-6 inline-block text-sm text-[hsl(var(--contrast-500))] hover:text-[hsl(var(--foreground))]"
+        href="/account/payment-methods/"
+      >
+        Back to payment methods
+      </Link>
+
+      <h1 className="mb-8 font-[family-name:var(--font-family-heading)] text-4xl font-medium leading-none tracking-tight">
+        Add payment method
+      </h1>
+
+      <AccountPaymentsMicroapp assets={assets} countries={countries} />
+    </div>
+  );
+}

--- a/core/app/[locale]/(default)/account/payment-methods/page.tsx
+++ b/core/app/[locale]/(default)/account/payment-methods/page.tsx
@@ -39,9 +39,25 @@ export default async function PaymentMethodsPage({ params }: Props) {
         </Link>
       </section>
 
+      <section className="mb-10">
+        <h2 className="mb-4 text-xl font-medium">Credit Card (Stripe)</h2>
+
+        <Link
+          className="flex min-h-44 w-full max-w-sm flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-[hsl(var(--contrast-200))] p-8 text-center transition-colors hover:border-[hsl(var(--foreground))] hover:bg-[hsl(var(--contrast-100))]"
+          href="/account/payment-methods/add?provider=stripeocs&method_type=card"
+        >
+          <span aria-hidden className="text-4xl leading-none">
+            +
+          </span>
+          <span className="font-[family-name:var(--font-family-mono)] text-xs uppercase tracking-wide text-[hsl(var(--contrast-500))]">
+            Add new payment method
+          </span>
+        </Link>
+      </section>
+
       <p className="text-sm text-[hsl(var(--contrast-400))]">
-        POC page with a fake provider list. Only the ECP (ACH) Add flow is wired, and it loads the
-        storefront-account-payments microapp.
+        POC page with a fake provider list. The ECP (ACH) and Stripe credit-card Add flows are wired, and each
+        loads the storefront-account-payments microapp.
       </p>
     </div>
   );

--- a/core/app/[locale]/(default)/account/payment-methods/page.tsx
+++ b/core/app/[locale]/(default)/account/payment-methods/page.tsx
@@ -1,0 +1,48 @@
+import { setRequestLocale } from 'next-intl/server';
+
+import { Link } from '~/components/link';
+
+interface Props {
+  params: Promise<{ locale: string }>;
+}
+
+// POC: a fake "list payment methods" page.
+//
+// In the real implementation the provider list and stored instruments come from
+// new Storefront GraphQL surfaces (see the vault-PROJECT-6074 design doc). Here we
+// hardcode a single ECP (ACH) section whose Add link loads the
+// storefront-account-payments microapp on /account/payment-methods/add.
+export default async function PaymentMethodsPage({ params }: Props) {
+  const { locale } = await params;
+
+  setRequestLocale(locale);
+
+  return (
+    <div>
+      <h1 className="mb-8 font-[family-name:var(--font-family-heading)] text-4xl font-medium leading-none tracking-tight">
+        Payment Methods
+      </h1>
+
+      <section className="mb-10">
+        <h2 className="mb-4 text-xl font-medium">ACH Direct Debit</h2>
+
+        <Link
+          className="flex min-h-44 w-full max-w-sm flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-[hsl(var(--contrast-200))] p-8 text-center transition-colors hover:border-[hsl(var(--foreground))] hover:bg-[hsl(var(--contrast-100))]"
+          href="/account/payment-methods/add?method_type=ecp"
+        >
+          <span aria-hidden className="text-4xl leading-none">
+            +
+          </span>
+          <span className="font-[family-name:var(--font-family-mono)] text-xs uppercase tracking-wide text-[hsl(var(--contrast-500))]">
+            Add new payment method
+          </span>
+        </Link>
+      </section>
+
+      <p className="text-sm text-[hsl(var(--contrast-400))]">
+        POC page with a fake provider list. Only the ECP (ACH) Add flow is wired, and it loads the
+        storefront-account-payments microapp.
+      </p>
+    </div>
+  );
+}

--- a/core/app/api/payments-proxy/[...path]/route.ts
+++ b/core/app/api/payments-proxy/[...path]/route.ts
@@ -1,0 +1,56 @@
+import { type NextRequest } from 'next/server';
+
+// Same-origin proxy for the account-payments microapp's direct-to-BigPay calls (the stored_instruments POST, and any
+// other calls it makes to `paymentsUrl`). It forwards server-to-server to the payments host, preserving the request
+// body and the Authorization (VAT) header, so the browser only ever makes a first-party request. This removes the CORS
+// problem and keeps the VAT off any third-party origin. See PROJECT-6074-STRIPE-PLAN.md (doc 11.4).
+const PAYMENTS_HOST = process.env.PAYMENTS_HOST ?? '';
+
+async function forward(request: NextRequest, path: string[]): Promise<Response> {
+  if (!PAYMENTS_HOST) {
+    return new Response('PAYMENTS_HOST is not configured', { status: 500 });
+  }
+
+  const { search } = new URL(request.url);
+  const target = `${PAYMENTS_HOST}/${path.join('/')}${search}`;
+
+  const headers = new Headers(request.headers);
+  headers.delete('host');
+
+  const hasBody = request.method !== 'GET' && request.method !== 'HEAD';
+
+  const upstream = await fetch(target, {
+    method: request.method,
+    headers,
+    body: hasBody ? await request.text() : undefined,
+    redirect: 'manual',
+  });
+
+  // Strip hop-by-hop / length headers that don't survive re-streaming.
+  const responseHeaders = new Headers(upstream.headers);
+  responseHeaders.delete('content-encoding');
+  responseHeaders.delete('content-length');
+  responseHeaders.delete('transfer-encoding');
+
+  return new Response(upstream.body, { status: upstream.status, headers: responseHeaders });
+}
+
+interface RouteContext {
+  params: Promise<{ path: string[] }>;
+}
+
+export async function GET(request: NextRequest, { params }: RouteContext): Promise<Response> {
+  return forward(request, (await params).path);
+}
+
+export async function POST(request: NextRequest, { params }: RouteContext): Promise<Response> {
+  return forward(request, (await params).path);
+}
+
+export async function PATCH(request: NextRequest, { params }: RouteContext): Promise<Response> {
+  return forward(request, (await params).path);
+}
+
+export async function DELETE(request: NextRequest, { params }: RouteContext): Promise<Response> {
+  return forward(request, (await params).path);
+}

--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -181,6 +181,7 @@
       "addresses": "Addresses",
       "logout": "Logout",
       "orders": "Orders",
+      "paymentMethods": "Payment Methods",
       "settings": "Account",
       "wishlists": "Wish lists"
     },


### PR DESCRIPTION
## What / Why

POC for headless payment-instrument vaulting in Catalyst ([PROJECT-6074](https://bigcommercecloud.atlassian.net/browse/PROJECT-6074)).

Reuses the [storefront-account-payments](https://github.com/bigcommerce/storefront-account-payments) microapp (the SPA Stencil already uses) to vault a **Stripe OCS credit card** from the My Account payment-methods page, end to end: render the Stripe Payment Element, confirm the setup intent, and store the instrument in BigPay.

## How

- **`getVaultContext`** mints the shopper Vault Access Token (VAT) and the provider vault initialization in one GraphQL round-trip: `createVaultToken` + `createVaultInitialization(providerId, currencyCode)`. The init result is a **typed union**; only the `StripeOcsVaultInit` arm is handled, and an unknown arm fails closed. The VAT and setup token only reach the browser inside the microapp's `storeContextData` at render.
- Assemble the microapp `storeContextData` (providerId, VAT, publishable key, setup-intent client secret, customer, countries) and mount the microapp for the `stripeocs` card flow. The microapp owns the Stripe Element and `confirmSetup`, so it needs no change.
- A same-origin **`payments-proxy`** route (`core/app/api/payments-proxy/[...path]/route.ts`) forwards the microapp's cross-origin `stored_instruments` POST server-to-server, avoiding CORS and keeping the VAT on a same-origin request.
- A placeholder payment-methods list page links per provider to the add route. The real provider and instrument list is a later Storefront GraphQL surface.

## Depends on

- **storefront** #5360: `createVaultToken` + `createVaultInitialization` GraphQL mutations.
- **bigpay** #10922: VAT mint and Stripe OCS vault init config.
- Store must have Stripe OCS connected, with experiment `PROJECT-7909.stripeocs_setup_intent_for_my_account_vaultings` enabled.

## Testing

Local dev against a CDVM store with the dependencies above. Point `ACCOUNT_PAYMENTS_MICROAPP_BASE` at the microapp bundle (prod or integration CDN, or a local build), open `/account/payment-methods`, add a Stripe test card, and confirm the instrument is stored (via `customer.storedPaymentInstruments`).

## Notes

POC scope: one provider (Stripe OCS card) and the add flow. List, edit, delete, and multi-provider routing are out of scope. This branch also carries `PROJECT-6074-STRIPE-PLAN.md`, the implementation plan.

[PROJECT-6074]: https://bigcommercecloud.atlassian.net/browse/PROJECT-6074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

🤖 Generated with [Claude Code](https://claude.com/claude-code)
