### PR TITLE
fix(cli): add @bigcommerce/catalyst CLI as a devDependency on create

### DIFF
--- a/.changeset/catalyst-cli-dev-dependency.md
+++ b/.changeset/catalyst-cli-dev-dependency.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst": patch
+---
+
+Add the `@bigcommerce/catalyst` CLI to a newly created project's `devDependencies` instead of `dependencies`. The CLI is a build-time tool (it only backs the `build`/`start`/`deploy` npm scripts) and is never imported at runtime, so it doesn't belong in runtime dependencies.

--- a/packages/catalyst/src/cli/lib/setup-core-project.spec.ts
+++ b/packages/catalyst/src/cli/lib/setup-core-project.spec.ts
@@ -12,6 +12,7 @@ const packageJsonSchema = z.looseObject({
   name: z.string().optional(),
   scripts: z.record(z.string(), z.string()).optional(),
   dependencies: z.record(z.string(), z.string()).optional(),
+  devDependencies: z.record(z.string(), z.string()).optional(),
 });
 
 let projectDir: string;
@@ -81,14 +82,25 @@ describe('setupCoreProject', () => {
     });
   });
 
-  it('adds @bigcommerce/catalyst dep at the CLI version', () => {
+  it('adds @bigcommerce/catalyst as a devDependency at the CLI version', () => {
+    writeCorePackageJson({ devDependencies: { prettier: '^3.0.0' } });
+
+    setupCoreProject(projectDir);
+
+    const pkg = readCorePackageJson();
+
+    expect(pkg.devDependencies?.['@bigcommerce/catalyst']).toBe(PACKAGE_INFO.version);
+    expect(pkg.devDependencies?.prettier).toBe('^3.0.0');
+  });
+
+  it('does not add @bigcommerce/catalyst to runtime dependencies', () => {
     writeCorePackageJson({ dependencies: { next: '^15.0.0' } });
 
     setupCoreProject(projectDir);
 
     const pkg = readCorePackageJson();
 
-    expect(pkg.dependencies?.['@bigcommerce/catalyst']).toBe(PACKAGE_INFO.version);
+    expect(pkg.dependencies?.['@bigcommerce/catalyst']).toBeUndefined();
     expect(pkg.dependencies?.next).toBe('^15.0.0');
   });
 

--- a/packages/catalyst/src/cli/lib/setup-core-project.ts
+++ b/packages/catalyst/src/cli/lib/setup-core-project.ts
@@ -8,7 +8,7 @@ import { sortPackageJsonFields } from './sort-package-json';
 
 const corePackageJsonSchema = z.looseObject({
   scripts: z.record(z.string(), z.string()).optional(),
-  dependencies: z.record(z.string(), z.string()).optional(),
+  devDependencies: z.record(z.string(), z.string()).optional(),
 });
 
 const writeJson = (path: string, value: unknown) => {
@@ -16,10 +16,12 @@ const writeJson = (path: string, value: unknown) => {
   writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
 };
 
-// Wires Catalyst CLI scripts and the `@bigcommerce/catalyst` dep into a freshly
-// extracted project. Always runs at create time, regardless of hosting choice —
-// `catalyst build` / `catalyst start` / `catalyst deploy` dispatch on project
-// state, so these scripts work for self-hosted projects too without rewrite.
+// Wires Catalyst CLI scripts and the `@bigcommerce/catalyst` dev dependency into
+// a freshly extracted project. Always runs at create time, regardless of hosting
+// choice — `catalyst build` / `catalyst start` / `catalyst deploy` dispatch on
+// project state, so these scripts work for self-hosted projects too without
+// rewrite. The CLI is a build-time tool (it only backs those npm scripts), never
+// imported at runtime, so it belongs in devDependencies, not dependencies.
 export const setupCoreProject = (projectDir: string) => {
   const corePackageJsonPath = join(projectDir, 'package.json');
   const pkg = corePackageJsonSchema.parse(JSON.parse(readFileSync(corePackageJsonPath, 'utf-8')));
@@ -31,8 +33,8 @@ export const setupCoreProject = (projectDir: string) => {
     deploy: 'npm run generate && catalyst deploy',
   };
 
-  pkg.dependencies = {
-    ...pkg.dependencies,
+  pkg.devDependencies = {
+    ...pkg.devDependencies,
     '@bigcommerce/catalyst': PACKAGE_INFO.version,
   };
 


### PR DESCRIPTION
Linear: [LTRAC-1159](https://linear.app/commerce/issue/LTRAC-1159)

## What/Why?

When creating a new Catalyst project, `setupCoreProject` wrote `@bigcommerce/catalyst` into the project's `dependencies`. That package is the Catalyst **CLI** — a build-time tool that only backs the generated `build` / `start` / `deploy` npm scripts. It is never imported by the storefront at runtime, so it belongs in `devDependencies`, not `dependencies`. Shipping it as a runtime dependency bloats production installs and misrepresents the dependency graph.

This moves it to `devDependencies`. `sortPackageJsonFields` already includes `devDependencies` in its canonical field order, so no change was needed there.

## Testing

`pnpm --filter @bigcommerce/catalyst test setup-core-project` — 6 tests pass, including a new assertion that the CLI is added under `devDependencies` and is **not** present in runtime `dependencies`. Typecheck and lint are clean.

## Migration

None. This only affects newly created/set-up projects. Existing projects are unaffected; if desired, users can manually move `@bigcommerce/catalyst` from `dependencies` to `devDependencies` in their `package.json`.