### PR TITLE
TRAC-1250: Add additional scopes missing from CLI create command

### DIFF
--- a/.changeset/trac-1250-cli-create-scopes.md
+++ b/.changeset/trac-1250-cli-create-scopes.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst": patch
+---
+
+Add `store_v2_products`, `store_v2_content`, and `store_sites` OAuth scopes so `catalyst create` no longer errors when creating a new channel with sample data.

--- a/packages/catalyst/src/cli/lib/auth.ts
+++ b/packages/catalyst/src/cli/lib/auth.ts
@@ -5,6 +5,9 @@ import { httpError } from './http-errors';
 export const DEVICE_OAUTH_CLIENT_ID = 'b8063bu6hhml4e0lqh22yut63atsbyv';
 export const DEVICE_OAUTH_SCOPES = [
   'store_v2_information',
+  'store_v2_products',
+  'store_v2_content',
+  'store_sites',
   'store_storefront_api',
   'store_infrastructure_deployments_manage',
   'store_infrastructure_logs_read_only',


### PR DESCRIPTION
## What/Why?

Adds `store_v2_products`, `store_v2_content`, and `store_sites` to the device OAuth scopes used by the CLI `create` command. Without these scopes, creating a new channel with sample data fails, since that flow needs to write products, content, and site data on the store.

## Testing

Ran `catalyst create` locally and confirmed channel creation with sample data no longer errors on missing scopes.

## Migration
No migration - will only affect new users using the `pnpm create @bigcommerce/catalyst@latest` command after we cut a new version