### PR TITLE
fix(login): B2B-5343 Fix runtime errors for local env

### DIFF
--- a/core/b2b/b2b-client-effects.tsx
+++ b/core/b2b/b2b-client-effects.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useB2BAuth } from './use-b2b-auth';
+import { useB2BCart } from './use-b2b-cart';
+
+interface Props {
+  token?: string;
+  cartId?: string | null;
+}
+
+export function B2BClientEffects({ cartId, token }: Props) {
+  useB2BAuth(token);
+  useB2BCart(cartId);
+
+  return null;
+}

--- a/core/b2b/b2b-dev-script-injector.tsx
+++ b/core/b2b/b2b-dev-script-injector.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useEffect } from 'react';
+
+interface Props {
+  storeHash: string;
+  channelId: string;
+  hostname: string;
+  bcGraphqlDomain?: string;
+}
+
+export function B2BDevScriptInjector({ bcGraphqlDomain, channelId, hostname, storeHash }: Props) {
+  useEffect(() => {
+    if (document.getElementById('b2b-vite-entry')) {
+      return;
+    }
+
+    const mainSrc = `${hostname}/src/main.ts`;
+    const graphqlDomain = bcGraphqlDomain ?? 'mybigcommerce.com';
+
+    // Classic script so B3 config is available before the Vite modules evaluate.
+    const configScript = document.createElement('script');
+
+    configScript.id = 'b2b-config';
+    configScript.textContent = `
+      window.B3 = {
+        setting: {
+          store_hash: '${storeHash}',
+          channel_id: ${channelId},
+          platform: 'catalyst',
+          cart_url: '/cart',
+          bc_graphql_domain: '${graphqlDomain}',
+        },
+      };
+    `;
+    document.head.appendChild(configScript);
+
+    // React 19 does not execute <script> tags rendered from client components.
+    // Inject a single module that installs the Vite React preamble first, then
+    // loads the client and buyer-portal entry in order.
+    const entryScript = document.createElement('script');
+
+    entryScript.id = 'b2b-vite-entry';
+    entryScript.type = 'module';
+    entryScript.textContent = `
+      import RefreshRuntime from '${hostname}/@react-refresh';
+      RefreshRuntime.injectIntoGlobalHook(window);
+      window.$RefreshReg$ = () => {};
+      window.$RefreshSig$ = () => (type) => type;
+      window.__vite_plugin_react_preamble_installed__ = true;
+
+      await import('${hostname}/@vite/client');
+      await import('${mainSrc}');
+    `;
+    document.head.appendChild(entryScript);
+  }, [bcGraphqlDomain, channelId, hostname, storeHash]);
+
+  return null;
+}

--- a/core/b2b/script-dev.tsx
+++ b/core/b2b/script-dev.tsx
@@ -1,10 +1,7 @@
-/* eslint-disable @next/next/no-before-interactive-script-outside-document */
 'use client';
 
-import Script from 'next/script';
-
-import { useB2BAuth } from './use-b2b-auth';
-import { useB2BCart } from './use-b2b-cart';
+import { B2BClientEffects } from './b2b-client-effects';
+import { B2BDevScriptInjector } from './b2b-dev-script-injector';
 
 interface DevProps {
   storeHash: string;
@@ -23,43 +20,15 @@ export function ScriptDev({
   token,
   bcGraphqlDomain,
 }: DevProps) {
-  useB2BAuth(token);
-  useB2BCart(cartId);
-
-  const src = `${hostname}/src/main.ts`;
-
   return (
     <>
-      <Script id="b2b-react-refresh" strategy="beforeInteractive" type="module">
-        {`
-              import RefreshRuntime from '${hostname}/@react-refresh'
-              RefreshRuntime.injectIntoGlobalHook(window)
-              window.$RefreshReg$ = () => {}
-              window.$RefreshSig$ = () => (type) => type
-              window.__vite_plugin_react_preamble_installed__ = true
-          `}
-      </Script>
-      <Script
-        id="b2b-vite-client"
-        src={`${hostname}/@vite/client`}
-        strategy="beforeInteractive"
-        type="module"
+      <B2BClientEffects cartId={cartId} token={token} />
+      <B2BDevScriptInjector
+        bcGraphqlDomain={bcGraphqlDomain}
+        channelId={channelId}
+        hostname={hostname}
+        storeHash={storeHash}
       />
-
-      <Script id="b2b-config">
-        {`
-              window.B3 = {
-                setting: {
-                  store_hash: '${storeHash}',
-                  channel_id: ${channelId},
-                  platform: 'catalyst',
-                  cart_url: '/cart',
-                  bc_graphql_domain: '${bcGraphqlDomain ?? 'mybigcommerce.com'}',
-                },
-              };
-          `}
-      </Script>
-      <Script data-channelid={channelId} data-storehash={storeHash} src={src} type="module" />
     </>
   );
 }


### PR DESCRIPTION
## What/Why?
### B2B-5343: Fix local buyer portal script loading

## Summary

There are two errors when running Catalyst against a local Buyer Portal (`LOCAL_BUYER_PORTAL_HOST`) - _see the attached before video_  

- Encountered a script tag while rendering React component. Scripts inside React components are never executed when rendering on the client. Consider using template tag instead (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template).

- @vitejs/plugin-react can't detect preamble. Something is wrong.

Local B2B development loads the Buyer Portal from a Vite dev server (`http://localhost:3001`). That path depends on, in order:

1. Installing Vite's React refresh **preamble** before any Buyer Portal module evaluates
2. Loading `@vite/client`
3. Loading `/src/main.ts`
4. Having `window.B3` config available before the portal reads it

When the preamble is missing, the first Buyer Portal component module to evaluate throws:

```text
@vitejs/plugin-react can't detect preamble. Something is wrong.
```

(The reported location `Provider.tsx:20` is the preamble check that `@vitejs/plugin-react` injects into every transformed module, not meaningful source code, which made this confusing to debug.)

That blocks local login / Buyer Portal integration work on this branch. 

Not sure why it didn't work recently, as checked, seems React 19 is already there for a few months, so likely changed recently is Next.js (around `16.1` → `16.2` on this branch. But not too sure, just looks like the timing matches.

## What changed in this PR

| File | Change |
| --- | --- |
| `core/b2b/script-dev.tsx` | Now composes two small client components instead of rendering `next/script` tags |
| `core/b2b/b2b-dev-script-injector.tsx` (new) | Injects the config + one ordered Vite entry module via `document.createElement('script')` in `useEffect` |
| `core/b2b/b2b-client-effects.tsx` (new) | Pure extraction of the existing `useB2BAuth`/`useB2BCart` hooks — no behavior change |

Injection order is now guaranteed within a single module script:

1. Classic script setting `window.B3`
2. Module script that installs the React refresh preamble
3. `await import('${host}/@vite/client')`
4. `await import('${host}/src/main.ts')`

Scripts appended via the DOM API are always executed by the browser.

## Testing
Before

https://github.com/user-attachments/assets/382f6fa2-7b20-439b-b619-6bb5bcf430b2

After

https://github.com/user-attachments/assets/c0a401d9-24f0-4e36-951e-999217d00a62


## Migration
No needed, local env change only