### PR TITLE
feat(cli): rename BIGCOMMERCE_API_HOST → CATALYST_API_HOST and resolve --api-host from project.json

### DIFF
--- a/.changeset/catalyst-api-host-config.md
+++ b/.changeset/catalyst-api-host-config.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst": minor
+---
+
+`catalyst` now reads the API host from `CATALYST_API_HOST` (renamed from `BIGCOMMERCE_API_HOST`) and resolves it with the same precedence as other credentials: `--api-host` flag > `CATALYST_API_HOST` > `.bigcommerce/project.json` `apiHost` > default `api.bigcommerce.com`. **Breaking:** the `BIGCOMMERCE_API_HOST` environment variable is no longer read — set `CATALYST_API_HOST` instead.

--- a/packages/catalyst/src/cli/commands/auth.ts
+++ b/packages/catalyst/src/cli/commands/auth.ts
@@ -6,7 +6,7 @@ import { consola } from '../lib/logger';
 import { LoginAbortedError, login as runInteractiveLogin } from '../lib/login';
 import { fetchProjects } from '../lib/project';
 import { getProjectConfig } from '../lib/project-config';
-import { loginUrlOption } from '../lib/shared-options';
+import { loginUrlOption, resolveApiHost } from '../lib/shared-options';
 
 const StoreProfileSchema = z.object({
   data: z.object({
@@ -64,13 +64,13 @@ Example:
   )
   .addOption(
     new Option('--api-host <host>', 'BigCommerce API host. The default is api.bigcommerce.com.')
-      .env('BIGCOMMERCE_API_HOST')
-      .default('api.bigcommerce.com')
+      .env('CATALYST_API_HOST')
       .hideHelp(),
   )
   .action(async (options) => {
     try {
       const config = getProjectConfig();
+      const apiHost = resolveApiHost(options, config);
 
       const storeHash = options.storeHash ?? config.get('storeHash');
       const accessToken = options.accessToken ?? config.get('accessToken');
@@ -85,12 +85,12 @@ Example:
         return;
       }
 
-      const store = await fetchStoreProfile(storeHash, accessToken, options.apiHost);
+      const store = await fetchStoreProfile(storeHash, accessToken, apiHost);
 
       const projectUuid = config.get('projectUuid');
 
       if (projectUuid) {
-        const projects = await fetchProjects(storeHash, accessToken, options.apiHost);
+        const projects = await fetchProjects(storeHash, accessToken, apiHost);
         const linkedProject = projects.find((p) => p.uuid === projectUuid);
 
         if (linkedProject) {
@@ -153,14 +153,14 @@ Examples:
   )
   .addOption(
     new Option('--api-host <host>', 'BigCommerce API host. The default is api.bigcommerce.com.')
-      .env('BIGCOMMERCE_API_HOST')
-      .default('api.bigcommerce.com')
+      .env('CATALYST_API_HOST')
       .hideHelp(),
   )
   .addOption(loginUrlOption())
   .action(async (options) => {
     try {
       const config = getProjectConfig();
+      const apiHost = resolveApiHost(options, config);
 
       const storeHash = options.storeHash ?? config.get('storeHash');
       const accessToken = options.accessToken ?? config.get('accessToken');
@@ -173,7 +173,7 @@ Examples:
         return;
       }
 
-      const credentials = await runInteractiveLogin(options.loginUrl, options.apiHost);
+      const credentials = await runInteractiveLogin(options.loginUrl, apiHost);
 
       config.set('storeHash', credentials.storeHash);
       config.set('accessToken', credentials.accessToken);

--- a/packages/catalyst/src/cli/commands/auth.ts
+++ b/packages/catalyst/src/cli/commands/auth.ts
@@ -1,4 +1,4 @@
-import { Command, Option } from 'commander';
+import { Command } from 'commander';
 import { z } from 'zod';
 
 import { assertAuthorized, UnauthorizedError } from '../lib/auth-errors';
@@ -6,7 +6,13 @@ import { consola } from '../lib/logger';
 import { LoginAbortedError, login as runInteractiveLogin } from '../lib/login';
 import { fetchProjects } from '../lib/project';
 import { getProjectConfig } from '../lib/project-config';
-import { loginUrlOption, resolveApiHost } from '../lib/shared-options';
+import {
+  accessTokenOption,
+  apiHostOption,
+  loginUrlOption,
+  resolveApiHost,
+  storeHashOption,
+} from '../lib/shared-options';
 
 const StoreProfileSchema = z.object({
   data: z.object({
@@ -50,23 +56,9 @@ Example:
 
   Logged in to My Store (abc123), connected to project my-project (43eba682-0c48-11f1-9bd5-827a48b0ce1e)`,
   )
-  .addOption(
-    new Option(
-      '--store-hash <hash>',
-      'BigCommerce store hash. Can be found in the URL of your store Control Panel.',
-    ).env('CATALYST_STORE_HASH'),
-  )
-  .addOption(
-    new Option(
-      '--access-token <token>',
-      'BigCommerce access token. Can be found after creating a store-level API account.',
-    ).env('CATALYST_ACCESS_TOKEN'),
-  )
-  .addOption(
-    new Option('--api-host <host>', 'BigCommerce API host. The default is api.bigcommerce.com.')
-      .env('CATALYST_API_HOST')
-      .hideHelp(),
-  )
+  .addOption(storeHashOption())
+  .addOption(accessTokenOption())
+  .addOption(apiHostOption())
   .action(async (options) => {
     try {
       const config = getProjectConfig();
@@ -139,23 +131,9 @@ Examples:
   # Login with existing credentials (skips interactive flow)
   $ catalyst auth login --store-hash <STORE_HASH> --access-token <ACCESS_TOKEN>`,
   )
-  .addOption(
-    new Option(
-      '--store-hash <hash>',
-      'BigCommerce store hash. Can be found in the URL of your store Control Panel.',
-    ).env('CATALYST_STORE_HASH'),
-  )
-  .addOption(
-    new Option(
-      '--access-token <token>',
-      'BigCommerce access token. Can be found after creating a store-level API account.',
-    ).env('CATALYST_ACCESS_TOKEN'),
-  )
-  .addOption(
-    new Option('--api-host <host>', 'BigCommerce API host. The default is api.bigcommerce.com.')
-      .env('CATALYST_API_HOST')
-      .hideHelp(),
-  )
+  .addOption(storeHashOption())
+  .addOption(accessTokenOption())
+  .addOption(apiHostOption())
   .addOption(loginUrlOption())
   .action(async (options) => {
     try {

--- a/packages/catalyst/src/cli/commands/channel.ts
+++ b/packages/catalyst/src/cli/commands/channel.ts
@@ -23,6 +23,7 @@ import {
   apiHostOption,
   loginUrlOption,
   projectUuidOption,
+  resolveApiHost,
   storeHashOption,
 } from '../lib/shared-options';
 import { getTelemetry } from '../lib/telemetry';
@@ -44,8 +45,9 @@ const parseChannelId = (value: string): number => {
 // .env.local nor .bigcommerce/project.json — so it logs the user in like
 // `catalyst project create`, rather than erroring like the operational commands.
 async function resolveCredentialsWithLogin(
-  options: { storeHash?: string; accessToken?: string; loginUrl: string; apiHost: string },
+  options: { storeHash?: string; accessToken?: string; loginUrl: string },
   config: Conf<ProjectConfigSchema>,
+  apiHost: string,
 ): Promise<{ storeHash: string; accessToken: string } | null> {
   const storeHash = options.storeHash ?? config.get('storeHash');
   const accessToken = options.accessToken ?? config.get('accessToken');
@@ -55,7 +57,7 @@ async function resolveCredentialsWithLogin(
   }
 
   try {
-    const credentials = await runInteractiveLogin(options.loginUrl, options.apiHost);
+    const credentials = await runInteractiveLogin(options.loginUrl, apiHost);
 
     config.set('storeHash', credentials.storeHash);
     config.set('accessToken', credentials.accessToken);
@@ -103,6 +105,7 @@ Examples:
   )
   .action(async (options) => {
     const config = getProjectConfig();
+    const apiHost = resolveApiHost(options, config);
     const { storeHash, accessToken } = resolveCredentials(options, config);
 
     await getTelemetry().identify(storeHash);
@@ -111,7 +114,7 @@ Examples:
       await runChannelSiteUrlFlow({
         storeHash,
         accessToken,
-        apiHost: options.apiHost,
+        apiHost,
         projectUuid: options.projectUuid ?? config.get('projectUuid'),
         channelId: options.channelId,
         hostname: options.hostname,
@@ -171,8 +174,9 @@ Examples:
   )
   .action(async (options) => {
     const config = getProjectConfig();
+    const apiHost = resolveApiHost(options, config);
 
-    const credentials = await resolveCredentialsWithLogin(options, config);
+    const credentials = await resolveCredentialsWithLogin(options, config, apiHost);
 
     if (!credentials) {
       consola.info(
@@ -191,7 +195,7 @@ Examples:
     let channelName: string | undefined;
 
     if (channelId === undefined) {
-      const channels = await fetchAvailableChannels(storeHash, accessToken, options.apiHost);
+      const channels = await fetchAvailableChannels(storeHash, accessToken, apiHost);
 
       if (channels.length === 0) {
         consola.info(
@@ -290,8 +294,9 @@ Examples:
     }
 
     const config = getProjectConfig();
+    const apiHost = resolveApiHost(options, config);
 
-    const credentials = await resolveCredentialsWithLogin(options, config);
+    const credentials = await resolveCredentialsWithLogin(options, config, apiHost);
 
     if (!credentials) {
       consola.info(
@@ -318,7 +323,7 @@ Examples:
     const channelData = await runCreateChannelFlow({
       storeHash,
       accessToken,
-      apiHost: options.apiHost,
+      apiHost,
       cliApiOrigin: options.cliApiOrigin,
       name: options.name,
       locale: options.locale,

--- a/packages/catalyst/src/cli/commands/deploy.spec.ts
+++ b/packages/catalyst/src/cli/commands/deploy.spec.ts
@@ -142,7 +142,7 @@ test('properly configured Command instance', () => {
     expect.arrayContaining([
       expect.objectContaining({ flags: '--store-hash <hash>' }),
       expect.objectContaining({ flags: '--access-token <token>' }),
-      expect.objectContaining({ flags: '--api-host <host>', defaultValue: 'api.bigcommerce.com' }),
+      expect.objectContaining({ flags: '--api-host <host>' }),
       expect.objectContaining({ flags: '--project-uuid <uuid>' }),
       expect.objectContaining({ flags: '--secret <value>' }),
       expect.objectContaining({ flags: '--dry-run' }),

--- a/packages/catalyst/src/cli/commands/deploy.ts
+++ b/packages/catalyst/src/cli/commands/deploy.ts
@@ -34,6 +34,7 @@ import {
   apiHostOption,
   envPathOption,
   projectUuidOption,
+  resolveApiHost,
   storeHashOption,
 } from '../lib/shared-options';
 import { getTelemetry } from '../lib/telemetry';
@@ -404,6 +405,7 @@ Example:
   .addOption(envPathOption())
   .action(async (options) => {
     const config = getProjectConfig();
+    const apiHost = resolveApiHost(options, config);
     const { storeHash, accessToken } = resolveCredentials(options, config);
     const telemetry = getTelemetry();
 
@@ -421,7 +423,7 @@ Example:
         return await selectOrCreateInfrastructureProject({
           storeHash,
           accessToken,
-          apiHost: options.apiHost,
+          apiHost,
         });
       } catch (error) {
         if (error instanceof NoLinkedProjectError) {
@@ -436,12 +438,7 @@ Example:
     };
 
     if (linkedProjectUuid) {
-      const existing = await fetchProject(
-        linkedProjectUuid,
-        storeHash,
-        accessToken,
-        options.apiHost,
-      );
+      const existing = await fetchProject(linkedProjectUuid, storeHash, accessToken, apiHost);
 
       if (existing) {
         projectUuid = linkedProjectUuid;
@@ -537,7 +534,7 @@ Example:
       process.exit(0);
     }
 
-    const uploadSignature = await generateUploadSignature(storeHash, accessToken, options.apiHost);
+    const uploadSignature = await generateUploadSignature(storeHash, accessToken, apiHost);
 
     await uploadBundleZip(uploadSignature.upload_url);
 
@@ -555,7 +552,7 @@ Example:
       uploadSignature.upload_uuid,
       storeHash,
       accessToken,
-      options.apiHost,
+      apiHost,
       environmentVariables,
     );
 
@@ -563,7 +560,7 @@ Example:
       deploymentUuid,
       storeHash,
       accessToken,
-      options.apiHost,
+      apiHost,
     );
 
     if (!options.updateSiteUrl) {
@@ -574,7 +571,7 @@ Example:
       await runChannelSiteUrlFlow({
         storeHash,
         accessToken,
-        apiHost: options.apiHost,
+        apiHost,
         projectUuid,
         preferHostname: deploymentHostname,
       });

--- a/packages/catalyst/src/cli/commands/domains.ts
+++ b/packages/catalyst/src/cli/commands/domains.ts
@@ -26,6 +26,7 @@ import {
   accessTokenOption,
   apiHostOption,
   projectUuidOption,
+  resolveApiHost,
   resolveProjectUuid,
   storeHashOption,
 } from '../lib/shared-options';
@@ -59,7 +60,7 @@ interface DomainCommandContext {
 interface DomainCommandOptions {
   storeHash?: string;
   accessToken?: string;
-  apiHost: string;
+  apiHost?: string;
   projectUuid?: string;
 }
 
@@ -73,6 +74,7 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 function resolveDomainCommandContext(options: DomainCommandOptions): DomainCommandContext {
   const config = getProjectConfig();
+  const apiHost = resolveApiHost(options, config);
   const { storeHash, accessToken } = resolveCredentials(options, config);
   const projectUuid = resolveProjectUuid(options);
 
@@ -80,7 +82,7 @@ function resolveDomainCommandContext(options: DomainCommandOptions): DomainComma
     projectUuid,
     storeHash,
     accessToken,
-    apiHost: options.apiHost,
+    apiHost,
   };
 }
 

--- a/packages/catalyst/src/cli/commands/logs.spec.ts
+++ b/packages/catalyst/src/cli/commands/logs.spec.ts
@@ -120,10 +120,7 @@ describe('command configuration', () => {
       expect.arrayContaining([
         expect.objectContaining({ flags: '--store-hash <hash>' }),
         expect.objectContaining({ flags: '--access-token <token>' }),
-        expect.objectContaining({
-          flags: '--api-host <host>',
-          defaultValue: 'api.bigcommerce.com',
-        }),
+        expect.objectContaining({ flags: '--api-host <host>' }),
         expect.objectContaining({ flags: '--project-uuid <uuid>' }),
         expect.objectContaining({ flags: '--format <format>', defaultValue: 'default' }),
       ]),

--- a/packages/catalyst/src/cli/commands/logs.ts
+++ b/packages/catalyst/src/cli/commands/logs.ts
@@ -12,6 +12,7 @@ import {
   accessTokenOption,
   apiHostOption,
   projectUuidOption,
+  resolveApiHost,
   resolveProjectUuid,
   storeHashOption,
 } from '../lib/shared-options';
@@ -335,13 +336,14 @@ Examples:
   .action(async (options) => {
     try {
       const config = getProjectConfig();
+      const apiHost = resolveApiHost(options, config);
       const { storeHash, accessToken } = resolveCredentials(options, config);
 
       await telemetry.identify(storeHash);
 
       const projectUuid = resolveProjectUuid(options);
 
-      await tailLogs(projectUuid, storeHash, accessToken, options.apiHost, options.format);
+      await tailLogs(projectUuid, storeHash, accessToken, apiHost, options.format);
     } catch (error) {
       consola.error(error);
       process.exit(1);
@@ -426,6 +428,7 @@ Examples:
   .action(async (options) => {
     try {
       const config = getProjectConfig();
+      const apiHost = resolveApiHost(options, config);
       const { storeHash, accessToken } = resolveCredentials(options, config);
 
       await telemetry.identify(storeHash);
@@ -433,7 +436,7 @@ Examples:
       const projectUuid = resolveProjectUuid(options);
       const { start, end } = resolveTimeWindow(options);
 
-      const result = await queryLogs(projectUuid, storeHash, accessToken, options.apiHost, {
+      const result = await queryLogs(projectUuid, storeHash, accessToken, apiHost, {
         start,
         end,
         method: options.method,

--- a/packages/catalyst/src/cli/commands/project.spec.ts
+++ b/packages/catalyst/src/cli/commands/project.spec.ts
@@ -484,10 +484,7 @@ describe('project link', () => {
       expect.arrayContaining([
         expect.objectContaining({ flags: '--store-hash <hash>' }),
         expect.objectContaining({ flags: '--access-token <token>' }),
-        expect.objectContaining({
-          flags: '--api-host <host>',
-          defaultValue: 'api.bigcommerce.com',
-        }),
+        expect.objectContaining({ flags: '--api-host <host>' }),
         expect.objectContaining({ flags: '--project-uuid <uuid>' }),
       ]),
     );

--- a/packages/catalyst/src/cli/commands/project.ts
+++ b/packages/catalyst/src/cli/commands/project.ts
@@ -20,6 +20,7 @@ import {
   apiHostOption,
   loginUrlOption,
   projectUuidOption,
+  resolveApiHost,
   storeHashOption,
 } from '../lib/shared-options';
 import { getTelemetry } from '../lib/telemetry';
@@ -76,13 +77,14 @@ Example:
   .addOption(apiHostOption())
   .action(async (options) => {
     const config = getProjectConfig();
+    const apiHost = resolveApiHost(options, config);
     const { storeHash, accessToken } = resolveCredentials(options, config);
 
     await getTelemetry().identify(storeHash);
 
     consola.start('Fetching projects...');
 
-    const projects = await fetchProjects(storeHash, accessToken, options.apiHost);
+    const projects = await fetchProjects(storeHash, accessToken, apiHost);
 
     consola.success('Projects fetched.');
 
@@ -131,6 +133,7 @@ Example:
   .addOption(loginUrlOption())
   .action(async (options) => {
     const config = getProjectConfig();
+    const apiHost = resolveApiHost(options, config);
 
     let storeHash = options.storeHash ?? config.get('storeHash');
     let accessToken = options.accessToken ?? config.get('accessToken');
@@ -141,7 +144,7 @@ Example:
       );
 
       try {
-        const credentials = await runInteractiveLogin(options.loginUrl, options.apiHost);
+        const credentials = await runInteractiveLogin(options.loginUrl, apiHost);
 
         storeHash = credentials.storeHash;
         accessToken = credentials.accessToken;
@@ -168,7 +171,7 @@ Example:
 
     const newProjectName = await input({ message: 'Enter a name for the new project:' });
 
-    const data = await createProject(newProjectName, storeHash, accessToken, options.apiHost);
+    const data = await createProject(newProjectName, storeHash, accessToken, apiHost);
 
     consola.success(`Project "${data.name}" created successfully.`);
 
@@ -202,6 +205,7 @@ Examples:
   .addOption(projectUuidOption())
   .action(async (options) => {
     const config = getProjectConfig();
+    const apiHost = resolveApiHost(options, config);
 
     const writeProjectConfig = (
       uuid: string,
@@ -235,7 +239,7 @@ Examples:
 
     try {
       selected = await selectOrCreateInfrastructureProject(
-        { storeHash, accessToken, apiHost: options.apiHost },
+        { storeHash, accessToken, apiHost },
         config.get('projectUuid'),
       );
     } catch (error) {
@@ -283,6 +287,7 @@ Examples:
   .option('--force', 'Skip the confirmation prompt before deleting.')
   .action(async (options) => {
     const config = getProjectConfig();
+    const apiHost = resolveApiHost(options, config);
     const { storeHash, accessToken } = resolveCredentials(options, config);
 
     await getTelemetry().identify(storeHash);
@@ -293,7 +298,7 @@ Examples:
     if (!targetUuid) {
       consola.start('Fetching projects...');
 
-      const projects = await fetchProjects(storeHash, accessToken, options.apiHost);
+      const projects = await fetchProjects(storeHash, accessToken, apiHost);
 
       consola.success('Projects fetched.');
 
@@ -354,7 +359,7 @@ Examples:
 
     consola.start(`Deleting project ${targetUuid}...`);
 
-    await deleteProject(targetUuid, storeHash, accessToken, options.apiHost);
+    await deleteProject(targetUuid, storeHash, accessToken, apiHost);
 
     consola.success(`Project ${targetUuid} deleted.`);
 

--- a/packages/catalyst/src/cli/lib/project-config.ts
+++ b/packages/catalyst/src/cli/lib/project-config.ts
@@ -7,6 +7,7 @@ export interface ProjectConfigSchema {
   framework: 'catalyst';
   storeHash?: string;
   accessToken?: string;
+  apiHost?: string;
   // Persistent deployment environment variables (KEY -> VALUE). Every entry is
   // sent to the deployment as a `secret` by `catalyst deploy`. Managed via the
   // `catalyst env` commands. Lives here (gitignored .bigcommerce/project.json)
@@ -28,6 +29,7 @@ export function getProjectConfig() {
       },
       storeHash: { type: 'string' },
       accessToken: { type: 'string' },
+      apiHost: { type: 'string' },
       env: {
         type: 'object',
         additionalProperties: { type: 'string' },

--- a/packages/catalyst/src/cli/lib/shared-options.spec.ts
+++ b/packages/catalyst/src/cli/lib/shared-options.spec.ts
@@ -1,0 +1,45 @@
+import Conf from 'conf';
+import { afterAll, afterEach, beforeAll, expect, test, vi } from 'vitest';
+
+import { mkTempDir } from './mk-temp-dir';
+import { getProjectConfig, ProjectConfigSchema } from './project-config';
+import { DEFAULT_API_HOST, resolveApiHost } from './shared-options';
+
+let tmpDir: string;
+let cleanup: () => Promise<void>;
+let config: Conf<ProjectConfigSchema>;
+
+beforeAll(async () => {
+  [tmpDir, cleanup] = await mkTempDir();
+  vi.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+  config = getProjectConfig();
+});
+
+afterEach(() => {
+  config.delete('apiHost');
+});
+
+afterAll(async () => {
+  vi.restoreAllMocks();
+  await cleanup();
+});
+
+test('returns the --api-host flag when provided', () => {
+  expect(resolveApiHost({ apiHost: 'flag.example.com' }, config)).toBe('flag.example.com');
+});
+
+test('falls back to config apiHost when the flag is missing', () => {
+  config.set('apiHost', 'config.example.com');
+
+  expect(resolveApiHost({}, config)).toBe('config.example.com');
+});
+
+test('falls back to the default host when neither flag nor config is set', () => {
+  expect(resolveApiHost({}, config)).toBe(DEFAULT_API_HOST);
+});
+
+test('the flag takes precedence over the config apiHost', () => {
+  config.set('apiHost', 'config.example.com');
+
+  expect(resolveApiHost({ apiHost: 'flag.example.com' }, config)).toBe('flag.example.com');
+});

--- a/packages/catalyst/src/cli/lib/shared-options.ts
+++ b/packages/catalyst/src/cli/lib/shared-options.ts
@@ -1,7 +1,10 @@
 import { Option } from 'commander';
+import type Conf from 'conf';
 
 import { DEFAULT_LOGIN_URL } from './auth';
-import { getProjectConfig } from './project-config';
+import { getProjectConfig, ProjectConfigSchema } from './project-config';
+
+export const DEFAULT_API_HOST = 'api.bigcommerce.com';
 
 export const storeHashOption = () =>
   new Option(
@@ -16,9 +19,11 @@ export const accessTokenOption = () =>
   ).env('CATALYST_ACCESS_TOKEN');
 
 export const apiHostOption = () =>
-  new Option('--api-host <host>', 'BigCommerce API host. The default is api.bigcommerce.com.')
-    .env('BIGCOMMERCE_API_HOST')
-    .default('api.bigcommerce.com')
+  new Option(
+    '--api-host <host>',
+    'BigCommerce API host. Read from .bigcommerce/project.json or CATALYST_API_HOST when not provided. Defaults to api.bigcommerce.com.',
+  )
+    .env('CATALYST_API_HOST')
     .hideHelp();
 
 export const loginUrlOption = () =>
@@ -51,3 +56,8 @@ export const resolveProjectUuid = (options: { projectUuid?: string }) => {
 
   return projectUuid;
 };
+
+export const resolveApiHost = (
+  options: { apiHost?: string },
+  config: Conf<ProjectConfigSchema>,
+): string => options.apiHost ?? config.get('apiHost') ?? DEFAULT_API_HOST;


### PR DESCRIPTION
Linear: [LTRAC-1249](https://linear.app/commerce/issue/LTRAC-1249)

## What/Why?

The CLI's `--api-host` was the odd one out among its config: bound to `BIGCOMMERCE_API_HOST` (not `CATALYST_`-prefixed) and resolved only as flag > env > hardcoded default via Commander — it couldn't be persisted in `.bigcommerce/project.json` like store hash / access token / project UUID.

This makes the API host a first-class `CATALYST_` config, resolved with the same precedence as the other credentials:

`--api-host` flag > `CATALYST_API_HOST` env > `.bigcommerce/project.json` `apiHost` > default `api.bigcommerce.com`

Key changes:
- `shared-options.ts`: rename the env binding to `CATALYST_API_HOST`, drop the Commander `.default('api.bigcommerce.com')`, and add a `resolveApiHost(options, config)` helper + `DEFAULT_API_HOST` constant (mirrors `resolveCredentials`/`resolveProjectUuid`).
- `project-config.ts`: add `apiHost?: string` to `ProjectConfigSchema` so it can be persisted/read from `project.json`.
- Route every command that accepts `--api-host` (`project`, `logs`, `domains`, `channel`, `deploy`, `auth`) through `resolveApiHost` instead of reading `options.apiHost` directly. Each action already has a `config` handle, so the resolver slots in at the top of the action. `create` is untouched (it builds its own host from `--bigcommerce-hostname`).

**Breaking change:** `BIGCOMMERCE_API_HOST` is no longer read — set `CATALYST_API_HOST` instead. It's a hidden/advanced knob (pre-GA), so blast radius is low; called out in the changeset.

Surfaced while reviewing the `catalyst debug` report (LTRAC-1087). The debug report's `CATALYST_API_HOST` label + `project.json` source will follow once #3110 merges (that branch is where the diagnostics collector lives).

## Testing

- New `shared-options.spec.ts` covers all four `resolveApiHost` precedence branches (flag / project.json / default / flag-beats-config).
- Updated `logs`/`deploy`/`project` command specs that asserted the old Commander default on `--api-host`.
- `pnpm typecheck` and `pnpm lint` clean; all touched command specs pass (199 tests across the 7 affected specs). The full-suite 100% coverage gate runs in CI (the `upgrade.*` integration specs are too slow/flaky to run locally).

## Migration

Replace `BIGCOMMERCE_API_HOST=...` with `CATALYST_API_HOST=...` in any environment or CI that overrides the API host. You can now also set `"apiHost"` in `.bigcommerce/project.json` or pass `--api-host`.