### PR TITLE
fix(cli): make auth login device-code UX consistent with create

### DIFF
--- a/.changeset/consistent-login-ux.md
+++ b/.changeset/consistent-login-ux.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst": patch
+---
+
+Unify the device-code login UX across `auth login`, `create`, and the channel commands. The CLI now waits for you to press Enter before opening the browser and best-effort copies the one-time code to your clipboard so you can paste it directly (the code is still printed as a fallback). Non-interactive/CI runs skip the prompt and open directly.

--- a/packages/catalyst/src/cli/lib/clipboard.spec.ts
+++ b/packages/catalyst/src/cli/lib/clipboard.spec.ts
@@ -1,0 +1,102 @@
+import { execa } from 'execa';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { copyToClipboard } from './clipboard';
+
+vi.mock('execa', () => ({ execa: vi.fn() }));
+
+const execaMock = vi.mocked(execa);
+
+function withPlatform(value: NodeJS.Platform): () => void {
+  const previous = Object.getOwnPropertyDescriptor(process, 'platform');
+
+  Object.defineProperty(process, 'platform', { value, configurable: true });
+
+  return () => {
+    if (previous) {
+      Object.defineProperty(process, 'platform', previous);
+    }
+  };
+}
+
+function withWaylandDisplay(value: string | undefined): () => void {
+  const previous = process.env.WAYLAND_DISPLAY;
+
+  if (value === undefined) {
+    delete process.env.WAYLAND_DISPLAY;
+  } else {
+    process.env.WAYLAND_DISPLAY = value;
+  }
+
+  return () => {
+    if (previous === undefined) {
+      delete process.env.WAYLAND_DISPLAY;
+    } else {
+      process.env.WAYLAND_DISPLAY = previous;
+    }
+  };
+}
+
+let restore: Array<() => void> = [];
+
+afterEach(() => {
+  restore.forEach((fn) => fn());
+  restore = [];
+  vi.clearAllMocks();
+});
+
+describe('copyToClipboard', () => {
+  test('uses pbcopy on macOS', async () => {
+    restore.push(withPlatform('darwin'));
+
+    const result = await copyToClipboard('CODE');
+
+    expect(result).toBe(true);
+    expect(execaMock).toHaveBeenCalledWith('pbcopy', [], { input: 'CODE' });
+  });
+
+  test('uses clip on Windows', async () => {
+    restore.push(withPlatform('win32'));
+
+    const result = await copyToClipboard('CODE');
+
+    expect(result).toBe(true);
+    expect(execaMock).toHaveBeenCalledWith('clip', [], { input: 'CODE' });
+  });
+
+  test('uses wl-copy on Wayland Linux sessions', async () => {
+    restore.push(withPlatform('linux'), withWaylandDisplay('wayland-0'));
+
+    const result = await copyToClipboard('CODE');
+
+    expect(result).toBe(true);
+    expect(execaMock).toHaveBeenCalledWith('wl-copy', [], { input: 'CODE' });
+  });
+
+  test('uses xclip on X11 Linux sessions', async () => {
+    restore.push(withPlatform('linux'), withWaylandDisplay(undefined));
+
+    const result = await copyToClipboard('CODE');
+
+    expect(result).toBe(true);
+    expect(execaMock).toHaveBeenCalledWith('xclip', ['-selection', 'clipboard'], { input: 'CODE' });
+  });
+
+  test('returns false on unsupported platforms without spawning anything', async () => {
+    restore.push(withPlatform('aix'));
+
+    const result = await copyToClipboard('CODE');
+
+    expect(result).toBe(false);
+    expect(execaMock).not.toHaveBeenCalled();
+  });
+
+  test('returns false when the clipboard utility fails', async () => {
+    restore.push(withPlatform('darwin'));
+    execaMock.mockRejectedValueOnce(new Error('command not found'));
+
+    const result = await copyToClipboard('CODE');
+
+    expect(result).toBe(false);
+  });
+});

--- a/packages/catalyst/src/cli/lib/clipboard.ts
+++ b/packages/catalyst/src/cli/lib/clipboard.ts
@@ -1,0 +1,48 @@
+import { execa } from 'execa';
+
+interface ClipboardCommand {
+  command: string;
+  args: string[];
+}
+
+// Resolve the platform-native clipboard utility. Returns null when we don't
+// know how to reach the clipboard on this platform, so callers can fall back to
+// simply printing the value.
+function clipboardCommand(): ClipboardCommand | null {
+  switch (process.platform) {
+    case 'darwin':
+      return { command: 'pbcopy', args: [] };
+
+    case 'win32':
+      return { command: 'clip', args: [] };
+
+    case 'linux':
+      // Wayland sessions expose wl-copy; X11 sessions typically ship xclip.
+      return process.env.WAYLAND_DISPLAY
+        ? { command: 'wl-copy', args: [] }
+        : { command: 'xclip', args: ['-selection', 'clipboard'] };
+
+    default:
+      return null;
+  }
+}
+
+// Best-effort copy of `text` to the system clipboard. Never throws — returns
+// `true` on success and `false` when the clipboard is unreachable (unknown
+// platform, missing utility, spawn failure). Callers must always print the
+// value as a fallback so the flow works even when the copy fails.
+export async function copyToClipboard(text: string): Promise<boolean> {
+  const clipboard = clipboardCommand();
+
+  if (!clipboard) {
+    return false;
+  }
+
+  try {
+    await execa(clipboard.command, clipboard.args, { input: text });
+
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/catalyst/src/cli/lib/login.spec.ts
+++ b/packages/catalyst/src/cli/lib/login.spec.ts
@@ -1,0 +1,129 @@
+import { input } from '@inquirer/prompts';
+import open from 'open';
+import { afterEach, beforeAll, beforeEach, describe, expect, MockInstance, test, vi } from 'vitest';
+
+import * as authLib from './auth';
+import * as clipboardLib from './clipboard';
+import { consola } from './logger';
+import { login } from './login';
+
+// eslint-disable-next-line import/dynamic-import-chunkname
+vi.mock('yocto-spinner', () => import('../../../tests/mocks/spinner'));
+vi.mock('open', () => ({ default: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('@inquirer/prompts', () => ({
+  confirm: vi.fn(),
+  input: vi.fn(),
+  password: vi.fn(),
+}));
+
+const inputMock = vi.mocked(input);
+const openMock = vi.mocked(open);
+
+const LOGIN_URL = 'https://login.example.com';
+const API_HOST = 'api.example.com';
+
+const DEVICE_CODE = {
+  device_code: 'device-code',
+  user_code: 'USER-CODE',
+  verification_uri: 'https://login.example.com/device',
+  expires_in: 600,
+  interval: 5,
+};
+
+const CREDENTIALS = {
+  access_token: 'access-token',
+  store_hash: 'store-hash',
+  context: 'stores/store-hash',
+  api_uri: 'https://api.example.com',
+};
+
+function withTtyValue(value: boolean): () => void {
+  const previous = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
+
+  Object.defineProperty(process.stdin, 'isTTY', { value, configurable: true });
+
+  return () => {
+    if (previous) {
+      Object.defineProperty(process.stdin, 'isTTY', previous);
+    } else {
+      Reflect.deleteProperty(process.stdin, 'isTTY');
+    }
+  };
+}
+
+let copyToClipboardSpy: MockInstance<typeof clipboardLib.copyToClipboard>;
+let restoreTty: (() => void) | undefined;
+
+beforeAll(() => {
+  consola.mockTypes(() => vi.fn());
+});
+
+beforeEach(() => {
+  vi.spyOn(authLib, 'requestDeviceCode').mockResolvedValue(DEVICE_CODE);
+  vi.spyOn(authLib, 'waitForDeviceToken').mockResolvedValue(CREDENTIALS);
+  copyToClipboardSpy = vi.spyOn(clipboardLib, 'copyToClipboard').mockResolvedValue(true);
+});
+
+afterEach(() => {
+  restoreTty?.();
+  restoreTty = undefined;
+  vi.clearAllMocks();
+});
+
+describe('device-code login', () => {
+  test('waits for Enter before opening the browser when interactive', async () => {
+    restoreTty = withTtyValue(true);
+
+    // The browser must not open until the user has pressed Enter, so assert it
+    // hasn't been called yet at the moment we prompt.
+    inputMock.mockImplementationOnce(() => {
+      expect(openMock).not.toHaveBeenCalled();
+
+      return Promise.resolve('');
+    });
+
+    const result = await login(LOGIN_URL, API_HOST);
+
+    expect(inputMock).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Press Enter to open your browser and sign in' }),
+    );
+    expect(openMock).toHaveBeenCalledWith(DEVICE_CODE.verification_uri);
+    expect(result).toEqual({ storeHash: 'store-hash', accessToken: 'access-token' });
+  });
+
+  test('copies the code to the clipboard once the user proceeds', async () => {
+    restoreTty = withTtyValue(true);
+    inputMock.mockResolvedValueOnce('');
+    copyToClipboardSpy.mockResolvedValueOnce(true);
+
+    await login(LOGIN_URL, API_HOST);
+
+    expect(copyToClipboardSpy).toHaveBeenCalledWith('USER-CODE');
+    expect(consola.info).toHaveBeenCalledWith(expect.stringContaining('clipboard'));
+  });
+
+  test('still completes and prints the code when the clipboard copy fails', async () => {
+    restoreTty = withTtyValue(true);
+    inputMock.mockResolvedValueOnce('');
+    copyToClipboardSpy.mockResolvedValueOnce(false);
+
+    const result = await login(LOGIN_URL, API_HOST);
+
+    // Code was printed as a fallback, but no clipboard confirmation shown.
+    expect(consola.info).toHaveBeenCalledWith(expect.stringContaining('USER-CODE'));
+    expect(consola.info).not.toHaveBeenCalledWith(expect.stringContaining('clipboard'));
+    expect(openMock).toHaveBeenCalledWith(DEVICE_CODE.verification_uri);
+    expect(result).toEqual({ storeHash: 'store-hash', accessToken: 'access-token' });
+  });
+
+  test('does not wait for Enter or touch the clipboard when non-interactive', async () => {
+    restoreTty = withTtyValue(false);
+
+    const result = await login(LOGIN_URL, API_HOST);
+
+    expect(inputMock).not.toHaveBeenCalled();
+    expect(copyToClipboardSpy).not.toHaveBeenCalled();
+    expect(openMock).toHaveBeenCalledWith(DEVICE_CODE.verification_uri);
+    expect(result).toEqual({ storeHash: 'store-hash', accessToken: 'access-token' });
+  });
+});

--- a/packages/catalyst/src/cli/lib/login.spec.ts
+++ b/packages/catalyst/src/cli/lib/login.spec.ts
@@ -74,13 +74,7 @@ describe('device-code login', () => {
   test('waits for Enter before opening the browser when interactive', async () => {
     restoreTty = withTtyValue(true);
 
-    // The browser must not open until the user has pressed Enter, so assert it
-    // hasn't been called yet at the moment we prompt.
-    inputMock.mockImplementationOnce(() => {
-      expect(openMock).not.toHaveBeenCalled();
-
-      return Promise.resolve('');
-    });
+    inputMock.mockResolvedValueOnce('');
 
     const result = await login(LOGIN_URL, API_HOST);
 
@@ -88,6 +82,11 @@ describe('device-code login', () => {
       expect.objectContaining({ message: 'Press Enter to open your browser and sign in' }),
     );
     expect(openMock).toHaveBeenCalledWith(DEVICE_CODE.verification_uri);
+    // The browser must not open until the user has pressed Enter: the prompt has
+    // to be invoked before the call to open the browser.
+    expect(inputMock.mock.invocationCallOrder[0]).toBeLessThan(
+      openMock.mock.invocationCallOrder[0],
+    );
     expect(result).toEqual({ storeHash: 'store-hash', accessToken: 'access-token' });
   });
 

--- a/packages/catalyst/src/cli/lib/login.ts
+++ b/packages/catalyst/src/cli/lib/login.ts
@@ -5,6 +5,7 @@ import yoctoSpinner from 'yocto-spinner';
 import { z } from 'zod';
 
 import { DEVICE_OAUTH_SCOPES, requestDeviceCode, waitForDeviceToken } from './auth';
+import { copyToClipboard } from './clipboard';
 import { UserActionableError } from './errors';
 import { consola } from './logger';
 
@@ -58,6 +59,23 @@ async function deviceCodeLogin(loginUrl: string): Promise<LoginResult> {
   consola.info(
     `${colorize('yellow', 'Your one-time code:')} ${colorize('bold', deviceCode.user_code)}`,
   );
+
+  // Wait for the user to acknowledge before hijacking their browser. This keeps
+  // the UX consistent across `create`, `auth login`, and the channel commands.
+  // In non-interactive contexts (CI, piped stdin) there's nobody to press
+  // Enter, so skip straight to opening the verification URL.
+  if (process.stdin.isTTY) {
+    await input({ message: 'Press Enter to open your browser and sign in' });
+
+    // Best-effort: drop the code on the clipboard so the user can paste it
+    // straight into the verification page. We already printed it above as a
+    // fallback, and a clipboard failure must never interrupt the flow.
+    const copied = await copyToClipboard(deviceCode.user_code);
+
+    if (copied) {
+      consola.info('Copied the code to your clipboard — paste it into the sign-in page.');
+    }
+  }
 
   try {
     await open(deviceCode.verification_uri);

--- a/packages/catalyst/vitest.setup.ts
+++ b/packages/catalyst/vitest.setup.ts
@@ -2,6 +2,12 @@ import { afterAll, afterEach, beforeAll, vi } from 'vitest';
 
 import { server } from './tests/mocks/node';
 
+// Default all specs to a non-interactive stdin so TTY-gated prompts don't fire
+// based on whether the test runner happens to inherit a terminal. Tests that
+// need to exercise interactive branches opt in explicitly (see the
+// `withTtyValue` helpers in the specs).
+Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+
 const mockTelemetryInstance = {
   correlationId: 'test-session-uuid',
   commandName: 'unknown',


### PR DESCRIPTION
Linear: [LTRAC-1092](https://linear.app/commerce/issue/LTRAC-1092)

## What/Why?
The device-code login flow diverged: `auth login` opened the browser immediately and made users copy the code by hand, while `create` waited for Enter. A user expected the code on their clipboard and got confused. All three commands (`auth login`, `create`, channel) already funnel through the shared `login()` in `lib/login.ts`, so this fixes it in one place: print the one-time code, wait for Enter before opening the browser, and best-effort copy the code to the clipboard (still printed as a fallback). Non-TTY/CI runs skip the Enter prompt and clipboard copy and open directly.

No new dependencies: a small `lib/clipboard.ts` shells out via the already-present `execa` to the platform-native utility (`pbcopy`/`clip`/`wl-copy`/`xclip`). It never throws — a copy failure can't interrupt login.

## Testing
- New `login.spec.ts` (4) and `clipboard.spec.ts` (6): browser not opened before Enter; clipboard copied on proceed; clipboard failure non-fatal with code still printed; non-interactive skips Enter/clipboard and opens directly; per-platform command selection.
- `typecheck` and `lint` pass.

## Migration
None.