### PR TITLE
test(inventory): BACK-734 Introduce backorder catalyst tests

### DIFF
--- a/core/tests/fixtures/index.ts
+++ b/core/tests/fixtures/index.ts
@@ -11,6 +11,7 @@ import { extendedBrowser } from './browser';
 import { CatalogFixture } from './catalog';
 import { CurrencyFixture } from './currency';
 import { CustomerFixture } from './customer';
+import { InventoryFixture } from './inventory';
 import { OrderFixture } from './order';
 import { extendedPage, toHaveURL } from './page';
 import { PromotionFixture } from './promotion';
@@ -25,6 +26,7 @@ interface Fixtures {
   catalog: CatalogFixture;
   customer: CustomerFixture;
   currency: CurrencyFixture;
+  inventory: InventoryFixture;
   promotion: PromotionFixture;
   redirects: RedirectsFixture;
   settings: SettingsFixture;
@@ -80,6 +82,16 @@ export const test = baseTest.extend<Fixtures>({
       await use(catalogFixture);
 
       await catalogFixture.cleanup();
+    },
+    { scope: 'test' },
+  ],
+  inventory: [
+    async ({ page }, use, currentTest) => {
+      const inventoryFixture = new InventoryFixture(page, currentTest);
+
+      await use(inventoryFixture);
+
+      await inventoryFixture.cleanup();
     },
     { scope: 'test' },
   ],

--- a/core/tests/fixtures/inventory/index.ts
+++ b/core/tests/fixtures/inventory/index.ts
@@ -1,0 +1,54 @@
+import { faker } from '@faker-js/faker';
+
+import { Fixture } from '~/tests/fixtures/fixture';
+import { BackorderMessage } from '~/tests/fixtures/utils/api/inventory';
+
+export class InventoryFixture extends Fixture {
+  private createdMessageIds: string[] = [];
+
+  async createBackorderMessage(input: {
+    name?: string;
+    message: string;
+    isDefault?: boolean;
+  }): Promise<BackorderMessage> {
+    this.skipIfReadonly();
+
+    const name = input.name ?? `auto-bo-msg-${faker.string.uuid()}`;
+    const messages = await this.api.inventory.createBackorderMessages([
+      { name, message: input.message, isDefault: input.isDefault },
+    ]);
+
+    const created = messages[0];
+
+    if (!created) {
+      throw new Error(`Failed to create backorder message "${name}"`);
+    }
+
+    this.createdMessageIds.push(created.id);
+
+    return created;
+  }
+
+  async configureProductBackorder(config: {
+    productId: number;
+    variantId?: number;
+    locationId: number;
+    backorderLimit: number;
+    backorderMessageId: number;
+  }): Promise<void> {
+    this.skipIfReadonly();
+
+    await this.api.inventory.configureLocationItems(config.locationId, [
+      {
+        productId: config.productId,
+        variantId: config.variantId,
+        backorderLimit: config.backorderLimit,
+        backorderMessageId: config.backorderMessageId,
+      },
+    ]);
+  }
+
+  async cleanup() {
+    await this.api.inventory.deleteBackorderMessages(this.createdMessageIds);
+  }
+}

--- a/core/tests/fixtures/utils/api/index.ts
+++ b/core/tests/fixtures/utils/api/index.ts
@@ -2,6 +2,7 @@ import { BlogApi, blogHttpClient } from '~/tests/fixtures/utils/api/blog';
 import { CatalogApi, catalogHttpClient } from '~/tests/fixtures/utils/api/catalog';
 import { CurrenciesApi, currenciesHttpClient } from '~/tests/fixtures/utils/api/currencies';
 import { CustomersApi, customersHttpClient } from '~/tests/fixtures/utils/api/customers';
+import { InventoryApi, inventoryHttpClient } from '~/tests/fixtures/utils/api/inventory';
 import { OrdersApi, ordersHttpClient } from '~/tests/fixtures/utils/api/orders';
 import { PromotionsApi, promotionsHttpClient } from '~/tests/fixtures/utils/api/promotions';
 import { RedirectsApi, redirectsHttpClient } from '~/tests/fixtures/utils/api/redirects';
@@ -14,6 +15,7 @@ export interface ApiClient {
   catalog: CatalogApi;
   customers: CustomersApi;
   currencies: CurrenciesApi;
+  inventory: InventoryApi;
   orders: OrdersApi;
   promotions: PromotionsApi;
   settings: SettingsApi;
@@ -27,6 +29,7 @@ export const httpApiClient: ApiClient = {
   catalog: catalogHttpClient,
   customers: customersHttpClient,
   currencies: currenciesHttpClient,
+  inventory: inventoryHttpClient,
   orders: ordersHttpClient,
   promotions: promotionsHttpClient,
   settings: settingsHttpClient,

--- a/core/tests/fixtures/utils/api/inventory/http.ts
+++ b/core/tests/fixtures/utils/api/inventory/http.ts
@@ -1,0 +1,187 @@
+/* eslint-disable no-console */
+import { z } from 'zod';
+
+import { httpClient } from '../client';
+
+import { AdjustInventoryItem, BackorderMessage, BackorderSettingsItem, InventoryApi } from '.';
+
+const BackorderMessageSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    message: z.string(),
+    isDefault: z.boolean(),
+  })
+  .transform(
+    (data): BackorderMessage => ({
+      id: data.id,
+      numericId: parseBackorderMessageId(data.id),
+      name: data.name,
+      message: data.message,
+      isDefault: data.isDefault,
+    }),
+  );
+
+function parseBackorderMessageId(opaqueId: string): number {
+  const match = /\d+$/.exec(opaqueId);
+
+  if (!match) {
+    throw new Error(`Cannot parse numeric ID from backorder message ID: ${opaqueId}`);
+  }
+
+  return Number(match[0]);
+}
+
+const GraphqlResponseSchema = z.object({
+  data: z.record(z.unknown()).nullable(),
+  errors: z.array(z.object({ message: z.string() })).optional(),
+});
+
+async function adminGraphql<T>(query: string, variables: Record<string, unknown>): Promise<T> {
+  const operationMatch = /(?:mutation|query)\s+(\w+)/.exec(query);
+  const operationName = operationMatch?.[1] ?? 'unknown';
+
+  console.log(`[adminGraphql] ${operationName} variables:`, JSON.stringify(variables, null, 2));
+
+  const parsed = await httpClient
+    .post('/graphql', { query, variables })
+    .parse(GraphqlResponseSchema);
+
+  console.log(`[adminGraphql] ${operationName} response:`, JSON.stringify(parsed, null, 2));
+
+  if (parsed.errors?.length) {
+    throw new Error(`Admin GraphQL error: ${parsed.errors.map((e) => e.message).join(', ')}`);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  return parsed.data as T;
+}
+
+const CREATE_BACKORDER_MESSAGES = `
+  mutation CreateBackorderMessages($input: CreateBackorderMessagesInput!) {
+    inventory {
+      createBackorderMessages(input: $input) {
+        errors {
+          errorDetails { fieldName, errorMessage, errorCode }
+        }
+      }
+    }
+  }
+`;
+
+const GET_BACKORDER_MESSAGES = `
+  query GetBackorderMessages($filters: GetBackorderMessagesFiltersInput) {
+    store {
+      inventory {
+        backorderMessages(filters: $filters) {
+          messages { id, name, message, isDefault }
+        }
+      }
+    }
+  }
+`;
+
+const DELETE_BACKORDER_MESSAGES = `
+  mutation DeleteBackorderMessages($filter: DeleteBackorderMessagesFilterInput) {
+    inventory {
+      deleteBackorderMessages(filter: $filter) {
+        errors {
+          errorDetails { fieldName, errorMessage, errorCode }
+        }
+      }
+    }
+  }
+`;
+
+interface GetBackorderMessagesResponse {
+  store: {
+    inventory: {
+      backorderMessages: {
+        messages: Array<{ id: string; name: string; message: string; isDefault: boolean }>;
+      };
+    };
+  };
+}
+
+export const inventoryHttpClient: InventoryApi = {
+  adjustAbsoluteLevel: async (items: AdjustInventoryItem[]): Promise<void> => {
+    const body = {
+      items: items.map((item) => ({
+        product_id: item.productId,
+        ...(item.variantId != null ? { variant_id: item.variantId } : {}),
+        location_id: item.locationId,
+        quantity: item.quantity,
+      })),
+      reason: 'Automated test adjustment',
+    };
+
+    console.log(
+      '[inventory] PUT /v3/inventory/adjustments/absolute body:',
+      JSON.stringify(body, null, 2),
+    );
+    await httpClient.put('/v3/inventory/adjustments/absolute', body);
+    console.log('[inventory] PUT /v3/inventory/adjustments/absolute succeeded');
+  },
+
+  configureLocationItems: async (
+    locationId: number,
+    settings: BackorderSettingsItem[],
+  ): Promise<void> => {
+    const body = {
+      settings: settings.map((item) => ({
+        identity: {
+          product_id: item.productId,
+          ...(item.variantId != null ? { variant_id: item.variantId } : {}),
+        },
+        ...(item.backorderLimit !== undefined ? { backorder_limit: item.backorderLimit } : {}),
+        ...(item.backorderMessageId !== undefined
+          ? { backorder_message_id: item.backorderMessageId }
+          : {}),
+      })),
+    };
+
+    console.log(
+      `[inventory] PUT /v3/inventory/locations/${locationId}/items body:`,
+      JSON.stringify(body, null, 2),
+    );
+    await httpClient.put(`/v3/inventory/locations/${locationId}/items`, body);
+    console.log(`[inventory] PUT /v3/inventory/locations/${locationId}/items succeeded`);
+  },
+
+  createBackorderMessages: async (
+    messages: Array<{ name: string; message: string; isDefault?: boolean }>,
+  ): Promise<BackorderMessage[]> => {
+    await adminGraphql(CREATE_BACKORDER_MESSAGES, {
+      input: { messages },
+    });
+
+    const names = messages.map((m) => m.name);
+    const data = await adminGraphql<GetBackorderMessagesResponse>(GET_BACKORDER_MESSAGES, {
+      filters: { names },
+    });
+
+    return data.store.inventory.backorderMessages.messages.map((m) =>
+      BackorderMessageSchema.parse(m),
+    );
+  },
+
+  getBackorderMessagesByNames: async (names: string[]): Promise<BackorderMessage[]> => {
+    const data = await adminGraphql<GetBackorderMessagesResponse>(GET_BACKORDER_MESSAGES, {
+      filters: { names },
+    });
+
+    return data.store.inventory.backorderMessages.messages.map((m) =>
+      BackorderMessageSchema.parse(m),
+    );
+  },
+
+  deleteBackorderMessages: async (messageIds: string[]): Promise<void> => {
+    if (messageIds.length === 0) {
+      return;
+    }
+
+    await adminGraphql(DELETE_BACKORDER_MESSAGES, {
+      filter: { messageIds },
+    });
+  },
+};

--- a/core/tests/fixtures/utils/api/inventory/index.ts
+++ b/core/tests/fixtures/utils/api/inventory/index.ts
@@ -1,0 +1,33 @@
+export interface BackorderMessage {
+  readonly id: string;
+  readonly numericId: number;
+  readonly name: string;
+  readonly message: string;
+  readonly isDefault: boolean;
+}
+
+export interface AdjustInventoryItem {
+  readonly productId: number;
+  readonly variantId?: number;
+  readonly locationId: number;
+  readonly quantity: number;
+}
+
+export interface BackorderSettingsItem {
+  readonly productId: number;
+  readonly variantId?: number;
+  readonly backorderLimit?: number | null;
+  readonly backorderMessageId?: number | null;
+}
+
+export interface InventoryApi {
+  adjustAbsoluteLevel: (items: AdjustInventoryItem[]) => Promise<void>;
+  configureLocationItems: (locationId: number, settings: BackorderSettingsItem[]) => Promise<void>;
+  createBackorderMessages: (
+    messages: Array<{ name: string; message: string; isDefault?: boolean }>,
+  ) => Promise<BackorderMessage[]>;
+  getBackorderMessagesByNames: (names: string[]) => Promise<BackorderMessage[]>;
+  deleteBackorderMessages: (messageIds: string[]) => Promise<void>;
+}
+
+export { inventoryHttpClient } from './http';

--- a/core/tests/fixtures/utils/api/settings/http.ts
+++ b/core/tests/fixtures/utils/api/settings/http.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { z } from 'zod';
 
 import { httpClient } from '../client';
@@ -10,12 +11,22 @@ const InventorySettingsSchema = z
     default_out_of_stock_message: z.string(),
     show_out_of_stock_message: z.boolean(),
     stock_level_display: z.enum(['dont_show', 'show', 'show_when_low']).nullable(),
+    show_backorder_availability_prompt: z.boolean().optional(),
+    backorder_availability_prompt: z.string().optional(),
+    show_backorder_message: z.boolean().optional(),
+    show_quantity_on_backorder: z.boolean().optional(),
+    show_quantity_on_hand: z.boolean().optional(),
   })
   .transform(
     (data): InventorySettings => ({
       defaultOutOfStockMessage: data.default_out_of_stock_message,
       showOutOfStockMessage: data.show_out_of_stock_message,
       stockLevelDisplay: data.stock_level_display,
+      showBackorderAvailabilityPrompt: data.show_backorder_availability_prompt,
+      backorderAvailabilityPrompt: data.backorder_availability_prompt,
+      showBackorderMessage: data.show_backorder_message,
+      showQuantityOnBackorder: data.show_quantity_on_backorder,
+      showQuantityOnHand: data.show_quantity_on_hand,
     }),
   );
 
@@ -23,6 +34,11 @@ const transformInventorySettingsData = (data: InventorySettings) => ({
   default_out_of_stock_message: data.defaultOutOfStockMessage,
   show_out_of_stock_message: data.showOutOfStockMessage,
   stock_level_display: data.stockLevelDisplay,
+  show_backorder_availability_prompt: data.showBackorderAvailabilityPrompt,
+  backorder_availability_prompt: data.backorderAvailabilityPrompt,
+  show_backorder_message: data.showBackorderMessage,
+  show_quantity_on_backorder: data.showQuantityOnBackorder,
+  show_quantity_on_hand: data.showQuantityOnHand,
 });
 
 export const settingsHttpClient: SettingsApi = {
@@ -34,6 +50,10 @@ export const settingsHttpClient: SettingsApi = {
     return resp.data;
   },
   setInventorySettings: async (settings: InventorySettings): Promise<void> => {
-    await httpClient.put(`/v3/settings/inventory`, transformInventorySettingsData(settings));
+    const body = transformInventorySettingsData(settings);
+
+    console.log('[settings] PUT /v3/settings/inventory body:', JSON.stringify(body, null, 2));
+    await httpClient.put(`/v3/settings/inventory`, body);
+    console.log('[settings] PUT /v3/settings/inventory succeeded');
   },
 };

--- a/core/tests/fixtures/utils/api/settings/index.ts
+++ b/core/tests/fixtures/utils/api/settings/index.ts
@@ -2,6 +2,11 @@ export interface InventorySettings {
   readonly defaultOutOfStockMessage?: string;
   readonly showOutOfStockMessage?: boolean;
   readonly stockLevelDisplay?: 'dont_show' | 'show' | 'show_when_low' | null;
+  readonly showBackorderAvailabilityPrompt?: boolean;
+  readonly backorderAvailabilityPrompt?: string;
+  readonly showBackorderMessage?: boolean;
+  readonly showQuantityOnBackorder?: boolean;
+  readonly showQuantityOnHand?: boolean;
 }
 
 export interface SettingsApi {

--- a/core/tests/ui/e2e/backorder.spec.ts
+++ b/core/tests/ui/e2e/backorder.spec.ts
@@ -1,0 +1,105 @@
+/* eslint-disable no-console */
+import { expect, test } from '~/tests/fixtures';
+import { getTranslations } from '~/tests/lib/i18n';
+import { TAGS } from '~/tests/tags';
+
+test(
+  'PDP shows backorder availability and cart shows backorder details',
+  { tag: [TAGS.writesData] },
+  async ({ page, catalog, settings, inventory }) => {
+    test.setTimeout(180_000);
+
+    const productT = await getTranslations('Product.ProductDetails');
+    const cartT = await getTranslations('Cart');
+
+    console.log('[backorder] Step 1: Setting inventory display settings');
+
+    await settings.setInventorySettings({
+      stockLevelDisplay: 'show',
+      showBackorderAvailabilityPrompt: true,
+      backorderAvailabilityPrompt: 'Available for backorder',
+      showBackorderMessage: true,
+      showQuantityOnBackorder: true,
+      showQuantityOnHand: true,
+    });
+    console.log('[backorder] Step 1 complete');
+
+    console.log('[backorder] Step 2: Creating product');
+
+    const product = await catalog.createSimpleProduct({
+      inventoryTracking: 'product',
+      inventoryLevel: 2,
+    });
+
+    console.log(
+      '[backorder] Step 2 complete: product id=%d path=%s variants=%j',
+      product.id,
+      product.path,
+      product.variants,
+    );
+
+    console.log('[backorder] Step 3: Creating backorder message');
+
+    const backorderMessage = await inventory.createBackorderMessage({
+      message: 'Ships in 2-3 weeks',
+    });
+
+    console.log(
+      '[backorder] Step 3 complete: message id=%s numericId=%d',
+      backorderMessage.id,
+      backorderMessage.numericId,
+    );
+
+    console.log('[backorder] Step 4: Configuring product backorder settings');
+
+    await inventory.configureProductBackorder({
+      productId: product.id,
+      locationId: 1,
+      backorderLimit: 10,
+      backorderMessageId: backorderMessage.numericId,
+    });
+    console.log('[backorder] Step 4 complete');
+
+    console.log('[backorder] Step 5: Waiting 61s for inventory projection pipeline');
+    await new Promise((resolve) => setTimeout(resolve, 61_000));
+    console.log('[backorder] Step 5 complete');
+
+    console.log('[backorder] Step 6: Navigating to PDP at %s', product.path);
+    await page.goto(product.path);
+    await page.waitForLoadState('networkidle');
+    console.log('[backorder] Step 6: Page loaded, checking assertions with retry');
+
+    await expect(async () => {
+      try {
+        await expect(page.getByText(productT('currentStock', { quantity: 2 }))).toBeVisible();
+        await expect(page.getByText('Available for backorder')).toBeVisible();
+      } catch {
+        await page.reload();
+        await page.waitForLoadState('networkidle');
+        await expect(page.getByText(productT('currentStock', { quantity: 2 }))).toBeVisible();
+        await expect(page.getByText('Available for backorder')).toBeVisible();
+      }
+    }).toPass({ timeout: 90_000, intervals: [2_000] });
+    console.log('[backorder] Step 6 complete: PDP assertions passed');
+
+    console.log('[backorder] Step 7: Setting qty to 5');
+    await page.getByRole('spinbutton', { name: productT('quantity') }).fill('5');
+    await expect(page.getByText(productT('backorderQuantity', { quantity: 3 }))).toBeVisible();
+    await expect(page.getByText('Ships in 2-3 weeks')).toBeVisible();
+    console.log('[backorder] Step 7 complete');
+
+    console.log('[backorder] Step 8: Adding to cart');
+    await page.getByRole('button', { name: productT('Submit.addToCart') }).click();
+    await expect(page.getByText(/added to/i).first()).toBeVisible();
+    console.log('[backorder] Step 8 complete');
+
+    console.log('[backorder] Step 9: Navigating to cart');
+    await page.goto('/cart');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText(cartT('quantityReadyToShip', { quantity: 2 }))).toBeVisible();
+    await expect(page.getByText(cartT('quantityOnBackorder', { quantity: 3 }))).toBeVisible();
+    await expect(page.getByText('Ships in 2-3 weeks')).toBeVisible();
+    console.log('[backorder] Step 9 complete: all assertions passed');
+  },
+);


### PR DESCRIPTION
## What/Why?
- Introduce catalyst end to end tests for backorders
   - This is to prevent any regressions in backorder functionality in Catalyst.

## Testing
CircleCi

## Migration
No migration. All new files