### PR TITLE
fix(b2b): B2B-5344 Allow non-production B2B API hosts

### DIFF
--- a/core/b2b/get-api-hostname.ts
+++ b/core/b2b/get-api-hostname.ts
@@ -2,6 +2,21 @@ import { z } from 'zod';
 
 const DEFAULT_API_HOST = 'https://api-b2b.bigcommerce.com';
 
+/**
+ * B2B API hosts a storefront is allowed to talk to.
+ *
+ * Production builds only honour `B2B_API_HOST` when it names one of these, so a
+ * misconfigured storefront can never send customer access tokens to an arbitrary
+ * origin. Keeping the internal environments here is what makes it possible to run
+ * a production build against a non-production store (CI / functional tests).
+ */
+const ALLOWED_API_HOSTS = new Set([
+  DEFAULT_API_HOST,
+  'https://api-b2b.staging.zone',
+  'https://api-b2b.integration.zone',
+  'https://api-b2b.service.bcdev',
+]);
+
 const ENV = z
   .object({
     env: z.object({
@@ -11,12 +26,27 @@ const ENV = z
   })
   .transform(({ env }) => env);
 
+const stripTrailingSlashes = (host: string) => host.replace(/\/+$/, '');
+
 export const getAPIHostname = () => {
   const { B2B_API_HOST, NODE_ENV } = ENV.parse(process);
+  const apiHost = stripTrailingSlashes(B2B_API_HOST);
 
-  if (NODE_ENV === 'production') {
-    return DEFAULT_API_HOST;
+  // Local development may point at a B2B API running anywhere, including localhost.
+  if (NODE_ENV !== 'production') {
+    return apiHost;
   }
 
-  return B2B_API_HOST;
+  if (ALLOWED_API_HOSTS.has(apiHost)) {
+    return apiHost;
+  }
+
+  if (apiHost !== DEFAULT_API_HOST) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `Ignoring B2B_API_HOST "${apiHost}": not a recognised BigCommerce B2B API host. Falling back to ${DEFAULT_API_HOST}.`,
+    );
+  }
+
+  return DEFAULT_API_HOST;
 };


### PR DESCRIPTION
## What/Why?

When `NODE_ENV=production` (expect local, other envs are all using this), then `B2B_API_HOST` always uses  **production** B2B API `https://api-b2b.bigcommerce.com'. So for a catalyst storefront deployed for a staging, integration, or dev store, login always fails, since it hit the production b2b-api. 

For example, I've enabled a catalyst storefront in staging env, store hash is `x9qgmakxu6`, but the calls went to **production** B2B API host.  See the [kibana logs](https://kibana.bigcommerce.net/goto/d0342d50-8fe1-11f1-969f-3f5b8a9d6691) for more details.

The change allow `B2B_API_HOST` passed in the env, and keeps a safety check, only known B2B API hosts are allowed, so non-prod stores can be tested with a real production build.

## Testing
I've tested with local, it works. Will do further verify in staging env after this PR merge.

**Before this change**

After `pnpm build` and `NODE_TLS_REJECT_UNAUTHORIZED=0 AUTH_TRUST_HOST=true PORT=4000 pnpm start` in local, I can see "something went wrong" in the UI. And the API call went to production, my local store hash is `zmnefhhmxn`, I can see hit the production API via [kibana logs](https://kibana.bigcommerce.net/goto/6efa14e0-8fe2-11f1-8fd1-5be6dbabbd69)

**After this change**

We can see it call local API and login successfully.
<img width="1467" height="644" alt="Screenshot 2026-08-04 at 7 52 45 pm" src="https://github.com/user-attachments/assets/fe43e75e-cfb6-4621-86e1-174c1d93f8ee" />

https://github.com/user-attachments/assets/68baea61-74f7-427f-94a3-66d0e7d82c65

Please note: this PR I've tested locally on top of https://github.com/bigcommerce/catalyst/pull/3160 since got some locally running issue.

## Migration
We can revert this change if not works for other lower envs, but production should be work as before