### PR TITLE
ci: TRAC-1235 make changesets release aware of integrations/b2b-makeswift

### DIFF
--- a/.github/workflows/changesets-release.yml
+++ b/.github/workflows/changesets-release.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - canary
       - integrations/makeswift
+      - integrations/b2b-makeswift
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -72,6 +73,8 @@ jobs:
           PACKAGE_NAME="@bigcommerce/catalyst-core"
           if [ "${{ github.ref_name }}" = "integrations/makeswift" ]; then
             PACKAGE_NAME="@bigcommerce/catalyst-makeswift"
+          elif [ "${{ github.ref_name }}" = "integrations/b2b-makeswift" ]; then
+            PACKAGE_NAME="@bigcommerce/catalyst-b2b-makeswift"
           fi
           VERSION=$(echo '${{ steps.changesets.outputs.publishedPackages }}' | jq -r --arg name "$PACKAGE_NAME" '.[] | select(.name == $name) | .version')
           if [ -z "$VERSION" ]; then


### PR DESCRIPTION
Jira: [TRAC-1235](https://bigcommercecloud.atlassian.net/browse/TRAC-1235)

## What/Why?

`changesets-release.yml` is shared, ref-driven infrastructure: canary and `integrations/makeswift` carry a byte-identical copy, and per-branch behavior comes from `github.ref_name`. To bring `integrations/b2b-makeswift` into the release process without drift, its awareness has to originate here on canary rather than only on the integration branch.

This adds `integrations/b2b-makeswift` to the workflow's push trigger and maps it to `@bigcommerce/catalyst-b2b-makeswift` in the headline-package resolver. Both are **inert on canary and `integrations/makeswift`** (a push only runs the workflow copy on the branch that was pushed, and the `elif` never matches their `ref_name`), so this is safe to land on canary immediately.

From here the change propagates to `integrations/makeswift` via `/sync-makeswift`, and `integrations/b2b-makeswift` carries the same file (see #3125, which gives that branch its distinct `@bigcommerce/catalyst-b2b-makeswift` identity + changeset guard).

Part of LTRAC-1095 (consolidate B2B branches) / LTRAC-1296. The `release-catalyst` skill's b2b release stage and the new `/sync-b2b-makeswift` skill are intentionally deferred to the WS3 upgrade (LTRAC-1297), since a b2b release stage depends on `/sync-b2b-makeswift` existing and on the branch actually being releasable.

## Testing

No behavior change on canary or `integrations/makeswift`. End-to-end validation happens on `integrations/b2b-makeswift` once #3125 lands: a changeset there should open a `Version Packages (integrations/b2b-makeswift)` PR resolving `@bigcommerce/catalyst-b2b-makeswift`.

## Migration

None.

[TRAC-1235]: https://bigcommercecloud.atlassian.net/browse/TRAC-1235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ