### PR TITLE
TRAC-1327: Standardize plural resource naming and use singular aliases

### DIFF
--- a/.changeset/ltrac-1327-plural-resource-commands.md
+++ b/.changeset/ltrac-1327-plural-resource-commands.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst": minor
+---
+
+Standardize resource commands on plural names: `catalyst project` is now `catalyst projects`, and `catalyst channel` is now `catalyst channels`, matching the already-plural `domains` and `logs`. The singular form of every resource command remains as an alias — `project`, `channel`, `domain`, and `log` all still resolve — so existing scripts keep working. Telemetry continues to report the canonical plural name regardless of which form was typed.

--- a/packages/catalyst/AGENTS.md
+++ b/packages/catalyst/AGENTS.md
@@ -8,7 +8,7 @@ CLI tool for Catalyst development and deployment — handles build, dev server, 
 src/cli/
 ├── index.ts          # Entry point (#!/usr/bin/env node)
 ├── program.ts        # Commander program setup, registers all commands
-├── commands/         # CLI command implementations (auth, build, deploy, logs, project, start, telemetry, version)
+├── commands/         # CLI command implementations (auth, build, channels, create, deploy, domains, env, logs, projects, start, telemetry, upgrade, version)
 ├── hooks/            # Pre/post action hooks (telemetry)
 └── lib/              # Utilities (auth, logger, project config, credentials, wrangler config, telemetry, deployment errors)
 templates/            # OpenNext config and public_headers template
@@ -18,15 +18,23 @@ dist/cli.js           # Bundled output (single ESM file)
 
 ## CLI Commands
 
+Resource-based commands are named in the plural (`projects`, `channels`, `domains`, `logs`). Each keeps the singular form as a commander alias (`project`, `channel`, `domain`, `log`) for backward compatibility — telemetry still reports the canonical plural name, since `getCommandPath` walks `Command.name()`.
+
 | Command | Description |
 |---------|-------------|
 | `auth whoami/login/logout` | Manage authentication (device code OAuth flow, credential storage) |
 | `build` | Build Catalyst project using OpenNext/Cloudflare adapter |
+| `channels create/link/update` | Manage BigCommerce channels |
+| `create` | Scaffold a new Catalyst project |
+| `debug` | Print diagnostic information about the local project |
 | `deploy` | Deploy to Cloudflare with bundle upload |
-| `logs` | View logs (`tail` default, `query` planned). Supports `--format` (default/json/pretty/short/request) |
-| `project create/list/link` | Manage BigCommerce infrastructure projects |
+| `domains add/list/status/claim/transfer/remove` | Manage custom domains for the linked project |
+| `env add/remove/list` | Manage persistent deployment environment variables |
+| `logs tail/query` | View logs (`tail` is the default). Supports `--format` (default/json/pretty/short/request) |
+| `projects create/list/link/delete` | Manage BigCommerce infrastructure projects |
 | `start` | Start local preview using OpenNext Cloudflare adapter |
 | `telemetry` | Enable/disable/check telemetry |
+| `upgrade` | Upgrade the project to a newer Catalyst release |
 | `version` | Display version and platform info |
 
 ## Development
@@ -52,7 +60,7 @@ pnpm build
 pnpm exec <repo-root>/packages/catalyst/dist/cli.js <command>
 ```
 
-For example: `pnpm exec <repo-root>/packages/catalyst/dist/cli.js project list`.
+For example: `pnpm exec <repo-root>/packages/catalyst/dist/cli.js projects list`.
 
 ## Build
 

--- a/packages/catalyst/README.md
+++ b/packages/catalyst/README.md
@@ -27,7 +27,7 @@ pnpm exec <repo-root>/packages/catalyst/dist/cli.js <command>
 For example:
 
 ```bash
-pnpm exec <repo-root>/packages/catalyst/dist/cli.js project list
+pnpm exec <repo-root>/packages/catalyst/dist/cli.js projects list
 pnpm exec <repo-root>/packages/catalyst/dist/cli.js logs tail
 pnpm exec <repo-root>/packages/catalyst/dist/cli.js logs query --start 2026-06-01T00:00:00Z --end 2026-06-02T00:00:00Z
 pnpm exec <repo-root>/packages/catalyst/dist/cli.js deploy

--- a/packages/catalyst/src/cli/commands/build.ts
+++ b/packages/catalyst/src/cli/commands/build.ts
@@ -172,7 +172,7 @@ Examples:
 
     if (!projectUuid) {
       throw new Error(
-        'Project UUID is required. Please run `catalyst project create` or `catalyst project link` or this command again with --project-uuid <uuid>.',
+        'Project UUID is required. Please run `catalyst projects create` or `catalyst projects link` or this command again with --project-uuid <uuid>.',
       );
     }
 

--- a/packages/catalyst/src/cli/commands/channels.spec.ts
+++ b/packages/catalyst/src/cli/commands/channels.spec.ts
@@ -12,7 +12,7 @@ import { mkTempDir } from '../lib/mk-temp-dir';
 import { getProjectConfig, ProjectConfigSchema } from '../lib/project-config';
 import { program } from '../program';
 
-import { channel } from './channel';
+import { channels } from './channels';
 
 vi.mock('@inquirer/prompts', () => ({
   select: vi.fn(),
@@ -92,33 +92,34 @@ afterAll(async () => {
   await cleanup();
 });
 
-describe('channel', () => {
+describe('channels', () => {
   test('has the update subcommand', () => {
-    expect(channel).toBeInstanceOf(Command);
-    expect(channel.name()).toBe('channel');
+    expect(channels).toBeInstanceOf(Command);
+    expect(channels.name()).toBe('channels');
+    expect(channels.aliases()).toContain('channel');
 
-    const update = channel.commands.find((cmd) => cmd.name() === 'update');
+    const update = channels.commands.find((cmd) => cmd.name() === 'update');
 
     expect(update).toBeDefined();
     expect(update?.description()).toContain('Update a BigCommerce channel');
   });
 
   test('has the link subcommand', () => {
-    const link = channel.commands.find((cmd) => cmd.name() === 'link');
+    const link = channels.commands.find((cmd) => cmd.name() === 'link');
 
     expect(link).toBeDefined();
     expect(link?.description()).toContain('Link this Catalyst project to a BigCommerce channel');
   });
 
   test('has the create subcommand', () => {
-    const create = channel.commands.find((cmd) => cmd.name() === 'create');
+    const create = channels.commands.find((cmd) => cmd.name() === 'create');
 
     expect(create).toBeDefined();
     expect(create?.description()).toContain('Create a new Catalyst storefront channel');
   });
 });
 
-describe('channel update', () => {
+describe('channels update', () => {
   test('happy path: prompts for channel and hostname, then PUTs', async () => {
     let putBody: unknown;
     let putChannelId: string | undefined;
@@ -146,7 +147,7 @@ describe('channel update', () => {
     await program.parseAsync([
       'node',
       'catalyst',
-      'channel',
+      'channels',
       'update',
       '--store-hash',
       storeHash,
@@ -173,7 +174,7 @@ describe('channel update', () => {
     await program.parseAsync([
       'node',
       'catalyst',
-      'channel',
+      'channels',
       'update',
       '--store-hash',
       storeHash,
@@ -208,7 +209,7 @@ describe('channel update', () => {
     await program.parseAsync([
       'node',
       'catalyst',
-      'channel',
+      'channels',
       'update',
       '--store-hash',
       storeHash,
@@ -240,7 +241,7 @@ describe('channel update', () => {
     await program.parseAsync([
       'node',
       'catalyst',
-      'channel',
+      'channels',
       'update',
       '--store-hash',
       storeHash,
@@ -248,7 +249,7 @@ describe('channel update', () => {
       accessToken,
     ]);
 
-    expect(consola.info).toHaveBeenCalledWith(expect.stringContaining('catalyst project create'));
+    expect(consola.info).toHaveBeenCalledWith(expect.stringContaining('catalyst projects create'));
     expect(exitMock).toHaveBeenCalledWith(0);
   });
 
@@ -265,7 +266,7 @@ describe('channel update', () => {
       program.parseAsync([
         'node',
         'catalyst',
-        'channel',
+        'channels',
         'update',
         '--store-hash',
         storeHash,
@@ -278,7 +279,7 @@ describe('channel update', () => {
   });
 });
 
-describe('channel link', () => {
+describe('channels link', () => {
   const initUrl =
     'https://cxm-prd.bigcommerceapp.com/stores/:storeHash/cli-api/v3/channels/:channelId/init';
 
@@ -305,7 +306,7 @@ describe('channel link', () => {
     await program.parseAsync([
       'node',
       'catalyst',
-      'channel',
+      'channels',
       'link',
       '--store-hash',
       storeHash,
@@ -344,7 +345,7 @@ describe('channel link', () => {
     await program.parseAsync([
       'node',
       'catalyst',
-      'channel',
+      'channels',
       'link',
       '--store-hash',
       storeHash,
@@ -375,7 +376,7 @@ describe('channel link', () => {
     await program.parseAsync([
       'node',
       'catalyst',
-      'channel',
+      'channels',
       'link',
       '--store-hash',
       storeHash,
@@ -405,7 +406,7 @@ describe('channel link', () => {
     await program.parseAsync([
       'node',
       'catalyst',
-      'channel',
+      'channels',
       'link',
       '--store-hash',
       storeHash,
@@ -428,7 +429,7 @@ describe('channel link', () => {
       ),
     );
 
-    await program.parseAsync(['node', 'catalyst', 'channel', 'link', '--channel-id', '2']);
+    await program.parseAsync(['node', 'catalyst', 'channels', 'link', '--channel-id', '2']);
 
     expect(config.get('storeHash')).toBe('mock-store-hash');
     expect(config.get('accessToken')).toBe('mock-access-token');
@@ -436,7 +437,7 @@ describe('channel link', () => {
   });
 });
 
-describe('channel create', () => {
+describe('channels create', () => {
   const eligibilityUrl =
     'https://cxm-prd.bigcommerceapp.com/stores/:storeHash/cli-api/v3/channels/catalyst/eligibility';
   const createUrl =
@@ -466,7 +467,7 @@ describe('channel create', () => {
     await program.parseAsync([
       'node',
       'catalyst',
-      'channel',
+      'channels',
       'create',
       '--store-hash',
       storeHash,
@@ -527,7 +528,7 @@ describe('channel create', () => {
     await program.parseAsync([
       'node',
       'catalyst',
-      'channel',
+      'channels',
       'create',
       '--store-hash',
       storeHash,
@@ -557,7 +558,7 @@ describe('channel create', () => {
     await program.parseAsync([
       'node',
       'catalyst',
-      'channel',
+      'channels',
       'create',
       '--store-hash',
       storeHash,
@@ -608,7 +609,7 @@ describe('channel create', () => {
     await program.parseAsync([
       'node',
       'catalyst',
-      'channel',
+      'channels',
       'create',
       '--store-hash',
       storeHash,

--- a/packages/catalyst/src/cli/commands/channels.ts
+++ b/packages/catalyst/src/cli/commands/channels.ts
@@ -43,7 +43,7 @@ const parseChannelId = (value: string): number => {
 // login (persisting on success). Returns null when the user aborts login.
 // `channel link` is an onboarding command — a fresh clone has neither
 // .env.local nor .bigcommerce/project.json — so it logs the user in like
-// `catalyst project create`, rather than erroring like the operational commands.
+// `catalyst projects create`, rather than erroring like the operational commands.
 async function resolveCredentialsWithLogin(
   options: { storeHash?: string; accessToken?: string; loginUrl: string },
   config: Conf<ProjectConfigSchema>,
@@ -82,10 +82,10 @@ const update = new Command('update')
     `
 Examples:
   # Pick a channel and hostname interactively
-  $ catalyst channel update
+  $ catalyst channels update
 
   # Skip both prompts
-  $ catalyst channel update --channel-id 123 --hostname my-storefront.example.com`,
+  $ catalyst channels update --channel-id 123 --hostname my-storefront.example.com`,
   )
   .addOption(storeHashOption())
   .addOption(accessTokenOption())
@@ -122,7 +122,7 @@ Examples:
     } catch (error) {
       if (error instanceof NoLinkedProjectError) {
         consola.info(
-          "When you're ready to create a project, run `catalyst project create` or re-run `catalyst channel update`.",
+          "When you're ready to create a project, run `catalyst projects create` or re-run `catalyst channels update`.",
         );
         process.exit(0);
 
@@ -146,13 +146,13 @@ const link = new Command('link')
     `
 Examples:
   # Pick a channel interactively (logs you in if needed)
-  $ catalyst channel link
+  $ catalyst channels link
 
   # Non-interactive
-  $ catalyst channel link --store-hash <hash> --access-token <token> --channel-id 123
+  $ catalyst channels link --store-hash <hash> --access-token <token> --channel-id 123
 
   # Append extra environment variables to .env.local
-  $ catalyst channel link --channel-id 123 --env MY_FLAG=1`,
+  $ catalyst channels link --channel-id 123 --env MY_FLAG=1`,
   )
   .addOption(storeHashOption())
   .addOption(accessTokenOption())
@@ -180,7 +180,7 @@ Examples:
 
     if (!credentials) {
       consola.info(
-        'Login aborted. Re-run `catalyst channel link` when you have your credentials ready.',
+        'Login aborted. Re-run `catalyst channels link` when you have your credentials ready.',
       );
       process.exit(0);
 
@@ -195,9 +195,9 @@ Examples:
     let channelName: string | undefined;
 
     if (channelId === undefined) {
-      const channels = await fetchAvailableChannels(storeHash, accessToken, apiHost);
+      const availableChannels = await fetchAvailableChannels(storeHash, accessToken, apiHost);
 
-      if (channels.length === 0) {
+      if (availableChannels.length === 0) {
         consola.info(
           'No storefront channels found on this store. Create one with `catalyst create` and try again.',
         );
@@ -208,14 +208,14 @@ Examples:
 
       channelId = await select({
         message: 'Which channel would you like to link?',
-        choices: sortChannelsByPlatform(channels).map((c) => ({
+        choices: sortChannelsByPlatform(availableChannels).map((c) => ({
           name: c.name,
           value: c.id,
           description: channelPlatformLabel(c.platform),
         })),
       });
 
-      channelName = channels.find((c) => c.id === channelId)?.name;
+      channelName = availableChannels.find((c) => c.id === channelId)?.name;
     }
 
     const initData = await getChannelInit(channelId, storeHash, accessToken, options.cliApiOrigin);
@@ -253,13 +253,13 @@ const create = new Command('create')
     `
 Examples:
   # Create a channel interactively (logs you in if needed)
-  $ catalyst channel create
+  $ catalyst channels create
 
   # Non-interactive, and link it to this project afterwards
-  $ catalyst channel create --name "My Store" --locale en --no-sample-data --link
+  $ catalyst channels create --name "My Store" --locale en --no-sample-data --link
 
   # Add additional storefront languages (max 4)
-  $ catalyst channel create --name "My Store" --additional-locales es fr`,
+  $ catalyst channels create --name "My Store" --additional-locales es fr`,
   )
   .addOption(storeHashOption())
   .addOption(accessTokenOption())
@@ -300,7 +300,7 @@ Examples:
 
     if (!credentials) {
       consola.info(
-        'Login aborted. Re-run `catalyst channel create` when you have your credentials ready.',
+        'Login aborted. Re-run `catalyst channels create` when you have your credentials ready.',
       );
       process.exit(0);
 
@@ -361,7 +361,10 @@ Examples:
     process.exit(0);
   });
 
-export const channel = new Command('channel')
+// Resource commands are plural; the singular form stays as an alias so existing
+// scripts and muscle memory keep working.
+export const channels = new Command('channels')
+  .alias('channel')
   .configureHelp({ showGlobalOptions: true })
   .description('Manage BigCommerce channels.')
   .addCommand(create)

--- a/packages/catalyst/src/cli/commands/create.spec.ts
+++ b/packages/catalyst/src/cli/commands/create.spec.ts
@@ -289,7 +289,7 @@ describe('happy paths', () => {
 // land in the scaffolded project's `.bigcommerce/project.json`, because that's
 // the only source `resolveCredentials` consults. Previously this was written
 // only on the `--hosting commerce` path, so a default scaffold left `catalyst
-// deploy` failing with "Missing credentials" and `catalyst project create`
+// deploy` failing with "Missing credentials" and `catalyst projects create`
 // re-prompting for login.
 describe('credential persistence', () => {
   const readProjectJson = (projectName: string): unknown =>

--- a/packages/catalyst/src/cli/commands/create.ts
+++ b/packages/catalyst/src/cli/commands/create.ts
@@ -391,7 +391,7 @@ Examples:
       // Persist the credentials we just authenticated with into the new
       // project's `.bigcommerce/project.json` (gitignored). Every command
       // resolves credentials from this file, so without it `catalyst deploy`
-      // and `catalyst project create` would fail or re-prompt for login
+      // and `catalyst projects create` would fail or re-prompt for login
       // immediately after `create` already logged the user in.
       //
       // Runs after `setupCommerceHosting` — which writes the same file to

--- a/packages/catalyst/src/cli/commands/deploy.spec.ts
+++ b/packages/catalyst/src/cli/commands/deploy.spec.ts
@@ -444,7 +444,7 @@ describe('linked project verification', () => {
     );
 
     expect(consola.info).toHaveBeenCalledWith(
-      "When you're ready to create a project, run `catalyst project create` or re-run `catalyst deploy`.",
+      "When you're ready to create a project, run `catalyst projects create` or re-run `catalyst deploy`.",
     );
     expect(exitMock).toHaveBeenCalledWith(0);
   });

--- a/packages/catalyst/src/cli/commands/deploy.ts
+++ b/packages/catalyst/src/cli/commands/deploy.ts
@@ -435,7 +435,7 @@ Example:
       } catch (error) {
         if (error instanceof NoLinkedProjectError) {
           consola.info(
-            "When you're ready to create a project, run `catalyst project create` or re-run `catalyst deploy`.",
+            "When you're ready to create a project, run `catalyst projects create` or re-run `catalyst deploy`.",
           );
           process.exit(0);
         }

--- a/packages/catalyst/src/cli/commands/domains.ts
+++ b/packages/catalyst/src/cli/commands/domains.ts
@@ -116,7 +116,7 @@ async function resolveDestinationProject(
 
   if (destinations.length === 0) {
     throw new UserActionableError(
-      'No other projects to transfer to. Create another project with `catalyst project create` first.',
+      'No other projects to transfer to. Create another project with `catalyst projects create` first.',
     );
   }
 
@@ -649,6 +649,7 @@ Examples:
   });
 
 export const domains = new Command('domains')
+  .alias('domain')
   .configureHelp({ showGlobalOptions: true })
   .description('Manage custom domains for the current Native Hosting project.')
   .addCommand(add)

--- a/packages/catalyst/src/cli/commands/logs.ts
+++ b/packages/catalyst/src/cli/commands/logs.ts
@@ -593,6 +593,7 @@ Examples:
   });
 
 export const logs = new Command('logs')
+  .alias('log')
   .configureHelp({ showGlobalOptions: true })
   .description('View logs from your deployed application.')
   .addCommand(tail, { isDefault: true })

--- a/packages/catalyst/src/cli/commands/projects.spec.ts
+++ b/packages/catalyst/src/cli/commands/projects.spec.ts
@@ -23,7 +23,7 @@ import { getProjectConfig, ProjectConfigSchema } from '../lib/project-config';
 import { getProjectState } from '../lib/project-state';
 import { program } from '../program';
 
-import { link, project } from './project';
+import { link, projects } from './projects';
 
 // eslint-disable-next-line import/dynamic-import-chunkname
 vi.mock('yocto-spinner', () => import('../../../tests/mocks/spinner'));
@@ -146,30 +146,31 @@ afterAll(async () => {
   await cleanup();
 });
 
-describe('project', () => {
+describe('projects', () => {
   test('has create, link, list, and delete subcommands', () => {
-    expect(project).toBeInstanceOf(Command);
-    expect(project.name()).toBe('project');
-    expect(project.description()).toBe('Manage your BigCommerce infrastructure project.');
+    expect(projects).toBeInstanceOf(Command);
+    expect(projects.name()).toBe('projects');
+    expect(projects.aliases()).toContain('project');
+    expect(projects.description()).toBe('Manage your BigCommerce infrastructure projects.');
 
-    const createCmd = project.commands.find((cmd) => cmd.name() === 'create');
+    const createCmd = projects.commands.find((cmd) => cmd.name() === 'create');
 
     expect(createCmd).toBeDefined();
     expect(createCmd?.description()).toContain('Create a new BigCommerce infrastructure project');
 
-    const linkCmd = project.commands.find((cmd) => cmd.name() === 'link');
+    const linkCmd = projects.commands.find((cmd) => cmd.name() === 'link');
 
     expect(linkCmd).toBeDefined();
     expect(linkCmd?.description()).toContain(
       'Link your local Catalyst project to a BigCommerce infrastructure project',
     );
 
-    const listCmd = project.commands.find((cmd) => cmd.name() === 'list');
+    const listCmd = projects.commands.find((cmd) => cmd.name() === 'list');
 
     expect(listCmd).toBeDefined();
     expect(listCmd?.description()).toContain('List BigCommerce infrastructure projects');
 
-    const deleteCmd = project.commands.find((cmd) => cmd.name() === 'delete');
+    const deleteCmd = projects.commands.find((cmd) => cmd.name() === 'delete');
 
     expect(deleteCmd).toBeDefined();
     expect(deleteCmd?.description()).toContain(
@@ -184,14 +185,14 @@ describe('project', () => {
   });
 });
 
-describe('project create', () => {
+describe('projects create', () => {
   test('prompts for name and creates project', async () => {
     inputMock.mockResolvedValue('My New Project');
 
     await program.parseAsync([
       'node',
       'catalyst',
-      'project',
+      'projects',
       'create',
       '--store-hash',
       storeHash,
@@ -226,7 +227,7 @@ describe('project create', () => {
 
     inputMock.mockResolvedValueOnce('My New Project');
 
-    await program.parseAsync(['node', 'catalyst', 'project', 'create']);
+    await program.parseAsync(['node', 'catalyst', 'projects', 'create']);
 
     if (savedStoreHash !== undefined) process.env.CATALYST_STORE_HASH = savedStoreHash;
     if (savedAccessToken !== undefined) process.env.CATALYST_ACCESS_TOKEN = savedAccessToken;
@@ -264,7 +265,7 @@ describe('project create', () => {
     confirmMock.mockResolvedValueOnce(true);
     inputMock.mockResolvedValueOnce(storeHash).mockResolvedValueOnce('My New Project');
 
-    await program.parseAsync(['node', 'catalyst', 'project', 'create']);
+    await program.parseAsync(['node', 'catalyst', 'projects', 'create']);
 
     if (savedStoreHash !== undefined) process.env.CATALYST_STORE_HASH = savedStoreHash;
     if (savedAccessToken !== undefined) process.env.CATALYST_ACCESS_TOKEN = savedAccessToken;
@@ -295,13 +296,13 @@ describe('project create', () => {
     // Decline the manual-login fallback confirm() — aborts cleanly.
     confirmMock.mockResolvedValueOnce(false);
 
-    await program.parseAsync(['node', 'catalyst', 'project', 'create']);
+    await program.parseAsync(['node', 'catalyst', 'projects', 'create']);
 
     if (savedStoreHash !== undefined) process.env.CATALYST_STORE_HASH = savedStoreHash;
     if (savedAccessToken !== undefined) process.env.CATALYST_ACCESS_TOKEN = savedAccessToken;
 
     expect(consola.info).toHaveBeenCalledWith(
-      'Login aborted. Re-run `catalyst project create` when you have your credentials ready.',
+      'Login aborted. Re-run `catalyst projects create` when you have your credentials ready.',
     );
     expect(exitMock).toHaveBeenCalledWith(0);
     expect(config.get('projectUuid')).toBeUndefined();
@@ -320,7 +321,7 @@ describe('project create', () => {
       program.parseAsync([
         'node',
         'catalyst',
-        'project',
+        'projects',
         'create',
         '--store-hash',
         storeHash,
@@ -343,7 +344,7 @@ describe('project create', () => {
       program.parseAsync([
         'node',
         'catalyst',
-        'project',
+        'projects',
         'create',
         '--store-hash',
         storeHash,
@@ -356,12 +357,12 @@ describe('project create', () => {
   });
 });
 
-describe('project list', () => {
+describe('projects list', () => {
   test('fetches and displays projects', async () => {
     await program.parseAsync([
       'node',
       'catalyst',
-      'project',
+      'projects',
       'list',
       '--store-hash',
       storeHash,
@@ -386,13 +387,36 @@ describe('project list', () => {
     expect(exitMock).toHaveBeenCalledWith(0);
   });
 
+  test('runs under the singular `project` alias', async () => {
+    await program.parseAsync([
+      'node',
+      'catalyst',
+      'project',
+      'list',
+      '--store-hash',
+      storeHash,
+      '--access-token',
+      accessToken,
+    ]);
+
+    expect(consola.success).toHaveBeenCalledWith('Projects fetched.');
+
+    const output = vi
+      .mocked(consola.log)
+      .mock.calls.map(([msg]) => String(msg))
+      .join('\n');
+
+    expect(output).toContain('Project One (a23f5785-fd99-4a94-9fb3-945551623923)');
+    expect(exitMock).toHaveBeenCalledWith(0);
+  });
+
   test('marks the currently linked project with [linked]', async () => {
     config.set('projectUuid', projectUuid2);
 
     await program.parseAsync([
       'node',
       'catalyst',
-      'project',
+      'projects',
       'list',
       '--store-hash',
       storeHash,
@@ -417,7 +441,7 @@ describe('project list', () => {
     await program.parseAsync([
       'node',
       'catalyst',
-      'project',
+      'projects',
       'list',
       '--store-hash',
       storeHash,
@@ -437,7 +461,7 @@ describe('project list', () => {
     delete process.env.CATALYST_STORE_HASH;
     delete process.env.CATALYST_ACCESS_TOKEN;
 
-    await expect(program.parseAsync(['node', 'catalyst', 'project', 'list'])).rejects.toThrow(
+    await expect(program.parseAsync(['node', 'catalyst', 'projects', 'list'])).rejects.toThrow(
       'Missing credentials',
     );
 
@@ -462,7 +486,7 @@ describe('project list', () => {
       program.parseAsync([
         'node',
         'catalyst',
-        'project',
+        'projects',
         'list',
         '--store-hash',
         storeHash,
@@ -473,7 +497,7 @@ describe('project list', () => {
   });
 });
 
-describe('project link', () => {
+describe('projects link', () => {
   test('properly configured Command instance', () => {
     expect(link).toBeInstanceOf(Command);
     expect(link.name()).toBe('link');
@@ -494,7 +518,7 @@ describe('project link', () => {
     await program.parseAsync([
       'node',
       'catalyst',
-      'project',
+      'projects',
       'link',
       '--project-uuid',
       projectUuid1,
@@ -516,7 +540,7 @@ describe('project link', () => {
     await program.parseAsync([
       'node',
       'catalyst',
-      'project',
+      'projects',
       'link',
       '--store-hash',
       storeHash,
@@ -566,7 +590,7 @@ describe('project link', () => {
     await program.parseAsync([
       'node',
       'catalyst',
-      'project',
+      'projects',
       'link',
       '--store-hash',
       storeHash,
@@ -620,7 +644,7 @@ describe('project link', () => {
       program.parseAsync([
         'node',
         'catalyst',
-        'project',
+        'projects',
         'link',
         '--store-hash',
         storeHash,
@@ -667,7 +691,7 @@ describe('project link', () => {
       program.parseAsync([
         'node',
         'catalyst',
-        'project',
+        'projects',
         'link',
         '--store-hash',
         storeHash,
@@ -710,7 +734,7 @@ describe('project link', () => {
     await program.parseAsync([
       'node',
       'catalyst',
-      'project',
+      'projects',
       'link',
       '--store-hash',
       storeHash,
@@ -744,7 +768,7 @@ describe('project link', () => {
       program.parseAsync([
         'node',
         'catalyst',
-        'project',
+        'projects',
         'link',
         '--store-hash',
         storeHash,
@@ -754,7 +778,7 @@ describe('project link', () => {
     ).rejects.toThrow('No infrastructure project linked');
 
     expect(consola.info).toHaveBeenCalledWith(
-      "When you're ready to create a project, run `catalyst project create` or re-run `catalyst project link`.",
+      "When you're ready to create a project, run `catalyst projects create` or re-run `catalyst projects link`.",
     );
     expect(exitMock).toHaveBeenCalledWith(0);
   });
@@ -770,7 +794,7 @@ describe('project link', () => {
       program.parseAsync([
         'node',
         'catalyst',
-        'project',
+        'projects',
         'link',
         '--store-hash',
         storeHash,
@@ -793,7 +817,7 @@ describe('project link', () => {
       await program.parseAsync([
         'node',
         'catalyst',
-        'project',
+        'projects',
         'link',
         '--project-uuid',
         projectUuid1,
@@ -814,7 +838,7 @@ describe('project link', () => {
       await program.parseAsync([
         'node',
         'catalyst',
-        'project',
+        'projects',
         'link',
         '--project-uuid',
         projectUuid1,
@@ -839,7 +863,7 @@ describe('project link', () => {
       await program.parseAsync([
         'node',
         'catalyst',
-        'project',
+        'projects',
         'link',
         '--project-uuid',
         projectUuid1,
@@ -851,7 +875,7 @@ describe('project link', () => {
   });
 
   test('errors when no projectUuid, storeHash, or accessToken are provided', async () => {
-    await expect(program.parseAsync(['node', 'catalyst', 'project', 'link'])).rejects.toThrow(
+    await expect(program.parseAsync(['node', 'catalyst', 'projects', 'link'])).rejects.toThrow(
       'Missing credentials',
     );
 
@@ -866,12 +890,12 @@ describe('project link', () => {
   });
 });
 
-describe('project delete', () => {
+describe('projects delete', () => {
   test('with --project-uuid and --force deletes without prompting', async () => {
     await program.parseAsync([
       'node',
       'catalyst',
-      'project',
+      'projects',
       'delete',
       '--project-uuid',
       projectUuid1,
@@ -896,7 +920,7 @@ describe('project delete', () => {
     await program.parseAsync([
       'node',
       'catalyst',
-      'project',
+      'projects',
       'delete',
       '--project-uuid',
       projectUuid1,
@@ -938,7 +962,7 @@ describe('project delete', () => {
     await program.parseAsync([
       'node',
       'catalyst',
-      'project',
+      'projects',
       'delete',
       '--project-uuid',
       projectUuid1,
@@ -960,7 +984,7 @@ describe('project delete', () => {
     await program.parseAsync([
       'node',
       'catalyst',
-      'project',
+      'projects',
       'delete',
       '--store-hash',
       storeHash,
@@ -1000,7 +1024,7 @@ describe('project delete', () => {
     await program.parseAsync([
       'node',
       'catalyst',
-      'project',
+      'projects',
       'delete',
       '--store-hash',
       storeHash,
@@ -1039,7 +1063,7 @@ describe('project delete', () => {
     await program.parseAsync([
       'node',
       'catalyst',
-      'project',
+      'projects',
       'delete',
       '--store-hash',
       storeHash,
@@ -1064,7 +1088,7 @@ describe('project delete', () => {
     await program.parseAsync([
       'node',
       'catalyst',
-      'project',
+      'projects',
       'delete',
       '--store-hash',
       storeHash,
@@ -1084,7 +1108,7 @@ describe('project delete', () => {
     await program.parseAsync([
       'node',
       'catalyst',
-      'project',
+      'projects',
       'delete',
       '--project-uuid',
       projectUuid1,
@@ -1105,7 +1129,7 @@ describe('project delete', () => {
     await program.parseAsync([
       'node',
       'catalyst',
-      'project',
+      'projects',
       'delete',
       '--project-uuid',
       projectUuid1,
@@ -1125,7 +1149,7 @@ describe('project delete', () => {
     delete process.env.CATALYST_STORE_HASH;
     delete process.env.CATALYST_ACCESS_TOKEN;
 
-    await expect(program.parseAsync(['node', 'catalyst', 'project', 'delete'])).rejects.toThrow(
+    await expect(program.parseAsync(['node', 'catalyst', 'projects', 'delete'])).rejects.toThrow(
       'Missing credentials',
     );
 
@@ -1148,7 +1172,7 @@ describe('project delete', () => {
       program.parseAsync([
         'node',
         'catalyst',
-        'project',
+        'projects',
         'delete',
         '--project-uuid',
         projectUuid1,
@@ -1173,7 +1197,7 @@ describe('project delete', () => {
       program.parseAsync([
         'node',
         'catalyst',
-        'project',
+        'projects',
         'delete',
         '--project-uuid',
         projectUuid1,

--- a/packages/catalyst/src/cli/commands/projects.ts
+++ b/packages/catalyst/src/cli/commands/projects.ts
@@ -26,7 +26,7 @@ import {
 } from '../lib/shared-options';
 import { getTelemetry } from '../lib/telemetry';
 
-// `catalyst project link` runs from the project root, which is what
+// `catalyst projects link` runs from the project root, which is what
 // `setupCommerceHosting` and `installDependencies` expect.
 async function offerCommerceHostingSetup(
   projectUuid: string,
@@ -75,7 +75,7 @@ const list = new Command('list')
     'after',
     `
 Example:
-  $ catalyst project list`,
+  $ catalyst projects list`,
   )
   .addOption(storeHashOption())
   .addOption(accessTokenOption())
@@ -89,11 +89,11 @@ Example:
 
     consola.start('Fetching projects...');
 
-    const projects = await fetchProjects(storeHash, accessToken, apiHost);
+    const storeProjects = await fetchProjects(storeHash, accessToken, apiHost);
 
     consola.success('Projects fetched.');
 
-    if (projects.length === 0) {
+    if (storeProjects.length === 0) {
       consola.info('No projects found.');
       process.exit(0);
 
@@ -102,7 +102,7 @@ Example:
 
     const linkedProjectUuid = config.get('projectUuid');
 
-    const projectList = projects.map((p) => {
+    const projectList = storeProjects.map((p) => {
       const marker = p.uuid === linkedProjectUuid ? ` ${colorize('green', '[linked]')}` : '';
       const hostnames =
         p.deployment_hostnames.length === 0
@@ -130,7 +130,7 @@ const create = new Command('create')
     'after',
     `
 Example:
-  $ catalyst project create`,
+  $ catalyst projects create`,
   )
   .addOption(storeHashOption())
   .addOption(accessTokenOption())
@@ -161,7 +161,7 @@ Example:
       } catch (error) {
         if (error instanceof LoginAbortedError) {
           consola.info(
-            'Login aborted. Re-run `catalyst project create` when you have your credentials ready.',
+            'Login aborted. Re-run `catalyst projects create` when you have your credentials ready.',
           );
           process.exit(0);
 
@@ -199,10 +199,10 @@ export const link = new Command('link')
     `
 Examples:
   # Link interactively (prompts to select or create)
-  $ catalyst project link
+  $ catalyst projects link
 
   # Link using a project UUID directly
-  $ catalyst project link --project-uuid <UUID>`,
+  $ catalyst projects link --project-uuid <UUID>`,
   )
   .addOption(storeHashOption())
   .addOption(accessTokenOption())
@@ -250,7 +250,7 @@ Examples:
     } catch (error) {
       if (error instanceof NoLinkedProjectError) {
         consola.info(
-          "When you're ready to create a project, run `catalyst project create` or re-run `catalyst project link`.",
+          "When you're ready to create a project, run `catalyst projects create` or re-run `catalyst projects link`.",
         );
         process.exit(0);
 
@@ -277,13 +277,13 @@ const del = new Command('delete')
     `
 Examples:
   # Select a project to delete interactively
-  $ catalyst project delete
+  $ catalyst projects delete
 
   # Delete a specific project (still prompts for confirmation)
-  $ catalyst project delete --project-uuid <UUID>
+  $ catalyst projects delete --project-uuid <UUID>
 
   # Skip the confirmation prompt
-  $ catalyst project delete --project-uuid <UUID> --force`,
+  $ catalyst projects delete --project-uuid <UUID> --force`,
   )
   .addOption(storeHashOption())
   .addOption(accessTokenOption())
@@ -303,11 +303,11 @@ Examples:
     if (!targetUuid) {
       consola.start('Fetching projects...');
 
-      const projects = await fetchProjects(storeHash, accessToken, apiHost);
+      const storeProjects = await fetchProjects(storeHash, accessToken, apiHost);
 
       consola.success('Projects fetched.');
 
-      if (projects.length === 0) {
+      if (storeProjects.length === 0) {
         consola.info('No projects found.');
         process.exit(0);
 
@@ -319,7 +319,7 @@ Examples:
       const selected = await select({
         message: 'Select a project to delete (Press <enter> to select).',
         choices: [
-          ...projects.map((p) => ({
+          ...storeProjects.map((p) => ({
             name:
               p.uuid === linkedProjectUuid ? `${p.name} ${colorize('green', '[linked]')}` : p.name,
             value: p.uuid,
@@ -336,7 +336,7 @@ Examples:
         return;
       }
 
-      const matched = projects.find((p) => p.uuid === selected);
+      const matched = storeProjects.find((p) => p.uuid === selected);
 
       if (!matched) {
         throw new Error(`Selected project ${String(selected)} not found in fetched list.`);
@@ -376,9 +376,12 @@ Examples:
     process.exit(0);
   });
 
-export const project = new Command('project')
+// Resource commands are plural; the singular form stays as an alias so existing
+// scripts and muscle memory keep working.
+export const projects = new Command('projects')
+  .alias('project')
   .configureHelp({ showGlobalOptions: true })
-  .description('Manage your BigCommerce infrastructure project.')
+  .description('Manage your BigCommerce infrastructure projects.')
   .addCommand(create)
   .addCommand(list)
   .addCommand(link)

--- a/packages/catalyst/src/cli/index.spec.ts
+++ b/packages/catalyst/src/cli/index.spec.ts
@@ -27,11 +27,13 @@ describe('CLI program', () => {
     expect(commands).toContain('start');
     expect(commands).toContain('build');
     expect(commands).toContain('deploy');
-    expect(commands).toContain('project');
+    expect(commands).toContain('projects');
+    expect(commands).toContain('channels');
+    expect(commands).toContain('domains');
     expect(commands).toContain('auth');
     expect(commands).toContain('logs');
 
-    const projectCmd = program.commands.find((cmd) => cmd.name() === 'project');
+    const projectCmd = program.commands.find((cmd) => cmd.name() === 'projects');
 
     expect(projectCmd?.commands.map((c) => c.name())).toEqual(
       expect.arrayContaining(['create', 'list', 'link']),
@@ -48,6 +50,19 @@ describe('CLI program', () => {
     expect(logsCmd?.commands.map((c) => c.name())).toEqual(
       expect.arrayContaining(['tail', 'query']),
     );
+  });
+
+  // Resource commands are plural, but the singular form has to keep resolving so
+  // existing scripts (and anyone's muscle memory) don't break.
+  test.each([
+    ['projects', 'project'],
+    ['channels', 'channel'],
+    ['domains', 'domain'],
+    ['logs', 'log'],
+  ])('%s accepts the %s alias', (name, alias) => {
+    const cmd = program.commands.find((c) => c.name() === name);
+
+    expect(cmd?.aliases()).toContain(alias);
   });
 
   test('telemetry hooks are called when executing version command', async () => {

--- a/packages/catalyst/src/cli/lib/commerce-hosting.ts
+++ b/packages/catalyst/src/cli/lib/commerce-hosting.ts
@@ -163,7 +163,7 @@ async function promptForNewProjectName(api: CommerceHostingApiContext): Promise<
 }
 
 // Generic "select an existing project, or create a new one" prompt — used by
-// `catalyst project link` and by `catalyst deploy` when its linked project is
+// `catalyst projects link` and by `catalyst deploy` when its linked project is
 // missing. Distinct from `promptForCommerceHostingProject` which has
 // default-name + auto-create semantics tailored to `catalyst create`.
 //

--- a/packages/catalyst/src/cli/lib/create-channel-flow.ts
+++ b/packages/catalyst/src/cli/lib/create-channel-flow.ts
@@ -43,7 +43,7 @@ export interface CreateChannelFlowOptions {
 }
 
 // Shared channel-creation flow used by both `catalyst create` (while scaffolding)
-// and `catalyst channel create` (on an existing project). Prompts for anything
+// and `catalyst channels create` (on an existing project). Prompts for anything
 // not provided as a flag, then POSTs to create the Catalyst channel.
 export async function runCreateChannelFlow(
   options: CreateChannelFlowOptions,

--- a/packages/catalyst/src/cli/lib/login.ts
+++ b/packages/catalyst/src/cli/lib/login.ts
@@ -141,7 +141,7 @@ async function manualLogin(apiHost: string): Promise<LoginResult> {
 }
 
 // Interactive login orchestrator. Used by `catalyst create`, `catalyst auth
-// login`, and `catalyst project create` to gather credentials when none are
+// login`, and `catalyst projects create` to gather credentials when none are
 // supplied via flags/env/config.
 //
 // Happy path: opens the browser device-code flow. When that fails (e.g. the

--- a/packages/catalyst/src/cli/lib/project-state.spec.ts
+++ b/packages/catalyst/src/cli/lib/project-state.spec.ts
@@ -138,7 +138,7 @@ describe('getProjectState', () => {
     expect(state.isFullySetUp).toBe(true);
   });
 
-  test('linked but untransformed (e.g. after `catalyst project create` only)', async () => {
+  test('linked but untransformed (e.g. after `catalyst projects create` only)', async () => {
     await writeProjectJson(tmpDir, { projectUuid: 'abc-123' });
     await writeFileEnsured(join(tmpDir, 'proxy.ts'), '// proxy');
 

--- a/packages/catalyst/src/cli/lib/project-state.ts
+++ b/packages/catalyst/src/cli/lib/project-state.ts
@@ -17,7 +17,7 @@ export interface ProjectState {
   hasOpenNextDep: boolean;
 
   // Derived signals — `isLinked` reflects intent (UUID registered via
-  // `catalyst project create` or commerce-hosting setup); `isTransformed`
+  // `catalyst projects create` or commerce-hosting setup); `isTransformed`
   // reflects on-disk readiness (middleware.ts swapped in, OpenNext dep
   // installed). A deploy needs both, but `catalyst build` only cares about
   // `isTransformed` so it can dispatch to OpenNext vs `next build`.

--- a/packages/catalyst/src/cli/lib/shared-options.ts
+++ b/packages/catalyst/src/cli/lib/shared-options.ts
@@ -50,7 +50,7 @@ export const resolveProjectUuid = (options: { projectUuid?: string }) => {
 
   if (!projectUuid) {
     throw new Error(
-      'Project UUID is required. Please run either `catalyst project link` or `catalyst project create` or this command again with --project-uuid <uuid>.',
+      'Project UUID is required. Please run either `catalyst projects link` or `catalyst projects create` or this command again with --project-uuid <uuid>.',
     );
   }
 

--- a/packages/catalyst/src/cli/program.ts
+++ b/packages/catalyst/src/cli/program.ts
@@ -5,14 +5,14 @@ import PACKAGE_INFO from '../../package.json';
 
 import { auth } from './commands/auth';
 import { build } from './commands/build';
-import { channel } from './commands/channel';
+import { channels } from './commands/channels';
 import { create } from './commands/create';
 import { debug } from './commands/debug';
 import { deploy } from './commands/deploy';
 import { domains } from './commands/domains';
 import { env } from './commands/env';
 import { logs } from './commands/logs';
-import { project } from './commands/project';
+import { projects } from './commands/projects';
 import { start } from './commands/start';
 import { telemetry } from './commands/telemetry';
 import { upgrade } from './commands/upgrade';
@@ -51,9 +51,9 @@ program
   .addCommand(deploy)
   .addCommand(domains)
   .addCommand(logs)
-  .addCommand(project)
+  .addCommand(projects)
   .addCommand(env)
-  .addCommand(channel)
+  .addCommand(channels)
   .addCommand(auth)
   .addCommand(upgrade)
   .addCommand(telemetry)


### PR DESCRIPTION
Linear: [LTRAC-1327](https://linear.app/commerce/issue/LTRAC-1327/standardize-cli-resource-naming-singular-vs-plural)

## What/Why?

Resource subcommands were split between singular (`project`, `channel`) and plural (`domains`, `logs`). Canonical names are now plural across the board, with the singular kept as a commander alias so `catalyst project list` and friends keep resolving.

| Canonical | Alias |
|---|---|
| `catalyst projects` (was `project`) | `project` |
| `catalyst channels` (was `channel`) | `channel` |
| `catalyst domains` | `domain` |
| `catalyst logs` | `log` |

Non-resource commands (`env`, `auth`, and the verbs) are out of scope. Aliases show in help as `projects|project` — commander's default, which advertises that both forms work.

Two notes for review:

- Renaming the exported consts to plural collided with locals named `projects`/`channels` in the action handlers, which `@typescript-eslint/no-shadow` rejects. The locals were renamed (`storeProjects`, `availableChannels`) so the exports stay uniform with `domains`/`logs`/`auth`.
- The `AGENTS.md` command table was stale beyond the naming issue (missing `create`, `channels`, `domains`, `env`, `upgrade`, `debug`; claimed `logs query` was "planned"). Refreshed while it was open.

The bulk of the diff is the ~37 user-facing references — help examples, error messages, prompts — that named the singular commands.

## Testing

`pnpm test` (617 passing), `pnpm typecheck`, and `pnpm lint` green in `packages/catalyst`. New coverage: alias assertions in `index.spec.ts`, `projects.spec.ts`, and `channels.spec.ts`, plus an end-to-end test that `catalyst project list` still routes through the renamed command.

Verified against the built bundle that each alias resolves to the same subcommand tree:

```bash
cd packages/catalyst && pnpm build
node dist/cli.js --help  # projects|project, channels|channel, domains|domain, logs|log
node dist/cli.js project --help
node dist/cli.js channel --help
```

## Migration

None for CLI users — the singular form of every renamed command still resolves, so existing scripts keep working.

For rebases, two modules were renamed to match the convention `domains.ts`/`logs.ts` already followed, and their exported consts pluralized:

- `src/cli/commands/project.ts` → `projects.ts` (and its spec)
- `src/cli/commands/channel.ts` → `channels.ts` (and its spec)

`src/cli/lib/project.ts` (the API client) is unchanged and still singular.