### PR TITLE
LTRAC-1583: Add a unit test harness to core and expire in-memory KV entries

### DIFF
--- a/.changeset/ltrac-1583-memory-kv-ttl.md
+++ b/.changeset/ltrac-1583-memory-kv-ttl.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Expire entries in the in-memory KV layer after 60 seconds. `lib/kv` keeps a per-process `MemoryKvAdapter` in front of whichever shared adapter is selected (Cloudflare KV, Upstash, Vercel Runtime Cache) and skips the shared store whenever memory holds every requested key. Those entries never expired, so once a process had seen a key it stopped consulting the shared store for it entirely. Refreshes were then driven solely by the `expiryTime` each caller embeds in the cached value — and that path refetches from the **origin**, not from the shared store. So every process independently refetched on a clock starting from whenever it first cached the key, rather than picking up a value another process had already fetched and shared. Cached data was never wrong, but origin requests and cache writes scaled with process count. Capacity is also raised from 500 to 4096 entries, since cache keys include the query string and so accumulate faster than the number of real paths suggests.

--- a/core/lib/kv/adapters/memory.spec.ts
+++ b/core/lib/kv/adapters/memory.spec.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MemoryKvAdapter } from './memory';
+
+describe('MemoryKvAdapter', () => {
+  // `lru-cache` captures a reference to `performance` at module load. Vitest's
+  // fake timers replace the global with a new object that reference never sees,
+  // so the cache's clock has to be moved by stubbing the method in place.
+  // `lru-cache` records an entry's start time as `perf.now()` and treats a
+  // recorded start of exactly 0 as "no TTL set", so the clock must not start at
+  // zero — expiry would be silently disabled and every assertion below would
+  // pass regardless.
+  const CLOCK_BASE_MS = 1_000_000;
+
+  let now = CLOCK_BASE_MS;
+
+  const advanceBy = (ms: number) => {
+    now += ms;
+  };
+
+  beforeEach(() => {
+    now = CLOCK_BASE_MS;
+    vi.spyOn(performance, 'now').mockImplementation(() => now);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns what was set', async () => {
+    const adapter = new MemoryKvAdapter();
+
+    await adapter.set('key', { hello: 'world' });
+
+    expect(await adapter.mget('key')).toStrictEqual([{ hello: 'world' }]);
+  });
+
+  it('returns null for keys it has never seen', async () => {
+    const adapter = new MemoryKvAdapter();
+
+    expect(await adapter.mget('missing')).toStrictEqual([null]);
+  });
+
+  it('preserves key order across a mixed hit/miss batch', async () => {
+    const adapter = new MemoryKvAdapter();
+
+    await adapter.set('b', 'second');
+
+    expect(await adapter.mget('a', 'b', 'c')).toStrictEqual([null, 'second', null]);
+  });
+
+  // `KV.mget` writes shared-store misses back into memory, so a cached null
+  // must survive the round trip.
+  it('stores a null value without losing the entry', async () => {
+    const adapter = new MemoryKvAdapter();
+
+    await adapter.set('key', null);
+
+    expect(await adapter.mget('key')).toStrictEqual([null]);
+  });
+
+  // `KV.mget` skips the shared store while memory holds every requested key,
+  // so expiry is what lets a process observe another process's writes.
+  it('expires entries so reads fall through to the shared store', async () => {
+    const adapter = new MemoryKvAdapter();
+
+    await adapter.set('key', 'cached');
+
+    advanceBy(59_000);
+    expect(await adapter.mget('key')).toStrictEqual(['cached']);
+
+    advanceBy(2_000);
+    expect(await adapter.mget('key')).toStrictEqual([null]);
+  });
+
+  // Inside `with-routes`' shortest window (5 minutes for storefront status).
+  it('expires well within the shortest caller freshness window', async () => {
+    const adapter = new MemoryKvAdapter();
+
+    await adapter.set('key', 'cached');
+
+    advanceBy(1000 * 60 * 5);
+
+    expect(await adapter.mget('key')).toStrictEqual([null]);
+  });
+
+  it('lets an explicit ex override the default window', async () => {
+    const adapter = new MemoryKvAdapter();
+
+    await adapter.set('key', 'cached', { ex: 300 });
+
+    advanceBy(120_000);
+    expect(await adapter.mget('key')).toStrictEqual(['cached']);
+
+    advanceBy(181_000);
+    expect(await adapter.mget('key')).toStrictEqual([null]);
+  });
+
+  it('refreshes the window when a key is written again', async () => {
+    const adapter = new MemoryKvAdapter();
+
+    await adapter.set('key', 'first');
+    advanceBy(50_000);
+
+    await adapter.set('key', 'second');
+    advanceBy(50_000);
+
+    expect(await adapter.mget('key')).toStrictEqual(['second']);
+  });
+
+  // Keys include the query string, so distinct keys accumulate quickly.
+  it('evicts least-recently-used entries beyond its capacity', async () => {
+    const adapter = new MemoryKvAdapter();
+
+    await Promise.all(Array.from({ length: 4097 }, async (_, i) => adapter.set(`key-${i}`, i)));
+
+    expect(await adapter.mget('key-0')).toStrictEqual([null]);
+    expect(await adapter.mget('key-4096')).toStrictEqual([4096]);
+  });
+
+  it('holds well beyond the 500 entries it previously capped at', async () => {
+    const adapter = new MemoryKvAdapter();
+
+    await Promise.all(Array.from({ length: 2000 }, async (_, i) => adapter.set(`key-${i}`, i)));
+
+    expect(await adapter.mget('key-0', 'key-1999')).toStrictEqual([0, 1999]);
+  });
+});

--- a/core/lib/kv/adapters/memory.ts
+++ b/core/lib/kv/adapters/memory.ts
@@ -5,42 +5,53 @@ import { KvAdapter } from '../types';
 
 interface CacheEntry {
   value: unknown;
-  expiresAt: number;
 }
+
+// This adapter also sits in front of the shared adapters: `KV.mget` skips the
+// shared store whenever memory holds every requested key. Without an expiry
+// that short-circuit is permanent, and the only thing left driving refreshes is
+// the `expiryTime` callers embed in the value -- which refetches from the
+// origin rather than re-reading the shared store. Expiring here is what lets a
+// process pick up a value another process already fetched.
+//
+// 60s is Workers KV's floor for `cacheTtl` on a read; matching it keeps one
+// staleness window rather than one per layer. It stays inside the shortest
+// window callers embed in their own values — `with-routes` stores 5 minutes for
+// storefront status, 30 minutes for routes.
+const DEFAULT_TTL_MS = 60_000;
+
+// Bounds memory under key churn. Cache keys include the query string, so
+// distinct keys accumulate much faster than the number of real paths suggests.
+const MAX_ENTRIES = 4096;
 
 export class MemoryKvAdapter implements KvAdapter {
   private kv = new LRUCache<string, CacheEntry>({
-    max: 500,
+    max: MAX_ENTRIES,
+    ttl: DEFAULT_TTL_MS,
+    // Not `allowStale`. Serving an expired entry needs a background refresh to
+    // replace it, and `KV.mget` has no `waitUntil` handle to run one on — so a
+    // stale value would never be replaced. Expired reads fall through to the
+    // shared store instead.
+    //
+    // `ttlResolution: 0` reads the clock on every lookup rather than debouncing
+    // it behind a 1ms `setTimeout`, which avoids scheduling a timer per
+    // operation on runtimes where timers are tied to the request lifetime.
+    ttlResolution: 0,
   });
 
   async mget<Data>(...keys: string[]) {
-    const entries = keys.map((key) => this.kv.get(key)?.value);
+    // `LRUCache.get` returns undefined past the TTL, so expiry is the cache's
+    // job rather than a hand-rolled `expiresAt` check.
+    const entries = keys.map((key) => this.kv.get(key)?.value ?? null);
 
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    return entries as Data[];
+    return entries as Array<Data | null>;
   }
 
   async set<Data>(key: string, value: Data, options: { ex?: number } = {}) {
-    this.kv.set(key, {
-      value,
-      expiresAt: options.ex ? Date.now() + options.ex * 1_000 : Number.MAX_SAFE_INTEGER,
-    });
+    // `ex` overrides the default window for this entry only.
+    this.kv.set(key, { value }, options.ex ? { ttl: options.ex * 1_000 } : undefined);
 
     return value;
-  }
-
-  private async get<Data>(key: string) {
-    const entry = this.kv.get(key);
-
-    if (!entry) {
-      return null;
-    }
-
-    if (entry.expiresAt < Date.now()) {
-      return null;
-    }
-
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    return entry.value as Data;
   }
 }

--- a/core/package.json
+++ b/core/package.json
@@ -16,6 +16,7 @@
     "build": "npm run generate && next build",
     "build:analyze": "ANALYZE=true npm run build",
     "start": "next start",
+    "test": "vitest run",
     "prelint": "next typegen",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "typecheck": "tsc --noEmit"
@@ -113,6 +114,7 @@
     "prettier-plugin-tailwindcss": "^0.6.12",
     "tailwindcss": "^3.4.17",
     "tailwindcss-animate": "1.0.7",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^3.2.4"
   }
 }

--- a/core/vitest.config.ts
+++ b/core/vitest.config.ts
@@ -1,0 +1,17 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    // Scoped to `lib/` on purpose: `tests/` holds Playwright specs, which
+    // share the `*.spec.ts` suffix but must not be collected by Vitest.
+    include: ['lib/**/*.spec.ts'],
+    exclude: ['**/node_modules/**', '**/.next/**'],
+  },
+  resolve: {
+    alias: {
+      '~': fileURLToPath(new URL('.', import.meta.url)),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,6 +312,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.15.30)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.29.2)(msw@2.9.0(@types/node@22.15.30)(typescript@5.8.3))(terser@5.16.9)(yaml@2.8.1)
 
   packages/catalyst:
     dependencies:
@@ -8361,7 +8364,6 @@ packages:
   puppeteer@24.10.0:
     resolution: {integrity: sha512-Oua9VkGpj0S2psYu5e6mCer6W9AU9POEQh22wRgSXnLXASGH+MwLUVWgLCLeP9QPHHcJ7tySUlg4Sa9OJmaLpw==}
     engines: {node: '>=18'}
-    deprecated: < 24.15.0 is no longer supported
     hasBin: true
 
   pure-rand@6.1.0:


### PR DESCRIPTION
Linear: [LTRAC-1583](https://linear.app/commerce/issue/LTRAC-1583/in-memory-kv-layer-never-expires-so-isolates-never-pick-up-each-others)

Two commits: the test harness `core` has never had, and the fix it exists to cover. Base for #3170.

## What/Why?

`lib/kv` keeps a per-process `MemoryKvAdapter` in front of whichever shared adapter is selected, and `KV.mget` skips the shared store whenever memory holds every requested key. Nothing ever expired those entries, so that short-circuit was permanent — once a process had seen a key it never consulted the shared store again, could not observe a refresh another process had written, and re-ran the refresh itself.

Caught on a deployed store:

- `01:19:01` — `storeStatus` written, window ends `01:24:01`
- `01:21:12` — a request reads the **previous** value and revalidates again

That read never reached the shared store despite a fresher value having sat there for two minutes. A later trace showed a route entry served from memory **14 hours** stale.

**Nothing was ever served incorrectly.** Staleness stayed bounded by the caller's own `expiryTime`, and stale-while-revalidate still served fast and refreshed behind the request. The cost was duplicated work — origin fetches and cache writes scaling with process count rather than being shared.

## The two values

**60s TTL** (was 30s) — matches Workers KV's floor for `cacheTtl` on a read, so the layers share one staleness window rather than one each. It sits inside the shortest window callers embed in their values (5 min for storefront status, 30 for routes).

**4096 entries** (was 500) — cache keys include the query string, so distinct keys accumulate much faster than the number of real paths suggests; a crawler walking `?utm_*` permutations alone can churn through the old limit.

## The trade, stated plainly

This adds a shared-store read per key per window that we previously didn't do, in exchange for origin fetches and cache writes no longer multiplying by process count. Storefront API calls are the scarce resource and KV reads are cheap, so it's favourable — but it isn't free.

It also pairs with a follow-up: `CloudflareKvAdapter` passing `cacheTtl` on the read would serve those extra reads from the colo cache, shared across every isolate in a data centre. That belongs in #3170, since this layer also fronts Upstash and Vercel. Worth noting the two only work together — `cacheTtl` is inert if memory never expires, because the read never happens.

## Considered and not adopted

**`allowStale` + `noDeleteOnStaleGet`** would serve an expired entry instantly and refresh it off the response path, which is nicer than a blocking read. It needs somewhere to run the refresh: `KV.mget` is called from `with-routes.ts:262` without the request's event and has no `waitUntil` handle. Returning stale values with no refresh would reinstate the exact bug this fixes.

**Single-flight on revalidation** — two concurrent requests observing the same stale entry currently fire two origin fetches and two KV writes, seen twice in traces including two writes to the same route key 207ms apart. That revalidation lives in `with-routes`, not here.

Also unchanged: `KV.mget` filters memory values with `.filter(Boolean)`, so a legitimately cached `null` — a path with no route — reads as a miss and re-hits the shared store.

## Testing

`vitest run` — 10 pass. Lint and `tsc --noEmit` clean.

`memory.spec.ts` covers the round trip, key ordering across a mixed hit/miss batch, `null` round-tripping, expiry at the default window, expiry inside the callers' shortest window, `ex` overriding the default, the window refreshing on rewrite, eviction at capacity, and that capacity now exceeds the old 500.

**Verified both changed values fail their specs when reverted** — removing the TTL breaks two specs, restoring `max: 500` breaks the capacity spec. Two things made that non-obvious, both noted at their call sites:

- `lru-cache` captures a reference to the `performance` object at module load. Vitest's fake timers replace the global with a new object that reference never sees, so the cache's clock has to be moved by stubbing the method in place.
- `lru-cache` treats a recorded start time of exactly `0` as "no TTL". The fake clock therefore starts at a non-zero baseline — starting at zero makes every expiry assertion pass whether or not the TTL works, which is how this nearly shipped green.

## Migration

None. No API change; the only behavioural difference is that a process re-reads the shared store for a key it has held for more than 60 seconds.