### PR TITLE
fix(cli): show not-enabled guidance on 404 for project create

### DIFF
--- a/.changeset/project-create-not-enabled.md
+++ b/.changeset/project-create-not-enabled.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst": patch
+---
+
+`project create` now shows the actionable "Infrastructure Projects API not enabled — contact support to join the beta" guidance when the API responds `404`, matching the existing `403` handling, instead of a cryptic `Failed to create project: Not Found`.

--- a/packages/catalyst/src/cli/lib/project.spec.ts
+++ b/packages/catalyst/src/cli/lib/project.spec.ts
@@ -1,0 +1,34 @@
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '../../../tests/mocks/node';
+
+import { createProject } from './project';
+
+const API = { storeHash: 'store', accessToken: 'token', apiHost: 'api.example.com' };
+const CREATE_PROJECT_URL = 'https://:apiHost/stores/:storeHash/v3/infrastructure/projects';
+
+const NOT_ENABLED_MESSAGE =
+  'Infrastructure Projects API not enabled. If you are part of the beta, contact support@bigcommerce.com to enable it.';
+
+describe('createProject', () => {
+  // The API returns 403 when the store lacks the scope and 404 when the
+  // Infrastructure Projects feature flag is off. Both mean "not enabled for this
+  // store", so both surface the same actionable "join the beta" guidance rather
+  // than a cryptic `Failed to create project: Not Found`.
+  it.each([403, 404])(
+    'surfaces the not-enabled guidance when the API responds %i',
+    async (status) => {
+      server.use(
+        http.post(
+          CREATE_PROJECT_URL,
+          () => new HttpResponse(null, { status, statusText: 'Not Found' }),
+        ),
+      );
+
+      await expect(
+        createProject('my-project', API.storeHash, API.accessToken, API.apiHost),
+      ).rejects.toThrow(NOT_ENABLED_MESSAGE);
+    },
+  );
+});

--- a/packages/catalyst/src/cli/lib/project.ts
+++ b/packages/catalyst/src/cli/lib/project.ts
@@ -152,7 +152,9 @@ export async function createProject(
     throw new InfrastructureProjectValidationError(message);
   }
 
-  if (response.status === 403) {
+  // The API returns 403 (or 404 when the flag is off) if the store isn't in the
+  // Infrastructure Projects beta; both mean "not enabled for this store".
+  if (response.status === 403 || response.status === 404) {
     throw new UserActionableError(
       'Infrastructure Projects API not enabled. If you are part of the beta, contact support@bigcommerce.com to enable it.',
     );


### PR DESCRIPTION
Linear: [LTRAC-1089](https://linear.app/commerce/issue/LTRAC-1089)

## What/Why?
`createProject` mapped `403` to a friendly "Infrastructure Projects API not enabled — contact support to join the beta" message, but a `404` (what the API appears to return when the flag is off) fell through to a cryptic `Failed to create project: Not Found`. This treats `404` the same as `403`, surfacing the actionable guidance via `UserActionableError`.

**Open question:** the exact status the API returns when the flag is disabled should be confirmed with the API team — this handles both `403` and `404` to be safe.

## Testing
- `project.spec.ts` covers the not-enabled path (44 tests pass).
- `typecheck` and `lint` pass.

## Migration
None.