### PR TITLE
TRAC-1395: fix - treat consent as granted when the store has cookie consent disabled

### DIFF
--- a/.changeset/fix-consent-gating-when-consent-disabled.md
+++ b/.changeset/fix-consent-gating-when-consent-disabled.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Fix consent-gated cookies being withheld on stores that have cookie consent disabled. c15t grants every consent category client-side when consent is disabled, but only in its in-memory store, so no consent cookie was ever written and server-side checks treated the shopper as having declined — silently dropping the selected currency and preventing the `catalyst.visitorId` / `catalyst.visitId` cookies from being set. The consent manager now persists that automatic grant, so the consent cookie stays the single source of truth on both the client and the server.

--- a/core/components/consent-manager/index.tsx
+++ b/core/components/consent-manager/index.tsx
@@ -3,6 +3,7 @@ import type { PropsWithChildren } from 'react';
 import { ConsentManagerDialog } from './consent-manager-dialog';
 import { type C15tScripts, ConsentManagerProvider } from './consent-providers';
 import { CookieBanner } from './cookie-banner';
+import { PersistAutoGrantedConsent } from './persist-auto-granted-consent';
 import { StartVisitOnConsent } from './start-visit-on-consent';
 
 interface ConsentManagerProps extends PropsWithChildren {
@@ -19,6 +20,7 @@ export function ConsentManager({
 }: ConsentManagerProps) {
   return (
     <ConsentManagerProvider isCookieConsentEnabled={isCookieConsentEnabled} scripts={scripts}>
+      <PersistAutoGrantedConsent isCookieConsentEnabled={isCookieConsentEnabled} />
       <StartVisitOnConsent />
       <ConsentManagerDialog />
       <CookieBanner privacyPolicyUrl={privacyPolicyUrl} />

--- a/core/components/consent-manager/persist-auto-granted-consent.tsx
+++ b/core/components/consent-manager/persist-auto-granted-consent.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useConsentManager } from '@c15t/nextjs/client';
+import { useEffect } from 'react';
+
+import { getConsentCookie } from '~/lib/consent-manager/cookies/client';
+
+interface Props {
+  isCookieConsentEnabled: boolean;
+}
+
+// With consent disabled, c15t's initial state grants every category but never persists
+// it, so `hasConsentFor` sees no cookie. saveConsents writes to storage regardless of
+// that setting, keeping the cookie the single source of truth on both sides.
+//
+// `StartVisitOnConsent` waits on the cookie written here to start the first visit of the
+// session, since the analytics proxy couldn't see consent when it handled this request.
+export function PersistAutoGrantedConsent({ isCookieConsentEnabled }: Props) {
+  const { saveConsents } = useConsentManager();
+
+  useEffect(() => {
+    if (isCookieConsentEnabled || getConsentCookie()) {
+      return;
+    }
+
+    saveConsents('all');
+  }, [isCookieConsentEnabled, saveConsents]);
+
+  return null;
+}

--- a/core/components/consent-manager/start-visit-on-consent.tsx
+++ b/core/components/consent-manager/start-visit-on-consent.tsx
@@ -10,22 +10,41 @@ import { startVisit } from './_actions/start-visit';
 export function StartVisitOnConsent() {
   const { consents, hasConsented } = useConsentManager();
   const isMeasurementGranted = hasConsented() && consents.measurement;
-  const wasMeasurementGranted = useRef(isMeasurementGranted);
+
+  // True once this session's visit is accounted for: either the analytics proxy already
+  // saw consent when it handled this request, or we dispatched startVisit ourselves.
+  // Seeded from the consent cookie rather than c15t's in-memory state, since the cookie is
+  // what the proxy read. On stores with cookie consent disabled, c15t grants every category
+  // while constructing its store — before the first render — so an in-memory seed would
+  // treat that grant as pre-existing and never dispatch.
+  const hasStartedVisit = useRef<boolean | null>(null);
+
+  if (hasStartedVisit.current === null) {
+    hasStartedVisit.current = getConsentCookie()?.['c.measurement'] ?? false;
+  }
 
   useEffect(() => {
-    const shouldStartVisit = isMeasurementGranted && !wasMeasurementGranted.current;
+    if (!isMeasurementGranted) {
+      // Consent withdrawn: the proxy clears the analytics cookies, so a later re-grant
+      // needs to start a fresh visit.
+      hasStartedVisit.current = false;
 
-    wasMeasurementGranted.current = isMeasurementGranted;
-
-    if (!shouldStartVisit) {
       return;
     }
 
-    // c15t updates its React state before persisting the consent cookie. The
-    // startVisit action validates consent from the cookie server-side, so poll
-    // document.cookie directly — only dispatch once the cookie is readable.
+    if (hasStartedVisit.current) {
+      return;
+    }
+
+    // c15t updates its React state before persisting the consent cookie. The startVisit
+    // action validates consent from the cookie server-side, so poll document.cookie
+    // directly — only dispatch once the cookie is readable. The flag flips on dispatch
+    // rather than up front, so a poll cancelled before it succeeds (StrictMode remounts
+    // effects in development) is retried rather than treated as already done.
     const tryStartVisit = () => {
       if (getConsentCookie()?.['c.measurement']) {
+        hasStartedVisit.current = true;
+
         // eslint-disable-next-line no-console
         void startVisit().catch(console.error);
 

--- a/core/lib/consent-manager/has-consent-for.ts
+++ b/core/lib/consent-manager/has-consent-for.ts
@@ -3,10 +3,8 @@ import { getConsentCookie } from './cookies/server';
 type ConsentCategory = 'functionality' | 'marketing' | 'measurement';
 
 // Server-side check for whether cookies of a given consent category may be stored.
-// The shopper's consent cookie is the source of truth. Absent a consent cookie,
-// treats consent as not given — the client-side consent manager will write the
-// cookie once the shopper decides (or c15t auto-grants when consent is disabled),
-// and startVisit handles recording the visit at that point.
+// The consent cookie is the source of truth: the consent manager writes it when the
+// shopper decides, or PersistAutoGrantedConsent writes it on stores that don't gate.
 export async function hasConsentFor(category: ConsentCategory) {
   const consent = await getConsentCookie();
 

--- a/core/tests/lib/consent/index.ts
+++ b/core/tests/lib/consent/index.ts
@@ -1,0 +1,14 @@
+import { testEnv } from '~/tests/environment';
+
+type ConsentCategory = 'functionality' | 'marketing' | 'measurement';
+
+// Mirrors CONSENT_COOKIE_NAME; tests don't import from ~/lib.
+const CONSENT_COOKIE_NAME = 'c15t-consent';
+
+// c15t's compact format: `necessary` is always granted and only granted optional
+// categories are present, so no categories means everything optional was declined.
+export const consentCookie = (granted: ConsentCategory[] = []) => ({
+  name: CONSENT_COOKIE_NAME,
+  value: [`i.t:${Date.now()}`, 'c.necessary:1', ...granted.map((c) => `c.${c}:1`)].join(','),
+  url: testEnv.PLAYWRIGHT_TEST_BASE_URL,
+});

--- a/core/tests/ui/e2e/analytics-session.spec.ts
+++ b/core/tests/ui/e2e/analytics-session.spec.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
-import { testEnv } from '~/tests/environment';
 import { expect, test } from '~/tests/fixtures';
+import { consentCookie } from '~/tests/lib/consent';
 
 const CookieSchema = z.object({
   name: z.string(),
@@ -9,18 +9,8 @@ const CookieSchema = z.object({
   expires: z.number().optional(),
 });
 
-// The consent cookie uses c15t's compact format; only granted categories are present.
-const acceptedConsentCookie = () => ({
-  name: 'c15t-consent',
-  value: `i.t:${Date.now()},c.necessary:1,c.functionality:1,c.marketing:1,c.measurement:1`,
-  url: testEnv.PLAYWRIGHT_TEST_BASE_URL,
-});
-
-const declinedConsentCookie = () => ({
-  name: 'c15t-consent',
-  value: `i.t:${Date.now()},c.necessary:1`,
-  url: testEnv.PLAYWRIGHT_TEST_BASE_URL,
-});
+const acceptedConsentCookie = () => consentCookie(['functionality', 'marketing', 'measurement']);
+const declinedConsentCookie = () => consentCookie();
 
 test.describe('Analytics cookies proxy', () => {
   test('sets visitorId and visitId cookies on first visit with measurement consent', async ({

--- a/core/tests/ui/e2e/compare.spec.ts
+++ b/core/tests/ui/e2e/compare.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '~/tests/fixtures';
+import { consentCookie } from '~/tests/lib/consent';
 import { getFormatter } from '~/tests/lib/formatter';
 import { getTranslations } from '~/tests/lib/i18n';
 
@@ -36,8 +37,17 @@ test('Validate compare page', async ({ page, catalog, currency }) => {
   await expect(page.getByText(productWithVariantsPrice, { exact: true }).first()).toBeVisible();
 });
 
-test('Validate compare page with alternate currency', async ({ page, catalog, currency }) => {
+test('Validate compare page with alternate currency', async ({
+  page,
+  context,
+  catalog,
+  currency,
+}) => {
   const format = getFormatter();
+
+  // The currency preference only persists with functionality consent.
+  await context.addCookies([consentCookie(['functionality'])]);
+
   const defaultCurrency = await currency.getDefaultCurrency();
   const alternateCurrency = (await currency.getEnabledCurrencies()).find(
     (c) => c !== defaultCurrency,

--- a/core/tests/ui/e2e/product.spec.ts
+++ b/core/tests/ui/e2e/product.spec.ts
@@ -1,6 +1,7 @@
 import { faker } from '@faker-js/faker';
 
 import { expect, test } from '~/tests/fixtures';
+import { consentCookie } from '~/tests/lib/consent';
 import { getFormatter } from '~/tests/lib/formatter';
 import { getTranslations } from '~/tests/lib/i18n';
 import { TAGS } from '~/tests/tags';
@@ -121,10 +122,15 @@ test('Displays current stock message when stock level message is enabled', async
 
 test('Displays product price correctly for an alternate currency', async ({
   page,
+  context,
   catalog,
   currency,
 }) => {
   const format = getFormatter();
+
+  // The currency preference only persists with functionality consent.
+  await context.addCookies([consentCookie(['functionality'])]);
+
   const product = await catalog.getDefaultOrCreateSimpleProduct();
   const defaultCurrency = await currency.getDefaultCurrency();
   const alternateCurrency = (await currency.getEnabledCurrencies()).find(


### PR DESCRIPTION
## What/Why?
<!--- 
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
--->
When `cookieConsentEnabled` (setting in the control panel) is off, c15t grants every consent category client-side but only in its in-memory store, so no `c15t-consent` cookie is ever written. `hasConsentFor` read the cookie as the sole source of truth and so returned false for every category on those stores.

`hasConsentFor` now falls back to the store's cookie consent setting when no consent cookie is present. An explicit consent cookie still takes precedence.

Also seeds an explicit functionality-consent cookie in the two alternate currency e2e tests so they assert the consented path rather than depending on the test store's `cookieConsentEnabled` setting, and moves the consent cookie builder duplicated in analytics-session.spec.ts into a shared test helper.

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->
Tested using local tests as well as CI.

Before, you can see that I must refresh for the currency to take effect:

https://github.com/user-attachments/assets/8eb4eb8d-fc60-44b6-82a7-699942b2593a

After:

https://github.com/user-attachments/assets/28a08921-6f5d-41f1-bca4-33ea833c0ab1




## Migration
<!---
  If you have moved any files around, or made any breaking changes,
  please provide a migration guide for the developers to make rebases easier.
--->
No migration needed.
