### PR TITLE
LTRAC-1326: Show progress feedback while creating a channel

### DIFF
--- a/packages/catalyst/src/cli/lib/create-channel-flow.spec.ts
+++ b/packages/catalyst/src/cli/lib/create-channel-flow.spec.ts
@@ -1,9 +1,10 @@
 import { checkbox, input, select } from '@inquirer/prompts';
-import { afterEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
 
 import { createChannel } from './channels';
 import { getChannelNameError, runCreateChannelFlow } from './create-channel-flow';
 import { UserActionableError } from './errors';
+import { consola } from './logger';
 import { getAvailableLocales } from './localization';
 
 vi.mock('@inquirer/prompts', () => ({
@@ -32,6 +33,10 @@ const baseOptions = {
   apiHost: 'api.bigcommerce.com',
   cliApiOrigin: 'https://cxm-prd.bigcommerceapp.com',
 };
+
+beforeAll(() => {
+  consola.mockTypes(() => vi.fn());
+});
 
 afterEach(() => {
   vi.clearAllMocks();
@@ -133,5 +138,24 @@ describe('runCreateChannelFlow', () => {
       baseOptions.accessToken,
       baseOptions.cliApiOrigin,
     );
+  });
+
+  test('shows progress feedback while the channel is being created', async () => {
+    mockCreateChannel.mockResolvedValue({
+      channelId: 42,
+      storefrontToken: 'token',
+      envVars: {},
+    });
+
+    await runCreateChannelFlow({
+      ...baseOptions,
+      name: 'My Store',
+      locale: 'en',
+      additionalLocales: [],
+      sampleData: false,
+    });
+
+    expect(consola.start).toHaveBeenCalledWith('Creating channel...');
+    expect(consola.success).toHaveBeenCalledWith('Channel created.');
   });
 });

--- a/packages/catalyst/src/cli/lib/create-channel-flow.spec.ts
+++ b/packages/catalyst/src/cli/lib/create-channel-flow.spec.ts
@@ -4,8 +4,8 @@ import { afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
 import { createChannel } from './channels';
 import { getChannelNameError, runCreateChannelFlow } from './create-channel-flow';
 import { UserActionableError } from './errors';
-import { consola } from './logger';
 import { getAvailableLocales } from './localization';
+import { consola } from './logger';
 
 vi.mock('@inquirer/prompts', () => ({
   input: vi.fn(),

--- a/packages/catalyst/src/cli/lib/create-channel-flow.ts
+++ b/packages/catalyst/src/cli/lib/create-channel-flow.ts
@@ -4,6 +4,7 @@ import { colorize } from 'consola/utils';
 import { createChannel, type CreatedChannel } from './channels';
 import { UserActionableError } from './errors';
 import { getAvailableLocales } from './localization';
+import { consola } from './logger';
 
 // Human-readable summary of the allowed characters, reused in the prompt
 // validation and the flag-path error so both surface the same guidance.
@@ -126,7 +127,12 @@ export async function runCreateChannelFlow(
       ],
     }));
 
-  return createChannel(
+  // The API call blocks for several seconds (it provisions the channel and,
+  // when requested, populates sample data), so surface a spinner here — without
+  // it the CLI looks frozen after the last prompt.
+  consola.start('Creating channel...');
+
+  const channel = await createChannel(
     name,
     storefrontLocale,
     additionalLocales,
@@ -135,4 +141,8 @@ export async function runCreateChannelFlow(
     accessToken,
     cliApiOrigin,
   );
+
+  consola.success('Channel created.');
+
+  return channel;
 }


### PR DESCRIPTION
## What/Why?

After confirming channel creation (and answering the sample-data prompt), the CLI appeared to freeze — the `createChannel` API call provisions the channel and, when requested, seeds sample data, which can take several seconds with no output in between.

Added a `consola.start`/`consola.success` pair around the call in `runCreateChannelFlow`, matching the existing "Fetching channels..." spinner pattern already used in `channel-site-flow.ts`.

Linear: https://linear.app/commerce/issue/LTRAC-1326/cli-gives-no-feedback-while-creating-a-channel

## Testing

- Added a test asserting `consola.start('Creating channel...')` and `consola.success('Channel created.')` are called.
- Ran `catalyst channel create` and `catalyst create` locally to confirm the spinner shows during the API call and clears with a success message.
- `vitest run src/cli/lib/create-channel-flow.spec.ts src/cli/commands/create.spec.ts src/cli/commands/channel.spec.ts` — 48/48 passing.

## Migration

N/A — no breaking changes or file moves.