### PR TITLE
feat(back): BACK-669 Display error message when quantity exceeds ATS

### DIFF
--- a/core/messages/en.json
+++ b/core/messages/en.json
@@ -469,6 +469,7 @@
       "additionalInformation": "Additional information",
       "currentStock": "{quantity, number} in stock",
       "backorderQuantity": "{quantity, number} will be on backorder",
+      "maxPurchasableQuantity": "The maximum purchasable quantity is {quantity, number}. Please adjust and try again.",
       "loadingMoreImages": "Loading more images",
       "imagesLoaded": "{count, plural, =1 {1 more image loaded} other {# more images loaded}}",
       "playVideo": "Play video",

--- a/core/vibes/soul/sections/product-detail/product-detail-form.tsx
+++ b/core/vibes/soul/sections/product-detail/product-detail-form.tsx
@@ -195,7 +195,13 @@ export function ProductDetailForm<F extends Field>({
       backorderMessage,
       showQuantityOnBackorder,
       unlimitedBackorder,
-    } = backorderDisplayData || { availableForBackorder: 0, availableOnHand: 0 };
+    } = backorderDisplayData || {
+      availableForBackorder: 0,
+      availableOnHand: 0,
+      backorderMessage: null,
+      showQuantityOnBackorder: false,
+      unlimitedBackorder: false,
+    };
 
     if (!showQuantityOnBackorder && !backorderMessage) {
       return undefined;
@@ -203,8 +209,23 @@ export function ProductDetailForm<F extends Field>({
 
     const orderQuantity = Number(formFields.quantity.value);
 
+    if (orderQuantity > availableForBackorder + availableOnHand) {
+      return {
+        backOrderErrorMessage: t('maxPurchasableQuantity', {
+          quantity: availableForBackorder + availableOnHand,
+        }),
+        backorderQuantityMessage: t('backorderQuantity', {
+          quantity: unlimitedBackorder
+            ? orderQuantity - availableOnHand
+            : Math.min(orderQuantity - availableOnHand, availableForBackorder),
+        }),
+        backorderInfoMessage: undefined,
+      };
+    }
+
     if (Number.isNaN(orderQuantity) || orderQuantity <= availableOnHand) {
       return {
+        backOrderErrorMessage: undefined,
         backorderQuantityMessage: undefined,
         backorderInfoMessage: undefined,
       };
@@ -212,12 +233,14 @@ export function ProductDetailForm<F extends Field>({
 
     if (!showQuantityOnBackorder) {
       return {
+        backOrderErrorMessage: undefined,
         backorderQuantityMessage: undefined,
         backorderInfoMessage: backorderMessage ?? undefined,
       };
     }
 
     return {
+      backOrderErrorMessage: undefined,
       backorderQuantityMessage: t('backorderQuantity', {
         quantity: unlimitedBackorder
           ? orderQuantity - availableOnHand
@@ -313,9 +336,20 @@ export function ProductDetailForm<F extends Field>({
               required
               value={quantityControl.value}
             />
-            <SubmitButton disabled={ctaDisabled}>{ctaLabel}</SubmitButton>
+            <SubmitButton disabled={ctaDisabled || !!backorderMessages?.backOrderErrorMessage}>
+              {ctaLabel}
+            </SubmitButton>
             {additionalActions}
           </div>
+
+          {!!backorderMessages?.backOrderErrorMessage && (
+            <FormStatus
+              className="ease-initial duration-400 opacity-100 transition-opacity"
+              type="error"
+            >
+              {backorderMessages.backOrderErrorMessage}
+            </FormStatus>
+          )}
         </div>
       </form>
     </FormProvider>


### PR DESCRIPTION
## What/Why?
Display error message on PDP if the quantity entered in form exceeds available to sell for the product.

## Testing
- Screencast

https://github.com/user-attachments/assets/13cac221-db82-4918-a0b8-82655c87b6fe



## Migration
While rebasing, there might be some conflicts if there is some custom styling on cart page. Those conflicts may occur in the following files:
- core/vibes/soul/sections/product-detail/product-detail-form.tsx
