### PR TITLE
TRAC-1633: Declare a revalidate window for published API requests

### DIFF
--- a/.changeset/makeswift-revalidate-target.md
+++ b/.changeset/makeswift-revalidate-target.md
@@ -1,0 +1,9 @@
+---
+"@bigcommerce/catalyst-makeswift": patch
+---
+
+Declare a revalidate window for Makeswift API requests, and add `MAKESWIFT_REVALIDATE_TARGET` to configure it.
+
+The Makeswift SDK tags its responses with `@@makeswift` but never declares a TTL. Under the `fetchCache = 'default-cache'` segment config, Next.js reads "no cache config" as "cache forever", so published content was cached indefinitely and only the `site.published` webhook could refresh it. On any host Makeswift cannot reach — a local dev server, or a deployment it isn't configured to notify — content froze permanently, and deleting `.next` was the only way to see an edit.
+
+Requests for the published site now declare a revalidate window: 3600 seconds by default, or 0 in development, where the webhook never arrives and the TTL is the only invalidation. Draft-mode requests are unchanged; they already opt out of caching, and adding a revalidate value there would trip Next.js's conflicting-config rule and cache the builder's live edits indefinitely.

--- a/core/.env.example
+++ b/core/.env.example
@@ -42,6 +42,11 @@ TURBO_REMOTE_CACHE_SIGNATURE_KEY=
 # This sets a sensible revalidation target for cached requests
 DEFAULT_REVALIDATE_TARGET=3600
 
+# How long Makeswift's published content may be cached, in seconds
+# Publishing revalidates the '@@makeswift' cache tag, so this is only a backstop
+# Defaults to 3600 in production, and 0 in development where Makeswift cannot reach the host
+# MAKESWIFT_REVALIDATE_TARGET=3600
+
 # OpenTelemetry Configuration (Optional)
 # See OPENTELEMETRY.md for detailed setup and usage instructions
 # See https://nextjs.org/docs/app/guides/open-telemetry for Next.js guide

--- a/core/lib/makeswift/client.ts
+++ b/core/lib/makeswift/client.ts
@@ -1,3 +1,4 @@
+import { type MakeswiftClient } from '@makeswift/runtime/client';
 import { Makeswift } from '@makeswift/runtime/next';
 import { getSiteVersion } from '@makeswift/runtime/next/server';
 import { strict } from 'assert';
@@ -9,7 +10,53 @@ import { runtime } from './runtime';
 
 strict(process.env.MAKESWIFT_SITE_API_KEY, 'MAKESWIFT_SITE_API_KEY is required');
 
-export const client = new Makeswift(process.env.MAKESWIFT_SITE_API_KEY, {
+// `Makeswift` narrows this to a non-null site version, but the client passes `null` for the
+// published site.
+type SiteVersionArg = Parameters<MakeswiftClient['fetchOptions']>[0];
+
+// Makeswift tags its API responses but declares no revalidate window, and
+// `app/[locale]/layout.tsx` sets `fetchCache = 'default-cache'`, so without a TTL Next.js
+// caches them indefinitely. In production the publish webhook revalidates the `@@makeswift`
+// tag, making this only a backstop; it stays long because time-based expiry serves the
+// previous response to the request that triggers the refresh. Makeswift cannot reach a local
+// dev server, where the TTL is the only invalidation, so development defaults to 0.
+const MAKESWIFT_REVALIDATE_TARGET = resolveRevalidateTarget();
+
+function resolveRevalidateTarget(): number {
+  const override = process.env.MAKESWIFT_REVALIDATE_TARGET;
+
+  if (override) {
+    return Number(override);
+  }
+
+  return process.env.NODE_ENV === 'development' ? 0 : 3600;
+}
+
+class CatalystMakeswift extends Makeswift {
+  fetchOptions(siteVersion: SiteVersionArg): Record<string, unknown> {
+    // The base implementation ignores this argument despite typing it as required.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const options = super.fetchOptions(siteVersion!);
+
+    // Draft mode already sets `cache: 'no-store'`; pairing that with `revalidate` makes
+    // Next.js discard both and fall back to caching the builder's edits indefinitely.
+    if (siteVersion != null) {
+      return options;
+    }
+
+    const { next } = options;
+
+    return {
+      ...options,
+      next: {
+        ...(typeof next === 'object' && next !== null ? next : {}),
+        revalidate: MAKESWIFT_REVALIDATE_TARGET,
+      },
+    };
+  }
+}
+
+export const client = new CatalystMakeswift(process.env.MAKESWIFT_SITE_API_KEY, {
   runtime,
 });
 


### PR DESCRIPTION
Jira: [TRAC-1633](https://bigcommercecloud.atlassian.net/browse/TRAC-1633)

## What/Why?

`@makeswift/runtime` tags its API responses with `@@makeswift` but never declares a revalidate window, so under `fetchCache = 'default-cache'` Next.js cached published content indefinitely and only the `site.published` webhook could refresh it — on hosts Makeswift cannot reach, most obviously a local dev server, content never updated at all. Requests for the published site now declare a TTL via `MAKESWIFT_REVALIDATE_TARGET`: 3600 in production, where the webhook is the real freshness mechanism and this is only a backstop, and 0 in development, where the webhook never arrives and the TTL is the only invalidation. Draft requests are skipped deliberately — the SDK already sets `cache: 'no-store'` for them, and adding `revalidate` alongside it makes Next.js discard both values and fall back to caching the builder's live edits indefinitely.

## Testing

Verified against `pnpm dev` by inspecting the on-disk fetch cache:

- **Development default (`0`)** — no `api.makeswift.com/v4|v5` entries are written; every request is fresh.
- **With `MAKESWIFT_REVALIDATE_TARGET=3600`** — entries appear as `revalidate: 3600`, `tags: ["@@makeswift"]`. Previously `31536000`.
- **No collateral damage** — BigCommerce Storefront queries stay at `revalidate: 3600`, since they all pass explicit `fetchOptions`.

To reproduce:

```bash
rm -rf .next && pnpm dev
curl -s -o /dev/null http://localhost:3000/
grep -l 'api.makeswift.com' .next/dev/cache/fetch-cache/* \
  | xargs -I{} jq -c '{revalidate, tags, url: .data.url}' {}
```

## Proof of fix

https://github.com/user-attachments/assets/e4ddb707-2d8a-4de8-93a0-824fe98bd489

## On Native Hosting (depends on https://github.com/bigcommerce/catalyst/pull/3183)


https://github.com/user-attachments/assets/6b4d1de1-bab0-4da8-9cb2-dd159e559cbe



## Migration

None. `MAKESWIFT_REVALIDATE_TARGET` is optional, and the defaults preserve current behaviour on hosts that receive publish webhooks. Hosts that don't will now refresh on the TTL instead of never. No files moved.
