### PR TITLE
ci: TRAC-1350 fix bundle-size baseline detection for b2b-makeswift

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -71,6 +71,8 @@ jobs:
           PKG_NAME=$(node -p "require('./pr/core/package.json').name")
           if [ "$PKG_NAME" = "@bigcommerce/catalyst-makeswift" ]; then
             echo "branch=integrations/makeswift" >> $GITHUB_OUTPUT
+          elif [ "$PKG_NAME" = "@bigcommerce/catalyst-b2b-makeswift" ]; then
+            echo "branch=integrations/b2b-makeswift" >> $GITHUB_OUTPUT
           else
             echo "branch=canary" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
Jira: [TRAC-1350](https://bigcommercecloud.atlassian.net/browse/TRAC-1350)

## What/Why?

`.github/workflows/bundle-size.yml`'s baseline-branch detection only special-cased `@bigcommerce/catalyst-makeswift` (→ `integrations/makeswift`); every other package name, including `@bigcommerce/catalyst-b2b-makeswift`, fell through to `canary`. Since `integrations/b2b-makeswift` carries substantial B2B-only code on top of makeswift, comparing its bundle against `canary` produced a misleading diff on every b2b-makeswift PR.

Adds an `elif` branch mapping `@bigcommerce/catalyst-b2b-makeswift` → `integrations/b2b-makeswift`, mirroring the existing pattern already used in `changesets-release.yml`'s package-resolution step.

Discovered during the LTRAC-1297 makeswift-upgrade climb; per team policy, landing this fix on `canary` first, then propagating down through `integrations/makeswift` → `integrations/b2b-makeswift` via the normal sync chain rather than patching it directly on the downstream branch.

## Rollout/Rollback

CI-only change, no runtime impact. Revert is a one-line diff if needed.

## Testing

Verified the exact bug by re-reading the workflow logic: `@bigcommerce/catalyst-b2b-makeswift` doesn't match the `catalyst-makeswift` string check, so it always fell to the `else` (canary) branch. Confirmed the fix's package name against `core/package.json` on `integrations/b2b-makeswift` and confirmed the matching pattern against `changesets-release.yml`'s existing b2b `elif`.

[TRAC-1350]: https://bigcommercecloud.atlassian.net/browse/TRAC-1350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ