### PR TITLE
TRAC-1269: feat - filter request rows out of logs query default output via entry_type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,18 +1,8 @@
 {
   "name": "@bigcommerce/catalyst",
   "description": "Catalyst is BigCommerce's composable front-end framework designed for building custom ecommerce storefronts.",
-  "keywords": [
-    "bigcommerce",
-    "ecommerce",
-    "storefront",
-    "headless",
-    "composable",
-    "nextjs"
-  ],
-  "license": "MIT",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "pnpm@10.12.4+sha512.5ea8b0deed94ed68691c9bad4c955492705c5eeb8a87ef86bc62c74a26b037b08ff9570f108b2e4dbd1dd1a9186fea925e527f141c648e85af45631074680184",
   "scripts": {
     "dev": "dotenv -e .env.local -- turbo run dev",
     "build": "dotenv -e .env.local -- turbo run build",
@@ -21,6 +11,9 @@
     "test:scripts": "node --test .github/scripts/__tests__/*.test.mts",
     "typecheck": "turbo typecheck",
     "changeset:version": "changeset version && node .github/scripts/sync-catalyst-version.mts"
+  },
+  "dependencies": {
+    "@opennextjs/cloudflare": "1.17.3"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.1",
@@ -32,5 +25,15 @@
     "turbo": "^2.5.4",
     "typescript": "^5.8.3",
     "unlighthouse": "^0.16.3"
-  }
+  },
+  "keywords": [
+    "bigcommerce",
+    "ecommerce",
+    "storefront",
+    "headless",
+    "composable",
+    "nextjs"
+  ],
+  "license": "MIT",
+  "packageManager": "pnpm@10.12.4+sha512.5ea8b0deed94ed68691c9bad4c955492705c5eeb8a87ef86bc62c74a26b037b08ff9570f108b2e4dbd1dd1a9186fea925e527f141c648e85af45631074680184"
 }

--- a/packages/catalyst/src/cli/commands/logs.spec.ts
+++ b/packages/catalyst/src/cli/commands/logs.spec.ts
@@ -823,6 +823,80 @@ describe('query subcommand', () => {
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining('GET /cart (500)'));
   });
 
+  const captureQueryParams = () => {
+    const captured: { params?: URLSearchParams } = {};
+
+    server.use(
+      http.get(
+        'https://:apiHost/stores/:storeHash/v3/infrastructure/logs/:projectUuid',
+        ({ request }) => {
+          captured.params = new URL(request.url).searchParams;
+
+          return HttpResponse.json({ data: [] });
+        },
+      ),
+    );
+
+    return captured;
+  };
+
+  test.each(['default', 'short'] as const)(
+    'requests only log entries from the API with the %s format',
+    async (format) => {
+      const captured = captureQueryParams();
+
+      await program.parseAsync(queryArgs(['--format', format]));
+
+      expect(captured.params?.get('entry_type')).toBe('log');
+    },
+  );
+
+  test.each(['request', 'json', 'pretty'] as const)(
+    'does not filter by entry_type with the %s format',
+    async (format) => {
+      const captured = captureQueryParams();
+
+      await program.parseAsync(queryArgs(['--format', format]));
+
+      expect(captured.params?.get('entry_type')).toBeNull();
+    },
+  );
+
+  // Rows an older API would return: no entry_type field, and the request
+  // row's message is exactly "<method> <url>".
+  const oldApiRequestRow = {
+    id: 'r1',
+    timestamp: '2026-06-01T12:00:00Z',
+    level: 'info',
+    messages: ['GET https://store.example/foo'],
+    request: { method: 'GET', url: 'https://store.example/foo', status_code: 200 },
+  };
+  const oldApiAppRow = {
+    id: 'a1',
+    timestamp: '2026-06-01T12:00:01Z',
+    level: 'info',
+    messages: ['checkout started'],
+    request: { method: 'GET', url: 'https://store.example/foo', status_code: 200 },
+  };
+
+  test('hides heuristic-matched request rows client-side against an older API', async () => {
+    server.use(
+      http.get('https://:apiHost/stores/:storeHash/v3/infrastructure/logs/:projectUuid', () =>
+        HttpResponse.json({ data: [oldApiAppRow, oldApiRequestRow] }),
+      ),
+    );
+
+    await program.parseAsync(queryArgs());
+
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining('checkout started'));
+    expect(consola.log).not.toHaveBeenCalledWith(
+      expect.stringContaining('GET https://store.example/foo'),
+    );
+    expect(consola.info).toHaveBeenCalledWith(
+      '1 entry shown, 1 request row hidden (oldest first, times in UTC). Use --format request to see request rows.',
+    );
+  });
+
   test('reports when no entries are found', async () => {
     server.use(
       http.get('https://:apiHost/stores/:storeHash/v3/infrastructure/logs/:projectUuid', () =>

--- a/packages/catalyst/src/cli/commands/logs.ts
+++ b/packages/catalyst/src/cli/commands/logs.ts
@@ -7,6 +7,7 @@ import { httpError } from '../lib/http-errors';
 import { consola } from '../lib/logger';
 import {
   formatLogEntry,
+  isRequestLogEntry,
   LOG_LEVELS,
   queryLogs,
   QueryLogsResult,
@@ -457,6 +458,8 @@ function printPaginationHints(
     ...(options.urlLike ? [`--url-like ${quoteArg(options.urlLike)}`] : []),
     ...(options.levelMin ? [`--level-min ${options.levelMin}`] : []),
     ...(options.limit != null ? [`--limit ${options.limit}`] : []),
+    // The entry_type filter derives from --format (default/short request only
+    // application logs), so echoing --format is enough to reproduce it.
     ...(options.format !== 'default' ? [`--format ${options.format}`] : []),
   ];
   const command = `${invocationPrefix()} logs query ${baseFlags.join(' ')}`;
@@ -486,6 +489,10 @@ a ready-to-run command when more entries are available), or toward newer
 entries with \`--before\`. Cursors are only valid with the same window and
 filters they came from. With \`--format json\`, the pagination cursors are
 emitted as a final \`{"meta": ...}\` line after the entries.
+
+The \`default\` and \`short\` formats show only application log output,
+excluding Cloudflare's auto-generated per-request rows. Use
+\`--format request\` (or \`json\`/\`pretty\`) to include them.
 
 Examples:
   # Last hour of logs
@@ -565,9 +572,14 @@ Examples:
       const projectUuid = resolveProjectUuid(options);
       const { start, end } = resolveTimeWindow(options);
 
+      // default/short show only application output, so ask the API to filter
+      // out Cloudflare's per-request rows (they don't consume the page limit).
+      const hideRequestRows = options.format === 'default' || options.format === 'short';
+
       const result = await queryLogs(projectUuid, storeHash, accessToken, apiHost, {
         start,
         end,
+        entryType: hideRequestRows ? 'log' : undefined,
         method: options.method,
         statusCode: options.statusCode,
         urlLike: options.urlLike,
@@ -612,10 +624,21 @@ Examples:
       // the narrowed value so it survives into the forEach closure.
       const lineFormat = options.format;
 
-      ordered.forEach((entry) => consola.log(formatLogEntry(entry, lineFormat)));
+      // Older API deployments ignore the entry_type param, so also drop
+      // request rows client-side — a no-op against new APIs.
+      const visible = hideRequestRows
+        ? ordered.filter((entry) => !isRequestLogEntry(entry))
+        : ordered;
+      const hiddenCount = ordered.length - visible.length;
+
+      visible.forEach((entry) => consola.log(formatLogEntry(entry, lineFormat)));
+
+      const shownPart = `${visible.length} ${visible.length === 1 ? 'entry' : 'entries'} shown`;
 
       consola.info(
-        `${entries.length} ${entries.length === 1 ? 'entry' : 'entries'} shown (oldest first, times in UTC).`,
+        hiddenCount > 0
+          ? `${shownPart}, ${hiddenCount} request ${hiddenCount === 1 ? 'row' : 'rows'} hidden (oldest first, times in UTC). Use --format request to see request rows.`
+          : `${shownPart} (oldest first, times in UTC).`,
       );
 
       printPaginationHints(result.meta?.cursor_pagination, start, end, options);

--- a/packages/catalyst/src/cli/lib/observability.spec.ts
+++ b/packages/catalyst/src/cli/lib/observability.spec.ts
@@ -5,7 +5,13 @@ import { server } from '../../../tests/mocks/node';
 
 import { UserActionableError } from './errors';
 import { consola } from './logger';
-import { formatLogEntry, formatV3Error, queryLogs, resolveTimeWindow } from './observability';
+import {
+  formatLogEntry,
+  formatV3Error,
+  isRequestLogEntry,
+  queryLogs,
+  resolveTimeWindow,
+} from './observability';
 
 const projectUuid = '6b202364-10f3-11f1-8bc7-fe9b9d8b14ab';
 const storeHash = 'test-store';
@@ -274,6 +280,64 @@ describe('formatLogEntry', () => {
     expect(line).toContain('UNKNOWN');
     expect(line).toContain('orphan log');
   });
+
+  test('renders a bare request line for request rows in the request format', () => {
+    const line = formatLogEntry(
+      {
+        timestamp: '2026-06-01T12:34:56.789Z',
+        entry_type: 'request',
+        level: 'info',
+        messages: ['GET https://store.example/foo'],
+        request: { method: 'GET', url: 'https://store.example/foo', status_code: 200 },
+      },
+      'request',
+    );
+
+    // No level bracket and no message — the message only duplicates the
+    // request details.
+    expect(line).toBe('[2026-06-01T12:34:56.789Z] GET https://store.example/foo (200)');
+  });
+});
+
+describe('isRequestLogEntry', () => {
+  test('trusts entry_type=request even when the message differs from method+url', () => {
+    expect(
+      isRequestLogEntry({
+        entry_type: 'request',
+        messages: ['something else entirely'],
+        request: { method: 'GET', url: '/cart', status_code: 200 },
+      }),
+    ).toBe(true);
+  });
+
+  test('trusts entry_type=log even when the message equals method+url', () => {
+    expect(
+      isRequestLogEntry({
+        entry_type: 'log',
+        messages: ['GET /cart'],
+        request: { method: 'GET', url: '/cart', status_code: 200 },
+      }),
+    ).toBe(false);
+  });
+
+  test('falls back to the message heuristic when entry_type is absent (older API)', () => {
+    expect(
+      isRequestLogEntry({
+        messages: ['GET https://store.example/foo'],
+        request: { method: 'GET', url: 'https://store.example/foo', status_code: 200 },
+      }),
+    ).toBe(true);
+  });
+
+  test('returns false for real application output or missing request details', () => {
+    expect(
+      isRequestLogEntry({
+        messages: ['rendering /cart failed'],
+        request: { method: 'GET', url: '/cart', status_code: 500 },
+      }),
+    ).toBe(false);
+    expect(isRequestLogEntry({ messages: ['GET /cart'] })).toBe(false);
+  });
 });
 
 describe('formatV3Error', () => {
@@ -460,6 +524,26 @@ describe('queryLogs', () => {
     expect(captured?.get('limit')).toBe('25');
     expect(captured?.get('after')).toBe('cursor_end');
     expect(captured?.get('before')).toBeNull();
+  });
+
+  test('forwards entryType as the entry_type query param', async () => {
+    let captured: URLSearchParams | undefined;
+
+    server.use(
+      http.get(logsUrl, ({ request }) => {
+        captured = new URL(request.url).searchParams;
+
+        return HttpResponse.json({ data: [] });
+      }),
+    );
+
+    await queryLogs(projectUuid, storeHash, accessToken, apiHost, {
+      start: '2026-06-01T00:00:00Z',
+      end: '2026-06-02T00:00:00Z',
+      entryType: 'log',
+    });
+
+    expect(captured?.get('entry_type')).toBe('log');
   });
 
   test('forwards a before cursor', async () => {

--- a/packages/catalyst/src/cli/lib/observability.ts
+++ b/packages/catalyst/src/cli/lib/observability.ts
@@ -13,6 +13,7 @@ const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 
 const logEntrySchema = z.object({
   timestamp: z.string().nullable().optional(),
+  entry_type: z.string().optional(),
   level: z.string().optional(),
   messages: z.array(z.unknown()).optional(),
   is_exception: z.boolean().optional(),
@@ -58,6 +59,7 @@ export type QueryLogsResult = z.infer<typeof queryLogsSchema>;
 export interface QueryLogsParams {
   start: string;
   end: string;
+  entryType?: 'log' | 'request';
   method?: string;
   statusCode?: number;
   urlLike?: string;
@@ -203,12 +205,27 @@ function isRedundantExceptionName(name: string, message: string): boolean {
 const stringifyMessage = (message: unknown) =>
   typeof message === 'string' ? message : JSON.stringify(message);
 
+const joinMessages = (messages: LogEntry['messages']) =>
+  (messages ?? []).map(stringifyMessage).join(' ').replace(/\s+/g, ' ').trim();
+
+// Identifies Cloudflare's auto-generated per-request invocation row (as
+// opposed to real application output like console.* or exceptions).
+export function isRequestLogEntry(entry: LogEntry): boolean {
+  if (entry.entry_type != null) return entry.entry_type === 'request';
+
+  // Older API deployments don't send entry_type. Fall back to a heuristic:
+  // the auto-generated row's message is exactly "<method> <url>", duplicating
+  // the entry's request details.
+  const method = entry.request?.method;
+  const url = entry.request?.url;
+
+  if (!method || !url) return false;
+
+  return joinMessages(entry.messages) === `${method} ${url}`;
+}
+
 export function formatLogEntry(entry: LogEntry, format: LogLineFormat = 'default'): string {
-  const message = (entry.messages ?? [])
-    .map(stringifyMessage)
-    .join(' ')
-    .replace(/\s+/g, ' ')
-    .trim();
+  const message = joinMessages(entry.messages);
 
   if (format === 'short') return message;
 
@@ -236,6 +253,13 @@ export function formatLogEntry(entry: LogEntry, format: LogLineFormat = 'default
     if (parts.length > 0) requestStr = ` ${parts.join(' ')}${status}`;
   }
 
+  // A request row carries no application output — its message only duplicates
+  // the request details — so print it as a bare request line, without a level
+  // bracket or message.
+  if (format === 'request' && isRequestLogEntry(entry)) {
+    return `[${entry.timestamp ?? UNKNOWN_TIME}]${requestStr}`;
+  }
+
   // `requestStr` is empty outside the `request` format, so the level stays
   // adjacent to the timestamp there and only slides after the request details
   // when they are present.
@@ -254,6 +278,7 @@ export async function queryLogs(
   search.set('start', params.start);
   search.set('end', params.end);
 
+  if (params.entryType) search.set('entry_type', params.entryType);
   if (params.method) search.set('method', params.method);
   if (params.statusCode != null) search.set('status_code', String(params.statusCode));
   if (params.urlLike) search.set('url:like', params.urlLike); // colon param

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@opennextjs/cloudflare':
+        specifier: 1.17.3
+        version: 1.17.3(encoding@0.1.13)(next@16.2.11(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(react-dom@19.1.7(react@19.1.7))(react@19.1.7))(wrangler@4.31.0)
     devDependencies:
       '@changesets/changelog-github':
         specifier: ^0.5.1


### PR DESCRIPTION
## What/Why?
<!--- 
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
--->
The `logs query` output used to show all logs regardless of whether they were Cloudflare's request logs or application logs. Now the command, by default, only shows application logs. 

To show request logs, the user must use the `request` or `json` format.

## Testing
<!---
  Provide as much information as you can about how you tested and
  how another developer can test.
--->
Tested locally.

## Migration
<!---
  If you have moved any files around, or made any breaking changes,
  please provide a migration guide for the developers to make rebases easier.
--->
No breaking changes.
