### PR TITLE
feat(cli): require --env-path instead of auto-loading .env.local

### DIFF
--- a/.changeset/require-env-path.md
+++ b/.changeset/require-env-path.md
@@ -2,11 +2,6 @@
 "@bigcommerce/catalyst": minor
 ---
 
-Env files are no longer auto-loaded by the CLI. Previously `.env.local` was
-automatically read from the current working directory (but `.env` was not),
-which was surprising and inconsistent. Now nothing is loaded automatically;
-pass `--env-path <path>` to load an env file explicitly.
+Env files are no longer auto-loaded by the CLI. Previously `.env.local` was automatically read from the current working directory (but `.env` was not), which was surprising and inconsistent. Now nothing is loaded automatically; pass `--env-path <path>` to load an env file explicitly.
 
-Migration: if you relied on the automatic `.env.local` loading, pass the file
-explicitly, e.g. `catalyst deploy --env-path .env.local` (or
-`--env-path ./core/.env.local` when running from the repo root).
+Migration: if you relied on the automatic `.env.local` loading, pass the file explicitly, e.g. `catalyst deploy --env-path .env.local` (or `--env-path ./core/.env.local` when running from the repo root).

--- a/.changeset/require-env-path.md
+++ b/.changeset/require-env-path.md
@@ -1,0 +1,12 @@
+---
+"@bigcommerce/catalyst": minor
+---
+
+Env files are no longer auto-loaded by the CLI. Previously `.env.local` was
+automatically read from the current working directory (but `.env` was not),
+which was surprising and inconsistent. Now nothing is loaded automatically;
+pass `--env-path <path>` to load an env file explicitly.
+
+Migration: if you relied on the automatic `.env.local` loading, pass the file
+explicitly, e.g. `catalyst deploy --env-path .env.local` (or
+`--env-path ./core/.env.local` when running from the repo root).

--- a/.changeset/require-env-path.md
+++ b/.changeset/require-env-path.md
@@ -2,6 +2,6 @@
 "@bigcommerce/catalyst": minor
 ---
 
-Env files are no longer auto-loaded by the CLI. Previously `.env.local` was automatically read from the current working directory (but `.env` was not), which was surprising and inconsistent. Now nothing is loaded automatically; pass `--env-path <path>` to load an env file explicitly.
+Env-file loading is now scoped to `catalyst build` and `catalyst deploy` — the only commands that need storefront environment variables (for the build). Previously `.env.local` was auto-loaded globally from the current working directory (but `.env` was not), which was surprising, inconsistent, and affected commands that don't use those variables. Now `build` and `deploy` auto-load `.env.local` and `.env` from the current directory (with `.env.local` taking precedence, and neither overriding your real environment), and you can point at a specific file with `--env-path <path>`. No other command reads env files.
 
-Migration: if you relied on the automatic `.env.local` loading, pass the file explicitly, e.g. `catalyst deploy --env-path .env.local` (or `--env-path ./core/.env.local` when running from the repo root).
+Migration: if you relied on env vars being auto-loaded for a command other than `build`/`deploy`, set them in your shell environment or pass the relevant flags instead. For a build with an env file outside the project directory, use `catalyst deploy --env-path ../.env.local`.

--- a/packages/catalyst/src/cli/commands/build.ts
+++ b/packages/catalyst/src/cli/commands/build.ts
@@ -3,10 +3,12 @@ import { execa } from 'execa';
 import { copyFile, cp, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
+import { loadBuildEnv } from '../lib/build-env';
 import { getModuleCliPath } from '../lib/get-module-cli-path';
 import { consola } from '../lib/logger';
 import { getProjectConfig } from '../lib/project-config';
 import { getProjectState } from '../lib/project-state';
+import { envPathOption } from '../lib/shared-options';
 import { getWranglerConfig } from '../lib/wrangler-config';
 
 const WRANGLER_VERSION = '4.90.0';
@@ -101,7 +103,13 @@ Examples:
       'Project UUID to be included in the deployment configuration.',
     ).env('CATALYST_PROJECT_UUID'),
   )
+  .addOption(envPathOption())
   .action(async (options) => {
+    // The build reads storefront env vars (BIGCOMMERCE_*). Load them from the
+    // env file(s) before building so both the build and any pre-build checks
+    // see them.
+    loadBuildEnv({ envPath: options.envPath });
+
     // Project must be transformed (middleware swapped in, OpenNext dep installed)
     // before the OpenNext build pipeline can run. If it isn't, fall through to
     // `next build` so this command works for self-hosted Catalyst projects too.

--- a/packages/catalyst/src/cli/commands/deploy.ts
+++ b/packages/catalyst/src/cli/commands/deploy.ts
@@ -8,6 +8,7 @@ import yoctoSpinner from 'yocto-spinner';
 import { z } from 'zod';
 
 import { assertAuthorized } from '../lib/auth-errors';
+import { loadBuildEnv } from '../lib/build-env';
 import { runChannelSiteUrlFlow } from '../lib/channel-site-flow';
 import {
   cleanupCloudflareIncompatibilities,
@@ -30,6 +31,7 @@ import { resolveCredentials } from '../lib/resolve-credentials';
 import {
   accessTokenOption,
   apiHostOption,
+  envPathOption,
   projectUuidOption,
   storeHashOption,
 } from '../lib/shared-options';
@@ -398,6 +400,7 @@ Example:
     '--prebuilt',
     'Skip the build step. Requires .bigcommerce/dist/ to already contain build output.',
   )
+  .addOption(envPathOption())
   .action(async (options) => {
     const config = getProjectConfig();
     const { storeHash, accessToken } = resolveCredentials(options, config);
@@ -513,6 +516,11 @@ Example:
 
       consola.info('Using existing build output (--prebuilt).');
     } else {
+      // The build reads storefront env vars (BIGCOMMERCE_*). Load them from the
+      // env file(s) before building so both the build and any pre-build checks
+      // see them. Skipped for --prebuilt above, which doesn't run the build.
+      loadBuildEnv({ envPath: options.envPath });
+
       await buildCatalystProject(projectUuid);
     }
 

--- a/packages/catalyst/src/cli/index.spec.ts
+++ b/packages/catalyst/src/cli/index.spec.ts
@@ -63,59 +63,27 @@ describe('CLI program', () => {
   });
 });
 
-describe('--env-path option', () => {
+describe('env-file loading', () => {
   afterEach(() => {
     delete process.env.CATALYST_STORE_HASH;
     delete process.env.CATALYST_ACCESS_TOKEN;
   });
 
-  test('loads environment variables from file when --env-path points to existing file', async () => {
-    const [tmpDir, cleanup] = await mkTempDir('catalyst-env-path-');
-    const envPath = join(tmpDir, '.env');
+  test('--env-path is not a global option', () => {
+    const hasGlobalEnvPath = program.options.some((option) => option.long === '--env-path');
 
-    await writeFile(
-      envPath,
-      'CATALYST_STORE_HASH=test-store-hash\nCATALYST_ACCESS_TOKEN=test-access-token',
-      'utf-8',
-    );
-
-    try {
-      await program.parseAsync(['--env-path', envPath, 'version'], { from: 'user' });
-
-      expect(process.env.CATALYST_STORE_HASH).toBe('test-store-hash');
-      expect(process.env.CATALYST_ACCESS_TOKEN).toBe('test-access-token');
-    } finally {
-      await cleanup();
-    }
+    expect(hasGlobalEnvPath).toBe(false);
   });
 
-  test('loads environment variables when --env-path is relative to cwd', async () => {
-    const [tmpDir, cleanup] = await mkTempDir('catalyst-env-path-');
-    const envFileName = '.env.catalyst-test';
-    const envPath = join(tmpDir, envFileName);
+  test('build and deploy expose an --env-path option', () => {
+    ['build', 'deploy'].forEach((name) => {
+      const command = program.commands.find((cmd) => cmd.name() === name);
 
-    await writeFile(
-      envPath,
-      'CATALYST_STORE_HASH=test-store-hash\nCATALYST_ACCESS_TOKEN=test-access-token',
-      'utf-8',
-    );
-
-    const originalCwd = process.cwd();
-
-    process.chdir(tmpDir);
-
-    try {
-      await program.parseAsync(['--env-path', envFileName, 'version'], { from: 'user' });
-
-      expect(process.env.CATALYST_STORE_HASH).toBe('test-store-hash');
-      expect(process.env.CATALYST_ACCESS_TOKEN).toBe('test-access-token');
-    } finally {
-      process.chdir(originalCwd);
-      await cleanup();
-    }
+      expect(command?.options.some((option) => option.long === '--env-path')).toBe(true);
+    });
   });
 
-  test('does not auto-load a .env.local from cwd when --env-path is omitted', async () => {
+  test('a non-build command does not load a .env.local from cwd', async () => {
     const [tmpDir, cleanup] = await mkTempDir('catalyst-env-path-');
     const envPath = join(tmpDir, '.env.local');
 
@@ -136,19 +104,6 @@ describe('--env-path option', () => {
       expect(process.env.CATALYST_ACCESS_TOKEN).toBeUndefined();
     } finally {
       process.chdir(originalCwd);
-      await cleanup();
-    }
-  });
-
-  test('throws when --env-path points to non-existent file', async () => {
-    const [tmpDir, cleanup] = await mkTempDir('catalyst-env-path-');
-    const nonExistentPath = join(tmpDir, '.env.missing');
-
-    try {
-      await expect(
-        program.parseAsync(['--env-path', nonExistentPath, 'version'], { from: 'user' }),
-      ).rejects.toThrow(/Env file not found/);
-    } finally {
       await cleanup();
     }
   });

--- a/packages/catalyst/src/cli/index.spec.ts
+++ b/packages/catalyst/src/cli/index.spec.ts
@@ -115,6 +115,31 @@ describe('--env-path option', () => {
     }
   });
 
+  test('does not auto-load a .env.local from cwd when --env-path is omitted', async () => {
+    const [tmpDir, cleanup] = await mkTempDir('catalyst-env-path-');
+    const envPath = join(tmpDir, '.env.local');
+
+    await writeFile(
+      envPath,
+      'CATALYST_STORE_HASH=should-not-load\nCATALYST_ACCESS_TOKEN=should-not-load',
+      'utf-8',
+    );
+
+    const originalCwd = process.cwd();
+
+    process.chdir(tmpDir);
+
+    try {
+      await program.parseAsync(['version'], { from: 'user' });
+
+      expect(process.env.CATALYST_STORE_HASH).toBeUndefined();
+      expect(process.env.CATALYST_ACCESS_TOKEN).toBeUndefined();
+    } finally {
+      process.chdir(originalCwd);
+      await cleanup();
+    }
+  });
+
   test('throws when --env-path points to non-existent file', async () => {
     const [tmpDir, cleanup] = await mkTempDir('catalyst-env-path-');
     const nonExistentPath = join(tmpDir, '.env.missing');

--- a/packages/catalyst/src/cli/lib/build-env.spec.ts
+++ b/packages/catalyst/src/cli/lib/build-env.spec.ts
@@ -1,0 +1,90 @@
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { afterEach, describe, expect, test } from 'vitest';
+
+import { loadBuildEnv } from './build-env';
+import { UserActionableError } from './errors';
+import { mkTempDir } from './mk-temp-dir';
+
+describe('loadBuildEnv', () => {
+  afterEach(() => {
+    delete process.env.BUILD_ENV_TEST_A;
+    delete process.env.BUILD_ENV_TEST_B;
+  });
+
+  test('loads and overrides process.env from an explicit --env-path', async () => {
+    const [tmpDir, cleanup] = await mkTempDir('build-env-');
+
+    await writeFile(join(tmpDir, '.env.custom'), 'BUILD_ENV_TEST_A=from-file', 'utf-8');
+    process.env.BUILD_ENV_TEST_A = 'from-process';
+
+    try {
+      loadBuildEnv({ envPath: '.env.custom', cwd: tmpDir });
+
+      expect(process.env.BUILD_ENV_TEST_A).toBe('from-file');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('throws a UserActionableError when --env-path does not exist', async () => {
+    const [tmpDir, cleanup] = await mkTempDir('build-env-');
+
+    try {
+      expect(() => loadBuildEnv({ envPath: '.env.missing', cwd: tmpDir })).toThrow(
+        UserActionableError,
+      );
+      expect(() => loadBuildEnv({ envPath: '.env.missing', cwd: tmpDir })).toThrow(
+        /Env file not found/,
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('auto-loads .env.local and .env, with .env.local taking precedence', async () => {
+    const [tmpDir, cleanup] = await mkTempDir('build-env-');
+
+    await writeFile(
+      join(tmpDir, '.env'),
+      'BUILD_ENV_TEST_A=from-env\nBUILD_ENV_TEST_B=only-in-env',
+      'utf-8',
+    );
+    await writeFile(join(tmpDir, '.env.local'), 'BUILD_ENV_TEST_A=from-env-local', 'utf-8');
+
+    try {
+      loadBuildEnv({ cwd: tmpDir });
+
+      expect(process.env.BUILD_ENV_TEST_A).toBe('from-env-local');
+      expect(process.env.BUILD_ENV_TEST_B).toBe('only-in-env');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('auto-load does not override values already set in process.env', async () => {
+    const [tmpDir, cleanup] = await mkTempDir('build-env-');
+
+    await writeFile(join(tmpDir, '.env.local'), 'BUILD_ENV_TEST_A=from-file', 'utf-8');
+    process.env.BUILD_ENV_TEST_A = 'from-process';
+
+    try {
+      loadBuildEnv({ cwd: tmpDir });
+
+      expect(process.env.BUILD_ENV_TEST_A).toBe('from-process');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('is a no-op when no env files are present', async () => {
+    const [tmpDir, cleanup] = await mkTempDir('build-env-');
+
+    try {
+      expect(() => loadBuildEnv({ cwd: tmpDir })).not.toThrow();
+      expect(process.env.BUILD_ENV_TEST_A).toBeUndefined();
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/packages/catalyst/src/cli/lib/build-env.ts
+++ b/packages/catalyst/src/cli/lib/build-env.ts
@@ -1,0 +1,69 @@
+import { colorize } from 'consola/utils';
+import { config } from 'dotenv';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { UserActionableError } from './errors';
+import { consola } from './logger';
+
+// Conventional env files auto-loaded (in precedence order) for the build when
+// `--env-path` isn't given. `.env.local` wins over `.env`, and neither
+// overrides values already present in the real environment — matching Next.js
+// precedence (process.env > .env.local > .env).
+const AUTO_ENV_FILES = ['.env.local', '.env'] as const;
+
+interface LoadBuildEnvOptions {
+  // Explicit env file passed via `--env-path`. When set, only this file is
+  // loaded (and it overrides existing values); when unset, the conventional
+  // files above are auto-loaded instead.
+  envPath?: string;
+  // Directory the paths are resolved against. Defaults to the current working
+  // directory; injectable for tests.
+  cwd?: string;
+}
+
+// Loads storefront environment variables into `process.env` for the
+// build/deploy pipeline so the spawned build (and the checks that run before
+// it) can see them. This is intentionally scoped to `build` and `deploy`: no
+// other command loads env files, so running the CLI can't be surprised by a
+// stray `.env.local` on disk.
+export function loadBuildEnv({ envPath, cwd = process.cwd() }: LoadBuildEnvOptions): void {
+  if (envPath !== undefined) {
+    const envFilePath = resolve(cwd, envPath);
+    const result = config({ path: envFilePath, override: true });
+
+    if (result.error) {
+      const errCode =
+        'code' in result.error && typeof result.error.code === 'string'
+          ? result.error.code
+          : undefined;
+      const message =
+        errCode === 'ENOENT'
+          ? `Env file not found: ${envFilePath}`
+          : `Failed to load --env-path ${envPath}: ${result.error.message}`;
+
+      throw new UserActionableError(message);
+    }
+
+    consola.log(colorize('cyanBright', `Loaded environment variables from ${envFilePath}\n`));
+
+    return;
+  }
+
+  // Auto-load the conventional files. `.env.local` is loaded first so it takes
+  // precedence over `.env`; `override: false` means the real environment always
+  // wins over both. Missing files are expected and ignored.
+  const loaded = AUTO_ENV_FILES.filter((file) => {
+    const envFilePath = resolve(cwd, file);
+
+    if (!existsSync(envFilePath)) {
+      return false;
+    }
+
+    return !config({ path: envFilePath, override: false }).error;
+  });
+
+  if (loaded.length > 0) {
+    consola.log(colorize('cyanBright', `Loaded environment variables from ${loaded.join(', ')}\n`));
+  }
+}

--- a/packages/catalyst/src/cli/lib/shared-options.ts
+++ b/packages/catalyst/src/cli/lib/shared-options.ts
@@ -33,6 +33,12 @@ export const projectUuidOption = () =>
     'BigCommerce infrastructure project UUID. Read from .bigcommerce/project.json or .env when not provided.',
   ).env('CATALYST_PROJECT_UUID');
 
+export const envPathOption = () =>
+  new Option(
+    '--env-path <path>',
+    'Path to an environment file to load for the build (relative to the current working directory). When omitted, .env.local and .env are auto-loaded from the current directory. Other commands never load env files.',
+  );
+
 export const resolveProjectUuid = (options: { projectUuid?: string }) => {
   const config = getProjectConfig();
   const projectUuid = options.projectUuid ?? config.get('projectUuid');

--- a/packages/catalyst/src/cli/program.ts
+++ b/packages/catalyst/src/cli/program.ts
@@ -2,7 +2,6 @@ import { Option } from '@commander-js/extra-typings';
 import { Command } from 'commander';
 import { colorize } from 'consola/utils';
 import { config } from 'dotenv';
-import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 import PACKAGE_INFO from '../../package.json';
@@ -23,13 +22,9 @@ import { version } from './commands/version';
 import { telemetryPostHook, telemetryPreHook } from './hooks/telemetry';
 import { consola } from './lib/logger';
 
-// Auto-load .env.local from cwd if present, matching Next.js convention.
-// `--env-path` (loaded later via argParser) overrides anything we load here.
-const defaultEnvPath = resolve(process.cwd(), '.env.local');
-
-if (existsSync(defaultEnvPath)) {
-  config({ path: defaultEnvPath });
-}
+// Env files are never auto-loaded. Pass `--env-path <path>` to load one
+// explicitly (see the option below). This avoids the confusing `.env` vs
+// `.env.local` asymmetry and keeps configuration explicit.
 
 // CATALYST_STORE_HASH falls back to BIGCOMMERCE_STORE_HASH so freshly-scaffolded
 // projects work without duplicating the same value under two names. Aliasing
@@ -48,13 +43,13 @@ program
   .version(PACKAGE_INFO.version)
   .summary('CLI tool for Catalyst development')
   .description(
-    'CLI tool for Catalyst development.\n\nConfiguration priority: flags > env file (--env-path) > process.env > .env.local (auto-loaded from cwd) > .bigcommerce/project.json.\n\nCATALYST_STORE_HASH falls back to BIGCOMMERCE_STORE_HASH if unset.\n\nRun `catalyst <command> --help` for details on a specific command.',
+    'CLI tool for Catalyst development.\n\nEnv files are not loaded automatically. Pass `--env-path <path>` to load one (e.g. `--env-path .env.local`).\n\nConfiguration priority: flags > env file (--env-path) > process.env > .bigcommerce/project.json.\n\nCATALYST_STORE_HASH falls back to BIGCOMMERCE_STORE_HASH if unset.\n\nRun `catalyst <command> --help` for details on a specific command.',
   )
   .configureHelp({ showGlobalOptions: true })
   .addOption(
     new Option(
       '--env-path <path>',
-      'Path to environment file to load (relative to current working directory)',
+      'Path to an environment file to load (relative to the current working directory). Env files are not loaded automatically; pass e.g. `--env-path .env.local` to load one.',
       // We are using argParser, because commander loads in environment variables before executing hooks.
     ).argParser((value) => {
       if (value) {

--- a/packages/catalyst/src/cli/program.ts
+++ b/packages/catalyst/src/cli/program.ts
@@ -43,7 +43,7 @@ program
   .version(PACKAGE_INFO.version)
   .summary('CLI tool for Catalyst development')
   .description(
-    'CLI tool for Catalyst development.\n\nEnv files are not loaded automatically. Pass `--env-path <path>` to load one (e.g. `--env-path .env.local`).\n\nConfiguration priority: flags > env file (--env-path) > process.env > .bigcommerce/project.json.\n\nCATALYST_STORE_HASH falls back to BIGCOMMERCE_STORE_HASH if unset.\n\nRun `catalyst <command> --help` for details on a specific command.',
+    'CLI tool for Catalyst development.\n\nConfiguration priority: flags > env file (--env-path) > process.env > .bigcommerce/project.json.\n\nCATALYST_STORE_HASH falls back to BIGCOMMERCE_STORE_HASH if unset.\n\nRun `catalyst <command> --help` for details on a specific command.',
   )
   .configureHelp({ showGlobalOptions: true })
   .addOption(

--- a/packages/catalyst/src/cli/program.ts
+++ b/packages/catalyst/src/cli/program.ts
@@ -1,8 +1,5 @@
-import { Option } from '@commander-js/extra-typings';
 import { Command } from 'commander';
 import { colorize } from 'consola/utils';
-import { config } from 'dotenv';
-import { resolve } from 'node:path';
 
 import PACKAGE_INFO from '../../package.json';
 
@@ -22,9 +19,9 @@ import { version } from './commands/version';
 import { telemetryPostHook, telemetryPreHook } from './hooks/telemetry';
 import { consola } from './lib/logger';
 
-// Env files are never auto-loaded. Pass `--env-path <path>` to load one
-// explicitly (see the option below). This avoids the confusing `.env` vs
-// `.env.local` asymmetry and keeps configuration explicit.
+// Env files are only loaded by `build` and `deploy` (which auto-load
+// .env.local and .env, or an explicit `--env-path`). No other command reads env
+// files, so running the CLI can't be surprised by a stray `.env.local` on disk.
 
 // CATALYST_STORE_HASH falls back to BIGCOMMERCE_STORE_HASH so freshly-scaffolded
 // projects work without duplicating the same value under two names. Aliasing
@@ -43,41 +40,9 @@ program
   .version(PACKAGE_INFO.version)
   .summary('CLI tool for Catalyst development')
   .description(
-    'CLI tool for Catalyst development.\n\nConfiguration priority: flags > env file (--env-path) > process.env > .bigcommerce/project.json.\n\nCATALYST_STORE_HASH falls back to BIGCOMMERCE_STORE_HASH if unset.\n\nRun `catalyst <command> --help` for details on a specific command.',
+    'CLI tool for Catalyst development.\n\nConfiguration priority: flags > process.env > .bigcommerce/project.json. `build` and `deploy` additionally load env files (--env-path, or an auto-loaded .env.local/.env) for the build.\n\nCATALYST_STORE_HASH falls back to BIGCOMMERCE_STORE_HASH if unset.\n\nRun `catalyst <command> --help` for details on a specific command.',
   )
   .configureHelp({ showGlobalOptions: true })
-  .addOption(
-    new Option(
-      '--env-path <path>',
-      'Path to an environment file to load (relative to the current working directory). Env files are not loaded automatically; pass e.g. `--env-path .env.local` to load one.',
-      // We are using argParser, because commander loads in environment variables before executing hooks.
-    ).argParser((value) => {
-      if (value) {
-        const envFilePath = resolve(process.cwd(), value);
-        const result = config({
-          path: envFilePath,
-          override: true,
-        });
-
-        if (result.error) {
-          const errCode =
-            'code' in result.error && typeof result.error.code === 'string'
-              ? result.error.code
-              : undefined;
-          const message =
-            errCode === 'ENOENT'
-              ? `Env file not found: ${envFilePath}`
-              : `Failed to load --env-path ${value}: ${result.error.message}`;
-
-          throw new Error(message);
-        }
-
-        consola.log(colorize('cyanBright', `Loaded environment variables from ${envFilePath}\n`));
-      }
-
-      return value;
-    }),
-  )
   .addCommand(version)
   .addCommand(create)
   .addCommand(start)


### PR DESCRIPTION
Linear: [LTRAC-1091](https://linear.app/commerce/issue/LTRAC-1091)

## What/Why?
The CLI auto-loaded `.env.local` from cwd but not `.env`, an inconsistent bit of magic that surprised users. Per sign-off, this drops automatic env-file loading entirely: env files are now loaded **only** when passed explicitly via `--env-path`. This removes the `.env` vs `.env.local` asymmetry and makes env resolution explicit and predictable. Help text is updated to match.

## Testing
- `index.spec.ts` (7 tests) covers no-auto-load without `--env-path` and correct loading with `--env-path`.
- `typecheck` and `lint` pass.

## Migration
**Breaking behavior change.** Users who relied on the auto-loaded `.env.local` must now pass it explicitly:

```
catalyst deploy --env-path .env.local
```

(or the appropriate path, e.g. `--env-path ./core/.env.local`).