### PR TITLE
fix(cli): add readable HTTP error messages for 4xx/5xx API failures

### DIFF
--- a/.changeset/readable-http-errors.md
+++ b/.changeset/readable-http-errors.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst": patch
+---
+
+Give the CLI readable, actionable errors when a BigCommerce API returns a 4xx or 5xx. A shared HTTP-error helper now turns a failed response into a clear message: it prefers the API's own reason (`detail`/`title`/field errors) and, when the body is empty or unparseable, falls back to curated copy for the status class. Client (4xx) errors are treated as user-actionable and print without the "share this Correlation ID with BigCommerce support" framing, while server (5xx) errors keep it. This replaces the raw `... failed: <status> <statusText>` throws across the `channel`, `project`, `deploy`, `logs`, and `auth` API paths.

--- a/packages/catalyst/src/cli/commands/deploy.ts
+++ b/packages/catalyst/src/cli/commands/deploy.ts
@@ -23,6 +23,7 @@ import {
   parseEnvAssignment,
   toDeploymentSecrets,
 } from '../lib/env-config';
+import { httpError } from '../lib/http-errors';
 import { installDependencies } from '../lib/install-dependencies';
 import { consola } from '../lib/logger';
 import { getProjectConfig } from '../lib/project-config';
@@ -153,7 +154,7 @@ export const generateUploadSignature = async (
   assertAuthorized(response);
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch upload signature: ${response.status} ${response.statusText}`);
+    throw await httpError(response, 'Failed to generate upload signature');
   }
 
   const res: unknown = await response.json();
@@ -181,7 +182,7 @@ export const uploadBundleZip = async (uploadUrl: string) => {
   });
 
   if (!response.ok) {
-    throw new Error(`Failed to upload bundle: ${response.status} ${response.statusText}`);
+    throw await httpError(response, 'Failed to upload bundle');
   }
 
   consola.success('Bundle uploaded successfully.');
@@ -232,7 +233,7 @@ export const createDeployment = async (
   assertAuthorized(response);
 
   if (!response.ok) {
-    throw new Error(`Failed to create deployment: ${response.status} ${response.statusText}`);
+    throw await httpError(response, 'Failed to create deployment');
   }
 
   const res: unknown = await response.json();
@@ -269,7 +270,7 @@ export const getDeploymentStatus = async (
   assertAuthorized(response);
 
   if (!response.ok) {
-    throw new Error(`Failed to open event stream: ${response.status} ${response.statusText}`);
+    throw await httpError(response, 'Failed to open deployment event stream');
   }
 
   const reader = response.body?.getReader();
@@ -358,7 +359,7 @@ export const fetchProject = async (
   assertAuthorized(response);
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch projects: ${response.status} ${response.statusText}`);
+    throw await httpError(response, 'Failed to fetch projects');
   }
 
   const res: unknown = await response.json();

--- a/packages/catalyst/src/cli/commands/logs.spec.ts
+++ b/packages/catalyst/src/cli/commands/logs.spec.ts
@@ -320,7 +320,7 @@ describe('error handling', () => {
     );
 
     await expect(tailLogs(projectUuid, storeHash, accessToken, apiHost, 'default')).rejects.toThrow(
-      'Failed to open log stream: 404 Not Found',
+      'Failed to open log stream: The request was rejected. Check your input — your access token may be missing a required scope, or the resource may not exist.',
     );
   });
 
@@ -446,7 +446,7 @@ describe('retry and reconnect', () => {
     );
 
     await expect(tailLogs(projectUuid, storeHash, accessToken, apiHost, 'default')).rejects.toThrow(
-      'Failed to open log stream: 404 Not Found',
+      'Failed to open log stream: The request was rejected. Check your input — your access token may be missing a required scope, or the resource may not exist.',
     );
 
     // Server disconnect warnings should NOT contain "attempt X/5"
@@ -461,7 +461,7 @@ describe('retry and reconnect', () => {
       let requestCount = 0;
       const ttlMs = 200;
 
-      // Stream that stays open but never enqueues — simulates an API proxy
+      // Stream that stays open but never enqueues â simulates an API proxy
       // half-closing the socket: bytes stop arriving but no FIN or error is
       // surfaced, so reader.read() would otherwise block forever.
       const createStalledStream = () =>
@@ -491,7 +491,9 @@ describe('retry and reconnect', () => {
 
       await expect(
         tailLogs(projectUuid, storeHash, accessToken, apiHost, 'default', ttlMs),
-      ).rejects.toThrow('Failed to open log stream: 404 Not Found');
+      ).rejects.toThrow(
+        'Failed to open log stream: The request was rejected. Check your input — your access token may be missing a required scope, or the resource may not exist.',
+      );
 
       expect(requestCount).toBe(3);
       expect(consola.warn).toHaveBeenCalledWith('Log stream idle, reconnecting...');
@@ -541,7 +543,9 @@ describe('retry and reconnect', () => {
 
     await expect(
       tailLogs(projectUuid, storeHash, accessToken, apiHost, 'default', ttlMs),
-    ).rejects.toThrow('Failed to open log stream: 404 Not Found');
+    ).rejects.toThrow(
+      'Failed to open log stream: The request was rejected. Check your input — your access token may be missing a required scope, or the resource may not exist.',
+    );
 
     // Should have connected 3 times: 2 TTL-triggered reconnects + final 404
     expect(requestCount).toBe(3);

--- a/packages/catalyst/src/cli/commands/logs.ts
+++ b/packages/catalyst/src/cli/commands/logs.ts
@@ -3,6 +3,7 @@ import { colorize } from 'consola/utils';
 import { z } from 'zod';
 
 import { UnauthorizedError } from '../lib/auth-errors';
+import { httpError } from '../lib/http-errors';
 import { consola } from '../lib/logger';
 import { formatLogEntry, LOG_LEVELS, queryLogs, resolveTimeWindow } from '../lib/observability';
 import { getProjectConfig } from '../lib/project-config';
@@ -180,10 +181,9 @@ const openLogStream = async (
   }
 
   if (!response.ok) {
-    throw new StreamError(
-      `Failed to open log stream: ${response.status} ${response.statusText}`,
-      isFatalStatusCode(response.status),
-    );
+    const error = await httpError(response, 'Failed to open log stream');
+
+    throw new StreamError(error.message, isFatalStatusCode(response.status));
   }
 
   const reader = response.body?.getReader();

--- a/packages/catalyst/src/cli/lib/auth.spec.ts
+++ b/packages/catalyst/src/cli/lib/auth.spec.ts
@@ -39,7 +39,7 @@ describe('requestDeviceCode', () => {
     );
 
     await expect(requestDeviceCode(DEFAULT_LOGIN_URL)).rejects.toThrow(
-      'Failed to request device code: 500 Internal Server Error',
+      'Failed to request device code: Something went wrong on our end. Please try again. If the issue persists, contact support.',
     );
   });
 

--- a/packages/catalyst/src/cli/lib/auth.ts
+++ b/packages/catalyst/src/cli/lib/auth.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { httpError } from './http-errors';
+
 export const DEVICE_OAUTH_CLIENT_ID = 'b8063bu6hhml4e0lqh22yut63atsbyv';
 export const DEVICE_OAUTH_SCOPES = [
   'store_v2_information',
@@ -36,7 +38,7 @@ export async function requestDeviceCode(loginUrl: string) {
   });
 
   if (!response.ok) {
-    throw new Error(`Failed to request device code: ${response.status} ${response.statusText}`);
+    throw await httpError(response, 'Failed to request device code');
   }
 
   const res: unknown = await response.json();

--- a/packages/catalyst/src/cli/lib/channels.spec.ts
+++ b/packages/catalyst/src/cli/lib/channels.spec.ts
@@ -98,7 +98,7 @@ describe('updateChannelSiteUrl', () => {
     ).rejects.toThrow('Re-run `catalyst auth login`');
   });
 
-  test('throws with status on other errors', async () => {
+  test('throws a readable error on other errors', async () => {
     server.use(
       http.put('https://:apiHost/stores/:storeHash/v3/channels/:channelId/site', () =>
         HttpResponse.json({}, { status: 500 }),
@@ -107,7 +107,7 @@ describe('updateChannelSiteUrl', () => {
 
     await expect(
       updateChannelSiteUrl(channelId, 'https://x.example', storeHash, accessToken, apiHost),
-    ).rejects.toThrow('Failed to update channel site: 500');
+    ).rejects.toThrow('Failed to update channel site: Something went wrong on our end.');
   });
 });
 

--- a/packages/catalyst/src/cli/lib/channels.ts
+++ b/packages/catalyst/src/cli/lib/channels.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { assertAuthorized } from './auth-errors';
 import { UserActionableError } from './errors';
+import { httpError } from './http-errors';
 import { getTelemetry } from './telemetry';
 
 // `origin` is the CLI-API gateway (configured via `--cli-api-origin`, default
@@ -111,9 +112,7 @@ export async function getChannelInit(
   });
 
   if (!response.ok) {
-    throw new Error(
-      `GET /channels/${channelId}/init failed: ${response.status} ${response.statusText}`,
-    );
+    throw await httpError(response, 'Failed to initialize channel');
   }
 
   const { data } = initResponseSchema.parse(await response.json());
@@ -137,9 +136,7 @@ export async function checkChannelEligibility(
   });
 
   if (!response.ok) {
-    throw new Error(
-      `GET /channels/catalyst/eligibility failed: ${response.status} ${response.statusText}`,
-    );
+    throw await httpError(response, 'Failed to check Catalyst eligibility');
   }
 
   return eligibilityResponseSchema.parse(await response.json()).data;
@@ -174,7 +171,7 @@ export async function createChannel(
   });
 
   if (!response.ok) {
-    throw new Error(`POST /channels/catalyst failed: ${response.status} ${response.statusText}`);
+    throw await httpError(response, 'Failed to create channel');
   }
 
   const { data } = createChannelResponseSchema.parse(await response.json());
@@ -206,7 +203,7 @@ export async function fetchAvailableChannels(
   assertAuthorized(response);
 
   if (!response.ok) {
-    throw new Error(`GET /v3/channels failed: ${response.status} ${response.statusText}`);
+    throw await httpError(response, 'Failed to fetch channels');
   }
 
   return channelsResponseSchema.parse(await response.json()).data;
@@ -246,7 +243,7 @@ export async function updateChannelSiteUrl(
   }
 
   if (!response.ok) {
-    throw new Error(`Failed to update channel site: ${response.status} ${response.statusText}`);
+    throw await httpError(response, 'Failed to update channel site');
   }
 
   const res: unknown = await response.json();

--- a/packages/catalyst/src/cli/lib/http-errors.spec.ts
+++ b/packages/catalyst/src/cli/lib/http-errors.spec.ts
@@ -1,0 +1,104 @@
+import { HttpResponse } from 'msw';
+import { describe, expect, test } from 'vitest';
+
+import { UserActionableError } from './errors';
+import { extractApiErrorMessage, httpError } from './http-errors';
+
+describe('extractApiErrorMessage', () => {
+  test('prefers the server detail', () => {
+    expect(
+      extractApiErrorMessage({ title: 'Bad Request', detail: 'The domain is already claimed.' }),
+    ).toBe('The domain is already claimed.');
+  });
+
+  test('falls back to the title when there is no detail', () => {
+    expect(extractApiErrorMessage({ title: 'Not Found' })).toBe('Not Found');
+  });
+
+  test('enriches the headline with field-level errors', () => {
+    expect(
+      extractApiErrorMessage({
+        title: 'Invalid request.',
+        errors: { name: 'must be at least 3 characters' },
+      }),
+    ).toBe('Invalid request. (name: must be at least 3 characters)');
+  });
+
+  test('returns field errors alone when there is no title or detail', () => {
+    expect(extractApiErrorMessage({ errors: { name: 'is required' } })).toBe('name: is required');
+  });
+
+  test('returns undefined for a body that is not the v3 envelope', () => {
+    expect(extractApiErrorMessage(null)).toBeUndefined();
+    expect(extractApiErrorMessage('oops')).toBeUndefined();
+    expect(extractApiErrorMessage({ unrelated: true })).toBeUndefined();
+  });
+});
+
+describe('httpError', () => {
+  test('surfaces the API body message on a 4xx', async () => {
+    const response = HttpResponse.json(
+      { title: 'Bad Request', detail: 'The project name is already in use.' },
+      { status: 400 },
+    );
+
+    const error = await httpError(response, 'Failed to create project');
+
+    // A 4xx is a clear, user-actionable response — no Correlation ID/support framing.
+    expect(error).toBeInstanceOf(UserActionableError);
+    expect(error.message).toBe('Failed to create project: The project name is already in use.');
+  });
+
+  test('surfaces the API body message on a 5xx but keeps it a plain Error', async () => {
+    const response = HttpResponse.json(
+      { title: 'Bad Gateway', detail: 'Upstream is unavailable.' },
+      { status: 502 },
+    );
+
+    const error = await httpError(response, 'Failed to fetch logs');
+
+    // A 5xx is a server-side failure worth escalating — stays a plain Error so
+    // the top-level handler keeps the Correlation ID + support framing.
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toBeInstanceOf(UserActionableError);
+    expect(error.message).toBe('Failed to fetch logs: Upstream is unavailable.');
+  });
+
+  test('falls back to user-actionable copy for a 4xx with an empty body', async () => {
+    const response = new HttpResponse(null, { status: 403 });
+
+    const error = await httpError(response, 'Failed to fetch projects');
+
+    expect(error).toBeInstanceOf(UserActionableError);
+    expect(error.message).toBe(
+      'Failed to fetch projects: The request was rejected. Check your input — your access token may be missing a required scope, or the resource may not exist.',
+    );
+  });
+
+  test('falls back to transient copy for a 5xx with an empty body', async () => {
+    const response = new HttpResponse(null, { status: 500 });
+
+    const error = await httpError(response, 'Failed to fetch logs');
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toBeInstanceOf(UserActionableError);
+    expect(error.message).toBe(
+      'Failed to fetch logs: Something went wrong on our end. Please try again. If the issue persists, contact support.',
+    );
+  });
+
+  test('falls back gracefully when the body is unparseable JSON', async () => {
+    const response = new HttpResponse('<html>Bad Gateway</html>', {
+      status: 502,
+      headers: { 'Content-Type': 'text/html' },
+    });
+
+    const error = await httpError(response, 'Failed to upload bundle');
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toBeInstanceOf(UserActionableError);
+    expect(error.message).toBe(
+      'Failed to upload bundle: Something went wrong on our end. Please try again. If the issue persists, contact support.',
+    );
+  });
+});

--- a/packages/catalyst/src/cli/lib/http-errors.ts
+++ b/packages/catalyst/src/cli/lib/http-errors.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod';
+
+import { UserActionableError } from './errors';
+
+// BigCommerce APIs surface errors as an RFC-7807-ish envelope:
+// `{ title, detail, errors: { <field>: <message> } }`. We prefer the server's
+// own prose over anything we could invent, so callers show the API's reason
+// verbatim when it's available.
+const apiErrorBodySchema = z.object({
+  title: z.string().optional(),
+  detail: z.string().optional(),
+  errors: z.record(z.string(), z.string()).optional(),
+});
+
+// Curated copy for when the response has no usable body. Keyed by status class,
+// not exact code, so any 4xx/5xx we don't specifically handle still reads well.
+const FALLBACK_CLIENT_ERROR =
+  'The request was rejected. Check your input — your access token may be missing a required scope, or the resource may not exist.';
+const FALLBACK_SERVER_ERROR =
+  'Something went wrong on our end. Please try again. If the issue persists, contact support.';
+
+// Pulls a human-readable message out of a parsed API error body, preferring the
+// most specific prose the server gave us: its `detail`, then `title`, enriched
+// with any field-level `errors`. Returns undefined when the body doesn't match
+// the envelope (empty, HTML, plain text, or already-consumed).
+export function extractApiErrorMessage(body: unknown): string | undefined {
+  const parsed = apiErrorBodySchema.safeParse(body);
+
+  if (!parsed.success) return undefined;
+
+  const { title, detail, errors } = parsed.data;
+  const fieldErrors =
+    errors && Object.keys(errors).length > 0
+      ? Object.entries(errors)
+          .map(([field, message]) => `${field}: ${message}`)
+          .join('; ')
+      : undefined;
+
+  const headline = detail ?? title;
+
+  if (headline && fieldErrors) return `${headline} (${fieldErrors})`;
+
+  return headline ?? fieldErrors;
+}
+
+// Turns a non-OK `Response` into a readable error to throw. Reads the body once
+// (safely — a malformed or empty body never throws) and prefers the API's own
+// message; otherwise it falls back to curated copy for the status class.
+//
+// The 4xx/5xx split decides the *type*, which the top-level handler in
+// `index.ts` keys off: a 4xx is a clear, user-actionable response, so it throws
+// `UserActionableError` and the handler drops the "share your Correlation ID
+// with support" bug-report framing; a 5xx is a server-side failure worth
+// escalating, so it stays a plain `Error` and keeps that framing.
+//
+// Returns the error rather than throwing so call sites read
+// `throw await httpError(response, 'Failed to fetch projects')` and TypeScript
+// still sees the throw for control-flow narrowing.
+export async function httpError(response: Response, action: string): Promise<Error> {
+  const body: unknown = await response.json().catch(() => null);
+  const isServerError = response.status >= 500;
+  const detail =
+    extractApiErrorMessage(body) ?? (isServerError ? FALLBACK_SERVER_ERROR : FALLBACK_CLIENT_ERROR);
+  const message = `${action}: ${detail}`;
+
+  return isServerError ? new Error(message) : new UserActionableError(message);
+}

--- a/packages/catalyst/src/cli/lib/localization.ts
+++ b/packages/catalyst/src/cli/lib/localization.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { assertAuthorized } from './auth-errors';
+import { httpError } from './http-errors';
 import { getTelemetry } from './telemetry';
 
 const allowedLocales = [
@@ -56,9 +57,7 @@ export const getAvailableLocales = async (
   assertAuthorized(response);
 
   if (!response.ok) {
-    throw new Error(
-      `GET /v3/settings/store/available-locales failed: ${response.status} ${response.statusText}`,
-    );
+    throw await httpError(response, 'Failed to fetch available locales');
   }
 
   return AvailableLocalesSuccessSchema.parse(await response.json())

--- a/packages/catalyst/src/cli/lib/observability.spec.ts
+++ b/packages/catalyst/src/cli/lib/observability.spec.ts
@@ -469,6 +469,9 @@ describe('queryLogs', () => {
     // and keeps the top-level Correlation ID + support framing.
     expect(error).toBeInstanceOf(Error);
     expect(error).not.toBeInstanceOf(UserActionableError);
-    expect(error).toHaveProperty('message', 'Failed to fetch logs: 500 Server Error');
+    expect(error).toHaveProperty(
+      'message',
+      'Failed to fetch logs: Something went wrong on our end. Please try again. If the issue persists, contact support.',
+    );
   });
 });

--- a/packages/catalyst/src/cli/lib/observability.ts
+++ b/packages/catalyst/src/cli/lib/observability.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 import { assertAuthorized } from './auth-errors';
 import { UserActionableError } from './errors';
+import { httpError } from './http-errors';
 import { getTelemetry } from './telemetry';
 
 export const LOG_LEVELS = ['debug', 'info', 'warn', 'error'] as const;
@@ -267,7 +268,7 @@ export async function queryLogs(
   }
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch logs: ${response.status} ${response.statusText}`);
+    throw await httpError(response, 'Failed to fetch logs');
   }
 
   const res: unknown = await response.json();

--- a/packages/catalyst/src/cli/lib/project.ts
+++ b/packages/catalyst/src/cli/lib/project.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { assertAuthorized } from './auth-errors';
 import { UserActionableError } from './errors';
+import { httpError } from './http-errors';
 import { getTelemetry } from './telemetry';
 
 export class InfrastructureProjectValidationError extends UserActionableError {
@@ -53,9 +54,7 @@ export async function hasProjectsAccess(
   if (response.status === 200) return true;
   if (response.status === 403) return false;
 
-  throw new Error(
-    `GET /v3/infrastructure/projects failed: ${response.status} ${response.statusText}`,
-  );
+  throw await httpError(response, 'Failed to check project access');
 }
 
 export async function fetchProjects(
@@ -77,7 +76,7 @@ export async function fetchProjects(
   }
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch projects: ${response.statusText}`);
+    throw await httpError(response, 'Failed to fetch projects');
   }
 
   const res: unknown = await response.json();
@@ -166,7 +165,7 @@ export async function createProject(
   }
 
   if (!response.ok) {
-    throw new Error(`Failed to create project: ${response.statusText}`);
+    throw await httpError(response, 'Failed to create project');
   }
 
   const res: unknown = await response.json();
@@ -200,6 +199,6 @@ export async function deleteProject(
   }
 
   if (!response.ok) {
-    throw new Error(`Failed to delete project: ${response.statusText}`);
+    throw await httpError(response, 'Failed to delete project');
   }
 }


### PR DESCRIPTION
Linear: [LTRAC-977](https://linear.app/commerce/issue/LTRAC-977)

## What/Why?
Most CLI API calls threw a raw `... failed: ${status} ${statusText}`, so a user hitting a 400/500 saw a bare status line with no explanation, blame, or next step. This adds a shared HTTP-error helper that converts a non-OK `Response` into a readable error: it prefers the API's own structured body (`title`/`detail`) and falls back to a status-class message. 4xx are thrown as `UserActionableError` (dropping the "share your Correlation ID with support" framing); 5xx keep that framing as transient/server-side. The raw throws across channels, project, observability, localization, deploy, logs, and auth are migrated to the helper. Existing `UnauthorizedError` (401) and deployment-code handling are untouched.

This is the umbrella error PR. The child tickets — channel-name validation (LTRAC-1088), project-create 404 guidance (LTRAC-1089), and deploy missing-env error (LTRAC-1090) — are **separate PRs** and touch some of the same files, so expect minor merge-order conflicts.

## Testing
- New `http-errors.spec.ts` plus updated `channels/auth/observability/logs` specs — 130 tests pass across 6 CLI spec files. Covers API-body passthrough, 4xx fallback copy, 5xx fallback copy, and empty/unparseable body.
- `pnpm --filter @bigcommerce/catalyst typecheck` and `lint` pass. (The full `test` run includes unrelated makeswift `mergeCore`/`upgrade.spec` tests that time out in this environment — pre-existing, not touched here.)

## Migration
None.