### PR TITLE
fix: TRAC-1280 catch catalyst.ref clobbering in sync-makeswift conflict rules

### DIFF
--- a/.claude/skills/sync-makeswift/SKILL.md
+++ b/.claude/skills/sync-makeswift/SKILL.md
@@ -27,6 +27,12 @@ If the merge completes cleanly, skip to changeset cleanup. Otherwise, resolve co
 - `pnpm-lock.yaml`: accept canary's version (`git checkout --theirs pnpm-lock.yaml`), then regenerate with `pnpm install --no-frozen-lockfile`.
 - For all other conflicts, prefer canary's structure/patterns while preserving makeswift-specific additions (imports, components, config).
 
+**Check `core/package.json`'s nested `catalyst.version`/`catalyst.ref` fields even when they don't show up as a textual conflict.** These must always mirror the top-level `name`/`version` on this branch (e.g. `"version": "1.9.0"` → `catalyst.ref: "@bigcommerce/catalyst-makeswift@1.9.0"`), matching what the automated "Version Packages (`integrations/makeswift`)" bump sets them to. Because this is a small, self-contained hunk, git often merges it cleanly by taking canary's raw value (`@bigcommerce/catalyst-core@<version>`) without flagging a conflict — check it by hand every time:
+
+```bash
+grep -A3 '"catalyst"' core/package.json
+```
+
 After resolving all conflicts, stage everything and verify no unresolved conflicts remain:
 
 ```bash


### PR DESCRIPTION
Jira: [TRAC-1280](https://bigcommercecloud.atlassian.net/browse/TRAC-1280)

## What/Why?
The `sync-makeswift` skill's conflict-resolution rules for `core/package.json` only cover the top-level `name`/`version` fields. They miss the nested `catalyst.version`/`catalyst.ref` fields, which must mirror the branch's own package identity (e.g. `@bigcommerce/catalyst-makeswift@1.9.0` on `integrations/makeswift`) rather than canary's.

Because that nested object is a small, non-overlapping hunk, git's 3-way merge silently takes canary's incoming value (`@bigcommerce/catalyst-core@<version>`) instead of flagging a textual conflict — so this was never caught by the documented conflict rules. Discovered while running `/release-catalyst`: PR #3130 had picked up `catalyst.ref: "@bigcommerce/catalyst-core@1.10.1"` on the `integrations/makeswift` sync branch. The same bug already landed on `integrations/makeswift` itself via a prior sync merge, since the following Version Packages release (which would have auto-corrected it) never merged.

This PR documents the field as something to check by hand on every future sync.

## Rollout/Rollback
Docs-only change to `.claude/skills/sync-makeswift/SKILL.md`. No runtime impact; revert is a straight revert if needed.

## Testing
N/A (skill instructions only). Verified by hand against the `catalyst.ref` history across `canary` and `integrations/makeswift` commits.

[TRAC-1280]: https://bigcommercecloud.atlassian.net/browse/TRAC-1280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ