### PR TITLE
fix(ci): complete latest started Linear release instead of by version

### DIFF
--- a/.github/workflows/changesets-release.yml
+++ b/.github/workflows/changesets-release.yml
@@ -93,5 +93,10 @@ jobs:
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
           command: complete
-          version: ${{ steps.headline.outputs.tag }}
+          # No `version`: the `catalyst-release` pipeline is a scheduled pipeline
+          # whose started release is unversioned (the accumulating `sync` steps
+          # above run without a version). Passing `version` makes `complete` look
+          # up an existing release with that exact version, which never exists and
+          # fails with `No release found with version "…"`. Omitting it completes
+          # the latest started release — the one sync has been accumulating into.
           release_notes: /tmp/release-notes.md


### PR DESCRIPTION
Refs [LTRAC-1265](https://linear.app/commerce/issue/LTRAC-1265)

## What/Why?

The `Complete Linear release` step in `changesets-release.yml` fails on **every** publish:

```
Error: Not found - No release found with version "@bigcommerce/catalyst-core@1.9.0" for the specified pipeline.
```

Seen on both the `canary` core publish and the `integrations/makeswift` publish during the 1.9.0 release. (The package releases themselves — git tags, GitHub releases, npm — succeeded; only this tracking step failed.)

**Root cause:** the `catalyst-release` pipeline is a **scheduled** pipeline, so its releases are date-based and unversioned (the current one is literally named "New release"). The accumulating `Sync Linear release` step runs on every push *without* a `version`, so it only ever maintains that unversioned started release. But `Complete Linear release` passed `version: <tag>`, and per the action docs `complete` **with** a `version` looks up an *existing* release with that exact version — which never exists. Per the docs, `complete` **without** `version` "completes the latest started release", i.e. the one `sync` has been accumulating into.

The fix drops the `version` input from the complete step. Release notes are still fetched by tag and passed through `release_notes`, so the completed release keeps the generated notes.

**Reviewer note — shared pipeline caveat:** both `canary` and `integrations/makeswift` feed this one pipeline. "Complete latest started release" is unambiguous when a single release is open, but could be ambiguous if releases overlap across the two branches. The action docs recommend passing `version` for scheduled pipelines when releases overlap — but that requires the pre-publish syncs to be versioned too, which isn't possible before the version exists. If per-version release identity becomes necessary, a dedicated `catalyst-makeswift` pipeline (or a version-labeling step) would be the follow-up.

## Testing

Can't be exercised locally — it only runs on a real publish to `canary`/`integrations/makeswift`. Validated that the workflow YAML still parses and the `Complete Linear release` step retains `access_key`, `command`, and `release_notes` (only `version` removed); the `Resolve headline package` / `Fetch release notes` steps that fetch notes by tag are unchanged. Will confirm on the next release that the step completes green.

## Migration

None.