### PR TITLE
LTRAC-1617: Stop the in-memory KV fallback expiring its entries

### DIFF
--- a/core/lib/kv/adapters/memory.spec.ts
+++ b/core/lib/kv/adapters/memory.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { MemoryKvAdapter } from './memory';
+import { MemoryKvAdapter, SHARED_STORE_RECHECK_MS } from './memory';
 
 describe('MemoryKvAdapter', () => {
   // `lru-cache` captures a reference to `performance` at module load. Vitest's
@@ -28,7 +28,7 @@ describe('MemoryKvAdapter', () => {
   });
 
   it('returns what was set', async () => {
-    const adapter = new MemoryKvAdapter();
+    const adapter = new MemoryKvAdapter({ ttlMs: SHARED_STORE_RECHECK_MS });
 
     await adapter.set('key', { hello: 'world' });
 
@@ -36,13 +36,13 @@ describe('MemoryKvAdapter', () => {
   });
 
   it('returns null for keys it has never seen', async () => {
-    const adapter = new MemoryKvAdapter();
+    const adapter = new MemoryKvAdapter({ ttlMs: SHARED_STORE_RECHECK_MS });
 
     expect(await adapter.mget('missing')).toStrictEqual([null]);
   });
 
   it('preserves key order across a mixed hit/miss batch', async () => {
-    const adapter = new MemoryKvAdapter();
+    const adapter = new MemoryKvAdapter({ ttlMs: SHARED_STORE_RECHECK_MS });
 
     await adapter.set('b', 'second');
 
@@ -52,7 +52,7 @@ describe('MemoryKvAdapter', () => {
   // `KV.mget` writes shared-store misses back into memory, so a cached null
   // must survive the round trip.
   it('stores a null value without losing the entry', async () => {
-    const adapter = new MemoryKvAdapter();
+    const adapter = new MemoryKvAdapter({ ttlMs: SHARED_STORE_RECHECK_MS });
 
     await adapter.set('key', null);
 
@@ -62,7 +62,7 @@ describe('MemoryKvAdapter', () => {
   // `KV.mget` skips the shared store while memory holds every requested key,
   // so expiry is what lets a process observe another process's writes.
   it('expires entries so reads fall through to the shared store', async () => {
-    const adapter = new MemoryKvAdapter();
+    const adapter = new MemoryKvAdapter({ ttlMs: SHARED_STORE_RECHECK_MS });
 
     await adapter.set('key', 'cached');
 
@@ -75,7 +75,7 @@ describe('MemoryKvAdapter', () => {
 
   // Inside `with-routes`' shortest window (5 minutes for storefront status).
   it('expires well within the shortest caller freshness window', async () => {
-    const adapter = new MemoryKvAdapter();
+    const adapter = new MemoryKvAdapter({ ttlMs: SHARED_STORE_RECHECK_MS });
 
     await adapter.set('key', 'cached');
 
@@ -84,8 +84,8 @@ describe('MemoryKvAdapter', () => {
     expect(await adapter.mget('key')).toStrictEqual([null]);
   });
 
-  it('lets an explicit ex override the default window', async () => {
-    const adapter = new MemoryKvAdapter();
+  it('lets an explicit ex override the configured window', async () => {
+    const adapter = new MemoryKvAdapter({ ttlMs: SHARED_STORE_RECHECK_MS });
 
     await adapter.set('key', 'cached', { ex: 300 });
 
@@ -97,7 +97,7 @@ describe('MemoryKvAdapter', () => {
   });
 
   it('refreshes the window when a key is written again', async () => {
-    const adapter = new MemoryKvAdapter();
+    const adapter = new MemoryKvAdapter({ ttlMs: SHARED_STORE_RECHECK_MS });
 
     await adapter.set('key', 'first');
     advanceBy(50_000);
@@ -109,8 +109,32 @@ describe('MemoryKvAdapter', () => {
   });
 
   // Keys include the query string, so distinct keys accumulate quickly.
-  it('evicts least-recently-used entries beyond its capacity', async () => {
+  // `createKVAdapter` falls back to this adapter when no shared store is
+  // configured. Expiring there would empty both layers at once and leave
+  // `with-routes` with no cached value, turning its background refresh into a
+  // blocking origin fetch on the request path.
+  it('never expires when constructed without a window', async () => {
     const adapter = new MemoryKvAdapter();
+
+    await adapter.set('key', 'cached');
+
+    advanceBy(1000 * 60 * 60);
+
+    expect(await adapter.mget('key')).toStrictEqual(['cached']);
+  });
+
+  it('still honours an explicit ex when constructed without a window', async () => {
+    const adapter = new MemoryKvAdapter();
+
+    await adapter.set('key', 'cached', { ex: 60 });
+
+    advanceBy(61_000);
+
+    expect(await adapter.mget('key')).toStrictEqual([null]);
+  });
+
+  it('evicts least-recently-used entries beyond its capacity', async () => {
+    const adapter = new MemoryKvAdapter({ ttlMs: SHARED_STORE_RECHECK_MS });
 
     await Promise.all(Array.from({ length: 4097 }, async (_, i) => adapter.set(`key-${i}`, i)));
 
@@ -119,7 +143,7 @@ describe('MemoryKvAdapter', () => {
   });
 
   it('holds well beyond the 500 entries it previously capped at', async () => {
-    const adapter = new MemoryKvAdapter();
+    const adapter = new MemoryKvAdapter({ ttlMs: SHARED_STORE_RECHECK_MS });
 
     await Promise.all(Array.from({ length: 2000 }, async (_, i) => adapter.set(`key-${i}`, i)));
 

--- a/core/lib/kv/adapters/memory.ts
+++ b/core/lib/kv/adapters/memory.ts
@@ -7,37 +7,56 @@ interface CacheEntry {
   value: unknown;
 }
 
-// This adapter also sits in front of the shared adapters: `KV.mget` skips the
-// shared store whenever memory holds every requested key. Without an expiry
-// that short-circuit is permanent, and the only thing left driving refreshes is
-// the `expiryTime` callers embed in the value -- which refetches from the
-// origin rather than re-reading the shared store. Expiring here is what lets a
-// process pick up a value another process already fetched.
+// How long the L1 copy of a value survives before `KV.mget` has to consult the
+// shared store again. `KV.mget` skips the shared store whenever memory holds
+// every requested key, so without an expiry that short-circuit is permanent:
+// the only thing left driving refreshes is the `expiryTime` callers embed in
+// the value, which refetches from the origin rather than re-reading the shared
+// store. Expiring here is what lets a process pick up a value another process
+// already fetched.
 //
 // 60s is Workers KV's floor for `cacheTtl` on a read; matching it keeps one
 // staleness window rather than one per layer. It stays inside the shortest
 // window callers embed in their own values — `with-routes` stores 5 minutes for
 // storefront status, 30 minutes for routes.
-const DEFAULT_TTL_MS = 60_000;
+//
+// Only applied when there is a shared store to defer to. `createKVAdapter`
+// falls back to this same adapter when no shared store is configured, and there
+// expiring would be actively harmful: both layers would empty together, leaving
+// the caller with no cached value at all and sending it down `with-routes`'
+// blocking origin fetch every 60s instead of its intended 30-minute background
+// refresh.
+export const SHARED_STORE_RECHECK_MS = 60_000;
 
 // Bounds memory under key churn. Cache keys include the query string, so
 // distinct keys accumulate much faster than the number of real paths suggests.
 const MAX_ENTRIES = 4096;
 
+interface MemoryKvAdapterOptions {
+  // Omit for an unbounded window: entries then leave only by LRU eviction.
+  ttlMs?: number;
+}
+
 export class MemoryKvAdapter implements KvAdapter {
-  private kv = new LRUCache<string, CacheEntry>({
-    max: MAX_ENTRIES,
-    ttl: DEFAULT_TTL_MS,
-    // Not `allowStale`. Serving an expired entry needs a background refresh to
-    // replace it, and `KV.mget` has no `waitUntil` handle to run one on — so a
-    // stale value would never be replaced. Expired reads fall through to the
-    // shared store instead.
-    //
-    // `ttlResolution: 0` reads the clock on every lookup rather than debouncing
-    // it behind a 1ms `setTimeout`, which avoids scheduling a timer per
-    // operation on runtimes where timers are tied to the request lifetime.
-    ttlResolution: 0,
-  });
+  private kv: LRUCache<string, CacheEntry>;
+
+  constructor({ ttlMs }: MemoryKvAdapterOptions = {}) {
+    this.kv = new LRUCache<string, CacheEntry>({
+      max: MAX_ENTRIES,
+      // `lru-cache` rejects a non-positive `ttl`, so the key is omitted rather
+      // than passed as 0.
+      ...(ttlMs === undefined ? {} : { ttl: ttlMs }),
+      // Not `allowStale`. Serving an expired entry needs a background refresh to
+      // replace it, and `KV.mget` has no `waitUntil` handle to run one on — so a
+      // stale value would never be replaced. Expired reads fall through to the
+      // shared store instead.
+      //
+      // `ttlResolution: 0` reads the clock on every lookup rather than debouncing
+      // it behind a 1ms `setTimeout`, which avoids scheduling a timer per
+      // operation on runtimes where timers are tied to the request lifetime.
+      ttlResolution: 0,
+    });
+  }
 
   async mget<Data>(...keys: string[]) {
     // `LRUCache.get` returns undefined past the TTL, so expiry is the cache's

--- a/core/lib/kv/index.spec.ts
+++ b/core/lib/kv/index.spec.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { kv } from './index';
+
+// `lru-cache` captures a reference to `performance` at module load, so the
+// clock has to be moved by stubbing the method in place rather than with fake
+// timers. A recorded start time of exactly 0 reads as "no TTL", hence the
+// non-zero baseline.
+const CLOCK_BASE_MS = 1_000_000;
+const SIXTY_ONE_SECONDS = 61_000;
+
+describe('kv', () => {
+  let now = CLOCK_BASE_MS;
+
+  const advanceBy = (ms: number) => {
+    now += ms;
+  };
+
+  beforeEach(() => {
+    now = CLOCK_BASE_MS;
+    vi.spyOn(performance, 'now').mockImplementation(() => now);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // With no shared store configured, `createKVAdapter` falls back to an
+  // in-process adapter. If both it and the L1 in front of it expired, a value
+  // would vanish entirely once the window passed — and `with-routes` treats a
+  // missing entry as a blocking origin fetch rather than a background refresh.
+  it('keeps values past the L1 window when no shared store is configured', async () => {
+    await kv.set('no-shared-store', { value: 'cached' });
+
+    advanceBy(SIXTY_ONE_SECONDS);
+
+    expect(await kv.get('no-shared-store')).toStrictEqual({ value: 'cached' });
+  });
+
+  it('reads back a value it just wrote', async () => {
+    await kv.set('immediate', { value: 'cached' });
+
+    expect(await kv.get('immediate')).toStrictEqual({ value: 'cached' });
+  });
+
+  it('returns null for a key it has never seen', async () => {
+    expect(await kv.get('never-written')).toBeNull();
+  });
+
+  it('resolves several keys in the order requested', async () => {
+    await kv.set('first', 1);
+    await kv.set('second', 2);
+
+    expect(await kv.mget('first', 'second')).toStrictEqual([1, 2]);
+  });
+});

--- a/core/lib/kv/index.ts
+++ b/core/lib/kv/index.ts
@@ -1,11 +1,14 @@
-import { MemoryKvAdapter } from './adapters/memory';
+import { MemoryKvAdapter, SHARED_STORE_RECHECK_MS } from './adapters/memory';
 import { KvAdapter, SetCommandOptions } from './types';
 
 interface Config {
   logger?: boolean;
 }
 
-const memoryKv = new MemoryKvAdapter();
+// L1 in front of whichever adapter `createKVAdapter` selects. Expires so a
+// process periodically re-reads the shared store and picks up values other
+// processes wrote.
+const memoryKv = new MemoryKvAdapter({ ttlMs: SHARED_STORE_RECHECK_MS });
 
 class KV<Adapter extends KvAdapter> implements KvAdapter {
   private kv?: Adapter;
@@ -95,6 +98,11 @@ async function createKVAdapter() {
     return new UpstashKvAdapter();
   }
 
+  // Deliberately unbounded, unlike the L1 above. This is the fallback when no
+  // shared store is configured, so there is nothing to re-read: expiring here
+  // would empty both layers together and leave `with-routes` with no cached
+  // value, sending every request past the window into its blocking origin
+  // fetch rather than its background refresh.
   return new MemoryKvAdapter();
 }
 


### PR DESCRIPTION
Linear: [LTRAC-1617](https://linear.app/commerce/issue/LTRAC-1617/memory-kv-ttl-regressed-the-no-shared-store-fallback-into-a-blocking)

Regression from #3176, on canary since today. **No changeset** — #3176 is merged but unreleased, so its changeset is still pending on canary. This corrects that work before it ships rather than changing anything a consumer has seen.

## What/Why?

The 60s window added in #3176 was meant for the **L1 copy in front of a shared store**, so a process periodically re-reads it and picks up values other processes wrote. But `createKVAdapter` falls back to *the same adapter class* when no shared store is configured — so both layers got the window and now empty together.

That matters because `with-routes` treats a missing entry differently from a stale one:

```ts
if (routeCache && routeCache.expiryTime < Date.now()) {
  event.waitUntil(updateRouteCache(...));   // background, non-blocking
} else if (!routeCache) {
  routeCache = await updateRouteCache(...); // BLOCKING origin fetch
}
```

With both layers empty the value is **gone**, not stale, so every request past the window takes the blocking branch. A route that refreshed in the background every 30 minutes now blocks on a Storefront API call every 60 seconds — roughly 30x the origin requests, and moved onto the request path.

Reproduced against canary:

```
kv.set('probe-key', { ... })
kv.get('probe-key')     -> { route: 'x', expiryTime: ... }
// advance 61s
kv.get('probe-key')     -> null
```

Before #3176 that second read returned the value.

**Who it hits:** any deployment with no `CATALYST_ROUTES_KV` binding, no Upstash, and not on Vercel — self-hosted installs without Upstash, native hosting until #3170 lands, and local dev.

## Fix

Make the window opt-in. It exists so the L1 defers to a *shared* store; where the fallback is itself in-process memory there is nothing to defer to, so it stays unbounded as it was before #3176.

- `MemoryKvAdapter` takes `{ ttlMs }` — omitted means entries leave only by LRU eviction
- `KV`'s L1 passes `SHARED_STORE_RECHECK_MS` (60s)
- `createKVAdapter`'s fallback passes nothing

The 4096-entry capacity from #3176 is unchanged and applies to both.

## Testing

16 pass. Lint and `tsc --noEmit` clean.

The regression test exercises the real `kv` singleton rather than the adapter in isolation, because the bug lives in how the two layers **compose** — and that's precisely why nothing caught it. Every spec in #3176 constructed `MemoryKvAdapter` directly and asserted on it alone, so the L1-plus-fallback interaction had no coverage at all.

**Verified it fails when the fallback is given the window back**, so it pins the actual regression rather than just describing it. Also added adapter-level coverage that a bare `new MemoryKvAdapter()` never expires, while an explicit `ex` still works.

## Migration

None. Restores pre-#3176 behaviour for the memory-only path; the shared-store path is unaffected.