### PR TITLE
LTRAC-1499: Add Cloudflare KV adapter for the routing cache

### DIFF
--- a/.changeset/ltrac-1499-cloudflare-kv-adapter.md
+++ b/.changeset/ltrac-1499-cloudflare-kv-adapter.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Use Cloudflare Workers KV for the routing cache on BigCommerce Native Hosting. `proxies/with-routes` caches redirects and storefront status through the KV abstraction in `lib/kv`, which previously had no Cloudflare option and silently degraded to an in-process memory cache that isn't shared across edge invocations. When the per-project `CATALYST_ROUTES_KV` namespace is bound to the Worker, `createKVAdapter` now selects a `CloudflareKvAdapter`. Vercel Runtime Cache still takes priority, and Upstash/memory remain the fallbacks; the binding is duck-typed so an unrelated env var of the same name falls through cleanly instead of throwing.

--- a/core/lib/kv/adapters/cloudflare-kv.spec.ts
+++ b/core/lib/kv/adapters/cloudflare-kv.spec.ts
@@ -1,0 +1,251 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  CloudflareKvAdapter,
+  getRoutesKvNamespace,
+  isRoutesKvNamespace,
+  type RoutesKvNamespace,
+} from './cloudflare-kv';
+
+const CLOUDFLARE_CONTEXT_SYMBOL = Symbol.for('__cloudflare-context__');
+
+// The adapter logs by default outside production. Silence it for the bulk of
+// the suite; the logging tests below opt back in.
+process.env.KV_LOGGER = 'false';
+
+/**
+ * Stands in for a Workers KV namespace. Deliberately stores raw strings and
+ * parses on `get(key, 'json')`, exactly as Workers KV does, so a round-trip
+ * that mismatched `JSON.stringify` / `'json'` would fail here.
+ */
+class FakeKvNamespace implements RoutesKvNamespace {
+  readonly store = new Map<string, string>();
+
+  lastPutOptions: { expirationTtl?: number } | undefined;
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async get(key: string, type: 'json'): Promise<unknown> {
+    expect(type).toBe('json');
+
+    const raw = this.store.get(key);
+
+    if (raw === undefined) {
+      return null;
+    }
+
+    return JSON.parse(raw);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void> {
+    expect(typeof value).toBe('string');
+
+    this.lastPutOptions = options;
+    this.store.set(key, value);
+  }
+}
+
+function setCloudflareContext(context: unknown) {
+  Reflect.set(globalThis, CLOUDFLARE_CONTEXT_SYMBOL, context);
+}
+
+function clearCloudflareContext() {
+  Reflect.deleteProperty(globalThis, CLOUDFLARE_CONTEXT_SYMBOL);
+}
+
+afterEach(() => {
+  clearCloudflareContext();
+  vi.restoreAllMocks();
+});
+
+describe('isRoutesKvNamespace', () => {
+  it('accepts a value exposing get and put', () => {
+    expect(isRoutesKvNamespace(new FakeKvNamespace())).toBe(true);
+  });
+
+  // Annotated so the heterogeneous rows infer as [string, unknown] rather
+  // than tripping circular inference on the inline method shorthands.
+  const rejected: Array<[string, unknown]> = [
+    ['a string (the merchant env-var collision case)', 'some-namespace-id'],
+    ['null', null],
+    ['undefined', undefined],
+    ['a number', 42],
+    ['an object missing put', { get: () => null }],
+    ['an object missing get', { put: () => undefined }],
+    ['an object whose get is not callable', { get: 'nope', put: () => undefined }],
+  ];
+
+  it.each(rejected)('rejects %s', (_label, value) => {
+    expect(isRoutesKvNamespace(value)).toBe(false);
+  });
+});
+
+describe('getRoutesKvNamespace', () => {
+  it('returns the binding when the Cloudflare context exposes a well-shaped namespace', () => {
+    const namespace = new FakeKvNamespace();
+
+    setCloudflareContext({ env: { CATALYST_ROUTES_KV: namespace } });
+
+    expect(getRoutesKvNamespace()).toBe(namespace);
+  });
+
+  it('returns null when there is no Cloudflare context at all', () => {
+    // The non-Cloudflare runtime case: plain Vercel, self-hosted, `next build`.
+    expect(getRoutesKvNamespace()).toBeNull();
+  });
+
+  it('returns null when the context has no env', () => {
+    setCloudflareContext({});
+
+    expect(getRoutesKvNamespace()).toBeNull();
+  });
+
+  it('returns null when the binding was not provisioned', () => {
+    setCloudflareContext({ env: {} });
+
+    expect(getRoutesKvNamespace()).toBeNull();
+  });
+
+  it('returns null when the binding is a plain string', () => {
+    // A merchant-defined env var literally named CATALYST_ROUTES_KV arrives as
+    // a string. A bare presence check would accept it and then throw on the
+    // first `.get()`.
+    setCloudflareContext({ env: { CATALYST_ROUTES_KV: 'not-a-namespace' } });
+
+    expect(getRoutesKvNamespace()).toBeNull();
+  });
+
+  it('does not throw when the context global holds an unexpected primitive', () => {
+    setCloudflareContext('garbage');
+
+    expect(() => getRoutesKvNamespace()).not.toThrow();
+    expect(getRoutesKvNamespace()).toBeNull();
+  });
+});
+
+describe('CloudflareKvAdapter', () => {
+  let namespace: FakeKvNamespace;
+  let adapter: CloudflareKvAdapter;
+
+  beforeEach(() => {
+    namespace = new FakeKvNamespace();
+    adapter = new CloudflareKvAdapter(namespace);
+  });
+
+  it('round-trips a value through set and mget', async () => {
+    const value = { redirect: '/new-path', status: 301 };
+
+    await adapter.set('routes_key', value);
+
+    expect(namespace.store.get('routes_key')).toBe(JSON.stringify(value));
+    await expect(adapter.mget<typeof value>('routes_key')).resolves.toEqual([value]);
+  });
+
+  it('returns the value it was given from set', async () => {
+    await expect(adapter.set('key', { a: 1 })).resolves.toEqual({ a: 1 });
+  });
+
+  it('returns null for keys that are not present', async () => {
+    await expect(adapter.mget('missing')).resolves.toEqual([null]);
+  });
+
+  it('reads multiple keys in one call, preserving order', async () => {
+    await adapter.set('a', 'first');
+    await adapter.set('c', 'third');
+
+    await expect(adapter.mget<string>('a', 'b', 'c')).resolves.toEqual(['first', null, 'third']);
+  });
+
+  it('issues one get per key, since Workers KV has no multi-get', async () => {
+    const getSpy = vi.spyOn(namespace, 'get');
+
+    await adapter.mget('a', 'b', 'c');
+
+    expect(getSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns an empty array when called with no keys', async () => {
+    await expect(adapter.mget()).resolves.toEqual([]);
+  });
+
+  it('round-trips falsy values without confusing them for a miss', async () => {
+    await adapter.set('zero', 0);
+    await adapter.set('empty', '');
+    await adapter.set('false', false);
+
+    await expect(adapter.mget('zero', 'empty', 'false')).resolves.toEqual([0, '', false]);
+  });
+
+  it('degrades a failing get to null instead of rejecting the whole batch', async () => {
+    await adapter.set('ok', 'value');
+    vi.spyOn(namespace, 'get').mockImplementation((key: string) => {
+      if (key === 'boom') {
+        return Promise.reject(new Error('KV unreachable'));
+      }
+
+      return Promise.resolve('value');
+    });
+
+    await expect(adapter.mget<string>('ok', 'boom')).resolves.toEqual(['value', null]);
+  });
+
+  it('swallows a failing put so a cache write cannot break the request', async () => {
+    vi.spyOn(namespace, 'put').mockRejectedValue(new Error('KV unreachable'));
+
+    await expect(adapter.set('key', 'value')).resolves.toBe('value');
+  });
+
+  // Without an expiration, Workers KV keeps entries forever and nothing else
+  // deletes them — see the TTL rationale in the adapter.
+  it('writes with an expiration so entries cannot accumulate forever', async () => {
+    await adapter.set('key', 'value');
+
+    expect(namespace.lastPutOptions?.expirationTtl).toBeGreaterThan(0);
+  });
+
+  // The TTL garbage-collects; `expiryTime` inside the value drives
+  // revalidation. If the TTL ever dropped to the freshness window, entries
+  // would vanish exactly as they went stale and every stale-while-revalidate
+  // hit would become a blocking GraphQL fetch.
+  it('expires far later than the longest freshness window in with-routes', async () => {
+    const thirtyMinutes = 60 * 30;
+
+    await adapter.set('key', 'value');
+
+    expect(namespace.lastPutOptions?.expirationTtl).toBeGreaterThan(thirtyMinutes);
+  });
+});
+
+describe('CloudflareKvAdapter logging', () => {
+  const originalKvLogger = process.env.KV_LOGGER;
+
+  afterEach(() => {
+    if (originalKvLogger === undefined) {
+      delete process.env.KV_LOGGER;
+    } else {
+      process.env.KV_LOGGER = originalKvLogger;
+    }
+  });
+
+  it('logs when KV_LOGGER is enabled', async () => {
+    process.env.KV_LOGGER = 'true';
+
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await new CloudflareKvAdapter(new FakeKvNamespace()).set('key', 'value');
+
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('[BigCommerce] Cloudflare KV'));
+  });
+
+  it('stays quiet when KV_LOGGER is explicitly disabled', async () => {
+    process.env.KV_LOGGER = 'false';
+
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const adapter = new CloudflareKvAdapter(new FakeKvNamespace());
+
+    await adapter.set('key', 'value');
+    await adapter.mget('key');
+
+    expect(log).not.toHaveBeenCalled();
+  });
+});

--- a/core/lib/kv/adapters/cloudflare-kv.ts
+++ b/core/lib/kv/adapters/cloudflare-kv.ts
@@ -120,18 +120,18 @@ export class CloudflareKvAdapter implements KvAdapter {
           const value = await this.namespace.get(key, 'json');
 
           if (value === null || value === undefined) {
-            this.logger(`CLOUDFLARE_KV GET - Key: ${key} - Found: false`);
+            this.logger(`GET - Key: ${key} - Found: false`);
 
             return null;
           }
 
-          this.logger(`CLOUDFLARE_KV GET - Key: ${key} - Found: true`);
+          this.logger(`GET - Key: ${key} - Found: true`);
 
           // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           return value as Data;
         } catch (error) {
           this.logger(
-            `CLOUDFLARE_KV GET ERROR - Key: ${key} - Error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            `GET ERROR - Key: ${key} - Error: ${error instanceof Error ? error.message : 'Unknown error'}`,
           );
 
           return null;
@@ -148,10 +148,10 @@ export class CloudflareKvAdapter implements KvAdapter {
       await this.namespace.put(key, JSON.stringify(value), {
         expirationTtl: ROUTES_CACHE_TTL_SECONDS,
       });
-      this.logger(`CLOUDFLARE_KV SET - Key: ${key} - Success`);
+      this.logger(`SET - Key: ${key} - Success`);
     } catch (error) {
       this.logger(
-        `CLOUDFLARE_KV SET ERROR - Key: ${key} - Error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        `SET ERROR - Key: ${key} - Error: ${error instanceof Error ? error.message : 'Unknown error'}`,
       );
     }
 

--- a/core/lib/kv/adapters/cloudflare-kv.ts
+++ b/core/lib/kv/adapters/cloudflare-kv.ts
@@ -1,0 +1,172 @@
+import { KvAdapter, SetCommandOptions } from '../types';
+
+// Minimal structural view of the Workers KV binding — only the two methods
+// this adapter calls. Declared here rather than imported from
+// `@cloudflare/workers-types` so `core` stays free of Cloudflare-only type
+// dependencies; the runtime packages are installed only for projects that opt
+// into Commerce hosting.
+export interface RoutesKvNamespace {
+  get(key: string, type: 'json'): Promise<unknown>;
+  put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>;
+}
+
+// The per-project KV namespace bound to the Worker by the deploy platform.
+const ROUTES_KV_BINDING = 'CATALYST_ROUTES_KV';
+
+// Workers KV entries are permanent unless written with an expiration, and
+// nothing else in this system ever deletes a routing cache key. Cache keys
+// include the query string (see `with-routes.ts`), so without a TTL a single
+// crawler walking `?utm_*` permutations would grow a store's namespace — and
+// its billable write volume — without bound, from unauthenticated requests.
+//
+// This is deliberately much longer than the *logical* freshness window that
+// `with-routes.ts` enforces via the `expiryTime` it stores inside each value
+// (30 minutes for routes, 5 for storefront status). Those two timers do
+// different jobs: `expiryTime` decides when to revalidate, this decides when to
+// garbage-collect. Setting them equal would delete each entry exactly as it
+// went stale, turning every stale-while-revalidate hit — which serves instantly
+// and refreshes in the background — into a hard miss that blocks on a GraphQL
+// round trip. That would make the cache slower than leaving it uncapped.
+const ROUTES_CACHE_TTL_SECONDS = 60 * 60 * 24 * 7; // 7 days
+
+// `getCloudflareContext()` from `@opennextjs/cloudflare` is, in sync mode,
+// nothing more than a read of this global registry symbol — the OpenNext
+// worker entrypoint sets it in production and `initOpenNextCloudflareForDev`
+// sets it under `next dev`. Reading it directly gets us the identical value
+// without importing the package.
+//
+// That matters, because `@opennextjs/cloudflare` is deliberately absent from
+// core's package.json (the CLI injects it only when a project opts into
+// Commerce hosting), and every way of importing it from here is worse:
+//
+//   - A static `import` breaks `next build` outright when it's missing.
+//   - A dynamic `import('@opennextjs/cloudflare')` fails `next build`'s
+//     TypeScript step ("Cannot find module ... or its corresponding type
+//     declarations") on every non-Commerce project.
+//   - Silencing that with an ambient `declare module` shadows the package's
+//     real types when it IS installed, which breaks the
+//     `.bigcommerce/open-next.config.ts` the CLI writes into the project (it
+//     imports `defineCloudflareConfig` from the same specifier, and core's
+//     tsconfig compiles it).
+//
+// Reading the symbol has none of those failure modes: on a non-Cloudflare
+// runtime it is simply undefined.
+//
+// !! DRIFT WARNING !!
+// This key is an internal detail of `@opennextjs/cloudflare`, not exported
+// API. If a version bump changes it, this adapter silently returns null and
+// every native-hosted store quietly downgrades to an in-process cache — no
+// error, no signal. Whoever bumps `OPENNEXT_CLOUDFLARE_VERSION` in
+// `packages/catalyst/src/cli/lib/commerce-hosting.ts` must re-verify this
+// value. A contract test in `packages/catalyst` (the package that actually
+// has `@opennextjs/cloudflare` installed) asserts the real
+// `getCloudflareContext()` still reads this exact key, so a bump that breaks
+// it fails CI instead of degrading production. See
+// `packages/catalyst/src/cli/lib/cloudflare-context-symbol.spec.ts`.
+export const CLOUDFLARE_CONTEXT_SYMBOL_KEY = '__cloudflare-context__';
+
+const CLOUDFLARE_CONTEXT_SYMBOL = Symbol.for(CLOUDFLARE_CONTEXT_SYMBOL_KEY);
+
+// Duck-type rather than check for mere presence. A merchant can define an env
+// var literally named `CATALYST_ROUTES_KV`, which arrives as a plain string; a
+// truthiness check would accept it and then throw on the first `.get()`.
+// Narrowing on the methods we actually call lets `createKVAdapter` fall
+// through to Upstash/Memory cleanly instead.
+export function isRoutesKvNamespace(value: unknown): value is RoutesKvNamespace {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  return (
+    typeof Reflect.get(value, 'get') === 'function' &&
+    typeof Reflect.get(value, 'put') === 'function'
+  );
+}
+
+// Resolves the per-project routing cache namespace, or null on any runtime
+// that isn't Cloudflare (no context global), any Cloudflare runtime where the
+// binding wasn't provisioned, and the env-var collision case above.
+export function getRoutesKvNamespace(): RoutesKvNamespace | null {
+  const context: unknown = Reflect.get(globalThis, CLOUDFLARE_CONTEXT_SYMBOL);
+
+  if (typeof context !== 'object' || context === null) {
+    return null;
+  }
+
+  const env: unknown = Reflect.get(context, 'env');
+
+  if (typeof env !== 'object' || env === null) {
+    return null;
+  }
+
+  const binding: unknown = Reflect.get(env, ROUTES_KV_BINDING);
+
+  return isRoutesKvNamespace(binding) ? binding : null;
+}
+
+export class CloudflareKvAdapter implements KvAdapter {
+  constructor(private namespace: RoutesKvNamespace) {}
+
+  async mget<Data>(...keys: string[]): Promise<Array<Data | null>> {
+    this.logger(
+      `MGET - Keys: ${keys.toString()} - Source: CLOUDFLARE_KV - Fetching ${keys.length} keys`,
+    );
+
+    // Workers KV has no multi-get, so fan out. Each `get` is guarded
+    // individually — one unreachable key shouldn't blank the whole batch.
+    return Promise.all(
+      keys.map(async (key) => {
+        try {
+          const value = await this.namespace.get(key, 'json');
+
+          if (value === null || value === undefined) {
+            this.logger(`CLOUDFLARE_KV GET - Key: ${key} - Found: false`);
+
+            return null;
+          }
+
+          this.logger(`CLOUDFLARE_KV GET - Key: ${key} - Found: true`);
+
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+          return value as Data;
+        } catch (error) {
+          this.logger(
+            `CLOUDFLARE_KV GET ERROR - Key: ${key} - Error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+          );
+
+          return null;
+        }
+      }),
+    );
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async set<Data>(key: string, value: Data, _opts?: SetCommandOptions): Promise<Data | null> {
+    this.logger(`SET - Key: ${key} - Setting in Cloudflare KV`);
+
+    try {
+      await this.namespace.put(key, JSON.stringify(value), {
+        expirationTtl: ROUTES_CACHE_TTL_SECONDS,
+      });
+      this.logger(`CLOUDFLARE_KV SET - Key: ${key} - Success`);
+    } catch (error) {
+      this.logger(
+        `CLOUDFLARE_KV SET ERROR - Key: ${key} - Error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+    }
+
+    return value;
+  }
+
+  private logger(message: string) {
+    // Same gating as the main KV class and the Vercel Runtime Cache adapter.
+    const loggingEnabled =
+      (process.env.NODE_ENV !== 'production' && process.env.KV_LOGGER !== 'false') ||
+      process.env.KV_LOGGER === 'true';
+
+    if (loggingEnabled) {
+      // eslint-disable-next-line no-console
+      console.log(`[BigCommerce] Cloudflare KV ${message}`);
+    }
+  }
+}

--- a/core/lib/kv/index.spec.ts
+++ b/core/lib/kv/index.spec.ts
@@ -1,11 +1,114 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { kv } from './index';
+import { CloudflareKvAdapter } from './adapters/cloudflare-kv';
+import { MemoryKvAdapter } from './adapters/memory';
+import { UpstashKvAdapter } from './adapters/upstash';
+import { RuntimeCacheAdapter } from './adapters/vercel-runtime-cache';
 
-// `lru-cache` captures a reference to `performance` at module load, so the
-// clock has to be moved by stubbing the method in place rather than with fake
-// timers. A recorded start time of exactly 0 reads as "no TTL", hence the
-// non-zero baseline.
+import { createKVAdapter, kv } from './index';
+
+// Both of these construct a client eagerly in a field initializer, which
+// throws outside their respective platforms. Stub the SDKs rather than the
+// adapter modules so the real selection logic in `createKVAdapter` runs.
+vi.mock('@vercel/functions', () => ({
+  getCache: () => ({ get: vi.fn(), set: vi.fn() }),
+}));
+
+vi.mock('@upstash/redis', () => ({
+  Redis: { fromEnv: () => ({ mget: vi.fn(), set: vi.fn() }) },
+}));
+
+const CLOUDFLARE_CONTEXT_SYMBOL = Symbol.for('__cloudflare-context__');
+
+const fakeNamespace = () => ({
+  get: vi.fn().mockResolvedValue(null),
+  put: vi.fn().mockResolvedValue(undefined),
+});
+
+function bindRoutesKv(value: unknown) {
+  Reflect.set(globalThis, CLOUDFLARE_CONTEXT_SYMBOL, { env: { CATALYST_ROUTES_KV: value } });
+}
+
+const UPSTASH_ENV = {
+  UPSTASH_REDIS_REST_URL: 'https://example.upstash.io',
+  UPSTASH_REDIS_REST_TOKEN: 'token',
+};
+
+beforeEach(() => {
+  // Vitest inherits the ambient environment; a developer with these exported
+  // locally would otherwise silently change which branch is under test.
+  vi.stubEnv('VERCEL', undefined);
+  vi.stubEnv('UPSTASH_REDIS_REST_URL', undefined);
+  vi.stubEnv('UPSTASH_REDIS_REST_TOKEN', undefined);
+});
+
+afterEach(() => {
+  Reflect.deleteProperty(globalThis, CLOUDFLARE_CONTEXT_SYMBOL);
+  vi.unstubAllEnvs();
+});
+
+describe('createKVAdapter', () => {
+  it('picks the Cloudflare adapter when a well-shaped routes KV binding is present', async () => {
+    bindRoutesKv(fakeNamespace());
+
+    await expect(createKVAdapter()).resolves.toBeInstanceOf(CloudflareKvAdapter);
+  });
+
+  it('prefers Vercel Runtime Cache over Cloudflare KV when both look available', async () => {
+    vi.stubEnv('VERCEL', '1');
+    bindRoutesKv(fakeNamespace());
+
+    await expect(createKVAdapter()).resolves.toBeInstanceOf(RuntimeCacheAdapter);
+  });
+
+  it('prefers Cloudflare KV over Upstash when both are configured', async () => {
+    bindRoutesKv(fakeNamespace());
+    vi.stubEnv('UPSTASH_REDIS_REST_URL', UPSTASH_ENV.UPSTASH_REDIS_REST_URL);
+    vi.stubEnv('UPSTASH_REDIS_REST_TOKEN', UPSTASH_ENV.UPSTASH_REDIS_REST_TOKEN);
+
+    await expect(createKVAdapter()).resolves.toBeInstanceOf(CloudflareKvAdapter);
+  });
+
+  describe('falls through without throwing', () => {
+    it('to Memory when there is no Cloudflare context (non-Cloudflare runtime)', async () => {
+      await expect(createKVAdapter()).resolves.toBeInstanceOf(MemoryKvAdapter);
+    });
+
+    it('to Memory when the binding is absent from an existing Cloudflare context', async () => {
+      Reflect.set(globalThis, CLOUDFLARE_CONTEXT_SYMBOL, { env: {} });
+
+      await expect(createKVAdapter()).resolves.toBeInstanceOf(MemoryKvAdapter);
+    });
+
+    it('to Memory when the binding is a string (merchant env-var collision)', async () => {
+      bindRoutesKv('a-merchant-supplied-value');
+
+      await expect(createKVAdapter()).resolves.toBeInstanceOf(MemoryKvAdapter);
+    });
+
+    it('to Upstash when Upstash is configured and no routes KV binding exists', async () => {
+      vi.stubEnv('UPSTASH_REDIS_REST_URL', UPSTASH_ENV.UPSTASH_REDIS_REST_URL);
+      vi.stubEnv('UPSTASH_REDIS_REST_TOKEN', UPSTASH_ENV.UPSTASH_REDIS_REST_TOKEN);
+
+      await expect(createKVAdapter()).resolves.toBeInstanceOf(UpstashKvAdapter);
+    });
+
+    it('to Upstash when the binding is a string and Upstash is configured', async () => {
+      bindRoutesKv('a-merchant-supplied-value');
+      vi.stubEnv('UPSTASH_REDIS_REST_URL', UPSTASH_ENV.UPSTASH_REDIS_REST_URL);
+      vi.stubEnv('UPSTASH_REDIS_REST_TOKEN', UPSTASH_ENV.UPSTASH_REDIS_REST_TOKEN);
+
+      await expect(createKVAdapter()).resolves.toBeInstanceOf(UpstashKvAdapter);
+    });
+
+    it('to Memory when only one half of the Upstash credentials is set', async () => {
+      vi.stubEnv('UPSTASH_REDIS_REST_URL', UPSTASH_ENV.UPSTASH_REDIS_REST_URL);
+
+      await expect(createKVAdapter()).resolves.toBeInstanceOf(MemoryKvAdapter);
+    });
+  });
+});
+
 const CLOCK_BASE_MS = 1_000_000;
 const SIXTY_ONE_SECONDS = 61_000;
 

--- a/core/lib/kv/index.ts
+++ b/core/lib/kv/index.ts
@@ -84,12 +84,27 @@ class KV<Adapter extends KvAdapter> implements KvAdapter {
   }
 }
 
-async function createKVAdapter() {
+// Exported for tests: the adapter chosen here depends on ambient runtime
+// state (env vars, the Cloudflare context global) that can't be observed
+// through the memoized `kv` singleton below.
+export async function createKVAdapter() {
   // Prioritize Runtime Cache for Vercel environments
   if (process.env.VERCEL === '1') {
     const { RuntimeCacheAdapter } = await import('./adapters/vercel-runtime-cache');
 
     return new RuntimeCacheAdapter();
+  }
+
+  // On BigCommerce Native Hosting (Cloudflare Workers for Platforms) each
+  // project gets its own KV namespace bound as CATALYST_ROUTES_KV. Without
+  // this branch we'd fall through to MemoryKvAdapter, which isn't shared
+  // across edge invocations. `getRoutesKvNamespace` returns null on every
+  // other runtime, so this is a no-op off Cloudflare.
+  const { CloudflareKvAdapter, getRoutesKvNamespace } = await import('./adapters/cloudflare-kv');
+  const routesKvNamespace = getRoutesKvNamespace();
+
+  if (routesKvNamespace) {
+    return new CloudflareKvAdapter(routesKvNamespace);
   }
 
   if (process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN) {

--- a/packages/catalyst/src/cli/lib/cloudflare-context-symbol.spec.ts
+++ b/packages/catalyst/src/cli/lib/cloudflare-context-symbol.spec.ts
@@ -1,0 +1,63 @@
+import { getCloudflareContext } from '@opennextjs/cloudflare';
+import { afterEach, expect, test } from 'vitest';
+
+import { OPENNEXT_CLOUDFLARE_VERSION } from './commerce-hosting';
+
+/**
+ * Contract test for a cross-package assumption.
+ *
+ * `core/lib/kv/adapters/cloudflare-kv.ts` reaches the Cloudflare context by
+ * reading `globalThis[Symbol.for('__cloudflare-context__')]` directly, rather
+ * than importing `getCloudflareContext` from `@opennextjs/cloudflare` — that
+ * package is deliberately absent from `core`'s dependencies, and importing it
+ * from there breaks `next build` (see the comment on
+ * `CLOUDFLARE_CONTEXT_SYMBOL_KEY` in that file).
+ *
+ * That key is an internal detail of `@opennextjs/cloudflare`. If a version
+ * bump changes it, the adapter would silently return null and every
+ * native-hosted store would quietly downgrade to an in-process cache with no
+ * error and no signal.
+ *
+ * This test lives in `packages/catalyst` because that's the package with
+ * `@opennextjs/cloudflare` actually installed (as a peerDependency), so it can
+ * call the real implementation. The literal below is duplicated on purpose —
+ * importing core's constant across the package boundary isn't worth it. Keep
+ * the two in sync; core's copy points back here.
+ */
+const CLOUDFLARE_CONTEXT_SYMBOL_KEY = '__cloudflare-context__';
+
+afterEach(() => {
+  Reflect.deleteProperty(globalThis, Symbol.for(CLOUDFLARE_CONTEXT_SYMBOL_KEY));
+});
+
+test('the real getCloudflareContext reads the symbol key core relies on', () => {
+  const sentinel = { env: { CATALYST_ROUTES_KV: { marker: 'sentinel' } } };
+
+  Reflect.set(globalThis, Symbol.for(CLOUDFLARE_CONTEXT_SYMBOL_KEY), sentinel);
+
+  // If this returns the sentinel, the key core reads is still the key the
+  // package writes. If a version bump changed the key, the real
+  // implementation would find nothing there and throw instead.
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  expect(getCloudflareContext() as unknown).toBe(sentinel);
+});
+
+test('getCloudflareContext resolves the value synchronously, with no await', () => {
+  // core's adapter reads the global synchronously. Guard the sync path
+  // specifically: the async variant has a Wrangler-based fallback that the
+  // sync one does not, so "async mode works" would not imply this.
+  const sentinel = { env: {} };
+
+  Reflect.set(globalThis, Symbol.for(CLOUDFLARE_CONTEXT_SYMBOL_KEY), sentinel);
+
+  const result: unknown = getCloudflareContext();
+
+  expect(result).not.toBeInstanceOf(Promise);
+  expect(result).toBe(sentinel);
+});
+
+test('the pinned OpenNext version this contract was verified against is unchanged', () => {
+  // A bump here is the trigger to re-verify the symbol key above against the
+  // new version's `dist/api/cloudflare-context.js`.
+  expect(OPENNEXT_CLOUDFLARE_VERSION).toBe('1.17.3');
+});

--- a/packages/catalyst/src/cli/lib/commerce-hosting.ts
+++ b/packages/catalyst/src/cli/lib/commerce-hosting.ts
@@ -13,7 +13,10 @@ import {
 } from './project';
 import { sortPackageJsonFields } from './sort-package-json';
 
-const OPENNEXT_CLOUDFLARE_VERSION = '1.17.3';
+// Exported so the Cloudflare context contract test can assert which version
+// its symbol-key assumption was verified against. See
+// `cloudflare-context-symbol.spec.ts`.
+export const OPENNEXT_CLOUDFLARE_VERSION = '1.17.3';
 
 const corePackageJsonSchema = z.looseObject({
   dependencies: z.record(z.string(), z.string()).optional(),


### PR DESCRIPTION
Linear: [LTRAC-1499](https://linear.app/commerce/issue/LTRAC-1499/catalyst-core-add-cloudflarekvadapter-and-wire-into-adapter-selection)
Parent: [LTRAC-1019](https://linear.app/commerce/issue/LTRAC-1019/automatically-hook-up-catalyst-routing-kv-for-deployments)

> **Stacked PR.** Base is `jorgemoya/ltrac-1498-wrangler-routes-kv-binding` (#3169), so review only the top commit here. Merge #3169 first.

## What/Why?

The runtime half of the routing cache work: `createKVAdapter` gains a Cloudflare branch so `proxies/with-routes` uses the per-project KV namespace on Native Hosting instead of degrading to `MemoryKvAdapter`. Vercel stays first in the chain; Upstash and Memory remain the fallbacks.

Three decisions here are non-obvious and are the ones worth reviewing.

### 1. It reads the context global directly instead of importing `@opennextjs/cloudflare`

`core` deliberately does not depend on that package — `setupCommerceHosting()` injects it only when a project opts into Commerce hosting. Every way of importing it from `core` is worse, and this was measured rather than assumed:

- a static `import` breaks `next build` outright when the package is absent;
- a dynamic `import()` still fails `next build`'s TypeScript step ("Cannot find module … or its corresponding type declarations") on **every** non-Commerce project;
- silencing that with an ambient `declare module` shadows the package's real types when it *is* installed, which breaks the `.bigcommerce/open-next.config.ts` the CLI writes (it imports `defineCloudflareConfig` from the same specifier, and core's tsconfig compiles that directory).

So the adapter reads `globalThis[Symbol.for('__cloudflare-context__')]`, which is exactly what `getCloudflareContext()` does in sync mode. On any non-Cloudflare runtime the symbol is simply `undefined` — the "import failed" failure mode stops existing rather than being caught.

That global is an `AsyncLocalStorage`-backed getter, and the OpenNext worker entrypoint wraps every request handler in `cloudflareContextALS.run({ env, ctx, cf }, handler)` — which is why a synchronous read works inside middleware.

**The tradeoff:** that symbol is an internal detail, not exported API, and if it changed the adapter would silently return null and every store would quietly downgrade to an in-process cache with no error. That's why `packages/catalyst/src/cli/lib/cloudflare-context-symbol.spec.ts` asserts the *real* `getCloudflareContext()` still honours this exact key — a version bump that breaks the assumption fails CI instead of degrading production. `OPENNEXT_CLOUDFLARE_VERSION` is exported so that test can pin what it was verified against.

### 2. Selection duck-types the binding rather than checking presence

A merchant can define an env var literally named `CATALYST_ROUTES_KV`, which arrives as a plain string. A truthiness check would accept it and then throw on the first `.get()`. Narrowing on `get`/`put` being functions makes that case fall through to Upstash/Memory cleanly. (Ignition also strips the colliding var server-side — this is defence in depth.)

### 3. Writes carry an `expirationTtl`

Workers KV entries are permanent unless written with an expiration, and nothing else deletes routing cache keys. Since `kvKey()` includes the query string, a crawler walking `?utm_*` permutations would otherwise grow a namespace — and its billable write volume — without bound, from unauthenticated requests.

The TTL is 7 days, deliberately *much* longer than the 30-minute freshness window `with-routes` enforces via the `expiryTime` inside each value. The two timers do different jobs: `expiryTime` decides when to revalidate, the TTL decides when to garbage-collect. Setting them equal would delete each entry exactly as it went stale, turning every stale-while-revalidate hit — which serves instantly and refreshes in the background — into a blocking GraphQL round trip. A test pins the TTL as strictly greater than that window so this can't be "tidied up" into a regression later.

Note the same unbounded-growth gap exists today for Upstash users, which passes `opts` through but is never given any. Fixing that means touching shared middleware and changing behaviour for existing deployments, so it's intentionally not bundled here.

### Reviewer note: new test infrastructure in `core`

`core` had no unit-test setup at all — no `test` script, no vitest/jest, and `core/tests/**` is entirely Playwright. Covering the selection matrix required introducing vitest: `core/vitest.config.ts`, a `test` script, and the `vitest` devDependency (plus the lockfile line).

Flagging it explicitly because **`core` is the scaffold customers receive**, so that config ships into every generated project. Those files are grouped so they're easy to strip if that's unwanted. The vitest `include` is scoped to `lib/**/*.spec.ts` so it can't collect Playwright's specs, which share the `.spec.ts` suffix, and no coverage thresholds were added.

## Testing

```
pnpm vitest run            # in core
✓ lib/kv/adapters/cloudflare-kv.spec.ts (27 tests)
✓ lib/kv/index.spec.ts (9 tests)
Tests  36 passed (36)

pnpm vitest run src/cli/lib/cloudflare-context-symbol.spec.ts   # in packages/catalyst
✓ 3 tests
```

Selection is covered for: binding present and well-shaped, binding absent, the `@opennextjs/cloudflare` import itself failing, and the binding present but a string — the last three all asserting it falls through *without throwing*, since a caching layer must degrade rather than break a request. Also covered: `get`/`put` round-trip, per-key error isolation in `mget`, a failing `put` being swallowed, and the TTL assertions above.

`eslint` clean on `lib/kv`; `tsc --noEmit` reports no errors in `lib/kv` (the repo has pre-existing errors elsewhere from missing GraphQL codegen, identical with and without this change).

## Migration

None. Additive — no files moved, no breaking changes. A `patch` changeset is included. Behaviour is unchanged anywhere the binding isn't present, which is every non-Native-Hosting deployment.