### PR TITLE
fix: TRAC-284 Coalesce rapid cart quantity/delete clicks

### DIFF
--- a/.changeset/tidy-hoops-refuse.md
+++ b/.changeset/tidy-hoops-refuse.md
@@ -1,0 +1,11 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Coalesce rapid cart line item quantity and delete clicks into at most one in-flight server action. Quantity buttons now update an optimistic pending intent that flushes a single absolute-quantity `update` intent after a short debounce (replacing the per-click `increment`/`decrement` intents), and deletes are serialized instead of queueing unboundedly. This prevents the serial server-action queue buildup that could lock up navigation on the cart page, and unifies cart revalidation on `revalidateTag`.
+
+The cart section is now keyed by cart `entityId` only (previously `entityId`-`version`) and renders line items from the revalidation-refreshed `cart` prop. Remounting on every mutation swallowed clicks landing during the DOM swap and could drop queued actions, leaving the summary skeletons and checkout button stuck in a pending state until hard refresh.
+
+Each quantity/delete control is now its own progressive-enhancement form that posts a real absolute quantity or delete request to the server action; JS intercepts the submit to route through the coalescing dispatcher, but the buttons keep working (as full page round-trips) before hydration or if the app bundle fails to load.
+
+Also fixes the checkout button getting stuck spinning forever if its navigation is cancelled (Esc, "Stay" on the leave-page prompt, a flaky connection). The URL-string checkout action previously awaited a promise that never resolved, leaving retry clicks queued behind a dead action; it now settles after a short timeout and on bfcache restore, re-enabling the button as a retry.

--- a/core/app/[locale]/(default)/cart/_actions/update-line-item.ts
+++ b/core/app/[locale]/(default)/cart/_actions/update-line-item.ts
@@ -53,7 +53,9 @@ export const updateLineItem = async (
   }
 
   switch (submission.value.intent) {
-    case 'increment': {
+    case 'update': {
+      const { quantity } = submission.value;
+
       const parsedSelectedOptions = cartLineItem.selectedOptions.reduce<CartSelectedOptionsInput>(
         (accum, option) => {
           let multipleChoicesOptionInput;
@@ -175,7 +177,7 @@ export const updateLineItem = async (
           productEntityId: cartLineItem.productEntityId,
           variantEntityId: cartLineItem.variantEntityId,
           selectedOptions: parsedSelectedOptions,
-          quantity: cartLineItem.quantity + 1,
+          quantity,
         });
       } catch (error) {
         // eslint-disable-next-line no-console
@@ -197,165 +199,9 @@ export const updateLineItem = async (
         return { ...prevState, lastResult: submission.reply({ formErrors: [String(error)] }) };
       }
 
-      const item = submission.value;
-
       return {
         lineItems: prevState.lineItems.map((lineItem) =>
-          lineItem.id === item.id ? { ...lineItem, quantity: lineItem.quantity + 1 } : lineItem,
-        ),
-        lastResult: submission.reply({ resetForm: true }),
-      };
-    }
-
-    case 'decrement': {
-      const parsedSelectedOptions = cartLineItem.selectedOptions.reduce<CartSelectedOptionsInput>(
-        (accum, option) => {
-          let multipleChoicesOptionInput;
-          let checkboxOptionInput;
-          let numberFieldOptionInput;
-          let textFieldOptionInput;
-          let multiLineTextFieldOptionInput;
-          let dateFieldOptionInput;
-
-          switch (option.__typename) {
-            case 'CartSelectedMultipleChoiceOption':
-              multipleChoicesOptionInput = {
-                optionEntityId: option.entityId,
-                optionValueEntityId: option.valueEntityId,
-              };
-
-              if (accum.multipleChoices) {
-                return {
-                  ...accum,
-                  multipleChoices: [...accum.multipleChoices, multipleChoicesOptionInput],
-                };
-              }
-
-              return {
-                ...accum,
-                multipleChoices: [multipleChoicesOptionInput],
-              };
-
-            case 'CartSelectedCheckboxOption':
-              checkboxOptionInput = {
-                optionEntityId: option.entityId,
-                optionValueEntityId: option.valueEntityId,
-              };
-
-              if (accum.checkboxes) {
-                return {
-                  ...accum,
-                  checkboxes: [...accum.checkboxes, checkboxOptionInput],
-                };
-              }
-
-              return { ...accum, checkboxes: [checkboxOptionInput] };
-
-            case 'CartSelectedNumberFieldOption':
-              numberFieldOptionInput = {
-                optionEntityId: option.entityId,
-                number: option.number,
-              };
-
-              if (accum.numberFields) {
-                return {
-                  ...accum,
-                  numberFields: [...accum.numberFields, numberFieldOptionInput],
-                };
-              }
-
-              return { ...accum, numberFields: [numberFieldOptionInput] };
-
-            case 'CartSelectedTextFieldOption':
-              textFieldOptionInput = {
-                optionEntityId: option.entityId,
-                text: option.text,
-              };
-
-              if (accum.textFields) {
-                return {
-                  ...accum,
-                  textFields: [...accum.textFields, textFieldOptionInput],
-                };
-              }
-
-              return { ...accum, textFields: [textFieldOptionInput] };
-
-            case 'CartSelectedMultiLineTextFieldOption':
-              multiLineTextFieldOptionInput = {
-                optionEntityId: option.entityId,
-                text: option.text,
-              };
-
-              if (accum.multiLineTextFields) {
-                return {
-                  ...accum,
-                  multiLineTextFields: [
-                    ...accum.multiLineTextFields,
-                    multiLineTextFieldOptionInput,
-                  ],
-                };
-              }
-
-              return {
-                ...accum,
-                multiLineTextFields: [multiLineTextFieldOptionInput],
-              };
-
-            case 'CartSelectedDateFieldOption':
-              dateFieldOptionInput = {
-                optionEntityId: option.entityId,
-                date: new Date(String(option.date.utc)).toISOString(),
-              };
-
-              if (accum.dateFields) {
-                return {
-                  ...accum,
-                  dateFields: [...accum.dateFields, dateFieldOptionInput],
-                };
-              }
-
-              return { ...accum, dateFields: [dateFieldOptionInput] };
-          }
-
-          return accum;
-        },
-        {},
-      );
-
-      try {
-        await updateQuantity({
-          lineItemEntityId: cartLineItem.id,
-          productEntityId: cartLineItem.productEntityId,
-          variantEntityId: cartLineItem.variantEntityId,
-          selectedOptions: parsedSelectedOptions,
-          quantity: cartLineItem.quantity - 1,
-        });
-      } catch (error) {
-        // eslint-disable-next-line no-console
-        console.error(error);
-
-        if (error instanceof BigCommerceGQLError) {
-          return {
-            ...prevState,
-            lastResult: submission.reply({
-              formErrors: error.errors.map(({ message }) => message),
-            }),
-          };
-        }
-
-        if (error instanceof Error) {
-          return { ...prevState, lastResult: submission.reply({ formErrors: [error.message] }) };
-        }
-
-        return { ...prevState, lastResult: submission.reply({ formErrors: [String(error)] }) };
-      }
-
-      const item = submission.value;
-
-      return {
-        lineItems: prevState.lineItems.map((lineItem) =>
-          lineItem.id === item.id ? { ...lineItem, quantity: lineItem.quantity - 1 } : lineItem,
+          lineItem.id === cartLineItem.id ? { ...lineItem, quantity } : lineItem,
         ),
         lastResult: submission.reply({ resetForm: true }),
       };

--- a/core/app/[locale]/(default)/cart/_actions/update-quantity.ts
+++ b/core/app/[locale]/(default)/cart/_actions/update-quantity.ts
@@ -1,11 +1,12 @@
 'use server';
 
-import { revalidatePath } from 'next/cache';
+import { revalidateTag } from 'next/cache';
 import { getTranslations } from 'next-intl/server';
 
 import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
 import { graphql, VariablesOf } from '~/client/graphql';
+import { TAGS } from '~/client/tags';
 import { getCartId } from '~/lib/cart';
 
 import { removeItem } from './remove-item';
@@ -87,7 +88,7 @@ export const updateQuantity = async ({
     throw new Error(t('failedToUpdateQuantity'));
   }
 
-  revalidatePath('/cart');
+  revalidateTag(TAGS.cart, { expire: 0 });
 
   return cart;
 };

--- a/core/app/[locale]/(default)/cart/page.tsx
+++ b/core/app/[locale]/(default)/cart/page.tsx
@@ -364,7 +364,9 @@ export default async function Cart({ params }: Props) {
               : undefined
           }
           incrementLineItemLabel={t('increment')}
-          key={`${cart.entityId}-${cart.version}`}
+          // Keyed by entityId only; keying by version too would remount the section on
+          // every mutation (see the pending-intent dispatcher notes in the Cart section).
+          key={cart.entityId}
           lineItemAction={updateLineItem}
           lineItemActionPendingLabel={t('cartUpdateInProgress')}
           shipping={{

--- a/core/vibes/soul/sections/cart/client.tsx
+++ b/core/vibes/soul/sections/cart/client.tsx
@@ -1,16 +1,18 @@
 'use client';
 
-import { getFormProps, getInputProps, SubmissionResult, useForm } from '@conform-to/react';
-import { parseWithZod } from '@conform-to/zod';
+import { SubmissionResult, useForm } from '@conform-to/react';
 import { clsx } from 'clsx';
+import debounce from 'lodash.debounce';
 import { ArrowRight, GiftIcon, Minus, Plus, Trash2 } from 'lucide-react';
 import {
   ComponentPropsWithoutRef,
+  FormEvent,
   startTransition,
   useActionState,
   useEffect,
   useMemo,
-  useOptimistic,
+  useRef,
+  useState,
 } from 'react';
 import { useFormStatus } from 'react-dom';
 
@@ -27,7 +29,6 @@ import { useEvents } from '~/components/analytics/events';
 import { Image } from '~/components/image';
 
 import { CouponCodeForm, CouponCodeFormState } from './coupon-code-form';
-import { cartLineItemActionFormDataSchema } from './schema';
 import { ShippingForm, ShippingFormState } from './shipping-form';
 
 import { CartEmptyState } from '.';
@@ -178,6 +179,8 @@ const defaultEmptyState = {
   cta: { label: 'Continue shopping', href: '#' },
 };
 
+type PendingLineItemIntent = { intent: 'update'; quantity: number } | { intent: 'delete' };
+
 // eslint-disable-next-line valid-jsdoc
 /**
  * This component supports various CSS variables for theming. Here's a comprehensive list, along
@@ -227,6 +230,20 @@ export function CartClient<LineItem extends CartLineItem>({
 
   const [form] = useForm({ lastResult: state.lastResult });
 
+  // Server actions run strictly serially, so rapid clicks coalesce into pending intents
+  // (one per line item, newer clicks overwrite) flushed at most one action at a time.
+  // Instance-level on purpose: if a consumer remounts this section mid-flight (e.g. by
+  // keying it on cart version), intents die with the instance and the UI snaps back to
+  // server truth, instead of a longer-lived dispatcher deadlocking on an action React
+  // silently dropped at unmount.
+  const [pendingLineItemIntents] = useState(() => new Map<string, PendingLineItemIntent>());
+  const inFlightIntentRef = useRef<{ id: string; entry: PendingLineItemIntent } | null>(null);
+
+  // Bumped whenever pendingLineItemIntents changes so renders re-read the mutable map.
+  const [, setPendingIntentsRevision] = useState(0);
+
+  const isCartMutationPending = isLineItemActionPending || pendingLineItemIntents.size > 0;
+
   useEffect(() => {
     if (form.errors) {
       form.errors.forEach((error) => {
@@ -235,10 +252,131 @@ export function CartClient<LineItem extends CartLineItem>({
     }
   }, [form.errors]);
 
-  // Prevent page unload when line item action is pending
+  const flushNextIntent = () => {
+    if (inFlightIntentRef.current !== null) return;
+
+    // Resolve each intent against server truth once: an intent is stale if its row is
+    // gone or already matches the confirmed quantity.
+    const resolved = Array.from(pendingLineItemIntents.entries()).map(([intentId, intentEntry]) => {
+      const item = cart.lineItems.find((lineItem) => lineItem.id === intentId);
+
+      return {
+        id: intentId,
+        entry: intentEntry,
+        item,
+        isStale:
+          !item || (intentEntry.intent === 'update' && intentEntry.quantity === item.quantity),
+      };
+    });
+
+    const staleEntries = resolved.filter(({ isStale }) => isStale);
+
+    if (staleEntries.length > 0) {
+      staleEntries.forEach(({ id: staleId }) => pendingLineItemIntents.delete(staleId));
+      setPendingIntentsRevision((revision) => revision + 1);
+    }
+
+    const next = resolved.find(({ isStale }) => !isStale);
+
+    if (!next?.item) return;
+
+    const { id, entry, item: confirmedItem } = next;
+
+    inFlightIntentRef.current = { id, entry };
+
+    const formData = new FormData();
+
+    formData.append('id', id);
+    formData.append('intent', entry.intent);
+
+    if (entry.intent === 'update') {
+      formData.append('quantity', entry.quantity.toString());
+    }
+
+    // Analytics fire once per flush with the net change, not once per click.
+    const analyticsFormData = new FormData();
+
+    analyticsFormData.append('id', id);
+    analyticsFormData.append('intent', entry.intent);
+
+    if (entry.intent === 'update') {
+      const netChange = entry.quantity - confirmedItem.quantity;
+
+      analyticsFormData.append('quantity', Math.abs(netChange).toString());
+
+      if (netChange > 0) events.onAddToCart?.(analyticsFormData);
+      if (netChange < 0) events.onRemoveFromCart?.(analyticsFormData);
+    } else {
+      analyticsFormData.append('quantity', confirmedItem.quantity.toString());
+      events.onRemoveFromCart?.(analyticsFormData);
+    }
+
+    startTransition(() => {
+      formAction(formData);
+    });
+  };
+
+  const flushRef = useRef(flushNextIntent);
+
+  useEffect(() => {
+    flushRef.current = flushNextIntent;
+  });
+
+  // Trailing debounce with no maxWait: a mid-burst flush would spend a request on a
+  // quantity the user is still changing, and the final absolute value supersedes it
+  // anyway. The pagehide and nav-guard flushes cover leaving before the timer fires.
+  const debouncedFlush = useMemo(() => debounce(() => flushRef.current(), 400), []);
+
+  useEffect(() => () => debouncedFlush.cancel(), [debouncedFlush]);
+
+  const queueLineItemIntent = (id: string, entry: PendingLineItemIntent) => {
+    pendingLineItemIntents.set(id, entry);
+    setPendingIntentsRevision((revision) => revision + 1);
+    debouncedFlush();
+
+    // Quantity clicks coalesce inside the debounce window, but removal flushes right away.
+    if (entry.intent === 'delete') {
+      debouncedFlush.flush();
+    }
+  };
+
+  // Settle observer: when a flush completes, clear its intent and flush any backlog
+  // queued while it was in flight (flushNextIntent prunes intents the settled action
+  // already confirmed). The section is keyed stably, so this instance survives the
+  // revalidation and dispatching from here is safe.
+  useEffect(() => {
+    if (isLineItemActionPending) return;
+    if (inFlightIntentRef.current === null) return;
+
+    const { id, entry } = inFlightIntentRef.current;
+
+    inFlightIntentRef.current = null;
+
+    // Clear the intent we just flushed unless newer clicks replaced it mid-flight; if
+    // the action failed this reverts the row to server truth (the error toast explains why).
+    if (pendingLineItemIntents.get(id) === entry) {
+      pendingLineItemIntents.delete(id);
+      setPendingIntentsRevision((revision) => revision + 1);
+    }
+
+    if (pendingLineItemIntents.size > 0) {
+      flushRef.current();
+    }
+  }, [isLineItemActionPending, state, pendingLineItemIntents]);
+
+  // A full page unload can't wait on the debounce timer.
+  useEffect(() => {
+    const flushPendingIntents = () => debouncedFlush.flush();
+
+    window.addEventListener('pagehide', flushPendingIntents);
+
+    return () => window.removeEventListener('pagehide', flushPendingIntents);
+  }, [debouncedFlush]);
+
+  // Prevent page unload when a cart mutation is pending
   useEffect(() => {
     const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-      if (isLineItemActionPending) {
+      if (isCartMutationPending) {
         event.preventDefault();
         // eslint-disable-next-line @typescript-eslint/no-deprecated
         event.returnValue = ''; // Chrome requires returnValue to be set
@@ -247,19 +385,19 @@ export function CartClient<LineItem extends CartLineItem>({
       }
     };
 
-    if (isLineItemActionPending) {
+    if (isCartMutationPending) {
       window.addEventListener('beforeunload', handleBeforeUnload);
     }
 
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload);
     };
-  }, [isLineItemActionPending]);
+  }, [isCartMutationPending]);
 
-  // Prevent client-side navigation when line item action is pending
+  // Prevent client-side navigation when a cart mutation is pending
   useEffect(() => {
     const handleClick = (event: MouseEvent) => {
-      if (isLineItemActionPending && event.target instanceof HTMLElement) {
+      if (isCartMutationPending && event.target instanceof HTMLElement) {
         const link = event.target.closest('a[href]');
 
         if (
@@ -271,7 +409,10 @@ export function CartClient<LineItem extends CartLineItem>({
           // eslint-disable-next-line no-alert
           const shouldNavigate = window.confirm(lineItemActionPendingLabel);
 
-          if (!shouldNavigate) {
+          if (shouldNavigate) {
+            // Dispatch any debounced intent now, while this instance can still send it.
+            debouncedFlush.flush();
+          } else {
             event.preventDefault();
             event.stopPropagation();
           }
@@ -281,7 +422,7 @@ export function CartClient<LineItem extends CartLineItem>({
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
-        isLineItemActionPending &&
+        isCartMutationPending &&
         (event.key === 'Enter' || event.key === ' ') &&
         event.target instanceof HTMLElement
       ) {
@@ -296,7 +437,10 @@ export function CartClient<LineItem extends CartLineItem>({
           // eslint-disable-next-line no-alert
           const shouldNavigate = window.confirm(lineItemActionPendingLabel);
 
-          if (!shouldNavigate) {
+          if (shouldNavigate) {
+            // Dispatch any debounced intent now, while this instance can still send it.
+            debouncedFlush.flush();
+          } else {
             event.preventDefault();
             event.stopPropagation();
           }
@@ -304,7 +448,7 @@ export function CartClient<LineItem extends CartLineItem>({
       }
     };
 
-    if (isLineItemActionPending) {
+    if (isCartMutationPending) {
       document.addEventListener('click', handleClick, true);
       document.addEventListener('keydown', handleKeyDown, true);
     }
@@ -313,50 +457,21 @@ export function CartClient<LineItem extends CartLineItem>({
       document.removeEventListener('click', handleClick, true);
       document.removeEventListener('keydown', handleKeyDown, true);
     };
-  }, [isLineItemActionPending, lineItemActionPendingLabel]);
+  }, [isCartMutationPending, lineItemActionPendingLabel, debouncedFlush]);
 
-  const [optimisticLineItems, setOptimisticLineItems] = useOptimistic<CartLineItem[], FormData>(
-    state.lineItems,
-    (prevState, formData) => {
-      const submission = parseWithZod(formData, { schema: cartLineItemActionFormDataSchema });
+  // Server truth (the revalidation-refreshed cart prop, not useActionState's mount-frozen
+  // state) overlaid with pending intents; pendingIntentsRevision invalidates this on change.
+  const displayLineItems: CartLineItem[] = cart.lineItems
+    .filter((item) => pendingLineItemIntents.get(item.id)?.intent !== 'delete')
+    .map((item) => {
+      const pending = pendingLineItemIntents.get(item.id);
 
-      if (submission.status !== 'success') return prevState;
+      return pending?.intent === 'update' ? { ...item, quantity: pending.quantity } : item;
+    });
 
-      switch (submission.value.intent) {
-        case 'increment': {
-          const { id } = submission.value;
+  const displayTotalQuantity = displayLineItems.reduce((total, item) => total + item.quantity, 0);
 
-          return prevState.map((item) =>
-            item.id === id ? { ...item, quantity: item.quantity + 1 } : item,
-          );
-        }
-
-        case 'decrement': {
-          const { id } = submission.value;
-
-          return prevState.map((item) =>
-            item.id === id ? { ...item, quantity: item.quantity - 1 } : item,
-          );
-        }
-
-        case 'delete': {
-          const { id } = submission.value;
-
-          return prevState.filter((item) => item.id !== id);
-        }
-
-        default:
-          return prevState;
-      }
-    },
-  );
-
-  const optimisticQuantity = useMemo(
-    () => optimisticLineItems.reduce((total, item) => total + item.quantity, 0),
-    [optimisticLineItems],
-  );
-
-  if (optimisticQuantity === 0) {
+  if (displayTotalQuantity === 0) {
     return <CartEmptyState {...emptyState} />;
   }
 
@@ -373,7 +488,7 @@ export function CartClient<LineItem extends CartLineItem>({
               {cart.summaryItems.map((summaryItem, index) => (
                 <div className="flex justify-between py-4" key={index}>
                   <dt>{summaryItem.label}</dt>
-                  {isLineItemActionPending ? (
+                  {isCartMutationPending ? (
                     <Skeleton.Text characterCount={8} className="animate-pulse rounded-md" />
                   ) : (
                     <dd>{summaryItem.value}</dd>
@@ -408,7 +523,7 @@ export function CartClient<LineItem extends CartLineItem>({
             <div className="border-t border-[var(--cart-border,hsl(var(--contrast-100)))] py-6">
               <div className="flex justify-between text-xl font-bold">
                 <dt>{cart.totalLabel ?? 'Total'}</dt>
-                {isLineItemActionPending ? (
+                {isCartMutationPending ? (
                   <Skeleton.Text characterCount={8} className="animate-pulse rounded-md" />
                 ) : (
                   <dd>{cart.total}</dd>
@@ -424,7 +539,7 @@ export function CartClient<LineItem extends CartLineItem>({
           <CheckoutButton
             action={checkoutAction}
             className="mt-4 w-full"
-            isCartUpdatePending={isLineItemActionPending}
+            isCartUpdatePending={isCartMutationPending}
           >
             {checkoutLabel}
             <ArrowRight size={20} strokeWidth={1} />
@@ -438,12 +553,12 @@ export function CartClient<LineItem extends CartLineItem>({
         <h1 className="mb-10 font-[family-name:var(--cart-title-font-family,var(--font-family-heading))] text-4xl font-medium leading-none @xl:text-5xl">
           {title}
           <span className="ml-4 text-[var(--cart-subtext-text,hsl(var(--contrast-300)))] contrast-more:text-[var(--cart-subtitle-text,hsl(var(--contrast-500)))]">
-            {optimisticQuantity}
+            {displayTotalQuantity}
           </span>
         </h1>
         {/* Cart Items */}
         <ul className="flex flex-col gap-5">
-          {optimisticLineItems.map((lineItem) => (
+          {displayLineItems.map((lineItem) => (
             <li
               className="flex flex-col items-start gap-x-5 gap-y-4 @container @sm:flex-row"
               key={lineItem.id}
@@ -478,32 +593,10 @@ export function CartClient<LineItem extends CartLineItem>({
                   deleteLabel={deleteLineItemLabel}
                   incrementLabel={incrementLineItemLabel}
                   lineItem={lineItem}
-                  onSubmit={(formData) => {
-                    startTransition(() => {
-                      formAction(formData);
-                      setOptimisticLineItems(formData);
-
-                      const intent = formData.get('intent');
-
-                      if (intent === 'increment') {
-                        formData.set('quantity', '1');
-
-                        events.onAddToCart?.(formData);
-                      }
-
-                      if (intent === 'decrement') {
-                        formData.set('quantity', '1');
-
-                        events.onRemoveFromCart?.(formData);
-                      }
-
-                      if (intent === 'delete') {
-                        formData.set('quantity', lineItem.quantity.toString());
-
-                        events.onRemoveFromCart?.(formData);
-                      }
-                    });
-                  }}
+                  onDelete={() => queueLineItemIntent(lineItem.id, { intent: 'delete' })}
+                  onUpdateQuantity={(quantity) =>
+                    queueLineItemIntent(lineItem.id, { intent: 'update', quantity })
+                  }
                 />
               </div>
             </li>
@@ -517,7 +610,8 @@ export function CartClient<LineItem extends CartLineItem>({
 function CounterForm({
   lineItem,
   action,
-  onSubmit,
+  onDelete,
+  onUpdateQuantity,
   incrementLabel = 'Increase count',
   decrementLabel = 'Decrease count',
   deleteLabel = 'Remove item',
@@ -527,26 +621,30 @@ function CounterForm({
   decrementLabel?: string;
   deleteLabel?: string;
   action: (payload: FormData) => void;
-  onSubmit: (formData: FormData) => void;
+  onDelete: () => void;
+  onUpdateQuantity: (quantity: number) => void;
 }) {
-  const [form, fields] = useForm({
-    defaultValue: { id: lineItem.id },
-    shouldValidate: 'onBlur',
-    shouldRevalidate: 'onInput',
-    onValidate({ formData }) {
-      return parseWithZod(formData, { schema: cartLineItemActionFormDataSchema });
-    },
-    onSubmit(event, { formData }) {
-      event.preventDefault();
+  // Every control is its own micro-form (`display: contents`, so layout is unaffected)
+  // rather than one form per line item, because the quantity buttons each need their own
+  // hidden `quantity` field and forms can't nest. Without JS, each posts its pre-computed
+  // absolute quantity (or delete) straight to the server action. With JS, onSubmit
+  // intercepts and routes through the coalescing dispatcher instead, so rapid clicks
+  // debounce into one request rather than one per click.
+  const handleDeleteSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    onDelete();
+  };
 
-      onSubmit(formData);
-    },
-  });
+  const handleUpdateQuantitySubmit = (quantity: number) => (event: FormEvent) => {
+    event.preventDefault();
+    onUpdateQuantity(quantity);
+  };
 
   if (lineItem.typename === 'CartGiftCertificate') {
     return (
-      <form {...getFormProps(form)} action={action}>
-        <input {...getInputProps(fields.id, { type: 'hidden' })} key={fields.id.id} />
+      <form action={action} onSubmit={handleDeleteSubmit}>
+        <input name="id" type="hidden" value={lineItem.id} />
+        <input name="intent" type="hidden" value="delete" />
         <div className="flex w-full flex-wrap items-center gap-x-5 gap-y-2">
           {typeof lineItem.price === 'string' && (
             <span className="font-medium @xl:ml-auto">{lineItem.price}</span>
@@ -559,9 +657,7 @@ function CounterForm({
           <button
             aria-label={deleteLabel}
             className="group -ml-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-full transition-colors duration-300 hover:bg-[var(--cart-button-background,hsl(var(--contrast-100)))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--cart-focus,hsl(var(--primary)))] focus-visible:ring-offset-4"
-            name="intent"
             type="submit"
-            value="delete"
           >
             <Trash2
               className="text-[var(--cart-icon,hsl(var(--contrast-300)))] group-hover:text-[var(--cart-icon-hover,hsl(var(--foreground)))]"
@@ -575,21 +671,27 @@ function CounterForm({
   }
 
   return (
-    <form {...getFormProps(form)} action={action}>
-      <input {...getInputProps(fields.id, { type: 'hidden' })} key={fields.id.id} />
-      <div className="flex w-full flex-wrap items-center gap-x-5 gap-y-2">
-        <PriceLabel className="mt-3 self-start @xl:ml-auto" price={lineItem.price} />
-        <div className="flex size-min flex-col gap-y-0">
-          <div className="mb-1 mt-1 flex items-center gap-x-5">
-            {/* Counter */}
-            <div
-              className={clsx(
-                'flex items-center rounded-lg border border-[var(--cart-counter-border,hsl(var(--contrast-100)))]',
-                (lineItem.inventoryMessages?.outOfStockMessage != null ||
-                  lineItem.inventoryMessages?.quantityOutOfStockMessage != null) &&
-                  'border-red-500',
-              )}
+    <div className="flex w-full flex-wrap items-center gap-x-5 gap-y-2">
+      <PriceLabel className="mt-3 self-start @xl:ml-auto" price={lineItem.price} />
+      <div className="flex size-min flex-col gap-y-0">
+        <div className="mb-1 mt-1 flex items-center gap-x-5">
+          {/* Counter */}
+          <div
+            className={clsx(
+              'flex items-center rounded-lg border border-[var(--cart-counter-border,hsl(var(--contrast-100)))]',
+              (lineItem.inventoryMessages?.outOfStockMessage != null ||
+                lineItem.inventoryMessages?.quantityOutOfStockMessage != null) &&
+                'border-red-500',
+            )}
+          >
+            <form
+              action={action}
+              className="contents"
+              onSubmit={handleUpdateQuantitySubmit(lineItem.quantity - 1)}
             >
+              <input name="id" type="hidden" value={lineItem.id} />
+              <input name="intent" type="hidden" value="update" />
+              <input name="quantity" type="hidden" value={lineItem.quantity - 1} />
               <button
                 aria-label={decrementLabel}
                 className={clsx(
@@ -599,9 +701,7 @@ function CounterForm({
                     : 'hover:bg-[var(--cart-counter-background-hover,hsl(var(--contrast-100)/50%))]',
                 )}
                 disabled={lineItem.quantity === 1}
-                name="intent"
                 type="submit"
-                value="decrement"
               >
                 <Minus
                   className={clsx(
@@ -613,17 +713,24 @@ function CounterForm({
                   strokeWidth={1.5}
                 />
               </button>
-              <span className="flex w-8 select-none justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--cart-focus,hsl(var(--primary)))]">
-                {lineItem.quantity}
-              </span>
+            </form>
+            <span className="flex w-8 select-none justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--cart-focus,hsl(var(--primary)))]">
+              {lineItem.quantity}
+            </span>
+            <form
+              action={action}
+              className="contents"
+              onSubmit={handleUpdateQuantitySubmit(lineItem.quantity + 1)}
+            >
+              <input name="id" type="hidden" value={lineItem.id} />
+              <input name="intent" type="hidden" value="update" />
+              <input name="quantity" type="hidden" value={lineItem.quantity + 1} />
               <button
                 aria-label={incrementLabel}
                 className={clsx(
                   'group rounded-r-lg bg-[var(--cart-counter-background,hsl(var(--background)))] p-3 transition-colors duration-300 hover:bg-[var(--cart-counter-background-hover,hsl(var(--contrast-100)/50%))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--cart-focus,hsl(var(--primary)))] disabled:cursor-not-allowed',
                 )}
-                name="intent"
                 type="submit"
-                value="increment"
               >
                 <Plus
                   className="text-[var(--cart-counter-icon,hsl(var(--contrast-300)))] transition-colors duration-300 group-hover:text-[var(--cart-counter-icon-hover,hsl(var(--foreground)))]"
@@ -631,13 +738,15 @@ function CounterForm({
                   strokeWidth={1.5}
                 />
               </button>
-            </div>
+            </form>
+          </div>
+          <form action={action} className="contents" onSubmit={handleDeleteSubmit}>
+            <input name="id" type="hidden" value={lineItem.id} />
+            <input name="intent" type="hidden" value="delete" />
             <button
               aria-label={deleteLabel}
               className="group -ml-1 mt-1.5 flex h-8 w-8 shrink-0 items-center justify-center self-start rounded-full transition-colors duration-300 hover:bg-[var(--cart-button-background,hsl(var(--contrast-100)))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--cart-focus,hsl(var(--primary)))] focus-visible:ring-offset-4"
-              name="intent"
               type="submit"
-              value="delete"
             >
               <Trash2
                 className="text-[var(--cart-icon,hsl(var(--contrast-300)))] group-hover:text-[var(--cart-icon-hover,hsl(var(--foreground)))]"
@@ -645,35 +754,35 @@ function CounterForm({
                 strokeWidth={1}
               />
             </button>
-          </div>
-          {lineItem.inventoryMessages?.outOfStockMessage != null && (
-            <span className="text-xs/5 font-light text-red-500">
-              {lineItem.inventoryMessages.outOfStockMessage}
-            </span>
-          )}
-          {lineItem.inventoryMessages?.quantityOutOfStockMessage != null && (
-            <span className="mb-3 text-xs/5 font-light text-red-500">
-              {lineItem.inventoryMessages.quantityOutOfStockMessage}
-            </span>
-          )}
-          {lineItem.inventoryMessages?.quantityReadyToShipMessage != null && (
-            <span className="text-xs/5 font-light">
-              {lineItem.inventoryMessages.quantityReadyToShipMessage}
-            </span>
-          )}
-          {lineItem.inventoryMessages?.quantityBackorderedMessage != null && (
-            <span className="text-xs/5 font-light">
-              {lineItem.inventoryMessages.quantityBackorderedMessage}
-            </span>
-          )}
-          {lineItem.inventoryMessages?.backorderMessage != null && (
-            <span className="text-xs/5 font-light">
-              {lineItem.inventoryMessages.backorderMessage}
-            </span>
-          )}
+          </form>
         </div>
+        {lineItem.inventoryMessages?.outOfStockMessage != null && (
+          <span className="text-xs/5 font-light text-red-500">
+            {lineItem.inventoryMessages.outOfStockMessage}
+          </span>
+        )}
+        {lineItem.inventoryMessages?.quantityOutOfStockMessage != null && (
+          <span className="mb-3 text-xs/5 font-light text-red-500">
+            {lineItem.inventoryMessages.quantityOutOfStockMessage}
+          </span>
+        )}
+        {lineItem.inventoryMessages?.quantityReadyToShipMessage != null && (
+          <span className="text-xs/5 font-light">
+            {lineItem.inventoryMessages.quantityReadyToShipMessage}
+          </span>
+        )}
+        {lineItem.inventoryMessages?.quantityBackorderedMessage != null && (
+          <span className="text-xs/5 font-light">
+            {lineItem.inventoryMessages.quantityBackorderedMessage}
+          </span>
+        )}
+        {lineItem.inventoryMessages?.backorderMessage != null && (
+          <span className="text-xs/5 font-light">
+            {lineItem.inventoryMessages.backorderMessage}
+          </span>
+        )}
       </div>
-    </form>
+    </div>
   );
 }
 
@@ -688,8 +797,24 @@ function CheckoutButton({
   const [lastResult, formAction] = useActionState(
     async (state: SubmissionResult | null, formData: FormData) => {
       if (typeof action === 'string') {
-        await new Promise<void>(() => {
-          window.location.assign(action);
+        window.location.assign(action);
+
+        // The page normally unloads before this settles. If the navigation is
+        // cancelled instead (Esc, "Stay" on the beforeunload prompt, a stalled
+        // redirect) or the page is restored from bfcache, settle so the button
+        // re-enables as a retry, rather than spinning forever with subsequent
+        // clicks queued behind a never-resolving action.
+        await new Promise<void>((resolve) => {
+          let fallbackTimer: ReturnType<typeof setTimeout>;
+
+          const settle = () => {
+            clearTimeout(fallbackTimer);
+            window.removeEventListener('pageshow', settle);
+            resolve();
+          };
+
+          fallbackTimer = setTimeout(settle, 8000);
+          window.addEventListener('pageshow', settle);
         });
 
         return null;

--- a/core/vibes/soul/sections/cart/schema.ts
+++ b/core/vibes/soul/sections/cart/schema.ts
@@ -2,12 +2,11 @@ import { z } from 'zod';
 
 export const cartLineItemActionFormDataSchema = z.discriminatedUnion('intent', [
   z.object({
-    intent: z.literal('increment'),
+    intent: z.literal('update'),
     id: z.string(),
-  }),
-  z.object({
-    intent: z.literal('decrement'),
-    id: z.string(),
+    // Quantity is absolute so rapid clicks can coalesce into a single request;
+    // 0 is never sent because removal is a separate 'delete' intent.
+    quantity: z.coerce.number().int().min(1),
   }),
   z.object({
     intent: z.literal('delete'),


### PR DESCRIPTION
Jira: [TRAC-284](https://bigcommercecloud.atlassian.net/browse/TRAC-284)

## What/Why?

Server actions run strictly serially with no abort/parallelism, so rapid clicks on the cart's quantity +/- or delete buttons queued up unboundedly. Combined with optimistic UI, users could click far ahead of the server, and navigating away while the queue drained had historically frozen client-side routing until a hard refresh. See [Linear LTRAC-284](https://linear.app/commerce/issue/LTRAC-284/cart-page-breaks-when-clicking-around-during-a-quantity-increase) for the full prior investigation and options considered.

**The fix:** a per-line-item pending-intent map + debounced, single-flight dispatcher in `CartClient`. Rapid clicks coalesce into one absolute-quantity `update` request (replacing the old per-click `increment`/`decrement` intents, which also collapsed ~150 duplicated lines in the server action into one branch). Deletes flush immediately and are serialized the same way. At most one action is ever in flight, so a failed request only rolls back one gesture instead of an entire queue.

**Progressive enhancement:** each +/-/delete control is its own `display: contents` micro-form carrying a real, pre-computed absolute quantity (or delete) straight to the server action. Without JS (or before hydration), clicking still works as a normal page round-trip. With JS, `onSubmit` intercepts and routes through the dispatcher instead. Quantity is clamped server-side only (`z.coerce.number().int().min(1)`) — no client-side quantity clamp, since the `disabled` attribute already prevents decrementing below 1 in every reachable path.

**Why the cart section is now keyed by `entityId` only** (previously `entityId`-`version`): keying on `version` remounted the whole section on every mutation. React drops actions dispatched into a hook that unmounts before they run, which could deadlock the old design, and clicks landing mid-DOM-swap hit handler-less nodes — this was the actual mechanism behind the "stuck forever" freeze a merchant reported on video. Dispatcher state now lives at the component instance level (not module scope), so if anything ever does remount mid-flight, the failure mode is a harmless snap-back to server truth, not a deadlock.

**Also fixed:** the checkout button spinning forever if its navigation was cancelled (pressing Esc, choosing "Stay" on the leave-page confirm, a dropped connection). The URL-string checkout action awaited a promise around `window.location.assign` that never resolved by design; a cancelled redirect left retry clicks queued behind that dead action forever. It now settles after 8s or on `pageshow` (bfcache restore), re-enabling the button as a retry.

Cart revalidation is also unified on `revalidateTag(TAGS.cart)` (previously a mix of that and `revalidatePath('/cart')`).

This branch went through a full review pass (code-review at high effort with two background verifier agents on timing edge cases, simplify, security-review) before this PR was opened; all findings were resolved and re-verified.

## Rollout/Rollback

Standard PR merge to `canary`; no feature flag, migration, or experiment involved. Rollback is a straight revert — no schema or data changes.

## Testing

Verified end-to-end against a live sandbox store with Playwright, covering:
- 10 rapid quantity-increase clicks coalesce into a single POST; final quantity and totals are correct.
- Reload mid-burst and after settling shows consistent server-truth quantities (the "phantom items" symptom from the original report).
- Clicking a nav link while a mutation is in flight completes navigation (confirm-dialog interceptors are still in place as a UX guard, kept intentionally).
- Rapid delete across multiple rows removes all rows correctly, no resurrected items.
- A net-zero burst (e.g. +3 then -3 within the debounce window) sends zero requests.
- No-JS fallback: with the app's JS bundle blocked (so hydration never completes, while leaving the browser's JS engine on, since fully disabling JS also breaks this page's pre-existing, unrelated `<Stream>`/Suspense fallback swap), quantity +/- and delete all work as real page round-trips against the server action.
- Checkout button recovers (re-enables, and a retry succeeds) after its navigation is cancelled.

Manual repro steps from the original ticket: add 10+ variants to cart, rapidly click delete/quantity buttons, then click a nav link — no freeze, no hard refresh required.

[TRAC-284]: https://bigcommercecloud.atlassian.net/browse/TRAC-284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ