### PR TITLE
docs: TRAC-1290 add integrations/b2b-makeswift stage to /release-catalyst

### DIFF
--- a/.claude/skills/release-catalyst/SKILL.md
+++ b/.claude/skills/release-catalyst/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: release-catalyst
 description: >
-  Cut a new release of Catalyst (`@bigcommerce/catalyst-core` and `@bigcommerce/catalyst-makeswift`).
+  Cut a new release of Catalyst (`@bigcommerce/catalyst-core`, `@bigcommerce/catalyst-makeswift`,
+  and `@bigcommerce/catalyst-b2b-makeswift`).
   Use when the user says "/release-catalyst", "cut a release", "release catalyst", or asks to
-  publish new versions of the Catalyst packages. This skill orchestrates the full two-stage release
-  process: merging the Version Packages PR on canary, syncing integrations/makeswift, and pushing
-  @latest tags.
+  publish new versions of the Catalyst packages. This skill orchestrates the full release process:
+  merging the Version Packages PR on canary, syncing and releasing integrations/makeswift, then
+  integrations/b2b-makeswift, and pushing @latest tags.
 ---
 
 # Release Catalyst
@@ -94,27 +95,75 @@ git fetch origin --tags
 gh release view @bigcommerce/catalyst-makeswift@<version> --json tagName,name,isDraft,isPrerelease
 ```
 
-## Stage 3: Push `@latest` tags
+## Stage 3: Sync and release `integrations/b2b-makeswift`
 
-Update both `@latest` tags to point to the new releases:
+`integrations/b2b-makeswift` builds on `integrations/makeswift`, so it releases after Stage 2. If Stage 2 didn't cut a new makeswift release (no makeswift changes), skip this stage.
+
+### 3a. Sync branches
+
+Invoke the `/sync-integration-branch` skill with target `integrations/b2b-makeswift`, with one addition: during the sync (after merge, before pushing), also add a changeset for `@bigcommerce/catalyst-b2b-makeswift`:
+
+**Determine bump type**: Match the bump type from Stage 2 (the makeswift bump).
+
+**Create changeset file** (`.changeset/sync-makeswift-<version>.md`, where `<version>` uses hyphens instead of dots):
+
+```markdown
+---
+"@bigcommerce/catalyst-b2b-makeswift": <patch|minor|major>
+---
+
+Pulls in changes from the `@bigcommerce/catalyst-makeswift@<version>` release. For more information, see the [changelog entry](https://github.com/bigcommerce/catalyst/blob/<makeswift-sha>/core/CHANGELOG.md#<version-anchor>).
+```
+
+Where `<version>` is the makeswift version released in Stage 2, `<makeswift-sha>` is the Version Packages merge commit on `integrations/makeswift`, and `<version-anchor>` is that version with dots removed. The b2b package keeps its **own** version line: the bump type mirrors makeswift's, but the resulting `@bigcommerce/catalyst-b2b-makeswift` version number is independent of makeswift's.
+
+Include this changeset in the merge commit (amend if needed) alongside the normal sync work.
+
+### 3b. Merge the Version Packages (`integrations/b2b-makeswift`) PR
+
+After the sync lands, the Changesets action opens a "Version Packages (`integrations/b2b-makeswift`)" PR.
+
+```bash
+gh pr list --search "Version Packages (integrations/b2b-makeswift)" --state open --json number,title
+```
+
+Same flow as Stage 2b:
+- If checks aren't running (bot PR), push an empty commit to trigger CI, then **drop it before merging** by resetting to the parent and force-pushing.
+- Once approved and green, merge with `gh pr merge <number> --squash`.
+  - Same caveat as makeswift: squash merging is normally disallowed on `integrations/b2b-makeswift` to preserve merge bases for sync PRs. Temporarily enable it for this step, then re-disable.
+
+### 3c. Verify the b2b release
 
 ```bash
 git fetch origin --tags
-git tag @bigcommerce/catalyst-core@latest @bigcommerce/catalyst-core@<version> -f
-git tag @bigcommerce/catalyst-makeswift@latest @bigcommerce/catalyst-makeswift@<version> -f
-git push origin @bigcommerce/catalyst-core@latest -f
-git push origin @bigcommerce/catalyst-makeswift@latest -f
+gh release view @bigcommerce/catalyst-b2b-makeswift@<version> --json tagName,name,isDraft,isPrerelease
 ```
 
-Confirm both tags were pushed successfully.
+> **Large catch-up:** when reviving a branch that's many makeswift releases behind, run this stage once per makeswift **minor** tag (see the one-time catch-up in `/sync-integration-branch`), cutting a b2b release per rung so `@latest` marches forward cleanly.
 
-## Stage 4: Cleanup
+## Stage 4: Push `@latest` tags
+
+Update the `@latest` tags to point to the new releases (skip any package that didn't get a new release this run):
+
+```bash
+git fetch origin --tags
+git tag @bigcommerce/catalyst-core@latest @bigcommerce/catalyst-core@<core-version> -f
+git tag @bigcommerce/catalyst-makeswift@latest @bigcommerce/catalyst-makeswift@<makeswift-version> -f
+git tag @bigcommerce/catalyst-b2b-makeswift@latest @bigcommerce/catalyst-b2b-makeswift@<b2b-version> -f
+git push origin @bigcommerce/catalyst-core@latest -f
+git push origin @bigcommerce/catalyst-makeswift@latest -f
+git push origin @bigcommerce/catalyst-b2b-makeswift@latest -f
+```
+
+Confirm the tags were pushed successfully.
+
+## Stage 5: Cleanup
 
 ```bash
 git checkout canary
 git pull
 ```
 
-Delete any leftover local branches (`changeset-release/*`, `sync-integrations-makeswift`, `integrations/makeswift`).
+Delete any leftover local branches (`changeset-release/*`, `sync-integrations-makeswift`, `integrations/makeswift`, `sync-integrations-b2b-makeswift`, `integrations/b2b-makeswift`).
 
-Report the final state: both package versions released, tags updated, branches cleaned up.
+Report the final state: which package versions released, tags updated, branches cleaned up.


### PR DESCRIPTION
Jira: [TRAC-1290](https://bigcommercecloud.atlassian.net/browse/TRAC-1290)

## What/Why?

Deferred piece of the b2b release wiring (LTRAC-1296). `/release-catalyst` released `@bigcommerce/catalyst-core` and `@bigcommerce/catalyst-makeswift` but had no stage for `@bigcommerce/catalyst-b2b-makeswift`, so nothing moved its `@latest` tag. That tag matters, the CLI's `upgrade.ts` resolves `@bigcommerce/catalyst-b2b-makeswift@latest`, so without moving it `catalyst upgrade` stays pinned forever.

Adds a **Stage 3** (sync + release `integrations/b2b-makeswift`, mirroring the makeswift stage but sourced from `integrations/makeswift`), renumbers the tag-push (now Stage 4) and cleanup (Stage 5), and extends both to cover the b2b package.

Needed now rather than post-upgrade because the b2b upgrade climb (LTRAC-1297) cuts a release per rung, so the b2b release path has to exist first. The stage also notes the large-catch-up cadence: one b2b release per makeswift minor tag.

## Rollout/Rollback

Local tooling only (`.claude/skills/`), no runtime/app impact. Rollback = revert the commit.

## Testing

Skill markdown only. Verified the stage sequence reads 1 (canary) → 2 (makeswift) → 3 (b2b) → 4 (@latest tags) → 5 (cleanup). No code paths exercised; the stage will get its real exercise on the first b2b upgrade rung.

[TRAC-1290]: https://bigcommercecloud.atlassian.net/browse/TRAC-1290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ