### PR TITLE
TRAC-1250: Add missing storefront_api scope to device login flow

### DIFF
--- a/packages/catalyst/src/cli/lib/auth.ts
+++ b/packages/catalyst/src/cli/lib/auth.ts
@@ -5,11 +5,13 @@ import { httpError } from './http-errors';
 export const DEVICE_OAUTH_CLIENT_ID = 'b8063bu6hhml4e0lqh22yut63atsbyv';
 export const DEVICE_OAUTH_SCOPES = [
   'store_v2_information',
+  'store_storefront_api',
   'store_infrastructure_deployments_manage',
   'store_infrastructure_logs_read_only',
   'store_infrastructure_projects_manage',
   'store_channel_settings',
 ].join(' ');
+
 export const DEFAULT_LOGIN_URL = 'https://login.bigcommerce.com';
 
 export const DeviceCodeResponseSchema = z.object({


### PR DESCRIPTION
Jira: [TRAC-1193](https://bigcommercecloud.atlassian.net/browse/TRAC-1193)

## What/Why?
The device login flow's OAuth scope list was missing `store_storefront_api`, so tokens issued via `catalyst auth` didn't grant access to the storefront API. Adds that single scope to the existing list.

## Rollout/Rollback
Standard release; no migration or flag required. Revert the commit to roll back.

## Testing
Ran `catalyst auth login` locally and confirmed the device authorization request includes `store_storefront_api` in the requested scopes, and that CLI flows depending on the storefront API no longer fail with a 401/403.

[TRAC-1193]: https://bigcommercecloud.atlassian.net/browse/TRAC-1193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ