### PR TITLE
LTRAC-274: fix(core) - Disable webpage nav caching when logged in

### DIFF
--- a/.changeset/ltrac-274-webpage-nav-caching.md
+++ b/.changeset/ltrac-274-webpage-nav-caching.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Disable caching for the webpage sidebar navigation and route/raw-page resolution when a customer access token is present, so customer-only navigation links and pages aren't leaked to (or hidden from) other visitors via a shared cache.

--- a/core/app/[locale]/(default)/webpages/[id]/layout.tsx
+++ b/core/app/[locale]/(default)/webpages/[id]/layout.tsx
@@ -4,6 +4,7 @@ import { cache } from 'react';
 
 import { SidebarMenu } from '@/vibes/soul/sections/sidebar-menu';
 import { StickySidebarLayout } from '@/vibes/soul/sections/sticky-sidebar-layout';
+import { getSessionCustomerAccessToken } from '~/auth';
 import { client } from '~/client';
 import { graphql } from '~/client/graphql';
 import { revalidate } from '~/client/revalidate-target';
@@ -45,44 +46,48 @@ interface PageLink {
   href: string;
 }
 
-const getWebPageChildren = cache(async (id: string): Promise<PageLink[]> => {
-  const { data } = await client.fetch({
-    document: WebPageChildrenQuery,
-    variables: { id: decodeURIComponent(id) },
-    fetchOptions: { next: { revalidate } },
-  });
+const getWebPageChildren = cache(
+  async (id: string, customerAccessToken?: string): Promise<PageLink[]> => {
+    const { data } = await client.fetch({
+      document: WebPageChildrenQuery,
+      variables: { id: decodeURIComponent(id) },
+      customerAccessToken,
+      fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
+    });
 
-  if (!data.node) {
-    return [];
-  }
-
-  if (!('children' in data.node)) {
-    return [];
-  }
-
-  const { children } = data.node;
-
-  return removeEdgesAndNodes(children).reduce((acc: PageLink[], child) => {
-    if ('path' in child) {
-      return [...acc, { label: child.name, href: child.path }];
+    if (!data.node) {
+      return [];
     }
 
-    if ('link' in child) {
-      return [...acc, { label: child.name, href: child.link }];
+    if (!('children' in data.node)) {
+      return [];
     }
 
-    return acc;
-  }, []);
-});
+    const { children } = data.node;
+
+    return removeEdgesAndNodes(children).reduce((acc: PageLink[], child) => {
+      if ('path' in child) {
+        return [...acc, { label: child.name, href: child.path }];
+      }
+
+      if ('link' in child) {
+        return [...acc, { label: child.name, href: child.link }];
+      }
+
+      return acc;
+    }, []);
+  },
+);
 
 export default async function WebPageLayout({ params, children }: Props) {
   const { locale, id } = await params;
+  const customerAccessToken = await getSessionCustomerAccessToken();
 
   setRequestLocale(locale);
 
   return (
     <StickySidebarLayout
-      sidebar={<SidebarMenu links={getWebPageChildren(id)} />}
+      sidebar={<SidebarMenu links={getWebPageChildren(id, customerAccessToken)} />}
       sidebarSize="small"
     >
       {children}

--- a/core/proxies/with-routes.ts
+++ b/core/proxies/with-routes.ts
@@ -71,7 +71,7 @@ const getRoute = async (path: string, channelId?: string, customerAccessToken?: 
     document: GetRouteQuery,
     variables: { path },
     customerAccessToken,
-    fetchOptions: { next: { revalidate } },
+    fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
     channelId,
   });
 
@@ -93,7 +93,7 @@ const getRawWebPageContent = async (id: string, customerAccessToken?: string) =>
   const response = await client.fetch({
     document: getRawWebPageContentQuery,
     variables: { id },
-    fetchOptions: { next: { revalidate } },
+    fetchOptions: customerAccessToken ? { cache: 'no-store' } : { next: { revalidate } },
     customerAccessToken,
   });
 


### PR DESCRIPTION
Linear: [LTRAC-274](https://linear.app/commerce/issue/LTRAC-274/disable-webpage-navigation-caching-when-logged-in)

## What/Why?

The webpage sidebar navigation (child page links shown on `/webpages/[id]/*`) was always fetched anonymously with a `revalidate`-based cache, regardless of whether the visitor was logged in. That meant customer-restricted child pages could fail to show up for authenticated customers, and once fetched, the response was shared across all visitors via the fetch cache rather than being scoped to the session. `getWebPageChildren` (in `webpages/[id]/layout.tsx`) now threads the customer access token through and switches to `cache: 'no-store'` when one is present — the same pattern already used by the header, footer, and webpage `page-data` queries.

While in the area, also brought `getRoute` and `getRawWebPageContent` in `proxies/with-routes.ts` in line with the same pattern. Both already accepted a `customerAccessToken` param (added in #3013 for LTRAC-293) but never varied their own `fetch` cache behavior on it, which was an inconsistency worth closing even though the KV-level route cache was already bypassed for authenticated requests.

## Testing

- `pnpm build` passes with no type or lint errors.
- Manually reasoned through the cache branches; no existing automated tests cover customer-scoped caching for this flow (consistent with the precedent set in #3013).