### PR TITLE
LTRAC-1582: Preserve project.json contents through Commerce Hosting setup

### DIFF
--- a/.changeset/ltrac-1582-preserve-project-json.md
+++ b/.changeset/ltrac-1582-preserve-project-json.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst": patch
+---
+
+Stop `catalyst deploy` from wiping stored deployment environment variables. Commerce Hosting setup rebuilt `.bigcommerce/project.json` from scratch, dropping anything it didn't write itself — the `env` block managed by `catalyst env`, the persisted `apiHost`, and stored credentials when setup ran without them. Because `deploy` re-runs setup whenever the project isn't fully transformed, a routine deploy could silently discard variables that are sent as secrets on every deploy, leaving the next one to ship without them. Setup now merges into the existing file.

--- a/packages/catalyst/src/cli/commands/create.ts
+++ b/packages/catalyst/src/cli/commands/create.ts
@@ -394,9 +394,10 @@ Examples:
       // and `catalyst projects create` would fail or re-prompt for login
       // immediately after `create` already logged the user in.
       //
-      // Runs after `setupCommerceHosting` — which writes the same file to
-      // record `projectUuid` — because `Conf` merges into existing contents
-      // whereas that helper overwrites wholesale.
+      // Ordered after `setupCommerceHosting`, which writes the same file to
+      // record `projectUuid`. Both merge into existing contents now, so the
+      // order no longer matters for correctness — kept so the credentials
+      // written here are the ones that land last.
       if (storeHash && accessToken) {
         const projectConfig = getProjectConfig(projectDir);
 

--- a/packages/catalyst/src/cli/lib/commerce-hosting.spec.ts
+++ b/packages/catalyst/src/cli/lib/commerce-hosting.spec.ts
@@ -1,5 +1,5 @@
 import { confirm, input, select } from '@inquirer/prompts';
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
@@ -562,7 +562,9 @@ describe('promptForCommerceHostingProject', () => {
 
 describe('setupCommerceHosting', () => {
   const packageJsonSchema = z.record(z.string(), z.unknown());
-  const projectJsonSchema = z.object({
+  // Loose: `z.object` strips unknown keys, which would quietly discard the very
+  // fields (`env`, `apiHost`) the preservation tests below assert on.
+  const projectJsonSchema = z.looseObject({
     projectUuid: z.string(),
     framework: z.string(),
     storeHash: z.string().optional(),
@@ -598,6 +600,14 @@ describe('setupCommerceHosting', () => {
   function readCorePackageJson() {
     return packageJsonSchema.parse(
       JSON.parse(readFileSync(join(projectDir, 'package.json'), 'utf-8')),
+    );
+  }
+
+  function writeProjectJson(contents: unknown) {
+    mkdirSync(join(projectDir, '.bigcommerce'), { recursive: true });
+    writeFileSync(
+      join(projectDir, '.bigcommerce', 'project.json'),
+      JSON.stringify(contents, null, 2),
     );
   }
 
@@ -749,6 +759,114 @@ describe('setupCommerceHosting', () => {
 
     expect(projectJson.storeHash).toBe('abc123');
     expect(projectJson.accessToken).toBeUndefined();
+  });
+
+  describe('preserving existing project.json contents', () => {
+    // `catalyst deploy` re-runs setup whenever the project isn't transformed,
+    // so this fires on projects that already hold real values. Stored env vars
+    // are sent as secrets on every deploy, so losing them means the next deploy
+    // ships a worker without its storefront credentials.
+    it('keeps stored deployment env vars', async () => {
+      writeCorePackageJson({ scripts: { dev: 'next dev' } });
+      writeProjectJson({
+        projectUuid: 'old-uuid',
+        framework: 'catalyst',
+        env: { BIGCOMMERCE_STOREFRONT_TOKEN: 'token', BIGCOMMERCE_CHANNEL_ID: '1' },
+      });
+
+      await setupCommerceHosting({ projectDir, projectUuid: 'uuid-xyz' });
+
+      expect(readProjectJson()).toEqual({
+        projectUuid: 'uuid-xyz',
+        framework: 'catalyst',
+        env: { BIGCOMMERCE_STOREFRONT_TOKEN: 'token', BIGCOMMERCE_CHANNEL_ID: '1' },
+      });
+    });
+
+    // `apiHost` is equally a casualty, and unknown keys are carried through so
+    // a future addition to the config doesn't have to remember to update this.
+    it('keeps apiHost and keys it does not know about', async () => {
+      writeCorePackageJson({ scripts: { dev: 'next dev' } });
+      writeProjectJson({
+        projectUuid: 'old-uuid',
+        framework: 'catalyst',
+        apiHost: 'api.integration.zone',
+        somethingAddedLater: 'value',
+      });
+
+      await setupCommerceHosting({ projectDir, projectUuid: 'uuid-xyz' });
+
+      const projectJson = readProjectJson();
+
+      expect(projectJson.apiHost).toBe('api.integration.zone');
+      expect(projectJson.somethingAddedLater).toBe('value');
+    });
+
+    // Re-linking without credentials must not clear credentials the project
+    // already had: `projects link` calls this with whatever it happens to hold.
+    it('keeps stored credentials when none are supplied', async () => {
+      writeCorePackageJson({ scripts: { dev: 'next dev' } });
+      writeProjectJson({
+        projectUuid: 'old-uuid',
+        framework: 'catalyst',
+        storeHash: 'stored-hash',
+        accessToken: 'stored-token',
+      });
+
+      await setupCommerceHosting({ projectDir, projectUuid: 'uuid-xyz' });
+
+      expect(readProjectJson()).toEqual({
+        projectUuid: 'uuid-xyz',
+        framework: 'catalyst',
+        storeHash: 'stored-hash',
+        accessToken: 'stored-token',
+      });
+    });
+
+    it('overwrites stored credentials when new ones are supplied', async () => {
+      writeCorePackageJson({ scripts: { dev: 'next dev' } });
+      writeProjectJson({
+        projectUuid: 'old-uuid',
+        framework: 'catalyst',
+        storeHash: 'stored-hash',
+        accessToken: 'stored-token',
+      });
+
+      await setupCommerceHosting({
+        projectDir,
+        projectUuid: 'uuid-xyz',
+        storeHash: 'new-hash',
+        accessToken: 'new-token',
+      });
+
+      expect(readProjectJson()).toEqual({
+        projectUuid: 'uuid-xyz',
+        framework: 'catalyst',
+        storeHash: 'new-hash',
+        accessToken: 'new-token',
+      });
+    });
+
+    // Setup writes everything needed for a working project, so a corrupt file
+    // should be replaced rather than block the user from setting up at all.
+    it('starts fresh when the existing file is not valid JSON', async () => {
+      writeCorePackageJson({ scripts: { dev: 'next dev' } });
+      mkdirSync(join(projectDir, '.bigcommerce'), { recursive: true });
+      writeFileSync(join(projectDir, '.bigcommerce', 'project.json'), '{ not json');
+
+      await setupCommerceHosting({ projectDir, projectUuid: 'uuid-xyz' });
+
+      expect(readProjectJson()).toEqual({ projectUuid: 'uuid-xyz', framework: 'catalyst' });
+    });
+
+    it('starts fresh when the existing file holds a non-object', async () => {
+      writeCorePackageJson({ scripts: { dev: 'next dev' } });
+      writeProjectJson(['not', 'an', 'object']);
+
+      await setupCommerceHosting({ projectDir, projectUuid: 'uuid-xyz' });
+
+      expect(readProjectJson()).toEqual({ projectUuid: 'uuid-xyz', framework: 'catalyst' });
+    });
   });
 
   it('throws when package.json is missing', async () => {

--- a/packages/catalyst/src/cli/lib/commerce-hosting.ts
+++ b/packages/catalyst/src/cli/lib/commerce-hosting.ts
@@ -19,6 +19,25 @@ const corePackageJsonSchema = z.looseObject({
   dependencies: z.record(z.string(), z.string()).optional(),
 });
 
+// Loose on purpose: the point is to carry unknown keys through untouched, so
+// this only asserts the file holds an object at all.
+const projectJsonSchema = z.looseObject({});
+
+// Existing contents of `.bigcommerce/project.json`, or an empty object if it is
+// absent, unreadable, or not a JSON object. A corrupt file shouldn't fail setup
+// -- the keys this helper writes are enough to rebuild a working project.
+const readProjectJson = (path: string): Record<string, unknown> => {
+  if (!existsSync(path)) return {};
+
+  try {
+    const parsed = projectJsonSchema.safeParse(JSON.parse(readFileSync(path, 'utf-8')));
+
+    return parsed.success ? parsed.data : {};
+  } catch {
+    return {};
+  }
+};
+
 const writeJson = (path: string, value: unknown) => {
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
@@ -121,15 +140,27 @@ export const setupCommerceHosting = async ({
 
   writeJson(corePackageJsonPath, sortPackageJsonFields(pkg));
 
-  const projectJson: Record<string, string> = {
+  const projectJsonPath = join(projectDir, '.bigcommerce', 'project.json');
+
+  // Merge rather than rebuild. `catalyst env` stores deployment variables under
+  // `env` in this same file and `apiHost` is persisted here too, so
+  // constructing a fresh object silently dropped both. Losing `env` is the
+  // costly one: those entries are sent as secrets on every `catalyst deploy`,
+  // so a wipe means the next deploy ships a worker without its storefront
+  // credentials, with nothing in the output mentioning env vars. `deploy` and
+  // `projects link` both reach this on projects that already hold real values.
+  const projectJson: Record<string, unknown> = {
+    ...readProjectJson(projectJsonPath),
     projectUuid,
     framework: 'catalyst',
   };
 
+  // Absent means "not supplied on this run", not "clear it" -- linking without
+  // credentials must not drop credentials the project already had.
   if (storeHash) projectJson.storeHash = storeHash;
   if (accessToken) projectJson.accessToken = accessToken;
 
-  writeJson(join(projectDir, '.bigcommerce', 'project.json'), projectJson);
+  writeJson(projectJsonPath, projectJson);
 
   convertProxyToMiddleware(projectDir);
 };


### PR DESCRIPTION
Linear: [LTRAC-1582](https://linear.app/commerce/issue/LTRAC-1582/catalyst-deploy-silently-wipes-stored-deployment-env-vars-from)

## What/Why?

`setupCommerceHosting` built a fresh object and wrote it over `.bigcommerce/project.json`, so every key it doesn't set itself was dropped — the `env` block managed by `catalyst env`, the persisted `apiHost`, and stored credentials whenever setup ran without them.

**Losing `env` is the expensive one.** Those entries are sent as secrets on every `catalyst deploy`, so it isn't just local config going missing: the deploy that wipes them proceeds, and the next one ships a worker with no `BIGCOMMERCE_STOREFRONT_TOKEN` or `BIGCOMMERCE_CHANNEL_ID`. Nothing in the output mentions env vars, so the first sign is a broken storefront.

It fires during ordinary use, not some edge case. `deploy.ts:491` calls setup whenever `getProjectState().isTransformed` is false, behind a prompt that defaults to yes. `isTransformed` requires **all three** of `middleware.ts` present, `proxy.ts` absent, and `@opennextjs/cloudflare` installed — so a partly reverted project, a merge restoring `proxy.ts`, or an interrupted setup is enough. `projects link` reaches the same path.

Found while deploying a store to integration: the env vars were there before the deploy and gone after.

### Behaviour now

Merges into whatever is already on disk. Unknown keys are carried through untouched, so a later addition to the config doesn't have to remember this call site. Absent `storeHash`/`accessToken` means "not supplied on this run" rather than "clear it", so re-linking without credentials no longer discards the ones the project had. A corrupt or non-object file falls back to starting fresh, since setup writes everything a working project needs.

### Considered and rejected

Switching to `getProjectConfig()` would merge for free — `Conf` does it natively, and `create.ts` already relies on that. But its schema enforces `format: 'uuid'` on `projectUuid`, which would turn a malformed UUID into a hard failure and change behaviour well beyond this fix (several existing specs pass `'u'`). Worth considering on its own; not smuggled into a bug fix.

`create.ts` already worked around this by ordering its `Conf` writes after setup. Its comment described the old overwrite semantics, so I updated the comment rather than change the ordering.

## Testing

`commerce-hosting.spec.ts` — 55 pass, six new under `preserving existing project.json contents`: stored env vars survive, `apiHost` and unknown keys survive, stored credentials survive when none are supplied, supplied credentials still override, and malformed / non-object files fall back cleanly.

**Verified the three preservation specs fail against the previous behaviour** — reverted the merge and confirmed exactly those three break and nothing else.

Also ran every other spec that touches `project.json` — `create`, `projects`, `deploy`, `env`, `project-config`, `project-state` — 115 pass. Lint and `tsc --noEmit` clean.

One thing worth noting about the test change: the spec's `readProjectJson()` used `z.object`, which strips unknown keys and would have silently discarded the very fields these tests assert on. It's now `z.looseObject`.

Manual repro from the ticket:

1. `catalyst env add FOO=bar`, confirm with `catalyst env list`
2. Put the project in a non-transformed state (restore `proxy.ts`, remove `middleware.ts`)
3. `catalyst deploy`, accept the setup prompt
4. `catalyst env list` — empty before this change, intact after

## Migration

None.