### PR TITLE
LTRAC-1420: Fix OpenNext buildCommand failing on native Windows

### DIFF
--- a/.changeset/ltrac-1420-windows-opennext-buildcommand.md
+++ b/.changeset/ltrac-1420-windows-opennext-buildcommand.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst": patch
+---
+
+Fix `catalyst build`/`catalyst deploy` failing on native Windows during the OpenNext step. The generated `open-next.config.ts` hardcoded `node_modules/.bin/next build` as its `buildCommand`, which OpenNext runs through `execSync` (cmd.exe on Windows) — where the extensionless POSIX shim and forward-slash path fail to resolve. It now invokes `node ./node_modules/next/dist/bin/next build`, which works identically across sh and cmd.exe while still skipping the project's `generate` step.

--- a/packages/catalyst/templates/open-next.config.ts
+++ b/packages/catalyst/templates/open-next.config.ts
@@ -88,7 +88,14 @@ const cloudflareConfig = defineCloudflareConfig({
 });
 
 const config: OpenNextConfig = {
-  buildCommand: 'node_modules/.bin/next build',
+  // Invoke Next through `node` on its published bin rather than the
+  // `node_modules/.bin/next` shim. OpenNext runs this string via
+  // `execSync`, which shells out to cmd.exe on native Windows — where the
+  // extensionless POSIX shim and forward-slash path both fail to resolve.
+  // Calling `node <bin>` works identically across sh and cmd.exe (node.exe
+  // accepts forward slashes) while still bypassing the project's `build`
+  // script so the `generate` step is skipped.
+  buildCommand: 'node ./node_modules/next/dist/bin/next build',
   ...cloudflareConfig,
 };
 


### PR DESCRIPTION
Linear: [LTRAC-1420](https://linear.app/commerce/issue/LTRAC-1420/opennext-build-fails-on-native-windows-during-native-hosting-deploy)

## What/Why?

A closed-beta partner (Vortex IQ) hit a hard failure running `catalyst deploy` / `catalyst build` on **native Windows** during the OpenNext step, and had to move the build to WSL to proceed. Local `pnpm dev` worked — only the OpenNext/Native Hosting build path failed.

Root cause is a single line in the generated OpenNext config template (`packages/catalyst/templates/open-next.config.ts`):

```ts
buildCommand: 'node_modules/.bin/next build',
```

OpenNext executes this string via `@opennextjs/aws`'s `buildNextjsApp()`, which calls `cp.execSync(command, ...)`. `execSync` runs through the **system shell** — `/bin/sh` on Unix but **`cmd.exe` on Windows**. Under cmd.exe that command fails two ways:

- **Forward slashes** — cmd.exe treats `/` as a switch character and can't resolve `node_modules/.bin/next` as the command token.
- **No executable extension** — on Windows the runnable shim is `next.cmd`/`next.ps1`; the extensionless `.bin/next` is a POSIX `sh` script cmd.exe can't execute.

This template is only used on the OpenNext/Cloudflare deploy path (copied into `.bigcommerce/` by `build.ts` before the build), which is why `next dev` — routed through the package.json scripts and the pnpm/npm `.cmd` shims — works fine while the deploy build breaks.

The fix invokes Next through `node` on its published bin:

```ts
buildCommand: 'node ./node_modules/next/dist/bin/next build',
```

`node` resolves on PATH on every platform and node.exe accepts forward-slash paths, so this runs identically under `sh` and `cmd.exe`. It's exactly what the `.cmd`/`sh` shims exec internally, so behavior is unchanged — it still runs `next build` directly and deliberately skips the project's `generate` step (the reason `buildCommand` is hardcoded rather than deferring to the `build` script, which is `npm run generate && next build`).

Only the template changes; `core/.bigcommerce/open-next.config.ts` is a gitignored copy regenerated on every build.

## Testing

- Verified the execution mechanism: `@opennextjs/aws@3.9.16/dist/build/buildNextApp.js` runs `config.buildCommand` via `cp.execSync(command, { stdio: 'inherit', cwd })` (shell → cmd.exe on Windows).
- Confirmed `next`'s `bin` is `./dist/bin/next` and that the new command is equivalent to what the `.bin` shims exec.
- On non-Windows, `catalyst build` / `catalyst deploy` continue to build via OpenNext unchanged.
- Ideal follow-up: a maintainer with a native Windows box confirms `catalyst deploy` completes end-to-end without WSL.

## Migration

None. Config is regenerated on each build; no consumer action required.