### PR TITLE
feat(cli): add `catalyst debug` command to gather diagnostics for bug reports

### DIFF
--- a/.changeset/catalyst-debug-command.md
+++ b/.changeset/catalyst-debug-command.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst": minor
+---
+
+Add the `catalyst debug` command, which prints a diagnostic report (CLI version, runtime, detected package manager, project/config state, telemetry correlation ID, and which key files exist) to include when filing a bug report. Secrets and PII are never printed — credentials, stored env vars, and environment variables are reported by presence only, never by value. Use `--json` for machine-readable output.

--- a/.changeset/catalyst-debug-command.md
+++ b/.changeset/catalyst-debug-command.md
@@ -2,4 +2,4 @@
 "@bigcommerce/catalyst": minor
 ---
 
-Add the `catalyst debug` command, which prints a diagnostic report (CLI version, runtime, detected package manager, project/config state, telemetry correlation ID, and which key files exist) to include when filing a bug report. Secrets and PII are never printed — credentials, stored env vars, and environment variables are reported by presence only, never by value. Use `--json` for machine-readable output.
+Add the `catalyst debug` command, which prints a diagnostic report (CLI version, runtime, the project's package manager, project/config state, telemetry correlation ID, and which key files exist) to include when filing a bug report. Credentials and environment variables are resolved across the same chain a build uses (`process.env` > `.env.local` > `.env` > `.bigcommerce/project.json`) and reported by name and source only — secret values are never printed. Use `--json` for machine-readable output.

--- a/packages/catalyst/src/cli/commands/debug.spec.ts
+++ b/packages/catalyst/src/cli/commands/debug.spec.ts
@@ -1,0 +1,161 @@
+import { Command } from 'commander';
+import { afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
+
+import { collectDiagnostics, type Diagnostics } from '../lib/collect-diagnostics';
+import { consola } from '../lib/logger';
+import { program } from '../program';
+
+import { debug } from './debug';
+
+vi.mock('../lib/collect-diagnostics', () => ({
+  collectDiagnostics: vi.fn(),
+}));
+
+const fullDiagnostics: Diagnostics = {
+  cli: { name: '@bigcommerce/catalyst', version: '9.9.9' },
+  runtime: {
+    node: 'v20.0.0',
+    platform: 'darwin',
+    arch: 'arm64',
+    osRelease: '25.5.0',
+    packageManager: 'pnpm',
+  },
+  project: {
+    cwd: '/tmp/project',
+    projectUuid: 'uuid-123',
+    isLinked: true,
+    isTransformed: true,
+    isFullySetUp: true,
+    hasMiddleware: true,
+    hasProxy: false,
+    hasOpenNextDep: true,
+  },
+  config: {
+    storeHash: { present: true, source: 'project.json' },
+    accessToken: { present: true, source: 'process.env' },
+    projectUuid: { present: true, source: 'project.json' },
+    projectJsonKeys: ['projectUuid', 'storeHash'],
+    storedEnvKeys: ['FOO', 'BAR'],
+    // Both branches of the "set/not set" formatter.
+    envVars: { AUTH_SECRET: true, BIGCOMMERCE_CHANNEL_ID: false },
+  },
+  telemetry: { enabled: true, correlationId: 'corr-abc' },
+  // Both branches of the presence formatter.
+  files: { '.env.local': true, '.env': false },
+};
+
+const emptyDiagnostics: Diagnostics = {
+  cli: { name: '@bigcommerce/catalyst', version: '9.9.9' },
+  runtime: {
+    node: 'v20.0.0',
+    platform: 'linux',
+    arch: 'x64',
+    osRelease: '6.0.0',
+    packageManager: 'npm',
+  },
+  project: {
+    cwd: '/tmp/empty',
+    projectUuid: null,
+    isLinked: false,
+    isTransformed: false,
+    isFullySetUp: false,
+    hasMiddleware: false,
+    hasProxy: false,
+    hasOpenNextDep: false,
+  },
+  config: {
+    storeHash: { present: false, source: 'unset' },
+    accessToken: { present: false, source: 'unset' },
+    projectUuid: { present: false, source: 'unset' },
+    projectJsonKeys: [],
+    storedEnvKeys: [],
+    envVars: {},
+  },
+  telemetry: { enabled: false, correlationId: 'corr-xyz' },
+  files: {},
+};
+
+// The report is the last consola.log call (the program banner also logs, at
+// import time, so we take the most recent call rather than relying on order).
+const lastLogOutput = (): string => {
+  const calls = vi.mocked(consola.log).mock.calls;
+
+  return calls.length > 0 ? String(calls[calls.length - 1][0]) : '';
+};
+
+beforeAll(() => {
+  consola.wrapAll();
+});
+
+beforeEach(() => {
+  consola.mockTypes(() => vi.fn());
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+test('properly configured Command instance', () => {
+  expect(debug).toBeInstanceOf(Command);
+  expect(debug.name()).toBe('debug');
+  expect(debug.description()).toContain('diagnostic report');
+  expect(debug.options).toEqual(
+    expect.arrayContaining([expect.objectContaining({ long: '--json' })]),
+  );
+});
+
+test('prints a human-readable report by default', async () => {
+  vi.mocked(collectDiagnostics).mockReturnValue(fullDiagnostics);
+
+  await program.parseAsync(['node', 'catalyst', 'debug']);
+
+  const output = lastLogOutput();
+
+  expect(output).toContain('Catalyst CLI Diagnostics');
+  expect(output).toContain('@bigcommerce/catalyst');
+  expect(output).toContain('pnpm');
+  expect(output).toContain('Project UUID:       uuid-123');
+  expect(output).toContain('Linked:             yes');
+  expect(output).toContain('middleware.ts:      present');
+  expect(output).toContain('proxy.ts:           absent');
+  expect(output).toContain('OpenNext dep:       installed');
+  expect(output).toContain('Store hash:         present (source: project.json)');
+  expect(output).toContain('Access token:       present (source: process.env)');
+  expect(output).toContain('project.json keys:  projectUuid, storeHash');
+  expect(output).toContain('Stored env keys:    FOO, BAR');
+  expect(output).toContain('AUTH_SECRET: set');
+  expect(output).toContain('BIGCOMMERCE_CHANNEL_ID: not set');
+  expect(output).toContain('Enabled:            yes');
+  expect(output).toContain('Correlation ID:     corr-abc');
+  expect(output).toContain('.env.local: present');
+  expect(output).toContain('.env: absent');
+});
+
+test('renders the empty-project branches', async () => {
+  vi.mocked(collectDiagnostics).mockReturnValue(emptyDiagnostics);
+
+  await program.parseAsync(['node', 'catalyst', 'debug']);
+
+  const output = lastLogOutput();
+
+  expect(output).toContain('Project UUID:       (not linked)');
+  expect(output).toContain('Linked:             no');
+  expect(output).toContain('OpenNext dep:       not installed');
+  expect(output).toContain('Store hash:         not set');
+  expect(output).toContain('project.json keys:  (none)');
+  expect(output).toContain('Stored env keys:    (none)');
+  expect(output).toContain('Enabled:            no');
+});
+
+test('--json prints machine-readable output', async () => {
+  vi.mocked(collectDiagnostics).mockReturnValue(fullDiagnostics);
+
+  await program.parseAsync(['node', 'catalyst', 'debug', '--json']);
+
+  const output = lastLogOutput();
+
+  expect(() => {
+    JSON.parse(output);
+  }).not.toThrow();
+  expect(JSON.parse(output)).toEqual(fullDiagnostics);
+});

--- a/packages/catalyst/src/cli/commands/debug.spec.ts
+++ b/packages/catalyst/src/cli/commands/debug.spec.ts
@@ -22,8 +22,8 @@ const fullDiagnostics: Diagnostics = {
   },
   project: {
     cwd: '/tmp/project',
-    coreName: '@bigcommerce/catalyst-core',
-    coreVersion: '1.8.0',
+    storefrontName: '@bigcommerce/catalyst-core',
+    storefrontVersion: '1.8.0',
     projectUuid: 'uuid-123',
     isLinked: true,
     isTransformed: true,
@@ -59,8 +59,8 @@ const emptyDiagnostics: Diagnostics = {
   },
   project: {
     cwd: '/tmp/empty',
-    coreName: null,
-    coreVersion: null,
+    storefrontName: null,
+    storefrontVersion: null,
     projectUuid: null,
     isLinked: false,
     isTransformed: false,
@@ -122,7 +122,7 @@ test('prints a human-readable report by default', async () => {
   expect(output).toContain('Catalyst CLI Diagnostics');
   expect(output).toContain('@bigcommerce/catalyst');
   expect(output).toContain('pnpm');
-  expect(output).toContain('Catalyst core:      @bigcommerce/catalyst-core@1.8.0');
+  expect(output).toContain('Storefront:         @bigcommerce/catalyst-core@1.8.0');
   expect(output).toContain('Project UUID:       uuid-123');
   expect(output).toContain('Linked:             yes');
   expect(output).toContain('middleware.ts:      present');
@@ -152,7 +152,7 @@ test('renders the empty-project branches', async () => {
 
   const output = lastLogOutput();
 
-  expect(output).toContain('Catalyst core:      (unknown)');
+  expect(output).toContain('Storefront:         (unknown)');
   expect(output).toContain('Project UUID:       (not linked)');
   expect(output).toContain('Linked:             no');
   expect(output).toContain('OpenNext dep:       not installed');
@@ -163,15 +163,15 @@ test('renders the empty-project branches', async () => {
   expect(output).toContain('Enabled:            no');
 });
 
-test('shows the core version alone when the package name is unknown', async () => {
+test('shows the storefront version alone when the package name is unknown', async () => {
   vi.mocked(collectDiagnostics).mockReturnValue({
     ...emptyDiagnostics,
-    project: { ...emptyDiagnostics.project, coreName: null, coreVersion: '3.2.1' },
+    project: { ...emptyDiagnostics.project, storefrontName: null, storefrontVersion: '3.2.1' },
   });
 
   await program.parseAsync(['node', 'catalyst', 'debug']);
 
-  expect(lastLogOutput()).toContain('Catalyst core:      3.2.1');
+  expect(lastLogOutput()).toContain('Storefront:         3.2.1');
 });
 
 test('--json prints machine-readable output', async () => {

--- a/packages/catalyst/src/cli/commands/debug.spec.ts
+++ b/packages/catalyst/src/cli/commands/debug.spec.ts
@@ -22,6 +22,8 @@ const fullDiagnostics: Diagnostics = {
   },
   project: {
     cwd: '/tmp/project',
+    coreName: '@bigcommerce/catalyst-core',
+    coreVersion: '1.8.0',
     projectUuid: 'uuid-123',
     isLinked: true,
     isTransformed: true,
@@ -55,6 +57,8 @@ const emptyDiagnostics: Diagnostics = {
   },
   project: {
     cwd: '/tmp/empty',
+    coreName: null,
+    coreVersion: null,
     projectUuid: null,
     isLinked: false,
     isTransformed: false,
@@ -114,6 +118,7 @@ test('prints a human-readable report by default', async () => {
   expect(output).toContain('Catalyst CLI Diagnostics');
   expect(output).toContain('@bigcommerce/catalyst');
   expect(output).toContain('pnpm');
+  expect(output).toContain('Catalyst core:      @bigcommerce/catalyst-core@1.8.0');
   expect(output).toContain('Project UUID:       uuid-123');
   expect(output).toContain('Linked:             yes');
   expect(output).toContain('middleware.ts:      present');
@@ -139,6 +144,7 @@ test('renders the empty-project branches', async () => {
 
   const output = lastLogOutput();
 
+  expect(output).toContain('Catalyst core:      (unknown)');
   expect(output).toContain('Project UUID:       (not linked)');
   expect(output).toContain('Linked:             no');
   expect(output).toContain('OpenNext dep:       not installed');
@@ -146,6 +152,17 @@ test('renders the empty-project branches', async () => {
   expect(output).toContain('project.json keys:  (none)');
   expect(output).toContain('Stored env keys:    (none)');
   expect(output).toContain('Enabled:            no');
+});
+
+test('shows the core version alone when the package name is unknown', async () => {
+  vi.mocked(collectDiagnostics).mockReturnValue({
+    ...emptyDiagnostics,
+    project: { ...emptyDiagnostics.project, coreName: null, coreVersion: '3.2.1' },
+  });
+
+  await program.parseAsync(['node', 'catalyst', 'debug']);
+
+  expect(lastLogOutput()).toContain('Catalyst core:      3.2.1');
 });
 
 test('--json prints machine-readable output', async () => {

--- a/packages/catalyst/src/cli/commands/debug.spec.ts
+++ b/packages/catalyst/src/cli/commands/debug.spec.ts
@@ -36,8 +36,8 @@ const fullDiagnostics: Diagnostics = {
     projectUuid: { present: true, source: 'project.json' },
     projectJsonKeys: ['projectUuid', 'storeHash'],
     storedEnvKeys: ['FOO', 'BAR'],
-    // Both branches of the "set/not set" formatter.
-    envVars: { AUTH_SECRET: true, BIGCOMMERCE_CHANNEL_ID: false },
+    // Both branches of the source formatter (set-with-source and unset).
+    envVars: { AUTH_SECRET: 'process.env', BIGCOMMERCE_CHANNEL_ID: '.env.local', DB_URL: 'unset' },
   },
   telemetry: { enabled: true, correlationId: 'corr-abc' },
   // Both branches of the presence formatter.
@@ -123,8 +123,9 @@ test('prints a human-readable report by default', async () => {
   expect(output).toContain('Access token:       present (source: process.env)');
   expect(output).toContain('project.json keys:  projectUuid, storeHash');
   expect(output).toContain('Stored env keys:    FOO, BAR');
-  expect(output).toContain('AUTH_SECRET: set');
-  expect(output).toContain('BIGCOMMERCE_CHANNEL_ID: not set');
+  expect(output).toContain('AUTH_SECRET: set (process.env)');
+  expect(output).toContain('BIGCOMMERCE_CHANNEL_ID: set (.env.local)');
+  expect(output).toContain('DB_URL: not set');
   expect(output).toContain('Enabled:            yes');
   expect(output).toContain('Correlation ID:     corr-abc');
   expect(output).toContain('.env.local: present');

--- a/packages/catalyst/src/cli/commands/debug.spec.ts
+++ b/packages/catalyst/src/cli/commands/debug.spec.ts
@@ -39,7 +39,8 @@ const fullDiagnostics: Diagnostics = {
     projectJsonKeys: ['projectUuid', 'storeHash'],
     storedEnvKeys: ['FOO', 'BAR'],
     // Both branches of the source formatter (set-with-source and unset).
-    envVars: { AUTH_SECRET: 'process.env', BIGCOMMERCE_CHANNEL_ID: '.env.local', DB_URL: 'unset' },
+    cliEnvVars: { CATALYST_STORE_HASH: 'process.env', CATALYST_PROJECT_UUID: 'unset' },
+    buildEnvVars: { AUTH_SECRET: '.env.local', BIGCOMMERCE_CHANNEL_ID: 'unset' },
   },
   telemetry: { enabled: true, correlationId: 'corr-abc' },
   // Both branches of the presence formatter.
@@ -73,7 +74,8 @@ const emptyDiagnostics: Diagnostics = {
     projectUuid: { present: false, source: 'unset' },
     projectJsonKeys: [],
     storedEnvKeys: [],
-    envVars: {},
+    cliEnvVars: {},
+    buildEnvVars: {},
   },
   telemetry: { enabled: false, correlationId: 'corr-xyz' },
   files: {},
@@ -128,9 +130,12 @@ test('prints a human-readable report by default', async () => {
   expect(output).toContain('Access token:       present (source: process.env)');
   expect(output).toContain('project.json keys:  projectUuid, storeHash');
   expect(output).toContain('Stored env keys:    FOO, BAR');
-  expect(output).toContain('AUTH_SECRET: set (process.env)');
-  expect(output).toContain('BIGCOMMERCE_CHANNEL_ID: set (.env.local)');
-  expect(output).toContain('DB_URL: not set');
+  expect(output).toContain('CLI environment variables (used to run the CLI)');
+  expect(output).toContain('CATALYST_STORE_HASH: set (process.env)');
+  expect(output).toContain('CATALYST_PROJECT_UUID: not set');
+  expect(output).toContain('Build environment variables (used to build the Next.js app)');
+  expect(output).toContain('AUTH_SECRET: set (.env.local)');
+  expect(output).toContain('BIGCOMMERCE_CHANNEL_ID: not set');
   expect(output).toContain('Enabled:            yes');
   expect(output).toContain('Correlation ID:     corr-abc');
   expect(output).toContain('.env.local: present');

--- a/packages/catalyst/src/cli/commands/debug.spec.ts
+++ b/packages/catalyst/src/cli/commands/debug.spec.ts
@@ -36,6 +36,7 @@ const fullDiagnostics: Diagnostics = {
     storeHash: { present: true, source: 'project.json' },
     accessToken: { present: true, source: 'process.env' },
     projectUuid: { present: true, source: 'project.json' },
+    apiHost: { present: true, source: 'project.json' },
     projectJsonKeys: ['projectUuid', 'storeHash'],
     storedEnvKeys: ['FOO', 'BAR'],
     // Both branches of the source formatter (set-with-source and unset).
@@ -72,6 +73,7 @@ const emptyDiagnostics: Diagnostics = {
     storeHash: { present: false, source: 'unset' },
     accessToken: { present: false, source: 'unset' },
     projectUuid: { present: false, source: 'unset' },
+    apiHost: { present: false, source: 'unset' },
     projectJsonKeys: [],
     storedEnvKeys: [],
     cliEnvVars: {},
@@ -128,6 +130,7 @@ test('prints a human-readable report by default', async () => {
   expect(output).toContain('OpenNext dep:       installed');
   expect(output).toContain('Store hash:         present (source: project.json)');
   expect(output).toContain('Access token:       present (source: process.env)');
+  expect(output).toContain('API host:           present (source: project.json)');
   expect(output).toContain('project.json keys:  projectUuid, storeHash');
   expect(output).toContain('Stored env keys:    FOO, BAR');
   expect(output).toContain('CLI environment variables (used to run the CLI)');
@@ -154,6 +157,7 @@ test('renders the empty-project branches', async () => {
   expect(output).toContain('Linked:             no');
   expect(output).toContain('OpenNext dep:       not installed');
   expect(output).toContain('Store hash:         not set');
+  expect(output).toContain('API host:           default (api.bigcommerce.com)');
   expect(output).toContain('project.json keys:  (none)');
   expect(output).toContain('Stored env keys:    (none)');
   expect(output).toContain('Enabled:            no');

--- a/packages/catalyst/src/cli/commands/debug.ts
+++ b/packages/catalyst/src/cli/commands/debug.ts
@@ -18,6 +18,14 @@ const formatResolved = (value: ResolvedValue): string =>
 const formatSource = (source: ConfigSource): string =>
   source === 'unset' ? 'not set' : `set (${source})`;
 
+const formatCore = (name: string | null, version: string | null): string => {
+  if (!version) {
+    return '(unknown)';
+  }
+
+  return name ? `${name}@${version}` : version;
+};
+
 const formatList = (values: string[]): string => (values.length > 0 ? values.join(', ') : '(none)');
 
 // Build a human-readable, copy-pasteable report. Kept to plain text (no colors)
@@ -38,6 +46,7 @@ const formatReport = (d: Diagnostics): string => {
     '',
     'Project',
     `  Directory:          ${d.project.cwd}`,
+    `  Catalyst core:      ${formatCore(d.project.coreName, d.project.coreVersion)}`,
     `  Project UUID:       ${d.project.projectUuid ?? '(not linked)'}`,
     `  Linked:             ${yesNo(d.project.isLinked)}`,
     `  Transformed:        ${yesNo(d.project.isTransformed)}`,

--- a/packages/catalyst/src/cli/commands/debug.ts
+++ b/packages/catalyst/src/cli/commands/debug.ts
@@ -18,7 +18,7 @@ const formatResolved = (value: ResolvedValue): string =>
 const formatSource = (source: ConfigSource): string =>
   source === 'unset' ? 'not set' : `set (${source})`;
 
-const formatCore = (name: string | null, version: string | null): string => {
+const formatStorefront = (name: string | null, version: string | null): string => {
   if (!version) {
     return '(unknown)';
   }
@@ -49,7 +49,7 @@ const formatReport = (d: Diagnostics): string => {
     '',
     'Project',
     `  Directory:          ${d.project.cwd}`,
-    `  Catalyst core:      ${formatCore(d.project.coreName, d.project.coreVersion)}`,
+    `  Storefront:         ${formatStorefront(d.project.storefrontName, d.project.storefrontVersion)}`,
     `  Project UUID:       ${d.project.projectUuid ?? '(not linked)'}`,
     `  Linked:             ${yesNo(d.project.isLinked)}`,
     `  Transformed:        ${yesNo(d.project.isTransformed)}`,

--- a/packages/catalyst/src/cli/commands/debug.ts
+++ b/packages/catalyst/src/cli/commands/debug.ts
@@ -2,6 +2,7 @@ import { Command, Option } from 'commander';
 
 import {
   collectDiagnostics,
+  type ConfigSource,
   type Diagnostics,
   type ResolvedValue,
 } from '../lib/collect-diagnostics';
@@ -13,6 +14,9 @@ const presence = (value: boolean): string => (value ? 'present' : 'absent');
 
 const formatResolved = (value: ResolvedValue): string =>
   value.present ? `present (source: ${value.source})` : 'not set';
+
+const formatSource = (source: ConfigSource): string =>
+  source === 'unset' ? 'not set' : `set (${source})`;
 
 const formatList = (values: string[]): string => (values.length > 0 ? values.join(', ') : '(none)');
 
@@ -50,7 +54,7 @@ const formatReport = (d: Diagnostics): string => {
     `  Stored env keys:    ${formatList(d.config.storedEnvKeys)}`,
     '  Environment variables:',
     ...Object.entries(d.config.envVars).map(
-      ([name, isSet]) => `    ${name}: ${isSet ? 'set' : 'not set'}`,
+      ([name, source]) => `    ${name}: ${formatSource(source)}`,
     ),
     '',
     'Telemetry',

--- a/packages/catalyst/src/cli/commands/debug.ts
+++ b/packages/catalyst/src/cli/commands/debug.ts
@@ -1,0 +1,93 @@
+import { Command, Option } from 'commander';
+
+import {
+  collectDiagnostics,
+  type Diagnostics,
+  type ResolvedValue,
+} from '../lib/collect-diagnostics';
+import { consola } from '../lib/logger';
+
+const yesNo = (value: boolean): string => (value ? 'yes' : 'no');
+
+const presence = (value: boolean): string => (value ? 'present' : 'absent');
+
+const formatResolved = (value: ResolvedValue): string =>
+  value.present ? `present (source: ${value.source})` : 'not set';
+
+const formatList = (values: string[]): string => (values.length > 0 ? values.join(', ') : '(none)');
+
+// Build a human-readable, copy-pasteable report. Kept to plain text (no colors)
+// so it survives a paste into a GitHub issue or support ticket unchanged.
+const formatReport = (d: Diagnostics): string => {
+  const lines = [
+    'Catalyst CLI Diagnostics',
+    '',
+    'CLI',
+    `  Package:            ${d.cli.name}`,
+    `  Version:            ${d.cli.version}`,
+    '',
+    'Runtime',
+    `  Node:               ${d.runtime.node}`,
+    `  Platform:           ${d.runtime.platform} (${d.runtime.arch})`,
+    `  OS release:         ${d.runtime.osRelease}`,
+    `  Package manager:    ${d.runtime.packageManager}`,
+    '',
+    'Project',
+    `  Directory:          ${d.project.cwd}`,
+    `  Project UUID:       ${d.project.projectUuid ?? '(not linked)'}`,
+    `  Linked:             ${yesNo(d.project.isLinked)}`,
+    `  Transformed:        ${yesNo(d.project.isTransformed)}`,
+    `  Fully set up:       ${yesNo(d.project.isFullySetUp)}`,
+    `  middleware.ts:      ${presence(d.project.hasMiddleware)}`,
+    `  proxy.ts:           ${presence(d.project.hasProxy)}`,
+    `  OpenNext dep:       ${d.project.hasOpenNextDep ? 'installed' : 'not installed'}`,
+    '',
+    'Config (resolved without secrets)',
+    `  Store hash:         ${formatResolved(d.config.storeHash)}`,
+    `  Access token:       ${formatResolved(d.config.accessToken)}`,
+    `  Project UUID:       ${formatResolved(d.config.projectUuid)}`,
+    `  project.json keys:  ${formatList(d.config.projectJsonKeys)}`,
+    `  Stored env keys:    ${formatList(d.config.storedEnvKeys)}`,
+    '  Environment variables:',
+    ...Object.entries(d.config.envVars).map(
+      ([name, isSet]) => `    ${name}: ${isSet ? 'set' : 'not set'}`,
+    ),
+    '',
+    'Telemetry',
+    `  Enabled:            ${yesNo(d.telemetry.enabled)}`,
+    `  Correlation ID:     ${d.telemetry.correlationId}`,
+    '',
+    'Files',
+    ...Object.entries(d.files).map(([name, exists]) => `  ${name}: ${presence(exists)}`),
+  ];
+
+  return lines.join('\n');
+};
+
+export const debug = new Command('debug')
+  .configureHelp({ showGlobalOptions: true })
+  .description(
+    'Print a diagnostic report (CLI, runtime, project, and config state) to include when filing a bug report. Never prints secret values — credentials and env vars are reported by presence only.',
+  )
+  .addHelpText(
+    'after',
+    `
+Examples:
+  # Print a human-readable report
+  $ catalyst debug
+
+  # Print machine-readable JSON (useful for copy/paste or piping)
+  $ catalyst debug --json`,
+  )
+  .addOption(new Option('--json', 'Output the report as JSON.'))
+  .action((options: { json?: boolean }) => {
+    const diagnostics = collectDiagnostics();
+
+    if (options.json) {
+      consola.log(JSON.stringify(diagnostics, null, 2));
+
+      return;
+    }
+
+    consola.log(formatReport(diagnostics));
+  });

--- a/packages/catalyst/src/cli/commands/debug.ts
+++ b/packages/catalyst/src/cli/commands/debug.ts
@@ -62,6 +62,7 @@ const formatReport = (d: Diagnostics): string => {
     `  Store hash:         ${formatResolved(d.config.storeHash)}`,
     `  Access token:       ${formatResolved(d.config.accessToken)}`,
     `  Project UUID:       ${formatResolved(d.config.projectUuid)}`,
+    `  API host:           ${d.config.apiHost.present ? formatResolved(d.config.apiHost) : 'default (api.bigcommerce.com)'}`,
     `  project.json keys:  ${formatList(d.config.projectJsonKeys)}`,
     `  Stored env keys:    ${formatList(d.config.storedEnvKeys)}`,
     '',

--- a/packages/catalyst/src/cli/commands/debug.ts
+++ b/packages/catalyst/src/cli/commands/debug.ts
@@ -28,6 +28,9 @@ const formatCore = (name: string | null, version: string | null): string => {
 
 const formatList = (values: string[]): string => (values.length > 0 ? values.join(', ') : '(none)');
 
+const envVarLines = (vars: Record<string, ConfigSource>): string[] =>
+  Object.entries(vars).map(([name, source]) => `  ${name}: ${formatSource(source)}`);
+
 // Build a human-readable, copy-pasteable report. Kept to plain text (no colors)
 // so it survives a paste into a GitHub issue or support ticket unchanged.
 const formatReport = (d: Diagnostics): string => {
@@ -61,10 +64,12 @@ const formatReport = (d: Diagnostics): string => {
     `  Project UUID:       ${formatResolved(d.config.projectUuid)}`,
     `  project.json keys:  ${formatList(d.config.projectJsonKeys)}`,
     `  Stored env keys:    ${formatList(d.config.storedEnvKeys)}`,
-    '  Environment variables:',
-    ...Object.entries(d.config.envVars).map(
-      ([name, source]) => `    ${name}: ${formatSource(source)}`,
-    ),
+    '',
+    'CLI environment variables (used to run the CLI)',
+    ...envVarLines(d.config.cliEnvVars),
+    '',
+    'Build environment variables (used to build the Next.js app)',
+    ...envVarLines(d.config.buildEnvVars),
     '',
     'Telemetry',
     `  Enabled:            ${yesNo(d.telemetry.enabled)}`,

--- a/packages/catalyst/src/cli/lib/collect-diagnostics.spec.ts
+++ b/packages/catalyst/src/cli/lib/collect-diagnostics.spec.ts
@@ -57,8 +57,8 @@ describe('collectDiagnostics', () => {
 
     expect(d.project).toEqual({
       cwd: tmpDir,
-      coreName: null,
-      coreVersion: null,
+      storefrontName: null,
+      storefrontVersion: null,
       projectUuid: null,
       isLinked: false,
       isTransformed: false,
@@ -254,7 +254,7 @@ describe('collectDiagnostics', () => {
     });
   });
 
-  describe('Catalyst core version', () => {
+  describe('Storefront version', () => {
     const writePackageJson = (value: unknown) =>
       writeFileEnsured(join(tmpDir, 'package.json'), JSON.stringify(value));
 
@@ -263,8 +263,8 @@ describe('collectDiagnostics', () => {
 
       const d = collectDiagnostics({ cwd: tmpDir, env: emptyEnv });
 
-      expect(d.project.coreName).toBe('@bigcommerce/catalyst-core');
-      expect(d.project.coreVersion).toBe('1.8.0');
+      expect(d.project.storefrontName).toBe('@bigcommerce/catalyst-core');
+      expect(d.project.storefrontVersion).toBe('1.8.0');
     });
 
     test('prefers catalyst.version over the plain version', async () => {
@@ -274,14 +274,16 @@ describe('collectDiagnostics', () => {
         catalyst: { version: '1.9.1', ref: '@bigcommerce/catalyst-core@1.9.1' },
       });
 
-      expect(collectDiagnostics({ cwd: tmpDir, env: emptyEnv }).project.coreVersion).toBe('1.9.1');
+      expect(collectDiagnostics({ cwd: tmpDir, env: emptyEnv }).project.storefrontVersion).toBe(
+        '1.9.1',
+      );
     });
 
     test('null when package.json is absent', () => {
       const d = collectDiagnostics({ cwd: tmpDir, env: emptyEnv });
 
-      expect(d.project.coreName).toBeNull();
-      expect(d.project.coreVersion).toBeNull();
+      expect(d.project.storefrontName).toBeNull();
+      expect(d.project.storefrontVersion).toBeNull();
     });
 
     test('null version when package.json has no version field', async () => {
@@ -289,8 +291,8 @@ describe('collectDiagnostics', () => {
 
       const d = collectDiagnostics({ cwd: tmpDir, env: emptyEnv });
 
-      expect(d.project.coreName).toBe('some-project');
-      expect(d.project.coreVersion).toBeNull();
+      expect(d.project.storefrontName).toBe('some-project');
+      expect(d.project.storefrontVersion).toBeNull();
     });
 
     test('null when package.json is malformed', async () => {
@@ -298,8 +300,8 @@ describe('collectDiagnostics', () => {
 
       const d = collectDiagnostics({ cwd: tmpDir, env: emptyEnv });
 
-      expect(d.project.coreName).toBeNull();
-      expect(d.project.coreVersion).toBeNull();
+      expect(d.project.storefrontName).toBeNull();
+      expect(d.project.storefrontVersion).toBeNull();
     });
   });
 

--- a/packages/catalyst/src/cli/lib/collect-diagnostics.spec.ts
+++ b/packages/catalyst/src/cli/lib/collect-diagnostics.spec.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import PACKAGE_INFO from '../../../package.json';
 
-import { collectDiagnostics, REPORTED_ENV_VARS } from './collect-diagnostics';
+import { BUILD_ENV_VARS, CLI_ENV_VARS, collectDiagnostics } from './collect-diagnostics';
 import { mkTempDir } from './mk-temp-dir';
 
 vi.mock('./telemetry', () => ({
@@ -72,8 +72,10 @@ describe('collectDiagnostics', () => {
     expect(d.config.projectUuid).toEqual({ present: false, source: 'unset' });
     expect(d.config.projectJsonKeys).toEqual([]);
     expect(d.config.storedEnvKeys).toEqual([]);
-    expect(Object.values(d.config.envVars).every((v) => v === 'unset')).toBe(true);
-    expect(Object.keys(d.config.envVars)).toEqual([...REPORTED_ENV_VARS]);
+    expect(Object.keys(d.config.cliEnvVars)).toEqual([...CLI_ENV_VARS]);
+    expect(Object.keys(d.config.buildEnvVars)).toEqual([...BUILD_ENV_VARS]);
+    expect(Object.values(d.config.cliEnvVars).every((v) => v === 'unset')).toBe(true);
+    expect(Object.values(d.config.buildEnvVars).every((v) => v === 'unset')).toBe(true);
     expect(d.files).toEqual({
       '.env.local': false,
       '.env': false,
@@ -147,18 +149,25 @@ describe('collectDiagnostics', () => {
     });
 
     expect(d.config.storeHash).toEqual({ present: false, source: 'unset' });
-    expect(d.config.envVars.AUTH_SECRET).toBe('unset');
+    expect(d.config.buildEnvVars.AUTH_SECRET).toBe('unset');
   });
 
-  test('reports each env var by source only (never the value)', () => {
+  test('reports env vars by source only (never the value), split by consumer', () => {
     const d = collectDiagnostics({
       cwd: tmpDir,
-      env: { AUTH_SECRET: 'super-secret', BIGCOMMERCE_CHANNEL_ID: '1' },
+      env: {
+        CATALYST_ACCESS_TOKEN: 'tok',
+        AUTH_SECRET: 'super-secret',
+        BIGCOMMERCE_CHANNEL_ID: '1',
+      },
     });
 
-    expect(d.config.envVars.AUTH_SECRET).toBe('process.env');
-    expect(d.config.envVars.BIGCOMMERCE_CHANNEL_ID).toBe('process.env');
-    expect(d.config.envVars.BIGCOMMERCE_LOGIN_URL).toBe('unset');
+    // CLI-consumed vars land in cliEnvVars.
+    expect(d.config.cliEnvVars.CATALYST_ACCESS_TOKEN).toBe('process.env');
+    expect(d.config.cliEnvVars.BIGCOMMERCE_LOGIN_URL).toBe('unset');
+    // Build-consumed vars land in buildEnvVars.
+    expect(d.config.buildEnvVars.AUTH_SECRET).toBe('process.env');
+    expect(d.config.buildEnvVars.BIGCOMMERCE_CHANNEL_ID).toBe('process.env');
   });
 
   describe('env files (.env.local / .env)', () => {
@@ -170,8 +179,8 @@ describe('collectDiagnostics', () => {
 
       const d = collectDiagnostics({ cwd: tmpDir, env: emptyEnv });
 
-      expect(d.config.envVars.CATALYST_STORE_HASH).toBe('.env.local');
-      expect(d.config.envVars.BIGCOMMERCE_CHANNEL_ID).toBe('.env.local');
+      expect(d.config.cliEnvVars.CATALYST_STORE_HASH).toBe('.env.local');
+      expect(d.config.buildEnvVars.BIGCOMMERCE_CHANNEL_ID).toBe('.env.local');
       expect(d.config.storeHash).toEqual({ present: true, source: '.env.local' });
       // Never leaked into the real environment.
       expect(process.env.CATALYST_STORE_HASH).toBeUndefined();
@@ -192,9 +201,9 @@ describe('collectDiagnostics', () => {
       // Present in all three — process.env is highest priority.
       expect(d.config.accessToken).toEqual({ present: true, source: 'process.env' });
       // Present in .env.local and .env — .env.local wins.
-      expect(d.config.envVars.CATALYST_ACCESS_TOKEN).toBe('process.env');
+      expect(d.config.cliEnvVars.CATALYST_ACCESS_TOKEN).toBe('process.env');
       // Only in .env.
-      expect(d.config.envVars.AUTH_SECRET).toBe('.env');
+      expect(d.config.buildEnvVars.AUTH_SECRET).toBe('.env');
     });
 
     test('a malformed/unreadable env file does not break the report', async () => {
@@ -204,7 +213,7 @@ describe('collectDiagnostics', () => {
 
       const d = collectDiagnostics({ cwd: tmpDir, env: { AUTH_SECRET: 'x' } });
 
-      expect(d.config.envVars.AUTH_SECRET).toBe('process.env');
+      expect(d.config.buildEnvVars.AUTH_SECRET).toBe('process.env');
       expect(d.files['.env.local']).toBe(true);
     });
   });

--- a/packages/catalyst/src/cli/lib/collect-diagnostics.spec.ts
+++ b/packages/catalyst/src/cli/lib/collect-diagnostics.spec.ts
@@ -185,7 +185,7 @@ describe('collectDiagnostics', () => {
   });
 
   describe('env files (.env.local / .env)', () => {
-    test('resolves env vars and credentials from .env.local without loading them', async () => {
+    test('build vars resolve from .env.local, but CLI vars/credentials do not', async () => {
       await writeFileEnsured(
         join(tmpDir, '.env.local'),
         'CATALYST_STORE_HASH=fromlocal\nBIGCOMMERCE_CHANNEL_ID=42\n',
@@ -193,29 +193,33 @@ describe('collectDiagnostics', () => {
 
       const d = collectDiagnostics({ cwd: tmpDir, env: emptyEnv });
 
-      expect(d.config.cliEnvVars.CATALYST_STORE_HASH).toBe('.env.local');
+      // Build vars ARE loaded from .env files (by build/deploy).
       expect(d.config.buildEnvVars.BIGCOMMERCE_CHANNEL_ID).toBe('.env.local');
-      expect(d.config.storeHash).toEqual({ present: true, source: '.env.local' });
-      // Never leaked into the real environment.
+      // CLI vars are read only from process.env — a .env.local value is ignored,
+      // matching how the CLI actually resolves them (no other command loads env
+      // files). So a store hash sitting only in .env.local reads as unset.
+      expect(d.config.cliEnvVars.CATALYST_STORE_HASH).toBe('unset');
+      expect(d.config.storeHash).toEqual({ present: false, source: 'unset' });
+      // Never loaded into the real environment either.
       expect(process.env.CATALYST_STORE_HASH).toBeUndefined();
     });
 
-    test('process.env wins over .env.local, which wins over .env', async () => {
-      await writeFileEnsured(join(tmpDir, '.env.local'), 'CATALYST_ACCESS_TOKEN=local\n');
+    test('build var precedence: process.env > .env.local > .env', async () => {
+      await writeFileEnsured(join(tmpDir, '.env.local'), 'BIGCOMMERCE_STORE_HASH=local\n');
       await writeFileEnsured(
         join(tmpDir, '.env'),
-        'CATALYST_ACCESS_TOKEN=base\nAUTH_SECRET=base\n',
+        'BIGCOMMERCE_STORE_HASH=base\nAUTH_SECRET=base\n',
       );
 
       const d = collectDiagnostics({
         cwd: tmpDir,
-        env: { CATALYST_ACCESS_TOKEN: 'real' },
+        env: { BIGCOMMERCE_STOREFRONT_TOKEN: 'real' },
       });
 
-      // Present in all three — process.env is highest priority.
-      expect(d.config.accessToken).toEqual({ present: true, source: 'process.env' });
-      // Present in .env.local and .env — .env.local wins.
-      expect(d.config.cliEnvVars.CATALYST_ACCESS_TOKEN).toBe('process.env');
+      // Only in process.env.
+      expect(d.config.buildEnvVars.BIGCOMMERCE_STOREFRONT_TOKEN).toBe('process.env');
+      // In .env.local and .env — .env.local wins.
+      expect(d.config.buildEnvVars.BIGCOMMERCE_STORE_HASH).toBe('.env.local');
       // Only in .env.
       expect(d.config.buildEnvVars.AUTH_SECRET).toBe('.env');
     });

--- a/packages/catalyst/src/cli/lib/collect-diagnostics.spec.ts
+++ b/packages/catalyst/src/cli/lib/collect-diagnostics.spec.ts
@@ -1,0 +1,277 @@
+import { existsSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import PACKAGE_INFO from '../../../package.json';
+
+import { collectDiagnostics, REPORTED_ENV_VARS } from './collect-diagnostics';
+import { mkTempDir } from './mk-temp-dir';
+
+vi.mock('./telemetry', () => ({
+  getTelemetry: () => ({
+    correlationId: 'test-session-uuid',
+    isEnabled: () => false,
+  }),
+}));
+
+let tmpDir: string;
+let cleanup: () => Promise<void>;
+
+const writeFileEnsured = async (path: string, contents: string) => {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, contents);
+};
+
+const writeProjectJson = (cwd: string, value: unknown) =>
+  writeFileEnsured(join(cwd, '.bigcommerce', 'project.json'), JSON.stringify(value));
+
+const emptyEnv: NodeJS.ProcessEnv = {};
+
+beforeEach(async () => {
+  [tmpDir, cleanup] = await mkTempDir();
+});
+
+afterEach(async () => {
+  await cleanup();
+});
+
+describe('collectDiagnostics', () => {
+  test('reports CLI, runtime, and telemetry basics', () => {
+    const d = collectDiagnostics({ cwd: tmpDir, env: emptyEnv });
+
+    expect(d.cli.name).toBe('@bigcommerce/catalyst');
+    expect(d.cli.version).toBe(PACKAGE_INFO.version);
+    expect(d.runtime.node).toBe(process.version);
+    expect(d.runtime.platform).toBe(process.platform);
+    expect(d.runtime.arch).toBe(process.arch);
+    expect(typeof d.runtime.osRelease).toBe('string');
+    expect(['npm', 'pnpm', 'yarn', 'bun']).toContain(d.runtime.packageManager);
+    // Telemetry is stubbed by the global test setup.
+    expect(d.telemetry.correlationId).toBe('test-session-uuid');
+    expect(typeof d.telemetry.enabled).toBe('boolean');
+  });
+
+  test('empty project: everything unset/absent', () => {
+    const d = collectDiagnostics({ cwd: tmpDir, env: emptyEnv });
+
+    expect(d.project).toEqual({
+      cwd: tmpDir,
+      projectUuid: null,
+      isLinked: false,
+      isTransformed: false,
+      isFullySetUp: false,
+      hasMiddleware: false,
+      hasProxy: false,
+      hasOpenNextDep: false,
+    });
+    expect(d.config.storeHash).toEqual({ present: false, source: 'unset' });
+    expect(d.config.accessToken).toEqual({ present: false, source: 'unset' });
+    expect(d.config.projectUuid).toEqual({ present: false, source: 'unset' });
+    expect(d.config.projectJsonKeys).toEqual([]);
+    expect(d.config.storedEnvKeys).toEqual([]);
+    expect(Object.values(d.config.envVars).every((v) => !v)).toBe(true);
+    expect(Object.keys(d.config.envVars)).toEqual([...REPORTED_ENV_VARS]);
+    expect(d.files).toEqual({
+      '.env.local': false,
+      '.env': false,
+      '.bigcommerce/project.json': false,
+      '.bigcommerce/wrangler.jsonc': false,
+      '.open-next/': false,
+      'package.json': false,
+    });
+  });
+
+  test('config resolves from project.json, listing keys without values', async () => {
+    await writeProjectJson(tmpDir, {
+      projectUuid: 'uuid-from-file',
+      framework: 'catalyst',
+      storeHash: 'store-secret',
+      accessToken: 'token-secret',
+      env: { ZEBRA: 'z', ALPHA: 'a' },
+    });
+
+    const d = collectDiagnostics({ cwd: tmpDir, env: emptyEnv });
+
+    expect(d.project.projectUuid).toBe('uuid-from-file');
+    expect(d.config.storeHash).toEqual({ present: true, source: 'project.json' });
+    expect(d.config.accessToken).toEqual({ present: true, source: 'project.json' });
+    expect(d.config.projectUuid).toEqual({ present: true, source: 'project.json' });
+    expect(d.config.projectJsonKeys).toEqual([
+      'accessToken',
+      'env',
+      'framework',
+      'projectUuid',
+      'storeHash',
+    ]);
+    // Sorted, keys only.
+    expect(d.config.storedEnvKeys).toEqual(['ALPHA', 'ZEBRA']);
+  });
+
+  test('process.env wins over project.json for resolved source', async () => {
+    await writeProjectJson(tmpDir, {
+      storeHash: 'store-from-file',
+      accessToken: 'token-from-file',
+      projectUuid: 'uuid-from-file',
+    });
+
+    const d = collectDiagnostics({
+      cwd: tmpDir,
+      env: {
+        CATALYST_STORE_HASH: 'store-from-env',
+        CATALYST_ACCESS_TOKEN: 'token-from-env',
+        CATALYST_PROJECT_UUID: 'uuid-from-env',
+      },
+    });
+
+    expect(d.config.storeHash).toEqual({ present: true, source: 'process.env' });
+    expect(d.config.accessToken).toEqual({ present: true, source: 'process.env' });
+    expect(d.config.projectUuid).toEqual({ present: true, source: 'process.env' });
+  });
+
+  test('store hash falls back to the BIGCOMMERCE_STORE_HASH alias', () => {
+    const d = collectDiagnostics({
+      cwd: tmpDir,
+      env: { BIGCOMMERCE_STORE_HASH: 'aliased-store' },
+    });
+
+    expect(d.config.storeHash).toEqual({ present: true, source: 'process.env' });
+  });
+
+  test('whitespace-only values are treated as unset', () => {
+    const d = collectDiagnostics({
+      cwd: tmpDir,
+      env: { CATALYST_STORE_HASH: '   ', AUTH_SECRET: '\t' },
+    });
+
+    expect(d.config.storeHash).toEqual({ present: false, source: 'unset' });
+    expect(d.config.envVars.AUTH_SECRET).toBe(false);
+  });
+
+  test('reports each env var by presence only', () => {
+    const d = collectDiagnostics({
+      cwd: tmpDir,
+      env: { AUTH_SECRET: 'super-secret', BIGCOMMERCE_CHANNEL_ID: '1' },
+    });
+
+    expect(d.config.envVars.AUTH_SECRET).toBe(true);
+    expect(d.config.envVars.BIGCOMMERCE_CHANNEL_ID).toBe(true);
+    expect(d.config.envVars.BIGCOMMERCE_LOGIN_URL).toBe(false);
+  });
+
+  test('detects present files and directories', async () => {
+    await writeFileEnsured(join(tmpDir, '.env.local'), 'X=1');
+    await writeFileEnsured(join(tmpDir, '.env'), 'X=1');
+    await writeProjectJson(tmpDir, { projectUuid: 'x' });
+    await writeFileEnsured(join(tmpDir, '.bigcommerce', 'wrangler.jsonc'), '{}');
+    await mkdir(join(tmpDir, '.open-next'), { recursive: true });
+    await writeFileEnsured(join(tmpDir, 'package.json'), '{}');
+
+    const d = collectDiagnostics({ cwd: tmpDir, env: emptyEnv });
+
+    expect(d.files).toEqual({
+      '.env.local': true,
+      '.env': true,
+      '.bigcommerce/project.json': true,
+      '.bigcommerce/wrangler.jsonc': true,
+      '.open-next/': true,
+      'package.json': true,
+    });
+  });
+
+  test('non-string credential values in project.json are ignored', async () => {
+    await writeProjectJson(tmpDir, { storeHash: 123, accessToken: { nested: true } });
+
+    const d = collectDiagnostics({ cwd: tmpDir, env: emptyEnv });
+
+    expect(d.config.storeHash).toEqual({ present: false, source: 'unset' });
+    expect(d.config.accessToken).toEqual({ present: false, source: 'unset' });
+    // The keys are still reported as present, just without their values.
+    expect(d.config.projectJsonKeys).toEqual(['accessToken', 'storeHash']);
+  });
+
+  test.each([
+    ['malformed JSON', 'not json{'],
+    ['top-level null', 'null'],
+    ['top-level string', '"just a string"'],
+    ['top-level array', '[]'],
+  ])('treats %s in project.json as no config', async (_label, contents) => {
+    await writeFileEnsured(join(tmpDir, '.bigcommerce', 'project.json'), contents);
+
+    const d = collectDiagnostics({ cwd: tmpDir, env: emptyEnv });
+
+    expect(d.config.projectJsonKeys).toEqual([]);
+    expect(d.config.storedEnvKeys).toEqual([]);
+    expect(d.config.storeHash).toEqual({ present: false, source: 'unset' });
+  });
+
+  test.each([
+    ['non-object env', { env: 'nope' }],
+    ['null env', { env: null }],
+    ['array env', { env: [] }],
+    ['missing env', { projectUuid: 'x' }],
+  ])('storedEnvKeys is empty when project.json has %s', async (_label, value) => {
+    await writeProjectJson(tmpDir, value);
+
+    const d = collectDiagnostics({ cwd: tmpDir, env: emptyEnv });
+
+    expect(d.config.storedEnvKeys).toEqual([]);
+  });
+
+  test('does not create .bigcommerce/ as a side effect', () => {
+    collectDiagnostics({ cwd: tmpDir, env: emptyEnv });
+
+    expect(existsSync(join(tmpDir, '.bigcommerce'))).toBe(false);
+  });
+
+  test('defaults cwd and env to process values', () => {
+    // Exercises the default-parameter path (no options passed).
+    const d = collectDiagnostics();
+
+    expect(d.project.cwd).toBe(process.cwd());
+    expect(d.cli.name).toBe('@bigcommerce/catalyst');
+  });
+
+  describe('secret-masking guarantee', () => {
+    test('no secret value appears anywhere in the report', async () => {
+      const secrets = {
+        storeHash: 'STORE_HASH_SECRET_VALUE',
+        accessToken: 'ACCESS_TOKEN_SECRET_VALUE',
+        env: {
+          STOREFRONT_TOKEN: 'STOREFRONT_TOKEN_SECRET_VALUE',
+          DB_PASSWORD: 'DB_PASSWORD_SECRET_VALUE',
+        },
+      };
+
+      await writeProjectJson(tmpDir, { projectUuid: 'uuid-x', framework: 'catalyst', ...secrets });
+
+      const env: NodeJS.ProcessEnv = {
+        CATALYST_STORE_HASH: 'ENV_STORE_HASH_SECRET',
+        CATALYST_ACCESS_TOKEN: 'ENV_ACCESS_TOKEN_SECRET',
+        BIGCOMMERCE_STOREFRONT_TOKEN: 'ENV_STOREFRONT_TOKEN_SECRET',
+        AUTH_SECRET: 'ENV_AUTH_SECRET_VALUE',
+      };
+
+      const serialized = JSON.stringify(collectDiagnostics({ cwd: tmpDir, env }));
+
+      const leaked = [
+        secrets.storeHash,
+        secrets.accessToken,
+        secrets.env.STOREFRONT_TOKEN,
+        secrets.env.DB_PASSWORD,
+        env.CATALYST_STORE_HASH,
+        env.CATALYST_ACCESS_TOKEN,
+        env.BIGCOMMERCE_STOREFRONT_TOKEN,
+        env.AUTH_SECRET,
+      ];
+
+      leaked.forEach((value) => {
+        expect(serialized).not.toContain(value);
+      });
+
+      // Key names (not values) are still surfaced so support knows what's set.
+      expect(serialized).toContain('STOREFRONT_TOKEN');
+      expect(serialized).toContain('DB_PASSWORD');
+    });
+  });
+});

--- a/packages/catalyst/src/cli/lib/collect-diagnostics.spec.ts
+++ b/packages/catalyst/src/cli/lib/collect-diagnostics.spec.ts
@@ -70,6 +70,7 @@ describe('collectDiagnostics', () => {
     expect(d.config.storeHash).toEqual({ present: false, source: 'unset' });
     expect(d.config.accessToken).toEqual({ present: false, source: 'unset' });
     expect(d.config.projectUuid).toEqual({ present: false, source: 'unset' });
+    expect(d.config.apiHost).toEqual({ present: false, source: 'unset' });
     expect(d.config.projectJsonKeys).toEqual([]);
     expect(d.config.storedEnvKeys).toEqual([]);
     expect(Object.keys(d.config.cliEnvVars)).toEqual([...CLI_ENV_VARS]);
@@ -92,6 +93,7 @@ describe('collectDiagnostics', () => {
       framework: 'catalyst',
       storeHash: 'store-secret',
       accessToken: 'token-secret',
+      apiHost: 'api.example.com',
       env: { ZEBRA: 'z', ALPHA: 'a' },
     });
 
@@ -101,8 +103,10 @@ describe('collectDiagnostics', () => {
     expect(d.config.storeHash).toEqual({ present: true, source: 'project.json' });
     expect(d.config.accessToken).toEqual({ present: true, source: 'project.json' });
     expect(d.config.projectUuid).toEqual({ present: true, source: 'project.json' });
+    expect(d.config.apiHost).toEqual({ present: true, source: 'project.json' });
     expect(d.config.projectJsonKeys).toEqual([
       'accessToken',
+      'apiHost',
       'env',
       'framework',
       'projectUuid',
@@ -110,6 +114,16 @@ describe('collectDiagnostics', () => {
     ]);
     // Sorted, keys only.
     expect(d.config.storedEnvKeys).toEqual(['ALPHA', 'ZEBRA']);
+  });
+
+  test('resolves the API host from CATALYST_API_HOST', () => {
+    const d = collectDiagnostics({
+      cwd: tmpDir,
+      env: { CATALYST_API_HOST: 'api.staging.example.com' },
+    });
+
+    expect(d.config.apiHost).toEqual({ present: true, source: 'process.env' });
+    expect(d.config.cliEnvVars.CATALYST_API_HOST).toBe('process.env');
   });
 
   test('process.env wins over project.json for resolved source', async () => {

--- a/packages/catalyst/src/cli/lib/collect-diagnostics.spec.ts
+++ b/packages/catalyst/src/cli/lib/collect-diagnostics.spec.ts
@@ -70,7 +70,7 @@ describe('collectDiagnostics', () => {
     expect(d.config.projectUuid).toEqual({ present: false, source: 'unset' });
     expect(d.config.projectJsonKeys).toEqual([]);
     expect(d.config.storedEnvKeys).toEqual([]);
-    expect(Object.values(d.config.envVars).every((v) => !v)).toBe(true);
+    expect(Object.values(d.config.envVars).every((v) => v === 'unset')).toBe(true);
     expect(Object.keys(d.config.envVars)).toEqual([...REPORTED_ENV_VARS]);
     expect(d.files).toEqual({
       '.env.local': false,
@@ -145,18 +145,88 @@ describe('collectDiagnostics', () => {
     });
 
     expect(d.config.storeHash).toEqual({ present: false, source: 'unset' });
-    expect(d.config.envVars.AUTH_SECRET).toBe(false);
+    expect(d.config.envVars.AUTH_SECRET).toBe('unset');
   });
 
-  test('reports each env var by presence only', () => {
+  test('reports each env var by source only (never the value)', () => {
     const d = collectDiagnostics({
       cwd: tmpDir,
       env: { AUTH_SECRET: 'super-secret', BIGCOMMERCE_CHANNEL_ID: '1' },
     });
 
-    expect(d.config.envVars.AUTH_SECRET).toBe(true);
-    expect(d.config.envVars.BIGCOMMERCE_CHANNEL_ID).toBe(true);
-    expect(d.config.envVars.BIGCOMMERCE_LOGIN_URL).toBe(false);
+    expect(d.config.envVars.AUTH_SECRET).toBe('process.env');
+    expect(d.config.envVars.BIGCOMMERCE_CHANNEL_ID).toBe('process.env');
+    expect(d.config.envVars.BIGCOMMERCE_LOGIN_URL).toBe('unset');
+  });
+
+  describe('env files (.env.local / .env)', () => {
+    test('resolves env vars and credentials from .env.local without loading them', async () => {
+      await writeFileEnsured(
+        join(tmpDir, '.env.local'),
+        'CATALYST_STORE_HASH=fromlocal\nBIGCOMMERCE_CHANNEL_ID=42\n',
+      );
+
+      const d = collectDiagnostics({ cwd: tmpDir, env: emptyEnv });
+
+      expect(d.config.envVars.CATALYST_STORE_HASH).toBe('.env.local');
+      expect(d.config.envVars.BIGCOMMERCE_CHANNEL_ID).toBe('.env.local');
+      expect(d.config.storeHash).toEqual({ present: true, source: '.env.local' });
+      // Never leaked into the real environment.
+      expect(process.env.CATALYST_STORE_HASH).toBeUndefined();
+    });
+
+    test('process.env wins over .env.local, which wins over .env', async () => {
+      await writeFileEnsured(join(tmpDir, '.env.local'), 'CATALYST_ACCESS_TOKEN=local\n');
+      await writeFileEnsured(
+        join(tmpDir, '.env'),
+        'CATALYST_ACCESS_TOKEN=base\nAUTH_SECRET=base\n',
+      );
+
+      const d = collectDiagnostics({
+        cwd: tmpDir,
+        env: { CATALYST_ACCESS_TOKEN: 'real' },
+      });
+
+      // Present in all three — process.env is highest priority.
+      expect(d.config.accessToken).toEqual({ present: true, source: 'process.env' });
+      // Present in .env.local and .env — .env.local wins.
+      expect(d.config.envVars.CATALYST_ACCESS_TOKEN).toBe('process.env');
+      // Only in .env.
+      expect(d.config.envVars.AUTH_SECRET).toBe('.env');
+    });
+
+    test('a malformed/unreadable env file does not break the report', async () => {
+      // A directory named .env.local makes readFileSync throw — the layer is
+      // skipped rather than crashing.
+      await mkdir(join(tmpDir, '.env.local'), { recursive: true });
+
+      const d = collectDiagnostics({ cwd: tmpDir, env: { AUTH_SECRET: 'x' } });
+
+      expect(d.config.envVars.AUTH_SECRET).toBe('process.env');
+      expect(d.files['.env.local']).toBe(true);
+    });
+  });
+
+  describe('project package manager detection', () => {
+    test.each([
+      ['pnpm-lock.yaml', 'pnpm'],
+      ['yarn.lock', 'yarn'],
+      ['bun.lock', 'bun'],
+      ['bun.lockb', 'bun'],
+      ['package-lock.json', 'npm'],
+    ])('detects %s -> %s', async (lockfile, expected) => {
+      await writeFileEnsured(join(tmpDir, lockfile), '');
+
+      expect(collectDiagnostics({ cwd: tmpDir, env: emptyEnv }).runtime.packageManager).toBe(
+        expected,
+      );
+    });
+
+    test('falls back to the invoking package manager when no lockfile exists', () => {
+      const d = collectDiagnostics({ cwd: tmpDir, env: emptyEnv });
+
+      expect(['npm', 'pnpm', 'yarn', 'bun']).toContain(d.runtime.packageManager);
+    });
   });
 
   test('detects present files and directories', async () => {

--- a/packages/catalyst/src/cli/lib/collect-diagnostics.spec.ts
+++ b/packages/catalyst/src/cli/lib/collect-diagnostics.spec.ts
@@ -247,6 +247,18 @@ describe('collectDiagnostics', () => {
       );
     });
 
+    test('finds a lockfile in an ancestor directory (run from a subdirectory)', async () => {
+      await writeFileEnsured(join(tmpDir, 'pnpm-lock.yaml'), '');
+
+      const nested = join(tmpDir, 'apps', 'storefront');
+
+      await mkdir(nested, { recursive: true });
+
+      expect(collectDiagnostics({ cwd: nested, env: emptyEnv }).runtime.packageManager).toBe(
+        'pnpm',
+      );
+    });
+
     test('falls back to the invoking package manager when no lockfile exists', () => {
       const d = collectDiagnostics({ cwd: tmpDir, env: emptyEnv });
 

--- a/packages/catalyst/src/cli/lib/collect-diagnostics.spec.ts
+++ b/packages/catalyst/src/cli/lib/collect-diagnostics.spec.ts
@@ -57,6 +57,8 @@ describe('collectDiagnostics', () => {
 
     expect(d.project).toEqual({
       cwd: tmpDir,
+      coreName: null,
+      coreVersion: null,
       projectUuid: null,
       isLinked: false,
       isTransformed: false,
@@ -226,6 +228,55 @@ describe('collectDiagnostics', () => {
       const d = collectDiagnostics({ cwd: tmpDir, env: emptyEnv });
 
       expect(['npm', 'pnpm', 'yarn', 'bun']).toContain(d.runtime.packageManager);
+    });
+  });
+
+  describe('Catalyst core version', () => {
+    const writePackageJson = (value: unknown) =>
+      writeFileEnsured(join(tmpDir, 'package.json'), JSON.stringify(value));
+
+    test('reads name and version from package.json', async () => {
+      await writePackageJson({ name: '@bigcommerce/catalyst-core', version: '1.8.0' });
+
+      const d = collectDiagnostics({ cwd: tmpDir, env: emptyEnv });
+
+      expect(d.project.coreName).toBe('@bigcommerce/catalyst-core');
+      expect(d.project.coreVersion).toBe('1.8.0');
+    });
+
+    test('prefers catalyst.version over the plain version', async () => {
+      await writePackageJson({
+        name: '@bigcommerce/catalyst-core',
+        version: '0.0.0',
+        catalyst: { version: '1.9.1', ref: '@bigcommerce/catalyst-core@1.9.1' },
+      });
+
+      expect(collectDiagnostics({ cwd: tmpDir, env: emptyEnv }).project.coreVersion).toBe('1.9.1');
+    });
+
+    test('null when package.json is absent', () => {
+      const d = collectDiagnostics({ cwd: tmpDir, env: emptyEnv });
+
+      expect(d.project.coreName).toBeNull();
+      expect(d.project.coreVersion).toBeNull();
+    });
+
+    test('null version when package.json has no version field', async () => {
+      await writePackageJson({ name: 'some-project' });
+
+      const d = collectDiagnostics({ cwd: tmpDir, env: emptyEnv });
+
+      expect(d.project.coreName).toBe('some-project');
+      expect(d.project.coreVersion).toBeNull();
+    });
+
+    test('null when package.json is malformed', async () => {
+      await writeFileEnsured(join(tmpDir, 'package.json'), '{not json');
+
+      const d = collectDiagnostics({ cwd: tmpDir, env: emptyEnv });
+
+      expect(d.project.coreName).toBeNull();
+      expect(d.project.coreVersion).toBeNull();
     });
   });
 

--- a/packages/catalyst/src/cli/lib/collect-diagnostics.ts
+++ b/packages/catalyst/src/cli/lib/collect-diagnostics.ts
@@ -74,10 +74,11 @@ export interface Diagnostics {
   };
   project: {
     cwd: string;
-    // The storefront (Catalyst core) package name + version from the project's
-    // package.json, resolved the same way `upgrade` does. null when absent.
-    coreName: string | null;
-    coreVersion: string | null;
+    // The storefront package name + version from the project's package.json,
+    // resolved the same way `upgrade` does. `name` identifies the Catalyst
+    // family (catalyst-core, catalyst-makeswift, …). null when absent.
+    storefrontName: string | null;
+    storefrontVersion: string | null;
     projectUuid: string | null;
     isLinked: boolean;
     isTransformed: boolean;
@@ -215,17 +216,17 @@ const readProjectJson = (cwd: string): Record<string, unknown> | null => {
   return result.success ? result.data : null;
 };
 
-// Mirrors upgrade.ts: `catalyst.version` is the source of truth for the core
-// version, falling back to the plain `version`. `name` identifies which
-// Catalyst family the project is on (e.g. @bigcommerce/catalyst-core).
-const corePackageSchema = z.looseObject({
+// Mirrors upgrade.ts: `catalyst.version` is the source of truth for the
+// storefront version, falling back to the plain `version`. `name` identifies
+// which Catalyst family the project is on (e.g. @bigcommerce/catalyst-core).
+const storefrontPackageSchema = z.looseObject({
   name: z.string().optional(),
   version: z.string().optional(),
   catalyst: z.looseObject({ version: z.string().optional() }).optional(),
 });
 
-const readCoreInfo = (cwd: string): { name: string | null; version: string | null } => {
-  const result = corePackageSchema.safeParse(safeReadJson(join(cwd, 'package.json')));
+const readStorefrontInfo = (cwd: string): { name: string | null; version: string | null } => {
+  const result = storefrontPackageSchema.safeParse(safeReadJson(join(cwd, 'package.json')));
 
   if (!result.success) {
     return { name: null, version: null };
@@ -258,7 +259,7 @@ export function collectDiagnostics({
   const telemetry = getTelemetry();
   const projectJson = readProjectJson(cwd);
   const envLayers = buildEnvLayers(cwd, env);
-  const core = readCoreInfo(cwd);
+  const storefront = readStorefrontInfo(cwd);
 
   return {
     cli: {
@@ -274,8 +275,8 @@ export function collectDiagnostics({
     },
     project: {
       cwd,
-      coreName: core.name,
-      coreVersion: core.version,
+      storefrontName: storefront.name,
+      storefrontVersion: storefront.version,
       projectUuid: state.projectUuid ?? null,
       isLinked: state.isLinked,
       isTransformed: state.isTransformed,

--- a/packages/catalyst/src/cli/lib/collect-diagnostics.ts
+++ b/packages/catalyst/src/cli/lib/collect-diagnostics.ts
@@ -1,7 +1,7 @@
 import { parse } from 'dotenv';
 import { existsSync, readFileSync } from 'node:fs';
 import { release } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { z } from 'zod';
 
 import PACKAGE_INFO from '../../../package.json';
@@ -183,12 +183,32 @@ const resolveValue = (
 const asString = (value: unknown): string | undefined =>
   typeof value === 'string' ? value : undefined;
 
-// Detect the project's package manager from its lockfile, falling back to the
-// manager that invoked the CLI when no lockfile is present.
-const detectProjectPackageManager = (cwd: string): PackageManager => {
-  const match = PROJECT_LOCKFILES.find(([file]) => existsSync(join(cwd, file)));
+const lockfileManager = (dir: string): PackageManager | undefined =>
+  PROJECT_LOCKFILES.find(([file]) => existsSync(join(dir, file)))?.[1];
 
-  return match ? match[1] : detectPackageManager();
+// Detect the project's package manager from the nearest lockfile, walking up
+// from cwd so it still works when the CLI is run from a subdirectory (e.g.
+// `core/` in a monorepo, where the lockfile lives at the repo root). Falls back
+// to the manager that invoked the CLI when no lockfile is found anywhere.
+const detectProjectPackageManager = (cwd: string): PackageManager => {
+  let dir = cwd;
+
+  for (;;) {
+    const match = lockfileManager(dir);
+
+    if (match) {
+      return match;
+    }
+
+    const parent = dirname(dir);
+
+    if (parent === dir) {
+      // Reached the filesystem root without finding a lockfile.
+      return detectPackageManager();
+    }
+
+    dir = parent;
+  }
 };
 
 // An open object schema: known credential fields plus any other keys the file

--- a/packages/catalyst/src/cli/lib/collect-diagnostics.ts
+++ b/packages/catalyst/src/cli/lib/collect-diagnostics.ts
@@ -18,7 +18,7 @@ export const CLI_ENV_VARS = [
   'CATALYST_STORE_HASH',
   'CATALYST_ACCESS_TOKEN',
   'CATALYST_PROJECT_UUID',
-  'BIGCOMMERCE_API_HOST',
+  'CATALYST_API_HOST',
   'BIGCOMMERCE_LOGIN_URL',
   'CATALYST_TELEMETRY_DISABLED',
 ] as const;
@@ -90,6 +90,9 @@ export interface Diagnostics {
     storeHash: ResolvedValue;
     accessToken: ResolvedValue;
     projectUuid: ResolvedValue;
+    // The API host override. 'unset' means the CLI falls back to its default
+    // (api.bigcommerce.com). Resolved like the credentials above.
+    apiHost: ResolvedValue;
     // Top-level keys present in .bigcommerce/project.json (names only — values
     // are never included so masked secrets like accessToken can't leak).
     projectJsonKeys: string[];
@@ -293,6 +296,10 @@ export function collectDiagnostics({
       projectUuid: resolveValue(
         resolveEnvSource(envLayers, 'CATALYST_PROJECT_UUID'),
         asString(projectJson?.projectUuid),
+      ),
+      apiHost: resolveValue(
+        resolveEnvSource(envLayers, 'CATALYST_API_HOST'),
+        asString(projectJson?.apiHost),
       ),
       projectJsonKeys: projectJson ? Object.keys(projectJson).sort() : [],
       storedEnvKeys: readStoredEnvKeys(projectJson),

--- a/packages/catalyst/src/cli/lib/collect-diagnostics.ts
+++ b/packages/catalyst/src/cli/lib/collect-diagnostics.ts
@@ -10,21 +10,27 @@ import { detectPackageManager, type PackageManager } from './detect-package-mana
 import { getProjectState } from './project-state';
 import { getTelemetry } from './telemetry';
 
-// Env vars the CLI reads (see the config-priority chain in program.ts and
-// required-build-env.ts). We report only WHERE each is set (or that it is
-// unset) — never its value — so the diagnostic report can never leak a token,
-// secret, or store identifier.
-export const REPORTED_ENV_VARS = [
+// Env vars the CLI itself reads to run commands (credential/flag bindings in
+// shared-options.ts plus the telemetry opt-out). We report only WHERE each is
+// set (or that it is unset) — never its value — so the report can never leak a
+// token, secret, or store identifier.
+export const CLI_ENV_VARS = [
   'CATALYST_STORE_HASH',
-  'BIGCOMMERCE_STORE_HASH',
   'CATALYST_ACCESS_TOKEN',
   'CATALYST_PROJECT_UUID',
   'BIGCOMMERCE_API_HOST',
   'BIGCOMMERCE_LOGIN_URL',
+  'CATALYST_TELEMETRY_DISABLED',
+] as const;
+
+// Env vars the storefront (Next.js app) build reads, not the CLI. Mirrors
+// REQUIRED_BUILD_ENV_VARS in required-build-env.ts — the values `build`/`deploy`
+// assert on before shelling out to the OpenNext/Next.js build.
+export const BUILD_ENV_VARS = [
+  'BIGCOMMERCE_STORE_HASH',
   'BIGCOMMERCE_STOREFRONT_TOKEN',
   'BIGCOMMERCE_CHANNEL_ID',
   'AUTH_SECRET',
-  'CATALYST_TELEMETRY_DISABLED',
 ] as const;
 
 // Env files `build`/`deploy` auto-load, in precedence order (see build-env.ts).
@@ -89,9 +95,11 @@ export interface Diagnostics {
     projectJsonKeys: string[];
     // Names of persisted deployment env vars (project.json `env` map keys only).
     storedEnvKeys: string[];
-    // Reported env var name -> where it resolved from ('unset' if nowhere).
-    // The value is never included, only the source.
-    envVars: Record<string, ConfigSource>;
+    // Env var name -> where it resolved from ('unset' if nowhere), split by
+    // consumer: `cliEnvVars` are read by the CLI, `buildEnvVars` by the Next.js
+    // app build. The value is never included, only the source.
+    cliEnvVars: Record<string, ConfigSource>;
+    buildEnvVars: Record<string, ConfigSource>;
   };
   telemetry: {
     enabled: boolean;
@@ -143,6 +151,13 @@ const buildEnvLayers = (cwd: string, env: NodeJS.ProcessEnv): EnvLayer[] => {
 // value for any of the given keys. Returns only the source — never a value.
 const resolveEnvSource = (layers: EnvLayer[], ...keys: string[]): EnvSource | undefined =>
   layers.find((layer) => keys.some((key) => hasValue(layer.values[key])))?.source;
+
+// Map each named var to the layer it resolves from (or 'unset'), values omitted.
+const resolveEnvVars = (
+  layers: EnvLayer[],
+  names: readonly string[],
+): Record<string, ConfigSource> =>
+  Object.fromEntries(names.map((name) => [name, resolveEnvSource(layers, name) ?? 'unset']));
 
 // Resolve which source (if any) supplies a credential, without exposing the
 // value itself. Env layers win over project.json, matching build/deploy.
@@ -281,9 +296,8 @@ export function collectDiagnostics({
       ),
       projectJsonKeys: projectJson ? Object.keys(projectJson).sort() : [],
       storedEnvKeys: readStoredEnvKeys(projectJson),
-      envVars: Object.fromEntries(
-        REPORTED_ENV_VARS.map((name) => [name, resolveEnvSource(envLayers, name) ?? 'unset']),
-      ),
+      cliEnvVars: resolveEnvVars(envLayers, CLI_ENV_VARS),
+      buildEnvVars: resolveEnvVars(envLayers, BUILD_ENV_VARS),
     },
     telemetry: {
       enabled: telemetry.isEnabled(),

--- a/packages/catalyst/src/cli/lib/collect-diagnostics.ts
+++ b/packages/catalyst/src/cli/lib/collect-diagnostics.ts
@@ -1,3 +1,4 @@
+import { parse } from 'dotenv';
 import { existsSync, readFileSync } from 'node:fs';
 import { release } from 'node:os';
 import { join } from 'node:path';
@@ -10,8 +11,9 @@ import { getProjectState } from './project-state';
 import { getTelemetry } from './telemetry';
 
 // Env vars the CLI reads (see the config-priority chain in program.ts and
-// required-build-env.ts). We report only whether each is SET — never its value —
-// so the diagnostic report can never leak a token, secret, or store identifier.
+// required-build-env.ts). We report only WHERE each is set (or that it is
+// unset) — never its value — so the diagnostic report can never leak a token,
+// secret, or store identifier.
 export const REPORTED_ENV_VARS = [
   'CATALYST_STORE_HASH',
   'BIGCOMMERCE_STORE_HASH',
@@ -25,10 +27,27 @@ export const REPORTED_ENV_VARS = [
   'CATALYST_TELEMETRY_DISABLED',
 ] as const;
 
-// Where a resolved config value came from, following the CLI's priority chain
-// (process.env > .bigcommerce/project.json). Flags are excluded because `debug`
-// takes none of the credential flags itself.
-export type ConfigSource = 'process.env' | 'project.json' | 'unset';
+// Env files `build`/`deploy` auto-load, in precedence order (see build-env.ts).
+// `debug` doesn't load them into process.env — it only inspects their KEYS so
+// the report reflects what a build would resolve, without side effects.
+const ENV_FILES = ['.env.local', '.env'] as const;
+
+// Lockfile -> package manager, checked in this order. This detects the
+// project's package manager (what `build`/`deploy` shell out to) rather than
+// whatever invoked the CLI, which is what a bug report actually needs.
+const PROJECT_LOCKFILES: ReadonlyArray<readonly [string, PackageManager]> = [
+  ['pnpm-lock.yaml', 'pnpm'],
+  ['yarn.lock', 'yarn'],
+  ['bun.lock', 'bun'],
+  ['bun.lockb', 'bun'],
+  ['package-lock.json', 'npm'],
+];
+
+// Where a value resolved from, following the CLI's priority chain
+// (process.env > .env.local > .env > .bigcommerce/project.json). Flags are
+// excluded because `debug` takes none of the credential flags itself.
+export type EnvSource = 'process.env' | (typeof ENV_FILES)[number];
+export type ConfigSource = EnvSource | 'project.json' | 'unset';
 
 export interface ResolvedValue {
   present: boolean;
@@ -66,8 +85,9 @@ export interface Diagnostics {
     projectJsonKeys: string[];
     // Names of persisted deployment env vars (project.json `env` map keys only).
     storedEnvKeys: string[];
-    // Reported env var name -> whether it is set (never the value).
-    envVars: Record<string, boolean>;
+    // Reported env var name -> where it resolved from ('unset' if nowhere).
+    // The value is never included, only the source.
+    envVars: Record<string, ConfigSource>;
   };
   telemetry: {
     enabled: boolean;
@@ -87,14 +107,47 @@ export interface CollectDiagnosticsOptions {
 // mirroring how the build treats "" the same as unset (see required-build-env.ts).
 const hasValue = (value: string | undefined): boolean => value !== undefined && value.trim() !== '';
 
+interface EnvLayer {
+  source: EnvSource;
+  values: Record<string, string | undefined>;
+}
+
+// Build the ordered env layers the CLI resolves against: the real environment
+// first, then the auto-loaded env files. File values are parsed into memory
+// only to detect presence — they are never surfaced in the report.
+const buildEnvLayers = (cwd: string, env: NodeJS.ProcessEnv): EnvLayer[] => {
+  const layers: EnvLayer[] = [{ source: 'process.env', values: env }];
+
+  ENV_FILES.forEach((file) => {
+    const path = join(cwd, file);
+
+    if (!existsSync(path)) {
+      return;
+    }
+
+    try {
+      layers.push({ source: file, values: parse(readFileSync(path, 'utf-8')) });
+    } catch {
+      // A malformed/unreadable env file shouldn't break the report.
+    }
+  });
+
+  return layers;
+};
+
+// The first layer (process.env > .env.local > .env) that carries a non-empty
+// value for any of the given keys. Returns only the source — never a value.
+const resolveEnvSource = (layers: EnvLayer[], ...keys: string[]): EnvSource | undefined =>
+  layers.find((layer) => keys.some((key) => hasValue(layer.values[key])))?.source;
+
 // Resolve which source (if any) supplies a credential, without exposing the
-// value itself. process.env wins over project.json, matching program.ts.
+// value itself. Env layers win over project.json, matching build/deploy.
 const resolveValue = (
-  envValue: string | undefined,
+  envSource: EnvSource | undefined,
   configValue: string | undefined,
 ): ResolvedValue => {
-  if (hasValue(envValue)) {
-    return { present: true, source: 'process.env' };
+  if (envSource) {
+    return { present: true, source: envSource };
   }
 
   if (hasValue(configValue)) {
@@ -106,6 +159,14 @@ const resolveValue = (
 
 const asString = (value: unknown): string | undefined =>
   typeof value === 'string' ? value : undefined;
+
+// Detect the project's package manager from its lockfile, falling back to the
+// manager that invoked the CLI when no lockfile is present.
+const detectProjectPackageManager = (cwd: string): PackageManager => {
+  const match = PROJECT_LOCKFILES.find(([file]) => existsSync(join(cwd, file)));
+
+  return match ? match[1] : detectPackageManager();
+};
 
 // An open object schema: known credential fields plus any other keys the file
 // may carry, all kept as `unknown` so we can enumerate key names without
@@ -152,8 +213,7 @@ export function collectDiagnostics({
   const state = getProjectState(cwd);
   const telemetry = getTelemetry();
   const projectJson = readProjectJson(cwd);
-
-  const storeHashEnv = env.CATALYST_STORE_HASH ?? env.BIGCOMMERCE_STORE_HASH;
+  const envLayers = buildEnvLayers(cwd, env);
 
   return {
     cli: {
@@ -165,7 +225,7 @@ export function collectDiagnostics({
       platform: process.platform,
       arch: process.arch,
       osRelease: release(),
-      packageManager: detectPackageManager(),
+      packageManager: detectProjectPackageManager(cwd),
     },
     project: {
       cwd,
@@ -178,12 +238,23 @@ export function collectDiagnostics({
       hasOpenNextDep: state.hasOpenNextDep,
     },
     config: {
-      storeHash: resolveValue(storeHashEnv, asString(projectJson?.storeHash)),
-      accessToken: resolveValue(env.CATALYST_ACCESS_TOKEN, asString(projectJson?.accessToken)),
-      projectUuid: resolveValue(env.CATALYST_PROJECT_UUID, asString(projectJson?.projectUuid)),
+      storeHash: resolveValue(
+        resolveEnvSource(envLayers, 'CATALYST_STORE_HASH', 'BIGCOMMERCE_STORE_HASH'),
+        asString(projectJson?.storeHash),
+      ),
+      accessToken: resolveValue(
+        resolveEnvSource(envLayers, 'CATALYST_ACCESS_TOKEN'),
+        asString(projectJson?.accessToken),
+      ),
+      projectUuid: resolveValue(
+        resolveEnvSource(envLayers, 'CATALYST_PROJECT_UUID'),
+        asString(projectJson?.projectUuid),
+      ),
       projectJsonKeys: projectJson ? Object.keys(projectJson).sort() : [],
       storedEnvKeys: readStoredEnvKeys(projectJson),
-      envVars: Object.fromEntries(REPORTED_ENV_VARS.map((name) => [name, hasValue(env[name])])),
+      envVars: Object.fromEntries(
+        REPORTED_ENV_VARS.map((name) => [name, resolveEnvSource(envLayers, name) ?? 'unset']),
+      ),
     },
     telemetry: {
       enabled: telemetry.isEnabled(),

--- a/packages/catalyst/src/cli/lib/collect-diagnostics.ts
+++ b/packages/catalyst/src/cli/lib/collect-diagnostics.ts
@@ -1,0 +1,201 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { release } from 'node:os';
+import { join } from 'node:path';
+import { z } from 'zod';
+
+import PACKAGE_INFO from '../../../package.json';
+
+import { detectPackageManager, type PackageManager } from './detect-package-manager';
+import { getProjectState } from './project-state';
+import { getTelemetry } from './telemetry';
+
+// Env vars the CLI reads (see the config-priority chain in program.ts and
+// required-build-env.ts). We report only whether each is SET — never its value —
+// so the diagnostic report can never leak a token, secret, or store identifier.
+export const REPORTED_ENV_VARS = [
+  'CATALYST_STORE_HASH',
+  'BIGCOMMERCE_STORE_HASH',
+  'CATALYST_ACCESS_TOKEN',
+  'CATALYST_PROJECT_UUID',
+  'BIGCOMMERCE_API_HOST',
+  'BIGCOMMERCE_LOGIN_URL',
+  'BIGCOMMERCE_STOREFRONT_TOKEN',
+  'BIGCOMMERCE_CHANNEL_ID',
+  'AUTH_SECRET',
+  'CATALYST_TELEMETRY_DISABLED',
+] as const;
+
+// Where a resolved config value came from, following the CLI's priority chain
+// (process.env > .bigcommerce/project.json). Flags are excluded because `debug`
+// takes none of the credential flags itself.
+export type ConfigSource = 'process.env' | 'project.json' | 'unset';
+
+export interface ResolvedValue {
+  present: boolean;
+  source: ConfigSource;
+}
+
+export interface Diagnostics {
+  cli: {
+    name: string;
+    version: string;
+  };
+  runtime: {
+    node: string;
+    platform: string;
+    arch: string;
+    osRelease: string;
+    packageManager: PackageManager;
+  };
+  project: {
+    cwd: string;
+    projectUuid: string | null;
+    isLinked: boolean;
+    isTransformed: boolean;
+    isFullySetUp: boolean;
+    hasMiddleware: boolean;
+    hasProxy: boolean;
+    hasOpenNextDep: boolean;
+  };
+  config: {
+    storeHash: ResolvedValue;
+    accessToken: ResolvedValue;
+    projectUuid: ResolvedValue;
+    // Top-level keys present in .bigcommerce/project.json (names only — values
+    // are never included so masked secrets like accessToken can't leak).
+    projectJsonKeys: string[];
+    // Names of persisted deployment env vars (project.json `env` map keys only).
+    storedEnvKeys: string[];
+    // Reported env var name -> whether it is set (never the value).
+    envVars: Record<string, boolean>;
+  };
+  telemetry: {
+    enabled: boolean;
+    correlationId: string;
+  };
+  // Relative path -> whether the file/directory exists on disk. Presence only;
+  // contents are never read into the report.
+  files: Record<string, boolean>;
+}
+
+export interface CollectDiagnosticsOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+// A value counts as present only when it is a non-empty, non-whitespace string —
+// mirroring how the build treats "" the same as unset (see required-build-env.ts).
+const hasValue = (value: string | undefined): boolean => value !== undefined && value.trim() !== '';
+
+// Resolve which source (if any) supplies a credential, without exposing the
+// value itself. process.env wins over project.json, matching program.ts.
+const resolveValue = (
+  envValue: string | undefined,
+  configValue: string | undefined,
+): ResolvedValue => {
+  if (hasValue(envValue)) {
+    return { present: true, source: 'process.env' };
+  }
+
+  if (hasValue(configValue)) {
+    return { present: true, source: 'project.json' };
+  }
+
+  return { present: false, source: 'unset' };
+};
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === 'string' ? value : undefined;
+
+// An open object schema: known credential fields plus any other keys the file
+// may carry, all kept as `unknown` so we can enumerate key names without
+// coercing (or trusting the type of) their values.
+const projectJsonSchema = z.looseObject({});
+
+const safeReadJson = (path: string): unknown => {
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8'));
+  } catch {
+    return null;
+  }
+};
+
+// Read .bigcommerce/project.json as a raw object without going through
+// getProjectConfig() — that instantiates Conf and would create .bigcommerce/ as
+// a side effect (see project-state.ts). Returns null when absent, malformed, or
+// not a JSON object.
+const readProjectJson = (cwd: string): Record<string, unknown> | null => {
+  const result = projectJsonSchema.safeParse(
+    safeReadJson(join(cwd, '.bigcommerce', 'project.json')),
+  );
+
+  return result.success ? result.data : null;
+};
+
+const readStoredEnvKeys = (projectJson: Record<string, unknown> | null): string[] => {
+  const env = projectJson?.env;
+
+  if (typeof env === 'object' && env !== null && !Array.isArray(env)) {
+    return Object.keys(env).sort();
+  }
+
+  return [];
+};
+
+// Gather a diagnostic snapshot of the CLI, runtime, project, and config state.
+// By construction this never includes secret values — credentials are reported
+// as presence + source only, and file/env checks report existence only.
+export function collectDiagnostics({
+  cwd = process.cwd(),
+  env = process.env,
+}: CollectDiagnosticsOptions = {}): Diagnostics {
+  const state = getProjectState(cwd);
+  const telemetry = getTelemetry();
+  const projectJson = readProjectJson(cwd);
+
+  const storeHashEnv = env.CATALYST_STORE_HASH ?? env.BIGCOMMERCE_STORE_HASH;
+
+  return {
+    cli: {
+      name: PACKAGE_INFO.name,
+      version: PACKAGE_INFO.version,
+    },
+    runtime: {
+      node: process.version,
+      platform: process.platform,
+      arch: process.arch,
+      osRelease: release(),
+      packageManager: detectPackageManager(),
+    },
+    project: {
+      cwd,
+      projectUuid: state.projectUuid ?? null,
+      isLinked: state.isLinked,
+      isTransformed: state.isTransformed,
+      isFullySetUp: state.isFullySetUp,
+      hasMiddleware: state.hasMiddleware,
+      hasProxy: state.hasProxy,
+      hasOpenNextDep: state.hasOpenNextDep,
+    },
+    config: {
+      storeHash: resolveValue(storeHashEnv, asString(projectJson?.storeHash)),
+      accessToken: resolveValue(env.CATALYST_ACCESS_TOKEN, asString(projectJson?.accessToken)),
+      projectUuid: resolveValue(env.CATALYST_PROJECT_UUID, asString(projectJson?.projectUuid)),
+      projectJsonKeys: projectJson ? Object.keys(projectJson).sort() : [],
+      storedEnvKeys: readStoredEnvKeys(projectJson),
+      envVars: Object.fromEntries(REPORTED_ENV_VARS.map((name) => [name, hasValue(env[name])])),
+    },
+    telemetry: {
+      enabled: telemetry.isEnabled(),
+      correlationId: telemetry.correlationId,
+    },
+    files: {
+      '.env.local': existsSync(join(cwd, '.env.local')),
+      '.env': existsSync(join(cwd, '.env')),
+      '.bigcommerce/project.json': existsSync(join(cwd, '.bigcommerce', 'project.json')),
+      '.bigcommerce/wrangler.jsonc': existsSync(join(cwd, '.bigcommerce', 'wrangler.jsonc')),
+      '.open-next/': existsSync(join(cwd, '.open-next')),
+      'package.json': existsSync(join(cwd, 'package.json')),
+    },
+  };
+}

--- a/packages/catalyst/src/cli/lib/collect-diagnostics.ts
+++ b/packages/catalyst/src/cli/lib/collect-diagnostics.ts
@@ -278,8 +278,15 @@ export function collectDiagnostics({
   const state = getProjectState(cwd);
   const telemetry = getTelemetry();
   const projectJson = readProjectJson(cwd);
-  const envLayers = buildEnvLayers(cwd, env);
   const storefront = readStorefrontInfo(cwd);
+
+  // The CLI reads its own config only from the real environment (Commander
+  // `.env()` bindings) and .bigcommerce/project.json — never from .env files
+  // (see the note in program.ts). Only the storefront BUILD vars are loaded
+  // from .env.local/.env, and only by `build`/`deploy`, so only those are
+  // resolved across the file layers.
+  const cliEnv: EnvLayer[] = [{ source: 'process.env', values: env }];
+  const buildEnv = buildEnvLayers(cwd, env);
 
   return {
     cli: {
@@ -307,25 +314,25 @@ export function collectDiagnostics({
     },
     config: {
       storeHash: resolveValue(
-        resolveEnvSource(envLayers, 'CATALYST_STORE_HASH', 'BIGCOMMERCE_STORE_HASH'),
+        resolveEnvSource(cliEnv, 'CATALYST_STORE_HASH', 'BIGCOMMERCE_STORE_HASH'),
         asString(projectJson?.storeHash),
       ),
       accessToken: resolveValue(
-        resolveEnvSource(envLayers, 'CATALYST_ACCESS_TOKEN'),
+        resolveEnvSource(cliEnv, 'CATALYST_ACCESS_TOKEN'),
         asString(projectJson?.accessToken),
       ),
       projectUuid: resolveValue(
-        resolveEnvSource(envLayers, 'CATALYST_PROJECT_UUID'),
+        resolveEnvSource(cliEnv, 'CATALYST_PROJECT_UUID'),
         asString(projectJson?.projectUuid),
       ),
       apiHost: resolveValue(
-        resolveEnvSource(envLayers, 'CATALYST_API_HOST'),
+        resolveEnvSource(cliEnv, 'CATALYST_API_HOST'),
         asString(projectJson?.apiHost),
       ),
       projectJsonKeys: projectJson ? Object.keys(projectJson).sort() : [],
       storedEnvKeys: readStoredEnvKeys(projectJson),
-      cliEnvVars: resolveEnvVars(envLayers, CLI_ENV_VARS),
-      buildEnvVars: resolveEnvVars(envLayers, BUILD_ENV_VARS),
+      cliEnvVars: resolveEnvVars(cliEnv, CLI_ENV_VARS),
+      buildEnvVars: resolveEnvVars(buildEnv, BUILD_ENV_VARS),
     },
     telemetry: {
       enabled: telemetry.isEnabled(),

--- a/packages/catalyst/src/cli/lib/collect-diagnostics.ts
+++ b/packages/catalyst/src/cli/lib/collect-diagnostics.ts
@@ -68,6 +68,10 @@ export interface Diagnostics {
   };
   project: {
     cwd: string;
+    // The storefront (Catalyst core) package name + version from the project's
+    // package.json, resolved the same way `upgrade` does. null when absent.
+    coreName: string | null;
+    coreVersion: string | null;
     projectUuid: string | null;
     isLinked: boolean;
     isTransformed: boolean;
@@ -193,6 +197,28 @@ const readProjectJson = (cwd: string): Record<string, unknown> | null => {
   return result.success ? result.data : null;
 };
 
+// Mirrors upgrade.ts: `catalyst.version` is the source of truth for the core
+// version, falling back to the plain `version`. `name` identifies which
+// Catalyst family the project is on (e.g. @bigcommerce/catalyst-core).
+const corePackageSchema = z.looseObject({
+  name: z.string().optional(),
+  version: z.string().optional(),
+  catalyst: z.looseObject({ version: z.string().optional() }).optional(),
+});
+
+const readCoreInfo = (cwd: string): { name: string | null; version: string | null } => {
+  const result = corePackageSchema.safeParse(safeReadJson(join(cwd, 'package.json')));
+
+  if (!result.success) {
+    return { name: null, version: null };
+  }
+
+  return {
+    name: result.data.name ?? null,
+    version: result.data.catalyst?.version ?? result.data.version ?? null,
+  };
+};
+
 const readStoredEnvKeys = (projectJson: Record<string, unknown> | null): string[] => {
   const env = projectJson?.env;
 
@@ -214,6 +240,7 @@ export function collectDiagnostics({
   const telemetry = getTelemetry();
   const projectJson = readProjectJson(cwd);
   const envLayers = buildEnvLayers(cwd, env);
+  const core = readCoreInfo(cwd);
 
   return {
     cli: {
@@ -229,6 +256,8 @@ export function collectDiagnostics({
     },
     project: {
       cwd,
+      coreName: core.name,
+      coreVersion: core.version,
       projectUuid: state.projectUuid ?? null,
       isLinked: state.isLinked,
       isTransformed: state.isTransformed,

--- a/packages/catalyst/src/cli/program.ts
+++ b/packages/catalyst/src/cli/program.ts
@@ -7,6 +7,7 @@ import { auth } from './commands/auth';
 import { build } from './commands/build';
 import { channel } from './commands/channel';
 import { create } from './commands/create';
+import { debug } from './commands/debug';
 import { deploy } from './commands/deploy';
 import { domains } from './commands/domains';
 import { env } from './commands/env';
@@ -56,5 +57,6 @@ program
   .addCommand(auth)
   .addCommand(upgrade)
   .addCommand(telemetry)
+  .addCommand(debug)
   .hook('preAction', telemetryPreHook)
   .hook('postAction', telemetryPostHook);


### PR DESCRIPTION
Linear: [LTRAC-1087](https://linear.app/commerce/issue/LTRAC-1087)

## What/Why?

When a developer hits a CLI problem we currently rely on them describing their setup by hand. This adds `catalyst debug`, a single command that prints a diagnostic report they can attach to a bug report / GitHub issue to speed up triage.

The report covers:
- **CLI**: package name + version
- **Runtime**: Node version, platform/arch, OS release, detected package manager
- **Project**: cwd, `projectUuid`, and the `getProjectState` flags (linked / transformed / fully-set-up, middleware/proxy/OpenNext presence)
- **Config** (resolved *without* secrets): store hash / access token / project UUID as `{ present, source }` following the `process.env > project.json` priority chain; `project.json` top-level key names; stored deployment env var key names; and each CLI-relevant env var as a presence boolean
- **Telemetry**: enabled flag + correlation ID
- **Files**: existence-only checks for `.env.local`, `.env`, `.bigcommerce/project.json`, `.bigcommerce/wrangler.jsonc`, `.open-next/`, `package.json`

Notable decisions:
- **Secrets/PII are never printed** — this was a hard requirement. Credentials, stored env vars, and environment variables are reported by presence only, never by value. There's a dedicated test asserting no seeded secret value appears anywhere in the output.
- The collector (`collect-diagnostics.ts`) reads `project.json` **raw** rather than via `getProjectConfig()`, which would instantiate `Conf` and create `.bigcommerce/` as a side effect (same reasoning as `project-state.ts`). There's a regression test for the no-side-effect guarantee.
- Logic lives in a pure, injectable collector so the secret-masking guarantee is unit-testable; the command is a thin formatter (human-readable by default, `--json` for copy/paste or piping).

## Testing

```bash
# Human-readable report
catalyst debug

# Machine-readable
catalyst debug --json
```

- `pnpm test` — new specs (`collect-diagnostics.spec.ts`, `debug.spec.ts`) pass; both new source files are at 100% coverage (the repo's threshold gate).
- `pnpm typecheck` and `pnpm lint` clean.
- Verified end-to-end against a project with a populated `.bigcommerce/project.json` and secret env vars set: config sources resolve correctly and **no secret value leaks** into either output mode.
- Confirmed `debug` is registered and appears in top-level `catalyst --help`.

## Migration

None — additive new command.