### PR TITLE
LTRAC-955: feat - respect control panel default search sort settings

### DIFF
--- a/.changeset/nine-queens-bathe.md
+++ b/.changeset/nine-queens-bathe.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": minor
+---
+
+Respect default product search sort and product category sort settings from the control panel.

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page-data.ts
@@ -12,6 +12,7 @@ const CategoryPageQuery = graphql(
         category(entityId: $entityId) {
           entityId
           name
+          defaultProductSort
           ...BreadcrumbsFragment
           seo {
             pageTitle

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -127,6 +127,11 @@ export default async function Category(props: Props) {
 
   const taxDisplay = settings?.tax?.plp;
 
+  const categoryDefaultSort =
+    category.defaultProductSort && category.defaultProductSort !== 'DEFAULT'
+      ? category.defaultProductSort.toLowerCase()
+      : 'featured';
+
   const streamableFacetedSearch = Streamable.from(async () => {
     const searchParams = await props.searchParams;
     const currencyCode = await getPreferredCurrencyCode();
@@ -136,12 +141,14 @@ export default async function Category(props: Props) {
       customerAccessToken,
     );
     const parsedSearchParams = loadSearchParams?.(searchParams) ?? {};
+    const sort = typeof searchParams.sort === 'string' ? searchParams.sort : categoryDefaultSort;
 
     const search = await fetchFacetedSearch(
       {
         ...searchParams,
         ...parsedSearchParams,
         category: categoryId,
+        sort,
       },
       currencyCode,
       customerAccessToken,
@@ -269,7 +276,7 @@ export default async function Category(props: Props) {
         resetFiltersLabel={t('FacetedSearch.resetFilters')}
         showCompare={productComparisonsEnabled}
         showRating={showRating}
-        sortDefaultValue="featured"
+        sortDefaultValue={categoryDefaultSort}
         sortLabel={t('SortBy.sortBy')}
         sortOptions={[
           { value: 'featured', label: t('SortBy.featuredItems') },

--- a/core/app/[locale]/(default)/(faceted)/search/page-data.ts
+++ b/core/app/[locale]/(default)/(faceted)/search/page-data.ts
@@ -27,6 +27,9 @@ const SearchPageQuery = graphql(`
         tax {
           plp
         }
+        search {
+          defaultSearchProductSort
+        }
       }
     }
   }

--- a/core/app/[locale]/(default)/(faceted)/search/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/search/page.tsx
@@ -85,6 +85,8 @@ export default async function Search(props: Props) {
 
   const taxDisplay = settings?.tax?.plp;
 
+  const defaultProductSort = settings?.search.defaultSearchProductSort;
+
   const streamableFacetedSearch = Streamable.from(async () => {
     const searchParams = await props.searchParams;
     const customerAccessToken = await getSessionCustomerAccessToken();
@@ -95,11 +97,13 @@ export default async function Search(props: Props) {
       customerAccessToken,
     );
     const parsedSearchParams = loadSearchParams?.(searchParams) ?? {};
+    const sort = typeof searchParams.sort === 'string' ? searchParams.sort : defaultProductSort;
 
     const search = await fetchFacetedSearch(
       {
         ...searchParams,
         ...parsedSearchParams,
+        sort,
       },
       currencyCode,
       customerAccessToken,
@@ -258,7 +262,7 @@ export default async function Search(props: Props) {
       resetFiltersLabel={t('FacetedSearch.resetFilters')}
       showCompare={productComparisonsEnabled}
       showRating={showRating}
-      sortDefaultValue="featured"
+      sortDefaultValue={defaultProductSort?.toLowerCase() ?? 'featured'}
       sortLabel={t('SortBy.sortBy')}
       sortOptions={[
         { value: 'featured', label: t('SortBy.featuredItems') },


### PR DESCRIPTION
## What/Why?

The control panel setting for the default sorts for a search was not being respected by Catalyst. This PR addresses this issue by using the data exposed by the new endpoints in `ES-6675`.

## Testing

Updating product search from "z to a" to "a to z":

https://github.com/user-attachments/assets/949a4b9c-386b-4494-9b0f-8c10531afb68

Updating default category sort from "price ascending" to "a to z":

https://github.com/user-attachments/assets/da9dda9b-44b1-4b09-843f-73cb0884f479

## Migration

No migration guide needed.