### PR TITLE
TRAC-1324: Reuse credentials after project bootstrap to prevent redundant auth login

### DIFF
--- a/.changeset/ltrac-1324-persist-create-credentials.md
+++ b/.changeset/ltrac-1324-persist-create-credentials.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst": patch
+---
+
+Stop asking users to log in again after `catalyst create`. Credentials from the initial authentication are now written to the new project's `.bigcommerce/project.json` on every scaffold, not just `--hosting commerce`, so `catalyst deploy` no longer fails with "Missing credentials" and `catalyst project create` no longer re-prompts for login.

--- a/packages/catalyst/src/cli/commands/create.spec.ts
+++ b/packages/catalyst/src/cli/commands/create.spec.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { mkdirSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { afterAll, afterEach, beforeAll, describe, expect, MockInstance, test, vi } from 'vitest';
 
@@ -282,6 +282,113 @@ describe('happy paths', () => {
     expect(consola.warn).toHaveBeenCalledWith(
       '--use-existing has no effect without --hosting commerce. Ignoring.',
     );
+  });
+});
+
+// Regression tests for LTRAC-1324: credentials gathered during `create` have to
+// land in the scaffolded project's `.bigcommerce/project.json`, because that's
+// the only source `resolveCredentials` consults. Previously this was written
+// only on the `--hosting commerce` path, so a default scaffold left `catalyst
+// deploy` failing with "Missing credentials" and `catalyst project create`
+// re-prompting for login.
+describe('credential persistence', () => {
+  const readProjectJson = (projectName: string): unknown =>
+    JSON.parse(readFileSync(join(tmpDir, projectName, '.bigcommerce', 'project.json'), 'utf-8'));
+
+  test('persists flag-provided creds to project.json on a default (self-hosted) scaffold', async () => {
+    const projectName = uniqueProjectName();
+
+    await program.parseAsync([
+      'node',
+      'catalyst',
+      'create',
+      '--project-name',
+      projectName,
+      '--project-dir',
+      tmpDir,
+      '--store-hash',
+      storeHash,
+      '--access-token',
+      accessToken,
+      '--channel-id',
+      '42',
+      '--storefront-token',
+      'flag-storefront-token',
+    ]);
+
+    expect(setupCommerceHosting).not.toHaveBeenCalled();
+    expect(readProjectJson(projectName)).toMatchObject({ storeHash, accessToken });
+  });
+
+  test('persists device-login creds to project.json when no cred flags are passed', async () => {
+    const projectName = uniqueProjectName();
+
+    await program.parseAsync([
+      'node',
+      'catalyst',
+      'create',
+      '--project-name',
+      projectName,
+      '--project-dir',
+      tmpDir,
+      '--channel-id',
+      '42',
+      '--storefront-token',
+      'flag-storefront-token',
+    ]);
+
+    expect(login).toHaveBeenCalled();
+    expect(readProjectJson(projectName)).toMatchObject({
+      storeHash: 'login-store-hash',
+      accessToken: 'login-access-token',
+    });
+  });
+
+  test('preserves projectUuid written by commerce-hosting setup', async () => {
+    const projectName = uniqueProjectName();
+    // Must be a real UUID — the project.json schema enforces `format: 'uuid'`,
+    // and this test is the only one that lets Conf read the written file back.
+    const projectUuid = '43eba682-0c48-11f1-9bd5-827a48b0ce1e';
+
+    vi.mocked(promptForCommerceHostingProject).mockResolvedValueOnce({
+      uuid: projectUuid,
+      name: 'commerce-project',
+      deployment_hostnames: [],
+    });
+
+    // Stand in for the real helper, which overwrites project.json wholesale.
+    // The credential write has to merge into that rather than clobber it.
+    vi.mocked(setupCommerceHosting).mockImplementationOnce(({ projectDir, projectUuid: uuid }) => {
+      mkdirSync(join(projectDir, '.bigcommerce'), { recursive: true });
+      writeFileSync(
+        join(projectDir, '.bigcommerce', 'project.json'),
+        JSON.stringify({ projectUuid: uuid, framework: 'catalyst' }),
+      );
+
+      return Promise.resolve();
+    });
+
+    await program.parseAsync([
+      'node',
+      'catalyst',
+      'create',
+      '--project-name',
+      projectName,
+      '--project-dir',
+      tmpDir,
+      '--store-hash',
+      storeHash,
+      '--access-token',
+      accessToken,
+      '--channel-id',
+      '42',
+      '--storefront-token',
+      'flag-storefront-token',
+      '--hosting',
+      'commerce',
+    ]);
+
+    expect(readProjectJson(projectName)).toMatchObject({ projectUuid, storeHash, accessToken });
   });
 });
 

--- a/packages/catalyst/src/cli/commands/create.ts
+++ b/packages/catalyst/src/cli/commands/create.ts
@@ -23,6 +23,7 @@ import { installDependencies } from '../lib/install-dependencies';
 import { consola } from '../lib/logger';
 import { login, LoginAbortedError } from '../lib/login';
 import { hasProjectsAccess, type ProjectListItem } from '../lib/project';
+import { getProjectConfig } from '../lib/project-config';
 import { rewriteCorePackage } from '../lib/rewrite-core-package';
 import { setupCoreProject } from '../lib/setup-core-project';
 import { accessTokenOption, storeHashOption } from '../lib/shared-options';
@@ -332,10 +333,11 @@ Examples:
       envVars.BIGCOMMERCE_ACCESS_TOKEN = accessToken;
     }
 
-    // Pre-populate CATALYST_ACCESS_TOKEN so subsequent catalyst CLI commands
-    // (`catalyst deploy`, `catalyst project ...`, etc.) work without re-auth.
-    // CATALYST_STORE_HASH isn't written — the CLI falls back to BIGCOMMERCE_STORE_HASH
-    // (already in envVars from the channel init response) at startup.
+    // Convenience for shells that auto-load .env.local (direnv, dotenv-cli):
+    // exporting CATALYST_ACCESS_TOKEN lets the CLI's `--access-token` env
+    // binding pick it up. The CLI itself does *not* read this file when
+    // resolving credentials — `.bigcommerce/project.json`, written below, is
+    // what makes subsequent commands work without re-auth.
     if (accessToken) envVars.CATALYST_ACCESS_TOKEN = accessToken;
 
     // Resolve the Commerce Hosting project before extraction so credential checks
@@ -384,6 +386,22 @@ Examples:
           storeHash,
           accessToken,
         });
+      }
+
+      // Persist the credentials we just authenticated with into the new
+      // project's `.bigcommerce/project.json` (gitignored). Every command
+      // resolves credentials from this file, so without it `catalyst deploy`
+      // and `catalyst project create` would fail or re-prompt for login
+      // immediately after `create` already logged the user in.
+      //
+      // Runs after `setupCommerceHosting` — which writes the same file to
+      // record `projectUuid` — because `Conf` merges into existing contents
+      // whereas that helper overwrites wholesale.
+      if (storeHash && accessToken) {
+        const projectConfig = getProjectConfig(projectDir);
+
+        projectConfig.set('storeHash', storeHash);
+        projectConfig.set('accessToken', accessToken);
       }
 
       // Write env before install — matters for postinstall scripts that may

--- a/packages/catalyst/src/cli/lib/project-config.ts
+++ b/packages/catalyst/src/cli/lib/project-config.ts
@@ -15,9 +15,12 @@ export interface ProjectConfigSchema {
   env?: Record<string, string>;
 }
 
-export function getProjectConfig() {
+// `cwd` defaults to the process working directory — the project the user is
+// currently in. `catalyst create` passes the freshly-scaffolded project dir
+// explicitly, since that project isn't the cwd at the time it's seeded.
+export function getProjectConfig(cwd: string = process.cwd()) {
   return new Conf<ProjectConfigSchema>({
-    cwd: join(process.cwd(), '.bigcommerce'),
+    cwd: join(cwd, '.bigcommerce'),
     projectSuffix: '',
     configName: 'project',
     schema: {


### PR DESCRIPTION
## What/Why?

`catalyst create` only wrote credentials to `.bigcommerce/project.json` on the
`--hosting commerce` path, so a default scaffold left `catalyst deploy` failing with
"Missing credentials" and `catalyst project create` re-prompting for login. Now written
on every scaffold.

Worth a reviewer's eye: the write runs *after* `setupCommerceHosting`, which overwrites
`project.json` wholesale — `Conf` merges, so `projectUuid` survives.

## Testing

Three regression tests in `create.spec.ts`; full package suite 612 passing, typecheck and
lint clean.

```bash
pnpm create @bigcommerce/catalyst@latest   # authenticate
cd <project> && pnpm catalyst deploy       # no "Missing credentials"
pnpm catalyst project create               # no login re-prompt
```
<img width="864" height="424" alt="image" src="https://github.com/user-attachments/assets/54306d2e-f89b-46e7-bada-893d06edcc70" />

## Migration

None.
