### PR TITLE
feat(cli): add channel create command

### DIFF
--- a/packages/catalyst/src/cli/commands/channel.spec.ts
+++ b/packages/catalyst/src/cli/commands/channel.spec.ts
@@ -1,8 +1,8 @@
-import { confirm, select } from '@inquirer/prompts';
+import { checkbox, confirm, input, select } from '@inquirer/prompts';
 import { Command } from 'commander';
 import Conf from 'conf';
 import { http, HttpResponse } from 'msw';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { afterAll, afterEach, beforeAll, describe, expect, MockInstance, test, vi } from 'vitest';
 
@@ -18,6 +18,7 @@ vi.mock('@inquirer/prompts', () => ({
   select: vi.fn(),
   confirm: vi.fn(),
   input: vi.fn(),
+  checkbox: vi.fn(),
 }));
 // `channel link` can trigger the interactive device-code login (browser +
 // spinner); stub both so the no-credentials path runs headless in tests.
@@ -27,6 +28,8 @@ vi.mock('yocto-spinner', () => import('../../../tests/mocks/spinner'));
 
 const mockSelect = vi.mocked(select);
 const mockConfirm = vi.mocked(confirm);
+const mockInput = vi.mocked(input);
+const mockCheckbox = vi.mocked(checkbox);
 
 let exitMock: MockInstance;
 
@@ -105,6 +108,13 @@ describe('channel', () => {
 
     expect(link).toBeDefined();
     expect(link?.description()).toContain('Link this Catalyst project to a BigCommerce channel');
+  });
+
+  test('has the create subcommand', () => {
+    const create = channel.commands.find((cmd) => cmd.name() === 'create');
+
+    expect(create).toBeDefined();
+    expect(create?.description()).toContain('Create a new Catalyst storefront channel');
   });
 });
 
@@ -423,5 +433,199 @@ describe('channel link', () => {
     expect(config.get('storeHash')).toBe('mock-store-hash');
     expect(config.get('accessToken')).toBe('mock-access-token');
     expect(mockIdentify).toHaveBeenCalledWith('mock-store-hash');
+  });
+});
+
+describe('channel create', () => {
+  const eligibilityUrl =
+    'https://cxm-prd.bigcommerceapp.com/stores/:storeHash/cli-api/v3/channels/catalyst/eligibility';
+  const createUrl =
+    'https://cxm-prd.bigcommerceapp.com/stores/:storeHash/cli-api/v3/channels/catalyst';
+
+  test('creates a channel non-interactively and links it with --link', async () => {
+    let createBody: unknown;
+
+    server.use(
+      http.post(createUrl, async ({ request }) => {
+        createBody = await request.json();
+
+        return HttpResponse.json({
+          data: {
+            id: 42,
+            storefront_api_token: 'new-sft-token',
+            envVars: {
+              BIGCOMMERCE_STORE_HASH: storeHash,
+              BIGCOMMERCE_CHANNEL_ID: '42',
+              BIGCOMMERCE_STOREFRONT_TOKEN: 'new-sft-token',
+            },
+          },
+        });
+      }),
+    );
+
+    await program.parseAsync([
+      'node',
+      'catalyst',
+      'channel',
+      'create',
+      '--store-hash',
+      storeHash,
+      '--access-token',
+      accessToken,
+      '--name',
+      'My Store',
+      '--locale',
+      'en',
+      '--additional-locales',
+      'es',
+      'fr',
+      '--no-sample-data',
+      '--link',
+    ]);
+
+    // No prompts when every input is flag-provided (including --link).
+    expect(mockInput).not.toHaveBeenCalled();
+    expect(mockSelect).not.toHaveBeenCalled();
+    expect(mockCheckbox).not.toHaveBeenCalled();
+
+    expect(createBody).toEqual({
+      name: 'My Store',
+      initialData: { type: 'none' },
+      deployStorefront: true,
+      devOrigin: 'http://localhost:3000',
+      storefrontLanguage: 'en',
+      additionalLocales: ['es', 'fr'],
+    });
+
+    expect(mockIdentify).toHaveBeenCalledWith(storeHash);
+    expect(consola.success).toHaveBeenCalledWith(expect.stringContaining('Created channel 42'));
+
+    const envLocal = readFileSync(join(tmpDir, '.env.local'), 'utf8');
+
+    expect(envLocal).toContain('BIGCOMMERCE_CHANNEL_ID=42');
+    expect(envLocal).toContain('BIGCOMMERCE_STOREFRONT_TOKEN=new-sft-token');
+    expect(consola.success).toHaveBeenCalledWith(expect.stringContaining('Linked to channel 42'));
+    expect(exitMock).toHaveBeenCalledWith(0);
+  });
+
+  test('aborts cleanly when the store is not eligible', async () => {
+    let createCalled = false;
+
+    server.use(
+      http.get(eligibilityUrl, () =>
+        HttpResponse.json({
+          data: { eligible: false, message: 'Your plan does not support new channels.' },
+        }),
+      ),
+      http.post(createUrl, () => {
+        createCalled = true;
+
+        return HttpResponse.json({ data: {} });
+      }),
+    );
+
+    await program.parseAsync([
+      'node',
+      'catalyst',
+      'channel',
+      'create',
+      '--store-hash',
+      storeHash,
+      '--access-token',
+      accessToken,
+      '--name',
+      'My Store',
+      '--locale',
+      'en',
+      '--additional-locales',
+      'es',
+    ]);
+
+    expect(consola.warn).toHaveBeenCalledWith('Your plan does not support new channels.');
+    expect(createCalled).toBe(false);
+    expect(exitMock).toHaveBeenCalledWith(0);
+  });
+
+  test('prompts before linking and skips the .env.local write when declined', async () => {
+    const envPath = join(tmpDir, '.env.local');
+
+    rmSync(envPath, { force: true });
+
+    // Only the post-create link prompt should fire (create inputs are all flags).
+    mockSelect.mockResolvedValueOnce(false);
+
+    await program.parseAsync([
+      'node',
+      'catalyst',
+      'channel',
+      'create',
+      '--store-hash',
+      storeHash,
+      '--access-token',
+      accessToken,
+      '--name',
+      'My Store',
+      '--locale',
+      'en',
+      '--additional-locales',
+      'es',
+      '--no-sample-data',
+    ]);
+
+    expect(mockSelect).toHaveBeenCalledTimes(1);
+    expect(consola.success).toHaveBeenCalledWith(expect.stringContaining('Created channel 42'));
+    expect(consola.success).not.toHaveBeenCalledWith(expect.stringContaining('Linked to channel'));
+    expect(existsSync(envPath)).toBe(false);
+    expect(exitMock).toHaveBeenCalledWith(0);
+  });
+
+  test('interactive path prompts for name, locale, languages, and sample data', async () => {
+    let createBody: unknown;
+
+    server.use(
+      http.post(createUrl, async ({ request }) => {
+        createBody = await request.json();
+
+        return HttpResponse.json({
+          data: {
+            id: 42,
+            storefront_api_token: 'new-sft-token',
+            envVars: { BIGCOMMERCE_CHANNEL_ID: '42' },
+          },
+        });
+      }),
+    );
+
+    mockInput.mockResolvedValueOnce('Interactive Channel');
+    // select order: default locale, "add languages?", "sample data?", link prompt
+    mockSelect
+      .mockResolvedValueOnce('en')
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false);
+    mockCheckbox.mockResolvedValueOnce(['es']);
+
+    await program.parseAsync([
+      'node',
+      'catalyst',
+      'channel',
+      'create',
+      '--store-hash',
+      storeHash,
+      '--access-token',
+      accessToken,
+    ]);
+
+    expect(mockInput).toHaveBeenCalledTimes(1);
+    expect(mockCheckbox).toHaveBeenCalledTimes(1);
+    expect(createBody).toEqual({
+      name: 'Interactive Channel',
+      initialData: { type: 'none' },
+      deployStorefront: true,
+      devOrigin: 'http://localhost:3000',
+      storefrontLanguage: 'en',
+      additionalLocales: ['es'],
+    });
+    expect(consola.success).toHaveBeenCalledWith(expect.stringContaining('Created channel 42'));
   });
 });

--- a/packages/catalyst/src/cli/commands/channel.ts
+++ b/packages/catalyst/src/cli/commands/channel.ts
@@ -8,11 +8,13 @@ import { join } from 'node:path';
 import { runChannelSiteUrlFlow } from '../lib/channel-site-flow';
 import {
   channelPlatformLabel,
+  checkChannelEligibility,
   fetchAvailableChannels,
   getChannelInit,
   sortChannelsByPlatform,
 } from '../lib/channels';
 import { NoLinkedProjectError } from '../lib/commerce-hosting';
+import { runCreateChannelFlow } from '../lib/create-channel-flow';
 import { parseEnvAssignment } from '../lib/env-config';
 import { consola } from '../lib/logger';
 import { LoginAbortedError, login as runInteractiveLogin } from '../lib/login';
@@ -26,6 +28,7 @@ import {
   storeHashOption,
 } from '../lib/shared-options';
 import { getTelemetry } from '../lib/telemetry';
+import { writeEnv } from '../lib/write-env';
 
 const parseChannelId = (value: string): number => {
   const parsed = Number.parseInt(value, 10);
@@ -245,8 +248,124 @@ Examples:
     process.exit(0);
   });
 
+const create = new Command('create')
+  .configureHelp({ showGlobalOptions: true })
+  .description('Create a new Catalyst storefront channel on your BigCommerce store.')
+  .addHelpText(
+    'after',
+    `
+Examples:
+  # Create a channel interactively (logs you in if needed)
+  $ catalyst channel create
+
+  # Non-interactive, and link it to this project afterwards
+  $ catalyst channel create --name "My Store" --locale en --no-sample-data --link
+
+  # Add additional storefront languages (max 4)
+  $ catalyst channel create --name "My Store" --additional-locales es fr`,
+  )
+  .addOption(storeHashOption())
+  .addOption(accessTokenOption())
+  .addOption(apiHostOption())
+  .addOption(loginUrlOption())
+  .option('--name <name>', 'Name for the new channel. Skips the name prompt.')
+  .option(
+    '--locale <locale>',
+    'Default storefront locale (e.g. "en"). Skips the default-language prompt.',
+  )
+  .option(
+    '--additional-locales <locales...>',
+    'Additional storefront locales, max 4 (e.g. --additional-locales es fr). Skips the additional-languages prompt.',
+  )
+  .addOption(new Option('--sample-data', 'Install sample data on the new channel.'))
+  .addOption(new Option('--no-sample-data', 'Create the channel without sample data.'))
+  .option(
+    '--link',
+    'Link the new channel to this project — write its credentials to .env.local without prompting.',
+  )
+  .addOption(
+    new Option('--cli-api-origin <origin>', 'Catalyst CLI API origin')
+      .default('https://cxm-prd.bigcommerceapp.com')
+      .hideHelp(),
+  )
+  .action(async (options) => {
+    if (options.additionalLocales && options.additionalLocales.length > 4) {
+      consola.error('You can only set up to 4 additional locales.');
+      process.exit(1);
+
+      return;
+    }
+
+    const config = getProjectConfig();
+
+    const credentials = await resolveCredentialsWithLogin(options, config);
+
+    if (!credentials) {
+      consola.info(
+        'Login aborted. Re-run `catalyst channel create` when you have your credentials ready.',
+      );
+      process.exit(0);
+
+      return;
+    }
+
+    const { storeHash, accessToken } = credentials;
+
+    await getTelemetry().identify(storeHash);
+
+    const eligibility = await checkChannelEligibility(storeHash, accessToken, options.cliApiOrigin);
+
+    if (!eligibility.eligible) {
+      consola.warn(eligibility.message);
+      process.exit(0);
+
+      return;
+    }
+
+    const channelData = await runCreateChannelFlow({
+      storeHash,
+      accessToken,
+      apiHost: options.apiHost,
+      cliApiOrigin: options.cliApiOrigin,
+      name: options.name,
+      locale: options.locale,
+      additionalLocales: options.additionalLocales,
+      sampleData: options.sampleData,
+    });
+
+    consola.success(`Created channel ${channelData.channelId}.`);
+    consola.warn(
+      'A preview storefront has been deployed in your BigCommerce control panel. This preview may look different from your local environment as it may be running different code. Additionally, it may take a few minutes for the channel storefront to be accessible.',
+    );
+
+    // `--link` opts in non-interactively; otherwise ask before touching .env.local.
+    const shouldLink = options.link
+      ? true
+      : await select({
+          message: 'Would you like to link this channel to your project?',
+          choices: [
+            { name: 'Yes', value: true },
+            { name: 'No', value: false },
+          ],
+        });
+
+    if (shouldLink) {
+      // Same write path as `channel link`: write the channel's credentials to
+      // .env.local in the current working directory (where `dev`/`build`/`deploy` run).
+      writeEnv(process.cwd(), channelData.envVars);
+
+      consola.success(
+        `Linked to channel ${channelData.channelId} and wrote ${colorize('cyanBright', '.env.local')}.`,
+      );
+      consola.log(`Next steps:\n\n  ${colorize('yellow', 'pnpm run dev')}`);
+    }
+
+    process.exit(0);
+  });
+
 export const channel = new Command('channel')
   .configureHelp({ showGlobalOptions: true })
   .description('Manage BigCommerce channels.')
+  .addCommand(create)
   .addCommand(link)
   .addCommand(update);

--- a/packages/catalyst/src/cli/commands/create.ts
+++ b/packages/catalyst/src/cli/commands/create.ts
@@ -1,5 +1,5 @@
 import { Command, InvalidArgumentError, Option } from '@commander-js/extra-typings';
-import { checkbox, input, select } from '@inquirer/prompts';
+import { input, select } from '@inquirer/prompts';
 import { execSync } from 'child_process';
 import { colorize } from 'consola/utils';
 import { pathExistsSync } from 'fs-extra/esm';
@@ -10,17 +10,16 @@ import { DEFAULT_LOGIN_URL } from '../lib/auth';
 import {
   channelPlatformLabel,
   checkChannelEligibility,
-  createChannel,
   fetchAvailableChannels,
   getChannelInit,
   sortChannelsByPlatform,
 } from '../lib/channels';
 import { promptForCommerceHostingProject, setupCommerceHosting } from '../lib/commerce-hosting';
+import { runCreateChannelFlow } from '../lib/create-channel-flow';
 import { detectPackageManager } from '../lib/detect-package-manager';
 import { extractCatalyst } from '../lib/extract-catalyst';
 import { initGitRepo } from '../lib/init-git-repo';
 import { installDependencies } from '../lib/install-dependencies';
-import { getAvailableLocales } from '../lib/localization';
 import { consola } from '../lib/logger';
 import { login, LoginAbortedError } from '../lib/login';
 import { hasProjectsAccess, type ProjectListItem } from '../lib/project';
@@ -66,70 +65,6 @@ function parseEnvFlag(
   }
 
   return { ...previous, [key]: val };
-}
-
-async function handleChannelCreation(
-  storeHash: string,
-  accessToken: string,
-  apiHost: string,
-  cliApiOrigin: string,
-) {
-  const newChannelName = await input({
-    message: 'What would you like to name your new channel?',
-  });
-
-  const availableLocales = await getAvailableLocales(storeHash, accessToken, apiHost);
-
-  const storefrontLocale = await select({
-    message: 'Which default language would you like to set for your channel?',
-    default: 'en',
-    choices: availableLocales,
-    theme: {
-      style: {
-        help: () => colorize('dim', '(Select locale from the list or start typing the name)'),
-      },
-    },
-  });
-
-  const shouldAddAdditionalLocales = await select({
-    message: 'Would you like to add additional languages?',
-    choices: [
-      { name: 'Yes', value: true },
-      { name: 'No', value: false },
-    ],
-  });
-
-  let additionalLocales: string[] = [];
-
-  if (shouldAddAdditionalLocales) {
-    const localeChoices = availableLocales
-      .filter(({ value }) => value !== storefrontLocale)
-      .map(({ name, value }) => ({ name, value, description: value }));
-
-    additionalLocales = await checkbox({
-      message: 'Which additional languages would you like to add to your channel?',
-      choices: localeChoices,
-      validate: (items) => items.length <= 4 || 'You can only select up to 4 additional languages.',
-    });
-  }
-
-  const shouldInstallSampleData = await select({
-    message: 'Would you like to install sample data?',
-    choices: [
-      { name: 'Yes', value: true },
-      { name: 'No', value: false },
-    ],
-  });
-
-  return createChannel(
-    newChannelName,
-    storefrontLocale,
-    additionalLocales,
-    shouldInstallSampleData,
-    storeHash,
-    accessToken,
-    cliApiOrigin,
-  );
 }
 
 async function handleChannelSelection(storeHash: string, accessToken: string, apiHost: string) {
@@ -357,12 +292,12 @@ Examples:
         }
 
         if (shouldCreateChannel) {
-          const channelData = await handleChannelCreation(
+          const channelData = await runCreateChannelFlow({
             storeHash,
             accessToken,
             apiHost,
             cliApiOrigin,
-          );
+          });
 
           channelId = channelData.channelId;
           storefrontToken = channelData.storefrontToken;

--- a/packages/catalyst/src/cli/lib/create-channel-flow.ts
+++ b/packages/catalyst/src/cli/lib/create-channel-flow.ts
@@ -1,0 +1,102 @@
+import { checkbox, input, select } from '@inquirer/prompts';
+import { colorize } from 'consola/utils';
+
+import { createChannel, type CreatedChannel } from './channels';
+import { getAvailableLocales } from './localization';
+
+export interface CreateChannelFlowOptions {
+  storeHash: string;
+  accessToken: string;
+  apiHost: string;
+  cliApiOrigin: string;
+  // Non-interactive overrides. When a value is supplied the corresponding
+  // prompt is skipped, so a fully-flagged invocation runs headless.
+  name?: string;
+  locale?: string;
+  additionalLocales?: string[];
+  sampleData?: boolean;
+}
+
+// Shared channel-creation flow used by both `catalyst create` (while scaffolding)
+// and `catalyst channel create` (on an existing project). Prompts for anything
+// not provided as a flag, then POSTs to create the Catalyst channel.
+export async function runCreateChannelFlow(
+  options: CreateChannelFlowOptions,
+): Promise<CreatedChannel> {
+  const { storeHash, accessToken, apiHost, cliApiOrigin } = options;
+
+  const name =
+    options.name ??
+    (await input({
+      message: 'What would you like to name your new channel?',
+    }));
+
+  // The locale list backs both the default-locale and additional-locales
+  // prompts. Fetch it lazily and once — a fully-flagged run skips the call.
+  let availableLocales: Awaited<ReturnType<typeof getAvailableLocales>> | undefined;
+  const loadLocales = async () => {
+    availableLocales ??= await getAvailableLocales(storeHash, accessToken, apiHost);
+
+    return availableLocales;
+  };
+
+  const storefrontLocale =
+    options.locale ??
+    (await select({
+      message: 'Which default language would you like to set for your channel?',
+      default: 'en',
+      choices: await loadLocales(),
+      theme: {
+        style: {
+          help: () => colorize('dim', '(Select locale from the list or start typing the name)'),
+        },
+      },
+    }));
+
+  let additionalLocales = options.additionalLocales;
+
+  if (additionalLocales === undefined) {
+    const shouldAddAdditionalLocales = await select({
+      message: 'Would you like to add additional languages?',
+      choices: [
+        { name: 'Yes', value: true },
+        { name: 'No', value: false },
+      ],
+    });
+
+    additionalLocales = [];
+
+    if (shouldAddAdditionalLocales) {
+      const localeChoices = (await loadLocales())
+        .filter(({ value }) => value !== storefrontLocale)
+        .map(({ name: localeName, value }) => ({ name: localeName, value, description: value }));
+
+      additionalLocales = await checkbox({
+        message: 'Which additional languages would you like to add to your channel?',
+        choices: localeChoices,
+        validate: (items) =>
+          items.length <= 4 || 'You can only select up to 4 additional languages.',
+      });
+    }
+  }
+
+  const shouldInstallSampleData =
+    options.sampleData ??
+    (await select({
+      message: 'Would you like to install sample data?',
+      choices: [
+        { name: 'Yes', value: true },
+        { name: 'No', value: false },
+      ],
+    }));
+
+  return createChannel(
+    name,
+    storefrontLocale,
+    additionalLocales,
+    shouldInstallSampleData,
+    storeHash,
+    accessToken,
+    cliApiOrigin,
+  );
+}

--- a/packages/catalyst/tests/mocks/handlers.ts
+++ b/packages/catalyst/tests/mocks/handlers.ts
@@ -259,6 +259,40 @@ export const handlers = [
     }),
   ),
 
+  // Default handler for checkChannelEligibility — eligible by default. Tests
+  // covering the ineligible path should override with `server.use(...)`.
+  http.get('https://:apiHost/stores/:storeHash/cli-api/v3/channels/catalyst/eligibility', () =>
+    HttpResponse.json({ data: { eligible: true, message: 'Eligible.' } }),
+  ),
+
+  // Default handler for createChannel — returns a freshly-created Catalyst
+  // channel with its storefront token and env vars.
+  http.post('https://:apiHost/stores/:storeHash/cli-api/v3/channels/catalyst', () =>
+    HttpResponse.json({
+      data: {
+        id: 42,
+        storefront_api_token: 'new-sft-token',
+        envVars: {
+          BIGCOMMERCE_STORE_HASH: 'test-store',
+          BIGCOMMERCE_CHANNEL_ID: '42',
+          BIGCOMMERCE_STOREFRONT_TOKEN: 'new-sft-token',
+        },
+      },
+    }),
+  ),
+
+  // Default handler for getAvailableLocales — the channel-creation flow reads
+  // this to populate the language pickers.
+  http.get('https://:apiHost/stores/:storeHash/v3/settings/store/available-locales', () =>
+    HttpResponse.json({
+      data: [
+        { id: 'en', name: 'English', fallback: null, is_supported: true },
+        { id: 'es', name: 'Spanish', fallback: null, is_supported: true },
+        { id: 'fr', name: 'French', fallback: null, is_supported: true },
+      ],
+    }),
+  ),
+
   // Default handler for updateChannelSiteUrl — succeeds with a generic
   // payload. Tests that need to assert error handling should override.
   http.put('https://:apiHost/stores/:storeHash/v3/channels/:channelId/site', () =>


### PR DESCRIPTION
Linear: [LTRAC-976](https://linear.app/commerce/issue/LTRAC-976/add-channel-create-command)

## What/Why?

`catalyst create` already knows how to create a Catalyst storefront channel, but that flow was only reachable while scaffolding a brand-new project. This adds a `catalyst channel create` subcommand so a developer with an existing Catalyst project can create additional channels without re-scaffolding.

The channel-creation flow (prompts + `createChannel`) is extracted out of `create.ts` into a shared `create-channel-flow` lib, so `catalyst create` and `catalyst channel create` share one code path (no duplicated prompt/eligibility logic). The new subcommand:

- Resolves credentials the same way `channel link` does (flags/env → project config → interactive login), since it may run in a fresh context.
- Runs `checkChannelEligibility` first and exits cleanly with the API message when the store is ineligible.
- Prompts for name, default locale, additional locales (max 4), and sample data — each overridable via flags (`--name`, `--locale`, `--additional-locales`, `--sample-data`/`--no-sample-data`) for non-interactive use.
- After creation, offers to link the channel by writing its credentials to `.env.local` (same write path as `channel link`); `--link` opts in without prompting.

The shared flow fetches the available-locales list lazily, so a fully-flag-driven run makes no extra API call.

## Testing

- `pnpm --filter @bigcommerce/catalyst test` — full CLI suite green (37 spec files).
- New `channel.spec.ts` coverage: subcommand presence, non-interactive create + `--link` (asserts POST body and `.env.local`), eligibility-fail exit, the link/no-link prompt branches, and the interactive path.
- `pnpm --filter @bigcommerce/catalyst typecheck` and `lint` clean.

Manual: `catalyst channel create --help` lists the new command under `catalyst channel`.

## Migration

None. Extracting `handleChannelCreation` into a lib is behavior-preserving for `catalyst create`.