### PR TITLE
TRAC-1161: fix - Set request locale in generateMetadata before data fetch

### DIFF
--- a/.changeset/product-translations-revalidation-fallback.md
+++ b/.changeset/product-translations-revalidation-fallback.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Fix product, category, and brand content falling back to the default language after ISR revalidation. `generateMetadata` fetched page data through `cache()`-memoized loaders before calling `setRequestLocale`, so during background regeneration (no request) next-intl could not resolve the locale, the storefront client omitted `Accept-Language`, and the default-locale response poisoned the memoized cache for the whole render. `setRequestLocale(locale)` is now called before the fetch in each `generateMetadata`.

--- a/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/brand/[slug]/page.tsx
@@ -69,6 +69,9 @@ interface Props {
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
   const { slug, locale } = await props.params;
+
+  setRequestLocale(locale);
+
   const customerAccessToken = await getSessionCustomerAccessToken();
 
   const brandId = Number(slug);

--- a/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/(faceted)/category/[slug]/page.tsx
@@ -71,6 +71,9 @@ interface Props {
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
   const { slug, locale } = await props.params;
+
+  setRequestLocale(locale);
+
   const customerAccessToken = await getSessionCustomerAccessToken();
 
   const categoryId = Number(slug);

--- a/core/app/[locale]/(default)/product/[slug]/page.tsx
+++ b/core/app/[locale]/(default)/product/[slug]/page.tsx
@@ -43,6 +43,9 @@ interface Props {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug, locale } = await params;
+
+  setRequestLocale(locale);
+
   const customerAccessToken = await getSessionCustomerAccessToken();
 
   const productId = Number(slug);


### PR DESCRIPTION
Jira: [TRAC-1161](https://bigcommercecloud.atlassian.net/browse/TRAC-1161)

## What/Why?

- Product/category/brand content falls back to the default language after ISR revalidation; next-intl UI strings stay correct.
- Cause: `generateMetadata` fetches data via `cache()`-memoized loaders **before** `setRequestLocale`.
- On ISR regen (no request) `getServerLocale()` → `undefined` → client omits `Accept-Language` → default-locale content is fetched and poisons the memoized cache for the whole render.
- Masked on live requests (middleware sets the locale header), so it only surfaces on background regeneration.
- Fix: call `setRequestLocale(locale)` before the fetch in each `generateMetadata` — matches next-intl's static-rendering requirement.

## Testing

- `tsc --noEmit` clean for edited files.
- Runtime repro (prod build only — not `next dev`): set small `DEFAULT_REVALIDATE_TARGET`, `build && start`, load a non-default-locale page, wait past revalidate, reload twice → content stays translated (before fix: flips to default).
- Requires a store with a non-default **active** language + product translations.
- Manual testing

[TRAC-1161]: https://bigcommercecloud.atlassian.net/browse/TRAC-1161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ