### PR TITLE
TRAC-1330: Update log request format to include requests without message payloads

### DIFF
--- a/.changeset/ltrac-1330-tail-request-format.md
+++ b/.changeset/ltrac-1330-tail-request-format.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst": patch
+---
+
+Print every request under `catalyst logs tail --format request`, including requests that emitted no log messages. Previously each line was tied to a log entry, so a request that logged nothing disappeared from the stream. The `request` format now reads `[timestamp] METHOD URL (status) [LEVEL] message`, moving the level after the request details in both `logs tail` and `logs query`. `catalyst logs tail --help` now documents each format and notes that `default` and `short` only show requests with a message body.

--- a/packages/catalyst/src/cli/commands/logs.spec.ts
+++ b/packages/catalyst/src/cli/commands/logs.spec.ts
@@ -232,7 +232,7 @@ describe('format: short', () => {
 });
 
 describe('format: request', () => {
-  test('logs timestamp, level, request info, and message', async () => {
+  test('logs timestamp, request info, level, and message', async () => {
     await callTailLogs('request');
 
     expect(consola.log).toHaveBeenCalledWith(
@@ -241,6 +241,52 @@ describe('format: request', () => {
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining('(200)'));
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining('hello world'));
   });
+
+  test('orders the line as timestamp, request, level, message', async () => {
+    await callTailLogs('request');
+
+    const line =
+      vi
+        .mocked(consola.log)
+        .mock.calls.map(([arg]) => String(arg))
+        .find((text) => text.includes('hello world')) ?? '';
+
+    expect(line).toContain('hello world');
+    expect(line.indexOf('(200)')).toBeLessThan(line.indexOf('INFO'));
+    expect(line.indexOf('INFO')).toBeLessThan(line.indexOf('hello world'));
+  });
+
+  // Both cases render identically: with no message there is no level to show,
+  // so the line is just the request. Asserted by equality — the level is the
+  // only colorized segment, so these lines carry no ANSI codes to match around.
+  const bareRequestLine = '[2026-03-11T22:05:28.870Z] GET https://example.com/test (200)';
+
+  test('logs the request when the event has no log entries', async () => {
+    const event = { ...validLogEvent, logs: [] };
+
+    await callTailLogs('request', [`data: ${JSON.stringify(event)}\n\n`]);
+
+    expect(consola.log).toHaveBeenCalledWith(bareRequestLine);
+  });
+
+  test('omits the level and trailing separator when an entry has no messages', async () => {
+    const event = { ...validLogEvent, logs: [{ ...validLogEvent.logs[0], messages: [] }] };
+
+    await callTailLogs('request', [`data: ${JSON.stringify(event)}\n\n`]);
+
+    expect(consola.log).toHaveBeenCalledWith(bareRequestLine);
+  });
+
+  test.each(['default', 'short'] as const)(
+    'omits events with no log messages from the %s format',
+    async (format) => {
+      const event = { ...validLogEvent, logs: [] };
+
+      await callTailLogs(format, [`data: ${JSON.stringify(event)}\n\n`]);
+
+      expect(consola.log).not.toHaveBeenCalled();
+    },
+  );
 });
 
 describe('log event processing', () => {

--- a/packages/catalyst/src/cli/commands/logs.ts
+++ b/packages/catalyst/src/cli/commands/logs.ts
@@ -71,11 +71,34 @@ class StreamError extends Error {
 const formatMessages = (messages: unknown[]) =>
   messages.map((m) => (typeof m === 'string' ? m : JSON.stringify(m))).join(' ');
 
-const formatLogEvent = (
-  event: z.infer<typeof LogEventSchema>,
-  format: 'default' | 'short' | 'request',
-) => {
-  const { request, logs: logEntries, exceptions } = event;
+type LogEvent = z.infer<typeof LogEventSchema>;
+
+// Builds a `request` format line. The log entry is optional: a request that
+// logged nothing still has a timestamp, method, URL and status worth printing.
+const formatRequestLine = (event: LogEvent, entry?: LogEvent['logs'][number]) => {
+  const { request } = event;
+  const msg = entry ? formatMessages(entry.messages) : '';
+  const msgPart = msg ? ` ${msg}` : '';
+  // The level labels the message, so an entry with nothing to say prints as a
+  // bare request line — same as an event that carried no entries at all.
+  const level = msg ? entry?.level.toUpperCase() : undefined;
+  const levelPart = level ? ` [${colorize(LEVEL_COLORS[level] ?? 'white', level)}]` : '';
+
+  return (
+    `[${entry?.timestamp ?? event.timestamp}] ` +
+    `${request.method} ${request.url} (${request.status_code})${levelPart}${msgPart}`
+  );
+};
+
+const formatLogEvent = (event: LogEvent, format: 'default' | 'short' | 'request') => {
+  const { logs: logEntries, exceptions } = event;
+
+  // `request` output is about the request, not the messages it emitted, so an
+  // event with no log entries still prints one line. Otherwise requests that
+  // logged nothing silently disappear from the stream.
+  if (format === 'request' && logEntries.length === 0) {
+    consola.log(formatRequestLine(event));
+  }
 
   logEntries.forEach((entry) => {
     const msg = formatMessages(entry.messages);
@@ -88,10 +111,7 @@ const formatLogEvent = (
         break;
 
       case 'request':
-        consola.log(
-          `[${entry.timestamp}] [${coloredLevel}] ${request.method} ${request.url}` +
-            ` (${request.status_code}) ${msg}`,
-        );
+        consola.log(formatRequestLine(event, entry));
         break;
 
       default:
@@ -319,6 +339,19 @@ const tail = new Command('tail')
   .addHelpText(
     'after',
     `
+Formats:
+  default  One line per log message: timestamp, level, and message.
+  short    Message text only.
+  request  One line per log message: timestamp, request method, URL, status
+           code, level, and message. Requests that logged no messages are
+           printed too, without the level and message.
+  pretty   Indented JSON of the whole event.
+  json     Raw JSON, one event per line (useful for piping to other tools).
+
+The \`default\` and \`short\` formats only print requests that produced a log
+message. Use \`--format request\` (or \`json\`/\`pretty\`) to see every request,
+including ones with no message body.
+
 Examples:
   $ catalyst logs tail
 

--- a/packages/catalyst/src/cli/lib/observability.spec.ts
+++ b/packages/catalyst/src/cli/lib/observability.spec.ts
@@ -159,6 +159,9 @@ describe('formatLogEntry', () => {
 
     expect(line).toContain('GET /cart (500)');
     expect(line).toContain('boom');
+    // Order is [timestamp] request [LEVEL] message.
+    expect(line.indexOf('GET /cart')).toBeLessThan(line.indexOf('ERROR'));
+    expect(line.indexOf('ERROR')).toBeLessThan(line.indexOf('boom'));
   });
 
   test('prints only the message in the short format', () => {

--- a/packages/catalyst/src/cli/lib/observability.ts
+++ b/packages/catalyst/src/cli/lib/observability.ts
@@ -236,7 +236,10 @@ export function formatLogEntry(entry: LogEntry, format: LogLineFormat = 'default
     if (parts.length > 0) requestStr = ` ${parts.join(' ')}${status}`;
   }
 
-  return `[${entry.timestamp ?? UNKNOWN_TIME}] [${coloredLevel}]${requestStr}${exceptionStr} ${message}`;
+  // `requestStr` is empty outside the `request` format, so the level stays
+  // adjacent to the timestamp there and only slides after the request details
+  // when they are present.
+  return `[${entry.timestamp ?? UNKNOWN_TIME}]${requestStr} [${coloredLevel}]${exceptionStr} ${message}`;
 }
 
 export async function queryLogs(


### PR DESCRIPTION
Linear: [LTRAC-1330](https://linear.app/commerce/issue/LTRAC-1330/catalyst-logs-tail-format-request-omits-logs-without-a-message-body)

## What/Why?

`catalyst logs tail --format request` built every line inside `logs.forEach(...)`, so an event with an empty `logs` array printed nothing — a request that emitted no log messages vanished from the stream, in the one format whose subject is the request rather than the message. Such events now print a request-only line, carrying the event's own timestamp and omitting the level and message. `default` and `short` are deliberately unchanged: they're message-oriented views, so a message-less request still produces no line there, and `logs tail --help` now says so.

Also reorders the line to `[timestamp] METHOD URL (status) [LEVEL] message`, and applies the same order to `logs query` — `formatLogEntry` is shared, and divergent column order between the two commands seemed worse than the extra scope. `default`/`short` output there is byte-identical, since the request segment is empty for those formats.

```
[2026-03-11T22:05:28.870Z] GET https://example.com/test (200) [INFO] hello world
[2026-03-11T22:05:28.870Z] GET https://example.com/test (200)
```

## Testing

107 tests pass across the two touched specs, lint and typecheck clean.

```bash
cd packages/catalyst
pnpm vitest run src/cli/commands/logs.spec.ts src/cli/lib/observability.spec.ts
pnpm lint && pnpm typecheck
```

New coverage: a request-only line for `logs: []`, no dangling separator when an entry has empty `messages`, `default`/`short` still silent for a message-less event, and field ordering (asserted by index, so it holds with or without ANSI color codes).

**Manual test:**
<img width="1397" height="487" alt="image" src="https://github.com/user-attachments/assets/89bc47ee-133c-4810-ac58-04cb57b027eb" />

## Migration

None, though anything parsing `--format request` positionally would need updating. `json` and `pretty` are unaffected.