### PR TITLE
feat(core): TRAC-282 Update cart locale when switching language

### DIFF
--- a/.changeset/sync-cart-locale-on-switch.md
+++ b/.changeset/sync-cart-locale-on-switch.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Keep the cart's locale in sync when a shopper switches their storefront locale. Previously, changing the locale only updated the storefront URL and left the cart on its original locale. The locale switcher now calls the new `updateCartLocale` Storefront GraphQL mutation to update the active cart in place before navigating, mirroring the existing currency-switch behavior. This mutation is currently gated behind a store-side feature flag; until it's enabled, `updateCartLocale` returns `null` and the switch is a no-op.

--- a/core/components/header/_actions/switch-locale.ts
+++ b/core/components/header/_actions/switch-locale.ts
@@ -1,0 +1,66 @@
+'use server';
+
+import { revalidateTag } from 'next/cache';
+
+import { client } from '~/client';
+import { graphql } from '~/client/graphql';
+import { TAGS } from '~/client/tags';
+import { getCartId } from '~/lib/cart';
+
+const UpdateCartLocaleMutation = graphql(`
+  mutation UpdateCartLocaleMutation($input: UpdateCartLocaleInput!) {
+    cart {
+      updateCartLocale(input: $input) {
+        cart {
+          entityId
+        }
+        errors {
+          __typename
+          ... on Error {
+            message
+          }
+        }
+      }
+    }
+  }
+`);
+
+// Keeps the cart's locale in sync when the shopper switches their storefront
+// locale. Unlike currency, updating the locale mutates the cart in place, so the
+// cart ID does not change. This is best-effort: a failure here should not block
+// the locale navigation, so errors are logged rather than surfaced to the user.
+export const switchLocale = async (locale: string): Promise<void> => {
+  const cartId = await getCartId();
+
+  if (!cartId) {
+    return;
+  }
+
+  try {
+    const result = await client.fetch({
+      document: UpdateCartLocaleMutation,
+      variables: { input: { cartEntityId: cartId, data: { locale } } },
+    });
+
+    const updateCartLocale = result.data.cart.updateCartLocale;
+
+    // `updateCartLocale` is null when the feature is disabled for this store.
+    if (!updateCartLocale) {
+      return;
+    }
+
+    const { errors } = updateCartLocale;
+
+    if (errors.length > 0) {
+      // eslint-disable-next-line no-console
+      console.error('Error updating cart locale', errors);
+
+      return;
+    }
+
+    revalidateTag(TAGS.cart, { expire: 0 });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error updating cart locale', error);
+  }
+};

--- a/core/components/header/index.tsx
+++ b/core/components/header/index.tsx
@@ -16,6 +16,7 @@ import { getPreferredCurrencyCode } from '~/lib/currency';
 
 import { search } from './_actions/search';
 import { switchCurrency } from './_actions/switch-currency';
+import { switchLocale } from './_actions/switch-locale';
 import { CurrencyCode, HeaderFragment, HeaderLinksFragment } from './fragment';
 
 const GetCartCountQuery = graphql(`
@@ -176,6 +177,7 @@ export const Header = async () => {
         cartCount: streamableCartCount,
         activeLocaleId: locale,
         locales,
+        localeAction: switchLocale,
         currencies,
         activeCurrencyId: streamableActiveCurrencyId,
         currencyAction: switchCurrency,

--- a/core/vibes/soul/primitives/navigation/index.tsx
+++ b/core/vibes/soul/primitives/navigation/index.tsx
@@ -85,6 +85,7 @@ export type SearchResult =
     };
 
 type CurrencyAction = Action<SubmissionResult | null, FormData>;
+type LocaleAction = (locale: string) => Promise<void> | void;
 type SearchAction<S extends SearchResult> = Action<
   {
     searchResults: S[] | null;
@@ -105,6 +106,7 @@ interface Props<S extends SearchResult> {
   linksPosition?: 'center' | 'left' | 'right';
   locales?: Locale[];
   activeLocaleId?: string;
+  localeAction?: LocaleAction;
   currencies?: Currency[];
   activeCurrencyId?: Streamable<string | undefined>;
   currencyAction?: CurrencyAction;
@@ -283,6 +285,7 @@ export const Navigation = forwardRef(function Navigation<S extends SearchResult>
     linksPosition = 'center',
     activeLocaleId,
     locales,
+    localeAction,
     currencies: streamableCurrencies,
     activeCurrencyId: streamableActiveCurrencyId,
     currencyAction,
@@ -408,6 +411,7 @@ export const Navigation = forwardRef(function Navigation<S extends SearchResult>
                       {/* Locale / Language Dropdown */}
                       {locales.length > 1 ? (
                         <LocaleSwitcher
+                          action={localeAction}
                           activeLocaleId={activeLocaleId}
                           // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
                           locales={locales as [Locale, Locale, ...Locale[]]}
@@ -626,6 +630,7 @@ export const Navigation = forwardRef(function Navigation<S extends SearchResult>
           {/* Locale / Language Dropdown */}
           {locales && locales.length > 1 ? (
             <LocaleSwitcher
+              action={localeAction}
               activeLocaleId={activeLocaleId}
               className="hidden @4xl:block"
               // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
@@ -912,9 +917,11 @@ const useSwitchLocale = () => {
 function LocaleSwitcher({
   locales,
   activeLocaleId,
+  action,
   className,
 }: {
   activeLocaleId?: string;
+  action?: LocaleAction;
   locales: [Locale, ...Locale[]];
   className?: string;
 }) {
@@ -951,7 +958,14 @@ function LocaleSwitcher({
                   },
                 )}
                 key={id}
-                onSelect={() => startTransition(() => switchLocale(id))}
+                onSelect={() =>
+                  startTransition(async () => {
+                    // Sync the cart's locale first so the shopper lands on the
+                    // new locale with an already-updated cart.
+                    await action?.(id);
+                    switchLocale(id);
+                  })
+                }
               >
                 {label}
               </DropdownMenu.Item>


### PR DESCRIPTION
Jira: [TRAC-282](https://bigcommercecloud.atlassian.net/browse/TRAC-282)

## What/Why?

Switching the storefront locale left the cart on its original locale. Adds a `switchLocale` server action that calls the new `updateCartLocale` mutation to update the cart in place before navigating, mirroring the existing currency-switch behavior.

The mutation is flag-gated server-side and returns `null` when disabled — `switchLocale` no-ops in that case, and swallows/logs any other errors so a failure never blocks navigation.

## Testing

- `switchLocale` returns early with no cart, a `null` result (flag off), or mutation errors — navigation proceeds unaffected in all cases.


https://github.com/user-attachments/assets/ce4225b5-0067-49df-8596-55293ed20bf3



## Migration

N/A

[TRAC-282]: https://bigcommercecloud.atlassian.net/browse/TRAC-282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ