### PR TITLE
fix(core): TRAC-1425 Don't strip Expires from session cookie deletion directives

### DIFF
--- a/.changeset/trac-1425-session-cookie-deletion.md
+++ b/.changeset/trac-1425-session-cookie-deletion.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Fix session cookie deletion being silently broken after logout. `stripSessionCookieExpiry` was stripping `Expires` from all session token `Set-Cookie` headers, including deletion directives (empty value + `Expires=past`). This turned cookie deletions into permanent empty-value session cookies, so the browser never removed them and stale cookies accumulated across login/logout cycles.

--- a/core/proxies/with-auth.ts
+++ b/core/proxies/with-auth.ts
@@ -6,7 +6,9 @@ import { type ProxyFactory } from './compose-proxies';
 
 // Path matcher for any routes that require authentication
 const protectedPathPattern = new URLPattern({ pathname: `{/:locale}?/(account)/*` });
-const SESSION_TOKEN_COOKIE_RE = /^(__Secure-)?authjs\.session-token(\.\d+)?=/;
+// [^;] after = excludes deletion directives (empty value → = is immediately followed by ;),
+// so their Expires=past/max-age=0 is preserved and the browser actually removes the cookie.
+const SESSION_TOKEN_COOKIE_RE = /^(__Secure-)?authjs\.session-token(\.\d+)?=[^;]/;
 
 function redirectToLogin(url: string) {
   return NextResponse.redirect(new URL('/login', url), { status: 302 });


### PR DESCRIPTION
Jira: [TRAC-1425](<https://bigcommercecloud.atlassian.net/browse/TRAC-1425>)

## What/Why?

`stripSessionCookieExpiry` in `proxies/with-auth.ts` was introduced in [LTRAC-814](https://linear.app/commerce/issue/LTRAC-814/cli-build-leaves-stale-files-in-bigcommercedist-between-builds) to strip `Expires` from session token `Set-Cookie` headers (essential cookie classification compliance). The original regex matched any session token cookie header, including deletion directives — the empty-value cookies Auth.js sends to tell the browser to delete the cookie (`value=; Expires=Thu, 01 Jan 1970 00:00:00 GMT`).

Stripping `Expires` from a deletion directive turns it into a permanent empty-value session cookie. The browser stores it and never removes it, so stale session cookies survive logout. This was identified as a likely cause of the persistent session confusion and cart state issues reported by headless merchants (CHECKOUT-10255).

Fix: narrow `SESSION_TOKEN_COOKIE_RE` with `=[^;]` so headers where the value is empty (deletion directive: `=` immediately followed by `;`) are not matched. Their `Expires=past`/`max-age=0` is preserved and the browser removes the cookie.

## Testing

1. Log in to a Catalyst storefront
2. Log out
3. Inspect cookies in DevTools — `__Secure-authjs.session-token` should be absent after logout (previously it would persist as an empty-value cookie)
4. Log in and out multiple times; confirm no stale session token cookies accumulate

## Migration

No migration required.

[TRAC-1425]: https://bigcommercecloud.atlassian.net/browse/TRAC-1425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ