### PR TITLE
chore(deps): PROMO-1574 bump storefront-kit versions and style the promotion callouts

### DIFF
--- a/.changeset/promo-1574-promotion-callout-styles.md
+++ b/.changeset/promo-1574-promotion-callout-styles.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Style the promotion callouts with Storefront Kit's built-in `warning` variant instead of custom Tailwind classes. Bumps `storefront-kit` to `^0.32.3` (whose `styles` stylesheet is now plain CSS, so it imports cleanly under Turbopack) and wires up `storefront-kit/styles` plus the Storefront Kit `dist` content path so the Callout's design-system tokens resolve out of the box.

--- a/core/globals.css
+++ b/core/globals.css
@@ -1,3 +1,5 @@
+@import 'storefront-kit/styles';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/core/package.json
+++ b/core/package.json
@@ -79,7 +79,7 @@
     "schema-dts": "^1.1.5",
     "server-only": "^0.0.1",
     "sonner": "^1.7.4",
-    "storefront-kit": "^0.24.0",
+    "storefront-kit": "^0.32.3",
     "tailwindcss-radix": "^3.0.5",
     "uuid": "^11.1.0",
     "zod": "^3.25.51"

--- a/core/tailwind.config.js
+++ b/core/tailwind.config.js
@@ -4,7 +4,7 @@ const config = {
     './app/**/*.{ts,tsx}',
     './components/**/*.{ts,tsx}',
     './vibes/**/*.{ts,tsx}',
-    '!./node_modules/**', // Exclude everything in node_modules to speed up builds
+    './node_modules/storefront-kit/dist/**/*.{js,mjs}',
   ],
   theme: {
     extend: {

--- a/core/vibes/soul/primitives/product-card/index.tsx
+++ b/core/vibes/soul/primitives/product-card/index.tsx
@@ -185,18 +185,12 @@ export function ProductCard({
             )}
             {promotions != null && promotions.length > 0 && (
               <div className="mt-1.5">
-                <CalloutRoot
-                  className="items-start rounded-md border border-yellow-300 bg-yellow-50 px-2.5 py-1.5"
-                  size="small"
-                  variant="warning"
-                >
+                <CalloutRoot size="small" variant="warning">
                   <CalloutContent>
                     <CalloutHeader>
-                      <CalloutTitle className="text-xs font-semibold leading-snug text-yellow-900">
-                        {promotions[0]?.text ?? ''}
-                      </CalloutTitle>
+                      <CalloutTitle>{promotions[0]?.text ?? ''}</CalloutTitle>
                       {promotions.length > 1 && (
-                        <CalloutDescription className="text-xs text-yellow-900/70">
+                        <CalloutDescription>
                           {t('moreOffers', { count: promotions.length - 1 })}
                         </CalloutDescription>
                       )}

--- a/core/vibes/soul/sections/product-detail/index.tsx
+++ b/core/vibes/soul/sections/product-detail/index.tsx
@@ -216,17 +216,10 @@ export function ProductDetail<F extends Field>({
                           callouts.length > 0 ? (
                             <div className="flex flex-col gap-2">
                               {callouts.map((callout) => (
-                                <CalloutRoot
-                                  className="items-start rounded-md border border-yellow-300 bg-yellow-50 px-2.5 py-1.5"
-                                  key={callout.id}
-                                  size="small"
-                                  variant="warning"
-                                >
+                                <CalloutRoot key={callout.id} size="small" variant="warning">
                                   <CalloutContent>
                                     <CalloutHeader>
-                                      <CalloutTitle className="text-xs font-semibold leading-snug text-yellow-900">
-                                        {callout.text}
-                                      </CalloutTitle>
+                                      <CalloutTitle>{callout.text}</CalloutTitle>
                                     </CalloutHeader>
                                   </CalloutContent>
                                 </CalloutRoot>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,8 +213,8 @@ importers:
         specifier: ^1.7.4
         version: 1.7.4(react-dom@19.1.7(react@19.1.7))(react@19.1.7)
       storefront-kit:
-        specifier: ^0.24.0
-        version: 0.24.0(2eea54938541e43338f6c40ea8e1cef3)
+        specifier: ^0.32.3
+        version: 0.32.3(@base-ui/react@1.6.0(@date-fns/tz@1.2.0)(@types/react@19.2.7)(date-fns@4.1.0)(react-dom@19.1.7(react@19.1.7))(react@19.1.7))(@tailwindcss/container-queries@0.1.1(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.15.30)(typescript@5.8.3))))(@tailwindcss/typography@0.5.16(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.15.30)(typescript@5.8.3))))(embla-carousel-react@9.0.0-rc01(react@19.1.7))(lucide-react@0.474.0(react@19.1.7))(react-day-picker@9.7.0(react@19.1.7))(react-dom@19.1.7(react@19.1.7))(react@19.1.7)(sonner@1.7.4(react-dom@19.1.7(react@19.1.7))(react@19.1.7))(tailwindcss-animate@1.0.7(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.15.30)(typescript@5.8.3))))(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.15.30)(typescript@5.8.3)))
       tailwindcss-radix:
         specifier: ^3.0.5
         version: 3.0.5(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.15.30)(typescript@5.8.3)))
@@ -8361,6 +8361,7 @@ packages:
   puppeteer@24.10.0:
     resolution: {integrity: sha512-Oua9VkGpj0S2psYu5e6mCer6W9AU9POEQh22wRgSXnLXASGH+MwLUVWgLCLeP9QPHHcJ7tySUlg4Sa9OJmaLpw==}
     engines: {node: '>=18'}
+    deprecated: < 24.15.0 is no longer supported
     hasBin: true
 
   pure-rand@6.1.0:
@@ -8871,27 +8872,11 @@ packages:
     resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
     engines: {node: '>=4', npm: '>=6'}
 
-  storefront-kit@0.24.0:
-    resolution: {integrity: sha512-Mo+FcFpNs4AogAGAmhuQiteAMzPr1AvARfPzzfs2NVYZSkJ48ptVCGmmGzWXI3I7WX4D9u/I/wU2jsyUS7NtHA==}
+  storefront-kit@0.32.3:
+    resolution: {integrity: sha512-oI16AjLoqG84wkVlwMRVd3JQWpMWxayRp/HAJUAf+9wj2GuhDvcyO3HXrQGLsY6L5VT29CGkQQW+/Fv154MQng==}
     engines: {node: '>=18'}
     peerDependencies:
       '@base-ui/react': ^1.5.0
-      '@radix-ui/react-accordion': ^1.2.0
-      '@radix-ui/react-checkbox': ^1.3.0
-      '@radix-ui/react-dialog': ^1.1.0
-      '@radix-ui/react-dropdown-menu': ^2.1.0
-      '@radix-ui/react-hover-card': ^1.1.15
-      '@radix-ui/react-label': ^2.1.0
-      '@radix-ui/react-navigation-menu': ^1.2.0
-      '@radix-ui/react-popover': ^1.1.0
-      '@radix-ui/react-portal': ^1.1.0
-      '@radix-ui/react-radio-group': ^1.3.0
-      '@radix-ui/react-scroll-area': ^1.2.0
-      '@radix-ui/react-select': ^2.2.0
-      '@radix-ui/react-slot': ^1.2.0
-      '@radix-ui/react-tabs': ^1.1.0
-      '@radix-ui/react-toggle': ^1.1.0
-      '@radix-ui/react-toggle-group': ^1.1.0
       '@tailwindcss/container-queries': ^0.1.0
       '@tailwindcss/typography': ^0.5.0
       embla-carousel-react: ^8.0.0
@@ -8904,38 +8889,6 @@ packages:
       tailwindcss-animate: ^1.0.0
     peerDependenciesMeta:
       '@base-ui/react':
-        optional: true
-      '@radix-ui/react-accordion':
-        optional: true
-      '@radix-ui/react-checkbox':
-        optional: true
-      '@radix-ui/react-dialog':
-        optional: true
-      '@radix-ui/react-dropdown-menu':
-        optional: true
-      '@radix-ui/react-hover-card':
-        optional: true
-      '@radix-ui/react-label':
-        optional: true
-      '@radix-ui/react-navigation-menu':
-        optional: true
-      '@radix-ui/react-popover':
-        optional: true
-      '@radix-ui/react-portal':
-        optional: true
-      '@radix-ui/react-radio-group':
-        optional: true
-      '@radix-ui/react-scroll-area':
-        optional: true
-      '@radix-ui/react-select':
-        optional: true
-      '@radix-ui/react-slot':
-        optional: true
-      '@radix-ui/react-tabs':
-        optional: true
-      '@radix-ui/react-toggle':
-        optional: true
-      '@radix-ui/react-toggle-group':
         optional: true
       embla-carousel-react:
         optional: true
@@ -10850,9 +10803,9 @@ snapshots:
       '@typescript-eslint/parser': 8.28.0(eslint@8.57.1)(typescript@5.8.3)
       eslint: 8.57.1
       eslint-config-prettier: 9.1.0(eslint@8.57.1)
-      eslint-import-resolver-typescript: 3.9.1(eslint-plugin-import@2.31.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.9.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-gettext: 1.2.0
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.9.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jest: 28.11.0(@typescript-eslint/eslint-plugin@8.28.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(jest@29.7.0(@types/node@22.15.30)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.15.30)(typescript@5.8.3)))(typescript@5.8.3)
       eslint-plugin-jest-dom: 5.5.0(eslint@8.57.1)
       eslint-plugin-jest-formatting: 3.1.0(eslint@8.57.1)
@@ -16286,8 +16239,8 @@ snapshots:
       '@typescript-eslint/parser': 8.28.0(eslint@8.57.1)(typescript@5.8.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.9.1(eslint-plugin-import@2.31.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.9.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.9.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.4(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -16314,6 +16267,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.1
+      eslint: 8.57.1
+      get-tsconfig: 4.10.0
+      is-bun-module: 1.3.0
+      rspack-resolver: 1.2.2
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.14
+    optionalDependencies:
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -16336,6 +16304,17 @@ snapshots:
       '@typescript-eslint/parser': 8.28.0(eslint@8.57.1)(typescript@5.8.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.9.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1)(eslint@8.57.1):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.28.0(eslint@8.57.1)(typescript@5.8.3)
+      eslint: 8.57.1
+      eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.9.1(eslint-plugin-import@2.31.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
@@ -16350,7 +16329,7 @@ snapshots:
     dependencies:
       gettext-parser: 4.2.0
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.9.1)(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -16362,6 +16341,35 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.28.0(eslint@8.57.1)(typescript@5.8.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.9.1)(eslint@8.57.1):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.8
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 8.57.1
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -19927,7 +19935,7 @@ snapshots:
 
   stoppable@1.1.0: {}
 
-  storefront-kit@0.24.0(2eea54938541e43338f6c40ea8e1cef3):
+  storefront-kit@0.32.3(@base-ui/react@1.6.0(@date-fns/tz@1.2.0)(@types/react@19.2.7)(date-fns@4.1.0)(react-dom@19.1.7(react@19.1.7))(react@19.1.7))(@tailwindcss/container-queries@0.1.1(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.15.30)(typescript@5.8.3))))(@tailwindcss/typography@0.5.16(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.15.30)(typescript@5.8.3))))(embla-carousel-react@9.0.0-rc01(react@19.1.7))(lucide-react@0.474.0(react@19.1.7))(react-day-picker@9.7.0(react@19.1.7))(react-dom@19.1.7(react@19.1.7))(react@19.1.7)(sonner@1.7.4(react-dom@19.1.7(react@19.1.7))(react@19.1.7))(tailwindcss-animate@1.0.7(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.15.30)(typescript@5.8.3))))(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.15.30)(typescript@5.8.3))):
     dependencies:
       '@tailwindcss/container-queries': 0.1.1(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.15.30)(typescript@5.8.3)))
       '@tailwindcss/typography': 0.5.16(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.15.30)(typescript@5.8.3)))
@@ -19943,19 +19951,6 @@ snapshots:
       tailwindcss-animate: 1.0.7(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.15.30)(typescript@5.8.3)))
     optionalDependencies:
       '@base-ui/react': 1.6.0(@date-fns/tz@1.2.0)(@types/react@19.2.7)(date-fns@4.1.0)(react-dom@19.1.7(react@19.1.7))(react@19.1.7)
-      '@radix-ui/react-accordion': 1.2.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.7(react@19.1.7))(react@19.1.7)
-      '@radix-ui/react-checkbox': 1.3.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.7(react@19.1.7))(react@19.1.7)
-      '@radix-ui/react-dialog': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.7(react@19.1.7))(react@19.1.7)
-      '@radix-ui/react-dropdown-menu': 2.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.7(react@19.1.7))(react@19.1.7)
-      '@radix-ui/react-label': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.7(react@19.1.7))(react@19.1.7)
-      '@radix-ui/react-navigation-menu': 1.2.13(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.7(react@19.1.7))(react@19.1.7)
-      '@radix-ui/react-popover': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.7(react@19.1.7))(react@19.1.7)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.7(react@19.1.7))(react@19.1.7)
-      '@radix-ui/react-radio-group': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.7(react@19.1.7))(react@19.1.7)
-      '@radix-ui/react-select': 2.2.5(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.7(react@19.1.7))(react@19.1.7)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.7)(react@19.1.7)
-      '@radix-ui/react-toggle': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.7(react@19.1.7))(react@19.1.7)
-      '@radix-ui/react-toggle-group': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.7(react@19.1.7))(react@19.1.7)
       embla-carousel-react: 9.0.0-rc01(react@19.1.7)
       lucide-react: 0.474.0(react@19.1.7)
       react-day-picker: 9.7.0(react@19.1.7)


### PR DESCRIPTION
chore(deps): PROMO-1574 bump storefront-kit versions and style the promotion callouts using built-in styles

## What/Why?
The latest Storefront Kit fixed the issue with using @layer utilities.
the Callout component can be styled for Catalyst out-of-the-box so we need to revert tailwind classes and styles from promotions callouts using callout component.

## Testing
### Manual testing
#### Existing screenshots of homepage/PLP and PDP:

<img width="1763" height="837" alt="home-old" src="https://github.com/user-attachments/assets/87396af2-a35c-4a3b-bb23-8296d38a0a66" />

<img width="1700" height="872" alt="category-old" src="https://github.com/user-attachments/assets/f11238dd-a137-4dd2-b0b3-d22ef80d0026" />

<img width="1732" height="926" alt="pdp-old" src="https://github.com/user-attachments/assets/4c9ef228-1df3-4c94-a49b-1bd834719540" />

#### Screenshots of homepage/PLP and PDP after storefront-kit bump and style changes:

<img width="1384" height="854" alt="home-new" src="https://github.com/user-attachments/assets/faf9d9e8-1e4c-484c-ae45-99302828d238" />

<img width="1381" height="860" alt="category-new" src="https://github.com/user-attachments/assets/90b59120-c54e-46e6-bc5e-df5fc3991303" />

<img width="1382" height="878" alt="pdp-new" src="https://github.com/user-attachments/assets/1585c35e-ff6f-4acd-aeff-f988349b3adb" />

## Migration
None
