### PR TITLE
LTRAC-1462: Ship _headers so static assets are cached immutably

### DIFF
--- a/.changeset/ltrac-1462-static-asset-immutable-headers.md
+++ b/.changeset/ltrac-1462-static-asset-immutable-headers.md
@@ -1,0 +1,22 @@
+---
+"@bigcommerce/catalyst": patch
+---
+
+Ship the `_headers` file so hashed static assets get an immutable `Cache-Control`, instead of being revalidated on every repeat page view.
+
+`packages/catalyst/templates/public_headers` has always specified the right policy for `/_next/static/*`, but nothing ever copied it into the build output — `build.ts` wrote only `open-next.config.ts` and `wrangler.jsonc`, and no `_headers` file existed anywhere in the repo.
+
+Without it, Workers Assets serves those files with its own default. Measured on a deployed store, all 32 hashed assets on a product page returned:
+
+```
+cache-control: public, max-age=0, must-revalidate
+```
+
+`max-age=0, must-revalidate` on a **content-hashed** filename is wrong by construction: the hash *is* the version, so a given URL can never return different bytes. The header forced browsers to issue a conditional request for all 32 assets on every repeat view (~75ms each, all answered `304 Not Modified`), including 4 render-blocking CSS files and 3 fonts. With the intended `public,max-age=31536000,immutable`, those requests disappear entirely.
+
+The reason the header was missing at all is that `/_next/static/*` never reaches the Next.js server on Workers — Cloudflare's asset layer serves it directly, so Next's own immutable header never applies. `_headers` is the supported override, and OpenNext's `migrate` command generates a byte-identical `public/_headers` for exactly this reason, treating it as the app's responsibility.
+
+## What changed
+
+- `build.ts` now copies `templates/public_headers` to `.open-next/assets/_headers`. It is written *after* the OpenNext build, because that build regenerates the assets directory, and *before* the Wrangler dry-run so Wrangler validates it. The existing recursive copy into `.bigcommerce/dist/assets` carries it into the uploaded bundle.
+- Added a regression test asserting the copy happens. The original bug was not a wrong value but an absent one, with nothing asserting it — verified the new test fails when the copy is removed.

--- a/packages/catalyst/src/cli/commands/build.spec.ts
+++ b/packages/catalyst/src/cli/commands/build.spec.ts
@@ -1,5 +1,7 @@
 import { Command } from 'commander';
 import { execa } from 'execa';
+import { copyFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import { afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import { consola } from '../lib/logger';
@@ -134,6 +136,21 @@ test('threads --wrangler-version into the wrangler invocation', async () => {
     'pnpm',
     expect.arrayContaining(['dlx', `wrangler@${DEFAULT_WRANGLER_VERSION}`]),
     expect.anything(),
+  );
+});
+
+// Regression guard: `templates/public_headers` existed but was never copied,
+// so `/_next/static/*` shipped with the Workers Assets default of
+// `max-age=0, must-revalidate` and browsers revalidated every hashed asset on
+// every repeat view. Nothing asserted the copy, which is why it went unnoticed.
+test('writes _headers into the assets directory so static assets get immutable Cache-Control', async () => {
+  vi.mocked(getProjectState).mockReturnValue(transformedState);
+
+  await program.parseAsync(['node', 'catalyst', 'build']);
+
+  expect(copyFile).toHaveBeenCalledWith(
+    expect.stringContaining('public_headers'),
+    expect.stringContaining(join('.open-next', 'assets', '_headers')),
   );
 });
 

--- a/packages/catalyst/src/cli/commands/build.ts
+++ b/packages/catalyst/src/cli/commands/build.ts
@@ -82,6 +82,18 @@ export async function buildCatalystProject(
     },
   );
 
+  // Workers Assets serves `/_next/static/*` directly, bypassing the Next.js
+  // server that would normally set the immutable Cache-Control on it. Its
+  // default is `max-age=0, must-revalidate`, so browsers revalidate every
+  // hashed asset on every repeat view. `_headers` overrides that, and has to
+  // live inside the assets directory — written after the OpenNext build because
+  // that build regenerates the directory, and before the Wrangler dry-run so
+  // Wrangler validates it.
+  await copyFile(
+    join(getModuleCliPath(), 'templates', 'public_headers'),
+    join(openNextOutDir, 'assets', '_headers'),
+  );
+
   await execa(
     'pnpm',
     [


### PR DESCRIPTION
Linear: [LTRAC-1462](https://linear.app/commerce/issue/LTRAC-1462)

## What/Why?

`packages/catalyst/templates/public_headers` has always specified the right policy for `/_next/static/*`, but nothing ever copied it into the build output. `build.ts` wrote only `open-next.config.ts` and `wrangler.jsonc`, and no `_headers` file existed anywhere in the repo.

Without it, Workers Assets applies its own default. Measured on a deployed store — **all 32** hashed assets on a product page:

```
cache-control: public, max-age=0, must-revalidate
etag: "ea54572fc7599bec1529f18fae07fab9"
```

`max-age=0, must-revalidate` is wrong by construction for a **content-hashed** filename like `2080-_emu8td2.css`. The hash *is* the version, so a given URL can never return different bytes — yet browsers were forbidden from using a cached copy without asking first.

### Measured cost

| | |
| -- | -- |
| Hashed assets per product page | 32 (25 js, 4 css, 3 woff2) |
| One revalidation round trip | ~75-79ms → `304 Not Modified` |
| All 32 revalidated in parallel | 0.70-0.84s |

Every repeat page view issued 32 conditional requests, all answered "yes, use the copy you already had." HTTP/2 multiplexes them so it is not 32×75ms serially, but it is still several round trips plus 32 requests of overhead — and 4 of those CSS files and 3 fonts are **render-blocking**, so it delayed first paint on every repeat visit.

(The 0.70-0.84s figure is from a script that fetches each etag first, which a real browser already has cached — so treat the true repeat-visit cost as roughly half, ~350-400ms.)

With the intended `public,max-age=31536000,immutable`, all 32 requests disappear for a year.

### Why the header was missing at all

On Workers, `/_next/static/*` never reaches the Next.js server — Cloudflare's asset layer serves it directly from `.open-next/assets`, so the immutable header Next would normally set never applies. `_headers` is the supported override, and OpenNext's own `migrate` command generates a byte-identical `public/_headers`, treating it as the application's responsibility rather than something the adapter handles.

## Testing

`build.spec.ts` — 6/6 pass.

Added a regression test asserting the copy happens, and **verified it is a real guard**: removing the `copyFile` makes it fail, restoring it makes it pass. Worth having because the original bug was an *absent* value rather than a wrong one, with nothing asserting it — which is exactly how a correct template sat unused.

**Not yet verified on a deployed store.** After deploy the check is binary — re-request the same assets and confirm every one returns `public,max-age=31536000,immutable` instead of `max-age=0, must-revalidate`. At that point the revalidation benchmark above becomes moot, because a browser will not issue the requests at all.

## Migration

None. Build-output change only; no API surface, no file moves.

Placement note for reviewers: the copy runs **after** the OpenNext build, because that build regenerates `.open-next/assets` and would clobber anything written earlier, and **before** the Wrangler dry-run so Wrangler validates the file. The existing recursive copy into `.bigcommerce/dist/assets` carries it into the uploaded bundle.

Refs LTRAC-1462