### PR TITLE
LTRAC-1583: Add a unit test harness to core

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -16,6 +16,7 @@
     "build": "npm run generate && next build",
     "build:analyze": "ANALYZE=true npm run build",
     "start": "next start",
+    "test": "vitest run",
     "prelint": "next typegen",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "typecheck": "tsc --noEmit"
@@ -113,6 +114,7 @@
     "prettier-plugin-tailwindcss": "^0.6.12",
     "tailwindcss": "^3.4.17",
     "tailwindcss-animate": "1.0.7",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^3.2.4"
   }
 }

--- a/core/vitest.config.ts
+++ b/core/vitest.config.ts
@@ -1,0 +1,22 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    // Scoped to `lib/` on purpose: `tests/` holds Playwright specs, which
+    // share the `*.spec.ts` suffix but must not be collected by Vitest.
+    include: ['lib/**/*.spec.ts'],
+    exclude: ['**/node_modules/**', '**/.next/**'],
+    // `turbo run test` invokes this in every package that defines a `test`
+    // script, and Vitest treats an empty run as a failure by default. Nothing
+    // under `lib/` has specs yet, so without this the harness would fail CI on
+    // the very commit that introduces it.
+    passWithNoTests: true,
+  },
+  resolve: {
+    alias: {
+      '~': fileURLToPath(new URL('.', import.meta.url)),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,6 +312,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.15.30)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.29.2)(msw@2.9.0(@types/node@22.15.30)(typescript@5.8.3))(terser@5.16.9)(yaml@2.8.1)
 
   packages/catalyst:
     dependencies:
@@ -8361,7 +8364,6 @@ packages:
   puppeteer@24.10.0:
     resolution: {integrity: sha512-Oua9VkGpj0S2psYu5e6mCer6W9AU9POEQh22wRgSXnLXASGH+MwLUVWgLCLeP9QPHHcJ7tySUlg4Sa9OJmaLpw==}
     engines: {node: '>=18'}
-    deprecated: < 24.15.0 is no longer supported
     hasBin: true
 
   pure-rand@6.1.0:


### PR DESCRIPTION
Linear: [LTRAC-1583](https://linear.app/commerce/issue/LTRAC-1583/in-memory-kv-layer-never-expires-so-isolates-never-pick-up-each-others)

Base for #3170 and #3176.

## What/Why?

`core` has never had a unit test runner. `tests/` holds 63 Playwright specs run by `playwright test`; there was no `test` script, no runner, and no way to unit test anything under `lib/`.

This was originally bundled into #3170. Split out because "add a test runner to a package that has never had one" carries its own questions — layout, scoping, CI — that shouldn't be reviewed as a footnote to a caching change, and because two unrelated PRs needing it shouldn't be serialised behind each other.

**`include: ['lib/**/*.spec.ts']`** is the load-bearing part. Playwright specs share the `*.spec.ts` suffix, so an unscoped Vitest would collect all 63 and fail on their fixture imports. Verified the scoping holds: a run on this commit reports zero files despite those 63 being present.

**Colocated rather than under `tests/`**, matching `packages/catalyst`, where `build.spec.ts` sits next to `build.ts`. Putting them under `tests/` was considered — it would need either a separate suffix or a `testIgnore` entry, since `testDir: './tests'` means Playwright collects anything `.spec.ts` there, and `tests/lib/` already means "helpers for Playwright tests" so `tests/lib/kv` would read ambiguously.

**`passWithNoTests`** because `turbo run test` invokes this in every package defining a `test` script, and Vitest treats an empty run as a failure. Nothing under `lib/` has specs until the PRs building on this land, so without it this commit would fail the CI job it exists to enable. Reasonable to drop once specs are in — flagging it because it does mean a future broken `include` glob would fail silently rather than loudly.

**The `~` alias** mirrors the tsconfig path alias so `lib` code importing `~/...` resolves as it does in the app.

## Testing

`pnpm --filter @bigcommerce/catalyst-core test` exits 0 with `No test files found`. `pnpm install --frozen-lockfile` passes, so the lockfile entry is consistent.

The two PRs on top of this exercise it for real — #3170 adds 36 specs, #3176 adds 9.

## Migration

None. No changeset: dev tooling with no consumer-visible behaviour.