### PR TITLE
LTRAC-1458: Restore tag checking on regional cache hits

### DIFF
--- a/.changeset/ltrac-1458-remove-unusable-cache-purge.md
+++ b/.changeset/ltrac-1458-remove-unusable-cache-purge.md
@@ -1,0 +1,30 @@
+---
+"@bigcommerce/catalyst": patch
+---
+
+Restore tag checking on regional cache hits, replacing a CDN cache purge that never worked.
+
+`cachePurge` was declared in the generated `open-next.config.ts` but never had credentials on native hosting, so every purge attempt no-opped with `No cache zone ID or API token provided. Skipping cache purge.` The declaration alone was harmful: OpenNext's `isPurgeCacheEnabled()` only checks whether `cachePurge` is *declared*, not whether it works. Believing purge was handling invalidation, it disabled `shouldLazilyUpdateOnCacheHit` — documented as on by default for `'long-lived'` mode — and Catalyst additionally set `bypassTagCacheOnCacheHit: true`.
+
+A regional (Cache API) hit was therefore neither purged, nor refreshed from R2, nor checked against the tag cache. Stale data was served for the full `max-age` window (the route's `revalidate`, or a 30-minute default), and `revalidateTag` calls landing in that window had no effect on it.
+
+## Purge and tag-checking are alternatives, and we had neither
+
+`doShardedTagCache.writeTags()` always writes the revalidation time to its Durable Object shards and always clears the regional *tag* cache. Only the CDN purge is gated behind `isPurgeCacheEnabled()`. So tag invalidation was already durable — purge exists solely to evict *incremental cache* entries held in the Cache API, which is exactly the check `bypassTagCacheOnCacheHit` was skipping.
+
+Either mechanism delivers correct invalidation: purge evicts the entries, or the tag cache is consulted on hits. Catalyst was configured for the first and got neither.
+
+## What changed
+
+- Removed `bypassTagCacheOnCacheHit: true`, so the tag cache is consulted on a regional hit. The OpenNext docs require this option be paired with working purge: "make sure that the cache gets purged either by enabling the auto cache purging feature or manually."
+- Removed `cachePurge: purgeCache({ type: 'durableObject' })`, restoring `shouldLazilyUpdateOnCacheHit` to its documented default so a hit also refreshes from R2 in the background.
+
+The trade is an extra tag-cache read and R2 read on a cache hit, which is what those options were exchanging for correctness. Invalidation via `revalidateTag` now actually takes effect on regional cache hits.
+
+## Why purge was not simply fixed
+
+Purge requires a Cloudflare API token bound into the Worker, and a Worker binding is readable by the merchant's own application code. Cloudflare purge is zone-scoped and native hosting places all tenants on one shared zone, so a token extracted from any tenant could purge every other tenant's cache. Scoping it to Cache Purge alone reduces the severity but does not remove it.
+
+Instant invalidation via purge remains worth having — it is faster than tag-checking and avoids the extra reads. Restoring it needs a design that keeps the credential out of tenant Workers, such as routing purge through a platform-owned worker or an authenticated service endpoint with per-tenant authorization.
+
+The `NEXT_CACHE_DO_PURGE` Durable Object binding is intentionally left in place. OpenNext's worker template exports all three DO classes unconditionally, so the binding still resolves and no Durable Object migration is required; it is simply inert until purge returns.

--- a/packages/catalyst/templates/open-next.config.ts
+++ b/packages/catalyst/templates/open-next.config.ts
@@ -1,5 +1,4 @@
 import { defineCloudflareConfig, type OpenNextConfig } from '@opennextjs/cloudflare';
-import { purgeCache } from '@opennextjs/cloudflare/overrides/cache-purge/index';
 import r2IncrementalCache from '@opennextjs/cloudflare/overrides/incremental-cache/r2-incremental-cache';
 import { withRegionalCache } from '@opennextjs/cloudflare/overrides/incremental-cache/regional-cache';
 import doQueue from '@opennextjs/cloudflare/overrides/queue/do-queue';
@@ -7,9 +6,30 @@ import queueCache from '@opennextjs/cloudflare/overrides/queue/queue-cache';
 import doShardedTagCache from '@opennextjs/cloudflare/overrides/tag-cache/do-sharded-tag-cache';
 
 const cloudflareConfig = defineCloudflareConfig({
+  // No `bypassTagCacheOnCacheHit` and no `cachePurge`. Correct invalidation of
+  // regional (Cache API) entries needs one of two mechanisms: a CDN purge that
+  // evicts them, or a tag-cache check on every hit. They are alternatives, and
+  // Catalyst was configured for the first while having neither.
+  //
+  // Purge cannot be enabled safely here. It needs a Cloudflare API token bound
+  // into the Worker, and a Worker binding is readable by the merchant's own
+  // application code. Cloudflare purge is zone-scoped and native hosting puts
+  // every tenant on one shared zone, so a token extracted from any tenant could
+  // purge every other tenant's cache.
+  //
+  // Declaring `cachePurge` anyway was worse than not having it: OpenNext's
+  // `isPurgeCacheEnabled()` only checks whether it is *declared*, so it believed
+  // purge was handling invalidation and disabled `shouldLazilyUpdateOnCacheHit`
+  // (on by default for 'long-lived'), while `bypassTagCacheOnCacheHit` skipped
+  // the tag check. A hit was then neither purged, nor refreshed from R2, nor
+  // tag-checked, so `revalidateTag` had no effect on it until max-age expired.
+  //
+  // Omitting both takes the tag-checking route: the tag cache is consulted on a
+  // hit and the entry refreshes from R2 in the background. Costs an extra read
+  // per hit. Purge is still the faster option — restore it only together with a
+  // design that keeps the credential out of tenant Workers.
   incrementalCache: withRegionalCache(r2IncrementalCache, {
     mode: 'long-lived',
-    bypassTagCacheOnCacheHit: true,
   }),
   queue: queueCache(doQueue, {
     regionalCacheTtlSec: 5,
@@ -30,7 +50,6 @@ const cloudflareConfig = defineCloudflareConfig({
     },
   }),
   enableCacheInterception: false,
-  cachePurge: purgeCache({ type: 'durableObject' }),
 });
 
 const config: OpenNextConfig = {


### PR DESCRIPTION
Linear: [LTRAC-1458](https://linear.app/commerce/issue/LTRAC-1458)

## What/Why?

`revalidateTag` has had no effect on regional cache hits on native hosting. Two config options combined to disable every freshness mechanism at once.

`cachePurge` was declared but never had credentials, so every purge no-opped. Confirmed in the production Worker logs of a deployed store — three occurrences on 2026-08-18:

```
error  "No cache zone ID or API token provided. Skipping cache purge."
```

Declaring it was worse than omitting it. `isPurgeCacheEnabled()` only checks whether `cachePurge` is *declared*, not whether it works:

```js
export function isPurgeCacheEnabled() {
    const cdnInvalidation = globalThis.openNextConfig?.default?.override?.cdnInvalidation;
    return cdnInvalidation !== undefined && cdnInvalidation !== "dummy";
}
```

Believing purge was handling invalidation, OpenNext disabled `shouldLazilyUpdateOnCacheHit` — which its own types document as *"@default `true` in `long-lived` mode when cache purge is not used"*. We separately set `bypassTagCacheOnCacheHit: true`. So a regional (Cache API) hit was **neither purged, nor refreshed from R2, nor tag-checked**: served untouched for the full `max-age` window (the route's `revalidate`, or a 30-minute default), with any `revalidateTag` in that window having no effect on it.

### Purge and tag-checking are alternatives, and we had neither

`doShardedTagCache.writeTags()` always writes revalidation times to its DO shards and always clears the regional *tag* cache. Only the CDN purge is gated on `isPurgeCacheEnabled()`. So tag invalidation was already durable — purge exists specifically to evict *incremental cache* entries held in the Cache API, which is exactly the check `bypassTagCacheOnCacheHit` skips.

Either mechanism gives correct invalidation. This repo was configured for purge and had neither.

### Why not just fix purge

Purge needs `CACHE_PURGE_ZONE_ID` and `CACHE_PURGE_API_TOKEN` bound into the Worker. A Worker binding is readable by the merchant's own application code, and Cloudflare purge is **zone**-scoped while native hosting places every tenant on one shared zone — so a token extracted from any tenant could purge every other tenant's cache. Scoping it to Cache Purge only reduces the severity; it does not remove it. [ignition#327](https://github.com/bigcommerce/ignition/pull/327) attempted this and was closed for that reason.

There is no way to configure credential-free purge today: OpenNext's `purgeCacheByTags` hard-codes its two implementations, and the `CDNInvalidationHandler` override interface only exposes `invalidatePaths`, which the tag path does not use.

## Trade-off being accepted

Tag-checking on a hit costs a **Durable Object RPC**, not a local read. `hasBeenRevalidated` only short-circuits on the regional tag cache when a tag *has* been revalidated; the common case falls through to `stub.hasBeenRevalidated(...)`. That is why `bypassTagCacheOnCacheHit` exists.

Accepting it because correctness has to win here, and the practical cost should be modest: only `cart`, `checkout` and `customer` tags exist today (`core/client/tags.ts`), and most of those fetches are already `cache: 'no-store'`, so few cached entries carry a tag at all. `shardReplication` with `regionalReplication` also keeps the RPC reasonably local.

Considered and rejected: keeping `bypassTagCacheOnCacheHit: true` while dropping only `cachePurge`. `shouldLazilyUpdateOnCacheHit` would flip on, but it cannot deliver tag invalidation — `revalidateTag` records a revalidation time rather than rewriting the R2 entry, so a background R2 re-read returns the same stale value.

## Testing

Both removed fields are optional in OpenNext's types, so this is type-safe by construction and lands on documented defaults:

- `shouldLazilyUpdateOnCacheHit?` — *"@default `true` in `long-lived` mode when cache purge is not used, `false` otherwise."*
- `bypassTagCacheOnCacheHit?` — *"@default `true` if the auto cache purging is enabled, `false` otherwise"*, with the note *"When this is enabled, make sure that the cache gets purged either by enabling the auto cache purging feature or manually."*
- `cachePurge?` is optional on `CloudflareOverrides`.

No test asserts on this template's contents, so nothing needed updating — though that also means nothing would catch this regressing, which may be worth addressing separately.

**Not yet verified on a deployed store.** Suggested verification after deploy:

1. Confirm `No cache zone ID or API token provided` no longer appears in `catalyst logs tail`.
2. Call `revalidateTag` (e.g. a cart mutation) and confirm the next request reflects it rather than serving the regional entry.
3. **Measure the added latency** — compare p50/p95 on a product page and watch DO invocation counts via the WAE metrics. This is the number that decides whether purge is worth revisiting.

## Migration

None. Config-only change to a generated template; no API or file moves.

The `NEXT_CACHE_DO_PURGE` Durable Object binding is intentionally left in place on both sides (this repo's `wrangler-config.ts` and ignition's `metadata.go`). OpenNext's worker template exports all three DO classes unconditionally, so the binding still resolves and **no Durable Object migration is required** — deleting the class would have destroyed its storage. It is simply inert until purge returns.

Refs LTRAC-1458