### PR TITLE
LTRAC-1457: Revalidate via self-fetch instead of a Durable Object queue

### DIFF
--- a/.changeset/ltrac-1457-self-fetch-revalidation-queue.md
+++ b/.changeset/ltrac-1457-self-fetch-revalidation-queue.md
@@ -1,0 +1,37 @@
+---
+"@bigcommerce/catalyst": patch
+---
+
+Replace the Durable Object revalidation queue with a self-fetch queue, so ISR revalidation can work on native hosting at all.
+
+OpenNext's `doQueue` routes revalidation through a Durable Object whose constructor reads `env.WORKER_SELF_REFERENCE` and throws without it:
+
+```js
+this.service = env.WORKER_SELF_REFERENCE;
+if (!this.service)
+    throw new IgnorableError("No service binding for cache revalidation worker");
+```
+
+`queueCache.send()` catches that error and only logs, so revalidation would fail silently rather than surface.
+
+**That binding cannot exist on native hosting.** A Cloudflare `service` binding resolves against account-level Workers, and a Catalyst deployment is a script inside a dispatch namespace, which is not addressable that way. Adding it was attempted and rejected at upload:
+
+```
+400 Bad Request  code 10143
+Service binding 'WORKER_SELF_REFERENCE' references Worker
+'…' which was not found.
+```
+
+The `dispatch_namespace` binding sometimes suggested as the alternative is worse: OpenNext calls `.fetch()` directly on the value while that binding exposes `.get(name)`, and `.get()` accepts *any* script in the namespace — binding it into a tenant Worker would let any deployment invoke any other deployment's Worker.
+
+## What changed
+
+Revalidation does not require a binding. It is a `HEAD` request to the page's own public URL carrying the build-time preview secret — exactly what the Durable Object issues once it holds the service handle. `queue` now uses a small self-contained queue that issues that request with a plain `fetch`, which leaves and re-enters through the dispatch router and arrives at the same Worker. `global_fetch_strictly_public` is already set, so the subrequest is not short-circuited internally.
+
+It remains wrapped in `queueCache`, so concurrent stale hits for one path still collapse into a single revalidation.
+
+**Trade-off:** the Durable Object's retry and max-concurrency handling is lost. A failed revalidation is retried on the next stale hit rather than by the queue itself, and revalidations are no longer capped at a concurrency limit.
+
+The `NEXT_CACHE_DO_QUEUE` binding is intentionally left in place. OpenNext's worker template exports all three Durable Object classes unconditionally, so it still resolves and needs no Durable Object migration; it is simply inert.
+
+Note this is latent until ISR is adopted — the build currently produces no routes with a revalidate window, so the queue is never invoked.

--- a/.changeset/ltrac-1457-self-fetch-revalidation-queue.md
+++ b/.changeset/ltrac-1457-self-fetch-revalidation-queue.md
@@ -4,6 +4,10 @@
 
 Replace the Durable Object revalidation queue with a self-fetch queue, so ISR revalidation can work on native hosting at all.
 
+**This does not make anything faster, and changes no behavior today.** Catalyst currently ships no route with a revalidate window, so the queue is never invoked. From the built prerender manifest, every prerendered route is `initialRevalidateSeconds: false` and `dynamicRoutes` is empty. The `next: { revalidate }` options on the product and faceted-search queries are fetch-level data caching and do not feed this queue.
+
+What this fixes is a trap rather than a slowdown: with the previous config, the first route to adopt ISR would have failed to revalidate *silently*, because the error thrown below is an `IgnorableError` (`logLevel = 0`, dropped by OpenNext's logger under the default threshold). Pages would have gone permanently stale with nothing in the logs.
+
 OpenNext's `doQueue` routes revalidation through a Durable Object whose constructor reads `env.WORKER_SELF_REFERENCE` and throws without it:
 
 ```js
@@ -11,8 +15,6 @@ this.service = env.WORKER_SELF_REFERENCE;
 if (!this.service)
     throw new IgnorableError("No service binding for cache revalidation worker");
 ```
-
-`queueCache.send()` catches that error and only logs, so revalidation would fail silently rather than surface.
 
 **That binding cannot exist on native hosting.** A Cloudflare `service` binding resolves against account-level Workers, and a Catalyst deployment is a script inside a dispatch namespace, which is not addressable that way. Adding it was attempted and rejected at upload:
 
@@ -33,5 +35,3 @@ It remains wrapped in `queueCache`, so concurrent stale hits for one path still 
 **Trade-off:** the Durable Object's retry and max-concurrency handling is lost. A failed revalidation is retried on the next stale hit rather than by the queue itself, and revalidations are no longer capped at a concurrency limit.
 
 The `NEXT_CACHE_DO_QUEUE` binding is intentionally left in place. OpenNext's worker template exports all three Durable Object classes unconditionally, so it still resolves and needs no Durable Object migration; it is simply inert.
-
-Note this is latent until ISR is adopted — the build currently produces no routes with a revalidate window, so the queue is never invoked.

--- a/packages/catalyst/templates/open-next.config.ts
+++ b/packages/catalyst/templates/open-next.config.ts
@@ -1,9 +1,65 @@
 import { defineCloudflareConfig, type OpenNextConfig } from '@opennextjs/cloudflare';
 import r2IncrementalCache from '@opennextjs/cloudflare/overrides/incremental-cache/r2-incremental-cache';
 import { withRegionalCache } from '@opennextjs/cloudflare/overrides/incremental-cache/regional-cache';
-import doQueue from '@opennextjs/cloudflare/overrides/queue/do-queue';
 import queueCache from '@opennextjs/cloudflare/overrides/queue/queue-cache';
 import doShardedTagCache from '@opennextjs/cloudflare/overrides/tag-cache/do-sharded-tag-cache';
+
+// OpenNext's `doQueue` routes ISR revalidation through a Durable Object that
+// reads `env.WORKER_SELF_REFERENCE` and throws without it. That binding cannot
+// point at this Worker on native hosting: a Cloudflare `service` binding
+// resolves against account-level Workers, and a dispatch-namespace script is not
+// addressable that way. Attempting it is rejected at upload with error 10143,
+// "references Worker ... which was not found" — verified against a deployed
+// store.
+//
+// A service binding *would* resolve if it pointed at an account-level Worker,
+// and the dispatch router is one — binding it would route back here by hostname
+// and keep the Durable Object queue intact. That was rejected deliberately: it
+// would hand every tenant a handle able to reach any other tenant's Worker.
+// Public fetches can already reach those endpoints, but only through the
+// Cloudflare edge; an internal handle bypasses WAF and rate limiting, so it is
+// not an equivalent capability.
+//
+// A binding is not actually required. The revalidation is a HEAD request to the
+// page's own public URL carrying the build-time preview secret, which is exactly
+// what the Durable Object issues once it holds the service handle. Sending it
+// with a plain `fetch` leaves and re-enters through the dispatch router and
+// arrives at the same Worker. `global_fetch_strictly_public` is set, so the
+// subrequest is not short-circuited internally.
+//
+// Wrapped in `queueCache` below so concurrent stale hits for one path collapse
+// into a single revalidation. What is lost relative to the Durable Object is its
+// retry and max-concurrency handling; a failed revalidation is retried on the
+// next stale hit rather than by the queue itself.
+// Matches the Durable Object's default. Without a bound, a hanging revalidation
+// would sit in `waitUntil` holding the invocation alive.
+const REVALIDATION_TIMEOUT_MS = 10_000;
+
+const selfFetchQueue = {
+  name: 'self-fetch-queue',
+  async send({ MessageBody: { host, url } }: { MessageBody: { host: string; url: string } }) {
+    const protocol = host.includes('localhost') ? 'http' : 'https';
+
+    const response = await fetch(`${protocol}://${host}${url}`, {
+      method: 'HEAD',
+      headers: {
+        // Inlined at build time; authorizes the revalidation.
+        'x-prerender-revalidate': process.env.__NEXT_PREVIEW_MODE_ID ?? '',
+        'x-isr': '1',
+      },
+      signal: AbortSignal.timeout(REVALIDATION_TIMEOUT_MS),
+    });
+
+    // `fetch` resolves for 4xx/5xx, so a failed regeneration would otherwise be
+    // indistinguishable from success. Throwing surfaces it: `queueCache` logs
+    // the error and, with `waitForQueueAck`, skips caching the attempt — so the
+    // next stale hit retries rather than the failure being swallowed. Silent
+    // failure is the exact bug this queue exists to fix.
+    if (!response.ok) {
+      throw new Error(`Revalidation of ${url} failed with status ${response.status}`);
+    }
+  },
+};
 
 const cloudflareConfig = defineCloudflareConfig({
   // No `bypassTagCacheOnCacheHit` and no `cachePurge`. Correct invalidation of
@@ -31,7 +87,7 @@ const cloudflareConfig = defineCloudflareConfig({
   incrementalCache: withRegionalCache(r2IncrementalCache, {
     mode: 'long-lived',
   }),
-  queue: queueCache(doQueue, {
+  queue: queueCache(selfFetchQueue, {
     regionalCacheTtlSec: 5,
     waitForQueueAck: true,
   }),

--- a/packages/catalyst/templates/open-next.config.ts
+++ b/packages/catalyst/templates/open-next.config.ts
@@ -53,28 +53,16 @@ const selfFetchQueue = {
 };
 
 const cloudflareConfig = defineCloudflareConfig({
-  // No `bypassTagCacheOnCacheHit` and no `cachePurge`. Correct invalidation of
-  // regional (Cache API) entries needs one of two mechanisms: a CDN purge that
-  // evicts them, or a tag-cache check on every hit. They are alternatives, and
-  // Catalyst was configured for the first while having neither.
+  // The absence of `cachePurge` and `bypassTagCacheOnCacheHit` is deliberate.
+  // Invalidating regional (Cache API) entries needs either a CDN purge that
+  // evicts them or a tag-cache check on every hit; this takes the second.
   //
-  // Purge cannot be enabled safely here. It needs a Cloudflare API token bound
-  // into the Worker, and a Worker binding is readable by the merchant's own
-  // application code. Cloudflare purge is zone-scoped and native hosting puts
-  // every tenant on one shared zone, so a token extracted from any tenant could
-  // purge every other tenant's cache.
-  //
-  // Declaring `cachePurge` anyway was worse than not having it: OpenNext's
-  // `isPurgeCacheEnabled()` only checks whether it is *declared*, so it believed
-  // purge was handling invalidation and disabled `shouldLazilyUpdateOnCacheHit`
-  // (on by default for 'long-lived'), while `bypassTagCacheOnCacheHit` skipped
-  // the tag check. A hit was then neither purged, nor refreshed from R2, nor
-  // tag-checked, so `revalidateTag` had no effect on it until max-age expired.
-  //
-  // Omitting both takes the tag-checking route: the tag cache is consulted on a
-  // hit and the entry refreshes from R2 in the background. Costs an extra read
-  // per hit. Purge is still the faster option — restore it only together with a
-  // design that keeps the credential out of tenant Workers.
+  // Do not restore `cachePurge` without reading LTRAC-1458 first. OpenNext's
+  // `isPurgeCacheEnabled()` checks only whether it is *declared*, never whether
+  // it can authenticate, and declaring it turns off both
+  // `shouldLazilyUpdateOnCacheHit` and the tag check. A purge that cannot
+  // authenticate therefore leaves entries neither purged, nor refreshed from R2,
+  // nor tag-checked, and `revalidateTag` silently stops working.
   incrementalCache: withRegionalCache(r2IncrementalCache, {
     mode: 'long-lived',
   }),

--- a/packages/catalyst/templates/open-next.config.ts
+++ b/packages/catalyst/templates/open-next.config.ts
@@ -4,33 +4,22 @@ import { withRegionalCache } from '@opennextjs/cloudflare/overrides/incremental-
 import queueCache from '@opennextjs/cloudflare/overrides/queue/queue-cache';
 import doShardedTagCache from '@opennextjs/cloudflare/overrides/tag-cache/do-sharded-tag-cache';
 
-// OpenNext's `doQueue` routes ISR revalidation through a Durable Object that
-// reads `env.WORKER_SELF_REFERENCE` and throws without it. That binding cannot
-// point at this Worker on native hosting: a Cloudflare `service` binding
-// resolves against account-level Workers, and a dispatch-namespace script is not
-// addressable that way. Attempting it is rejected at upload with error 10143,
-// "references Worker ... which was not found" — verified against a deployed
-// store.
+// OpenNext's `doQueue` cannot be used on native hosting: its Durable Object
+// requires a `WORKER_SELF_REFERENCE` service binding, which a dispatch-namespace
+// script cannot have. See LTRAC-1457 for why the alternatives were rejected.
 //
-// A service binding *would* resolve if it pointed at an account-level Worker,
-// and the dispatch router is one — binding it would route back here by hostname
-// and keep the Durable Object queue intact. That was rejected deliberately: it
-// would hand every tenant a handle able to reach any other tenant's Worker.
-// Public fetches can already reach those endpoints, but only through the
-// Cloudflare edge; an internal handle bypasses WAF and rate limiting, so it is
-// not an equivalent capability.
-//
-// A binding is not actually required. The revalidation is a HEAD request to the
-// page's own public URL carrying the build-time preview secret, which is exactly
-// what the Durable Object issues once it holds the service handle. Sending it
-// with a plain `fetch` leaves and re-enters through the dispatch router and
-// arrives at the same Worker. `global_fetch_strictly_public` is set, so the
-// subrequest is not short-circuited internally.
+// No binding is required. The revalidation is a HEAD request to the page's own
+// public URL carrying the build-time preview secret, which is exactly what the
+// Durable Object issues once it holds the service handle. Sending it with a
+// plain `fetch` leaves and re-enters through the dispatch router and arrives at
+// the same Worker. `global_fetch_strictly_public` is set, so the subrequest is
+// not short-circuited internally.
 //
 // Wrapped in `queueCache` below so concurrent stale hits for one path collapse
 // into a single revalidation. What is lost relative to the Durable Object is its
 // retry and max-concurrency handling; a failed revalidation is retried on the
 // next stale hit rather than by the queue itself.
+
 // Matches the Durable Object's default. Without a bound, a hanging revalidation
 // would sit in `waitUntil` holding the invocation alive.
 const REVALIDATION_TIMEOUT_MS = 10_000;

--- a/packages/catalyst/templates/open-next.config.ts
+++ b/packages/catalyst/templates/open-next.config.ts
@@ -43,7 +43,9 @@ const selfFetchQueue = {
     const response = await fetch(`${protocol}://${host}${url}`, {
       method: 'HEAD',
       headers: {
-        // Inlined at build time; authorizes the revalidation.
+        // Inlined at build time; authorizes the revalidation. The name is
+        // Next's, so the leading underscores are not ours to rename.
+        // eslint-disable-next-line no-underscore-dangle
         'x-prerender-revalidate': process.env.__NEXT_PREVIEW_MODE_ID ?? '',
         'x-isr': '1',
       },


### PR DESCRIPTION
Linear: [LTRAC-1457](https://linear.app/commerce/issue/LTRAC-1457)

Replaces the ignition-side approach, which was tried and proven impossible — see [ignition#334](https://github.com/bigcommerce/ignition/pull/334) (closed).

## What/Why?

OpenNext's `doQueue` routes ISR revalidation through a Durable Object whose constructor reads `env.WORKER_SELF_REFERENCE` and throws without it:

```js
this.service = env.WORKER_SELF_REFERENCE;
if (!this.service)
    throw new IgnorableError("No service binding for cache revalidation worker");
```

`queueCache.send()` catches that and only logs, so revalidation fails **silently** rather than surfacing.

### The binding cannot exist on native hosting

This was tested, not assumed. A Cloudflare `service` binding resolves against **account-level Workers**, and a Catalyst deployment is a script inside a dispatch namespace, which is not addressable that way. Emitting the binding from ignition was rejected at upload:

```
PUT .../dispatch/namespaces/ignition-integration-us/scripts/16693302-…
400 Bad Request

code 10143
"Service binding 'WORKER_SELF_REFERENCE' references Worker
 '16693302-5d818746-…' which was not found."
```

No value for `service` would work — it is a platform constraint.

**The `dispatch_namespace` binding often suggested as the alternative is worse.** Beyond the API mismatch (OpenNext calls `.fetch()` directly; that binding exposes `.get(name)`), `.get()` accepts *any* script in the namespace — binding it into a tenant Worker would let any deployment invoke any other deployment's Worker. Categorically worse than the problem.

### The fix

Revalidation never needed a binding. It is a `HEAD` request to the page's own public URL carrying the build-time preview secret — exactly what the Durable Object issues once it holds the service handle. This issues it with a plain `fetch`, which leaves and re-enters through `platform-dispatch-router` and arrives at the same Worker. `global_fetch_strictly_public` is already set, so the subrequest is not short-circuited internally.

Still wrapped in `queueCache`, so concurrent stale hits for one path still collapse into a single revalidation.

**Trade-off, stated plainly:** the Durable Object's retry and max-concurrency handling is lost. A failed revalidation is retried on the next stale hit rather than by the queue, and revalidations are no longer capped at a concurrency limit. Accepted because the alternative is not "keep the Durable Object" — it is "revalidation does not work at all."

## Rollout/Rollback

**Latent — no behaviour change for existing stores.** The build currently produces **zero routes with a revalidate window**, so the queue is never invoked. This makes revalidation work for when ISR is adopted rather than fixing an active failure.

`NEXT_CACHE_DO_QUEUE` is intentionally left bound on both sides. OpenNext's worker template exports all three Durable Object classes unconditionally, so the binding still resolves and **no Durable Object migration is needed** — deleting the class would have destroyed its storage. It simply goes inert.

Rollback is reverting this commit.

## Testing

Type-checked against the real build context (`core/.bigcommerce`, where the template is compiled), including a deliberate-error probe to confirm the check actually validates and that the queue object satisfies OpenNext's `Queue` interface structurally.

**Not verifiable through normal traffic**, because nothing exercises the queue while there are no ISR routes. Confirming it end-to-end needs a temporary route exporting `revalidate` to create a real ISR entry, then observing that a stale hit triggers a regeneration rather than the `No service binding…` error. Happy to add that probe if reviewers want it before merge.

Refs LTRAC-1457