### PR TITLE
TRAC-238: Update PDP metadata images to use correct image url

### DIFF
--- a/.changeset/trac-238-pdp-metadata-image-url.md
+++ b/.changeset/trac-238-pdp-metadata-image-url.md
@@ -1,0 +1,19 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Fix the product page `og:image` tag pointing at an unfetchable URL. `ProductPageMetadataQuery` requested `urlTemplate`, which returns a URL containing a literal `{:size}` placeholder that the `<Image>` CDN loader substitutes at render time. `generateMetadata` has no such loader, so the placeholder was emitted verbatim into the Open Graph tag.
+
+## Migration
+
+In `core/app/[locale]/(default)/product/[slug]/page-data.ts`, update the `defaultImage` selection in `ProductPageMetadataQuery` to request a concrete URL:
+
+```diff
+  defaultImage {
+    altText
+-   url: urlTemplate(lossy: true)
++   url(width: 1200, lossy: true)
+  }
+```
+
+`width: 1200` matches the Open Graph and `summary_large_image` recommendation. Height is omitted intentionally — the stencil resizer fits the image inside the given box rather than cropping, so requesting `1200x630` would return a smaller square image for a square product photo.

--- a/core/app/[locale]/(default)/product/[slug]/page-data.ts
+++ b/core/app/[locale]/(default)/product/[slug]/page-data.ts
@@ -141,7 +141,7 @@ const ProductPageMetadataQuery = graphql(`
         path
         defaultImage {
           altText
-          url: urlTemplate(lossy: true)
+          url(width: 1200, lossy: true)
         }
         seo {
           pageTitle


### PR DESCRIPTION
## What/Why?

`ProductPageMetadataQuery` requested `urlTemplate`, which returns a URL containing a literal `{:size}` placeholder. `<Image>` expands that through the CDN loader at render time, but `generateMetadata` uses the value verbatim — so `og:image` pointed at an unfetchable URL.

`url(width: 1200)` returns a concrete URL instead. Height is omitted deliberately: the stencil resizer fits the image inside the given box rather than cropping, so asking for a social aspect ratio like `1200x630` would just return a smaller square image for a square product photo.

## Testing

View source on a PDP and confirm `og:image` contains `/stencil/1200w/` rather than `/stencil/{:size}/`, and that the URL loads.

## Migration

In `core/app/[locale]/(default)/product/[slug]/page-data.ts`, update the `defaultImage` selection in `ProductPageMetadataQuery`:

```diff
  defaultImage {
    altText
-   url: urlTemplate(lossy: true)
+   url(width: 1200, lossy: true)
  }
```

Also included as a `## Migration` section in the changeset.

[TRAC-238]: https://bigcommercecloud.atlassian.net/browse/TRAC-238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ