### PR TITLE
LTRAC-1498: Bind CATALYST_ROUTES_KV namespace in Wrangler config

### DIFF
--- a/.changeset/ltrac-1498-routes-kv-binding.md
+++ b/.changeset/ltrac-1498-routes-kv-binding.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst": patch
+---
+
+Bind a `CATALYST_ROUTES_KV` Cloudflare KV namespace in the generated Wrangler config, so the routing cache used by `proxies/with-routes` has a shared store on BigCommerce Native Hosting instead of degrading to a per-invocation in-memory cache. The generated config points at a local-only placeholder namespace id used by `wrangler dev`/`catalyst start` and the `wrangler deploy --dry-run` bundling step; the real per-project namespace is bound at deploy time.

--- a/packages/catalyst/src/cli/lib/wrangler-config.spec.ts
+++ b/packages/catalyst/src/cli/lib/wrangler-config.spec.ts
@@ -24,3 +24,28 @@ test('compatibility date handles month-end normalization', () => {
 test('config uses a YYYY-MM-DD compatibility date', () => {
   expect(getWranglerConfig('uuid').compatibility_date).toMatch(/^\d{4}-\d{2}-\d{2}$/u);
 });
+
+test('binds the routing cache KV namespace as CATALYST_ROUTES_KV', () => {
+  expect(getWranglerConfig('uuid').kv_namespaces).toContainEqual(
+    expect.objectContaining({ binding: 'CATALYST_ROUTES_KV' }),
+  );
+});
+
+test('routing cache KV namespace id is local-only, never a real namespace id', () => {
+  const routesKv = getWranglerConfig('uuid').kv_namespaces.find(
+    (namespace) => namespace.binding === 'CATALYST_ROUTES_KV',
+  );
+
+  // A provisioned Cloudflare KV namespace id is always 32 lowercase hex chars.
+  // Anything matching that shape here would mean local dev could reach a real
+  // store's routing cache.
+  expect(routesKv?.id).not.toMatch(/^[0-9a-f]{32}$/u);
+
+  // The id is also independent of the project — nothing per-project should
+  // leak into the local placeholder.
+  expect(routesKv?.id).toBe(
+    getWranglerConfig('a-different-uuid').kv_namespaces.find(
+      (namespace) => namespace.binding === 'CATALYST_ROUTES_KV',
+    )?.id,
+  );
+});

--- a/packages/catalyst/src/cli/lib/wrangler-config.ts
+++ b/packages/catalyst/src/cli/lib/wrangler-config.ts
@@ -1,8 +1,13 @@
-// The compatibility date, compatibility flags, Durable Object classes, and
-// migration tag below are mirrored in Ignition, which builds its own Worker
-// metadata at deploy time (pkg/cloudflare/upload/metadata.go and
+// The compatibility date, compatibility flags, Durable Object classes,
+// migration tag, and KV namespace binding below are mirrored in Ignition,
+// which builds its own Worker metadata at deploy time
+// (pkg/cloudflare/upload/metadata.go and
 // pkg/cloudflare/upload/migrations/migrations.go). Keep both sides in sync
 // when changing any of them.
+//
+// Note that only the CATALYST_ROUTES_KV *binding name* is shared with
+// Ignition — the namespace id here is a local-only placeholder (see below),
+// while Ignition binds the real per-project namespace it provisioned.
 export function getCompatibilityDate(now = new Date()): string {
   const date = new Date(now);
 
@@ -15,6 +20,20 @@ export function getCompatibilityDate(now = new Date()): string {
 
   return date.toISOString().slice(0, 10);
 }
+
+// Namespace id for the routing cache KV binding in the *generated* config,
+// which only ever drives local `wrangler dev`/`opennextjs-cloudflare preview`
+// (where Miniflare keys its simulated store under `.wrangler/state/v3/kv`)
+// and the `wrangler deploy --dry-run` bundling step, which never resolves
+// bindings against the Cloudflare API. Ignition overwrites this with the real
+// per-project namespace id when it uploads the Worker.
+//
+// The value is deliberately not a 32-char lowercase hex string — the only
+// shape a real provisioned Cloudflare namespace id can take — so it cannot
+// collide with a production store's cache even if this config were somehow
+// used against the live API. Such a request fails closed with an invalid-id
+// error instead of reading or writing someone's real routing cache.
+const LOCAL_ROUTES_KV_NAMESPACE_ID = 'catalyst-routes-kv-local';
 
 export function getWranglerConfig(projectUuid: string) {
   return {
@@ -46,6 +65,12 @@ export function getWranglerConfig(projectUuid: string) {
       {
         binding: 'NEXT_INC_CACHE_R2_BUCKET',
         bucket_name: `project-${projectUuid}`,
+      },
+    ],
+    kv_namespaces: [
+      {
+        binding: 'CATALYST_ROUTES_KV',
+        id: LOCAL_ROUTES_KV_NAMESPACE_ID,
       },
     ],
     durable_objects: {


### PR DESCRIPTION
Linear: [LTRAC-1498](https://linear.app/commerce/issue/LTRAC-1498/catalyst-cli-add-catalyst-routes-kv-binding-to-generated-wrangler)
Parent: [LTRAC-1019](https://linear.app/commerce/issue/LTRAC-1019/automatically-hook-up-catalyst-routing-kv-for-deployments)

## What/Why?

On BigCommerce Native Hosting, `proxies/with-routes` currently has no shared cache — `createKVAdapter` finds neither Vercel Runtime Cache nor Upstash, so it falls back to `MemoryKvAdapter`, an in-process LRU that isn't shared across edge invocations. Every project is getting its own Cloudflare KV namespace to fix that; this PR is the CLI half, adding the `CATALYST_ROUTES_KV` binding to the generated Wrangler config so local dev matches what ships.

This file already carries a "keep in sync with Ignition's `metadata.go`" contract, and that comment is extended to cover the new binding — with one clarification worth reading, because it's the part most likely to be misunderstood: **only the binding *name* is shared with Ignition.** The namespace id here is a local-only placeholder; Ignition overwrites it with the real per-project namespace it provisioned when it uploads the Worker.

The placeholder is `catalyst-routes-kv-local`, and its shape is deliberate. A real Cloudflare namespace id is always a 32-character lowercase hex string, so this value cannot be mistaken for one. If this config were ever pointed at the live API, the request fails closed with an invalid-id error rather than silently reading or writing a real store's routing cache. Locally it's just a key prefix for Miniflare's simulated store under `.wrangler/state/v3/kv`, and the `wrangler deploy --dry-run` bundling step never resolves bindings against the API at all.

No `vars` entry is needed — isolation in this design is structural (a Worker can only reach namespaces bound to it), so there's no scope or secret value to inject.

The runtime adapter that actually reads this binding ships separately in [LTRAC-1499](https://linear.app/commerce/issue/LTRAC-1499/catalyst-core-add-cloudflarekvadapter-and-wire-into-adapter-selection). Until that lands, the binding is present and simply unread, which is harmless — and it means this PR can merge on its own without changing any runtime behaviour.

## Testing

```
pnpm vitest run src/cli/lib/wrangler-config.spec.ts   # in packages/catalyst
✓ src/cli/lib/wrangler-config.spec.ts (6 tests)
```

Covers the binding being emitted with the expected name, and the placeholder id being distinguishable from a real Cloudflare namespace id.

To check by hand: run `catalyst build` on a project and inspect the generated `core/.bigcommerce/wrangler.jsonc` for the `kv_namespaces` entry, then `catalyst start` and confirm Miniflare creates the local store under `core/.wrangler/state/v3/kv`.

## Migration

None. Purely additive to generated config — no existing files move, no breaking changes, and no action required from anyone rebasing. A `patch` changeset is included.