### PR TITLE
fix(back): BACK-673 Hide ready to ship message for non backorder products

### DIFF
--- a/.changeset/back-669-quantity-exceeds-ats-error.md
+++ b/.changeset/back-669-quantity-exceeds-ats-error.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Display an error message and disable Add to Cart when the requested quantity exceeds available-to-sell (on-hand + backorder allowance) on the PDP.

--- a/.changeset/cart-ready-to-ship-message.md
+++ b/.changeset/cart-ready-to-ship-message.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Only show the "ready to ship" quantity message in the cart when part of the line item is also backordered. Previously it appeared any time `showQuantityOnHand` was enabled and any quantity was on hand, even for fully in-stock items where the message added no useful information.

--- a/core/app/[locale]/(default)/cart/page.tsx
+++ b/core/app/[locale]/(default)/cart/page.tsx
@@ -200,7 +200,8 @@ export default async function Cart({ params }: Props) {
         inventoryMessages = {
           quantityReadyToShipMessage:
             data.site.settings?.inventory?.showQuantityOnHand &&
-            !!item.stockPosition?.quantityOnHand
+            !!item.stockPosition?.quantityOnHand &&
+            !!item.stockPosition.quantityBackordered
               ? t('quantityReadyToShip', {
                   quantity: Number(item.stockPosition.quantityOnHand),
                 })


### PR DESCRIPTION
## What/Why?
- Hide ready to ship message for non backorder products
- Also contains change set for https://github.com/bigcommerce/catalyst/pull/3179


## Testing
- Screenshot

<img width="1719" height="788" alt="Screenshot 2026-08-19 at 4 46 35 pm" src="https://github.com/user-attachments/assets/7e06056f-4ebe-4901-bc42-9a0bfd7da162" />


## Migration
- core/app[locale]/default/cart/page.tsx
