### PR TITLE
LTRAC-1421: Surface clear error for non-JWT storefront token

### DIFF
--- a/.changeset/ltrac-1421-storefront-token-401.md
+++ b/.changeset/ltrac-1421-storefront-token-401.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-client": patch
+---
+
+Surface a clearer error when `BIGCOMMERCE_STOREFRONT_TOKEN` is not a storefront JWT. Previously an incompatible token (e.g. an OAuth access token) produced a bare 401 with no explanation. The client now detects when a 401 is returned with a token that isn't a well-formed storefront JWT and throws `InvalidStorefrontTokenError` explaining that a storefront JWT is required and how to generate one.

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -3,7 +3,7 @@ import { BigCommerceAuthError } from './gql-auth-error';
 import { BigCommerceGQLError } from './gql-error';
 import { InvalidStorefrontTokenError } from './invalid-storefront-token-error';
 import { parseGraphQLError } from './lib/error';
-import { isWellFormedStorefrontToken } from './lib/storefront-token';
+import { looksLikeJwt } from './lib/storefront-token';
 import { DocumentDecoration } from './types';
 import { getOperationInfo } from './utils/getOperationName';
 import { normalizeQuery } from './utils/normalizeQuery';
@@ -171,7 +171,7 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     });
 
     if (!response.ok) {
-      if (response.status === 401 && !isWellFormedStorefrontToken(this.config.storefrontToken)) {
+      if (response.status === 401 && !looksLikeJwt(this.config.storefrontToken)) {
         throw new InvalidStorefrontTokenError(response.status);
       }
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,7 +1,9 @@
 import { BigCommerceAPIError } from './api-error';
 import { BigCommerceAuthError } from './gql-auth-error';
 import { BigCommerceGQLError } from './gql-error';
+import { InvalidStorefrontTokenError } from './invalid-storefront-token-error';
 import { parseGraphQLError } from './lib/error';
+import { isWellFormedStorefrontToken } from './lib/storefront-token';
 import { DocumentDecoration } from './types';
 import { getOperationInfo } from './utils/getOperationName';
 import { normalizeQuery } from './utils/normalizeQuery';
@@ -169,6 +171,10 @@ class Client<FetcherRequestInit extends RequestInit = RequestInit> {
     });
 
     if (!response.ok) {
+      if (response.status === 401 && !isWellFormedStorefrontToken(this.config.storefrontToken)) {
+        throw new InvalidStorefrontTokenError(response.status);
+      }
+
       throw await BigCommerceAPIError.createFromResponse(response);
     }
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -3,5 +3,6 @@ export { BigCommerceGQLError } from './gql-error';
 export { BigCommerceAuthError } from './gql-auth-error';
 export { MissingCustomerAccessTokenError } from './missing-cat-error';
 export { InvalidCustomerAccessTokenError } from './invalid-cat-error';
+export { InvalidStorefrontTokenError } from './invalid-storefront-token-error';
 export { createClient } from './client';
 export { removeEdgesAndNodes } from './utils/removeEdgesAndNodes';

--- a/packages/client/src/invalid-storefront-token-error.ts
+++ b/packages/client/src/invalid-storefront-token-error.ts
@@ -9,7 +9,7 @@ export class InvalidStorefrontTokenError extends BigCommerceAPIError {
 
     this.name = 'InvalidStorefrontTokenError';
     this.message = [
-      `BigCommerce API returned ${status}: the configured storefront token does not appear to be a storefront JWT.`,
+      `BigCommerce API returned ${status}: the configured storefront token doesn't look like a JWT.`,
       '',
       'BIGCOMMERCE_STOREFRONT_TOKEN must be a storefront API JWT, not an OAuth access token or any other token type.',
       'Generate one via the Storefront API Token endpoint (POST /stores/{store_hash}/v3/storefront/api-token):',

--- a/packages/client/src/invalid-storefront-token-error.ts
+++ b/packages/client/src/invalid-storefront-token-error.ts
@@ -1,0 +1,19 @@
+import { BigCommerceAPIError } from './api-error';
+
+export class InvalidStorefrontTokenError extends BigCommerceAPIError {
+  constructor(
+    public status: number,
+    graphqlErrors: unknown[] = [],
+  ) {
+    super(status, graphqlErrors);
+
+    this.name = 'InvalidStorefrontTokenError';
+    this.message = [
+      `BigCommerce API returned ${status}: the configured storefront token does not appear to be a storefront JWT.`,
+      '',
+      'BIGCOMMERCE_STOREFRONT_TOKEN must be a storefront API JWT, not an OAuth access token or any other token type.',
+      'Generate one via the Storefront API Token endpoint (POST /stores/{store_hash}/v3/storefront/api-token):',
+      'https://developer.bigcommerce.com/docs/rest-authentication/tokens#create-a-token',
+    ].join('\n');
+  }
+}

--- a/packages/client/src/lib/storefront-token.ts
+++ b/packages/client/src/lib/storefront-token.ts
@@ -1,0 +1,23 @@
+const BASE64URL_SEGMENT = /^[A-Za-z0-9_-]+$/;
+
+// A BigCommerce storefront token is a JWT: three base64url segments
+// (header.payload.signature) whose payload decodes to a JSON object. Other
+// token types (e.g. OAuth access tokens) are opaque strings that do not match
+// this shape, so this lets us distinguish "wrong kind of token" from other
+// causes of a 401.
+export function isWellFormedStorefrontToken(token: string): boolean {
+  const segments = token.split('.');
+
+  if (segments.length !== 3 || !segments.every((segment) => BASE64URL_SEGMENT.test(segment))) {
+    return false;
+  }
+
+  try {
+    const payload = segments[1].replace(/-/g, '+').replace(/_/g, '/');
+    const decoded = JSON.parse(atob(payload)) as unknown;
+
+    return typeof decoded === 'object' && decoded !== null;
+  } catch {
+    return false;
+  }
+}

--- a/packages/client/src/lib/storefront-token.ts
+++ b/packages/client/src/lib/storefront-token.ts
@@ -1,11 +1,12 @@
 const BASE64URL_SEGMENT = /^[A-Za-z0-9_-]+$/;
 
-// A BigCommerce storefront token is a JWT: three base64url segments
-// (header.payload.signature) whose payload decodes to a JSON object. Other
-// token types (e.g. OAuth access tokens) are opaque strings that do not match
-// this shape, so this lets us distinguish "wrong kind of token" from other
-// causes of a 401.
-export function isWellFormedStorefrontToken(token: string): boolean {
+// Checks JWT shape only: three base64url segments (header.payload.signature)
+// whose payload decodes to a JSON object. This does NOT verify that the token
+// is actually a valid storefront token (Simple/Private/etc) — we have no way
+// to check that client-side without the storefront service's signing key.
+// It only rules out tokens that aren't JWTs at all (e.g. opaque OAuth access
+// tokens), which is the failure mode this is meant to catch.
+export function looksLikeJwt(token: string): boolean {
   const segments = token.split('.');
 
   if (segments.length !== 3 || !segments.every((segment) => BASE64URL_SEGMENT.test(segment))) {


### PR DESCRIPTION
Linear: [LTRAC-1421](https://linear.app/commerce/issue/LTRAC-1421/unclear-401-when-storefront-token-isnt-a-storefront-jwt)

## What/Why?

Vortex IQ (closed beta partner) hit a bare 401 during Native Hosting setup because `BIGCOMMERCE_STOREFRONT_TOKEN` wasn't a storefront JWT (e.g. an OAuth access token was supplied instead). The response gave no indication of the cause, leaving them to reverse-engineer that the token type mattered.

`packages/client/src/client.ts` now checks, on any 401 response, whether the configured storefront token is a well-formed JWT (three base64url segments with a JSON-decodable payload — see `isWellFormedStorefrontToken` in `packages/client/src/lib/storefront-token.ts`). If it isn't, it throws a new `InvalidStorefrontTokenError` (extends `BigCommerceAPIError`, so existing `instanceof BigCommerceAPIError` handling still works) explaining that a storefront JWT is required and linking to how to generate one. A 401 with a well-formed token still falls through to the existing generic error, so this doesn't mask other causes of a 401 (expired/revoked JWT, wrong store hash, etc.).

Includes a changeset for `@bigcommerce/catalyst-client` (patch).

## Testing

No automated tests included yet. Manual verification:

1. Set `BIGCOMMERCE_STOREFRONT_TOKEN` to a non-JWT value (e.g. a BigCommerce OAuth access token) and hit any storefront page/GraphQL query that uses `client.fetch`. Confirm the thrown error is `InvalidStorefrontTokenError` with the actionable message, instead of a bare "BigCommerce API returned 401".
2. Confirm a valid storefront JWT continues to work normally (no regression on the happy path).
3. Confirm a 401 caused by something else (e.g. a well-formed but expired/invalid JWT) still throws the original generic `BigCommerceAPIError`, not the new error.

Follow-up: add unit tests for `isWellFormedStorefrontToken` and the `client.ts` 401 branch (deferred out of this PR).

## Migration

None.