### PR TITLE
LTRAC-1343: docs - Settle whether scaffolded projects commit GraphQL artifacts

### DIFF
--- a/.changeset/ltrac-1343-document-graphql-artifacts.md
+++ b/.changeset/ltrac-1343-document-graphql-artifacts.md
@@ -1,0 +1,13 @@
+---
+'@bigcommerce/catalyst-core': patch
+---
+
+Document the two generated GraphQL files that show up untracked in a fresh project, and settle whether to commit them.
+
+`pnpm run generate` writes `bigcommerce.graphql` and `bigcommerce-graphql.d.ts` to the project root. `catalyst create` makes its initial commit before anything runs `generate`, so both files appear as untracked the first time you run `pnpm run dev` — with nothing in the project saying what they are, whether they matter at runtime, or which of "commit" and "gitignore" was intended.
+
+## What changed
+
+- `README.md` gains a **GraphQL Schema and Types** section: what each file is, that neither is read at request time, `pnpm run generate` as the command that produces them, and an explicit instruction to commit both. It also covers regeneration — `dev`, `build`, and `deploy` each run `generate` first, deployments always use the schema live on the channel rather than the committed copy, and a lint/typecheck-only CI job needs no store credentials precisely because the files are committed.
+- `core/.gitignore` gains a comment recording that the two files are left out on purpose, so the next person to read it doesn't "fix" the omission.
+- Monorepo-side, `CONTRIBUTING.md` explains why the root `.gitignore` does the opposite for contributors — they work against unreleased schemas on their own test stores, and CI regenerates before it lints and typechecks.

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ test-results/
 playwright-report/
 playwright/.cache/
 .tests
+# gql.tada artifacts from `pnpm run -r generate`. Ignored for contributors, who
+# work against unreleased schemas; scaffolded projects commit them instead — see
+# CONTRIBUTING.md and do not add these to core/.gitignore.
 bigcommerce.graphql
 bigcommerce-graphql.d.ts
 .DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,25 @@ The default branch for this repository is called `canary`. This is the primary d
 
 To contribute to the `canary` branch, you can create a new branch off of `canary` and submit a PR against that branch.
 
+## GraphQL Schema Artifacts
+
+`pnpm run -r generate` downloads the GraphQL Storefront API schema for the channel in your
+`core/.env.local` and writes `core/bigcommerce.graphql` plus the gql.tada introspection type
+`core/bigcommerce-graphql.d.ts`. Run it after cloning, and again whenever you need to pick up schema
+changes — `pnpm run dev` and `pnpm run build` in `core/` also run it first.
+
+**Both files are gitignored in this repository** (see the root `.gitignore`). That is the opposite of
+the guidance we give merchants, who are told to commit them in
+[`core/README.md`](core/README.md#graphql-schema-and-types), and the difference is intentional:
+contributors regularly work against an unreleased Storefront API schema on their own test store, so a
+committed schema here would produce a stream of diffs that belong to nobody's change and conflict
+constantly between `canary` and the `integrations/*` branches. CI regenerates the files from store
+credentials before it lints and typechecks — see `.github/workflows/basic.yml`.
+
+Keep it that way when you touch `.gitignore`: the entries in the root `.gitignore` cover the
+monorepo, and `core/.gitignore` — which becomes the scaffolded project's `.gitignore` — must not
+gain them.
+
 ## API Scope
 
 Catalyst is intended to work with the [BigCommerce Storefront GraphQL API](https://developer.bigcommerce.com/docs/storefront/graphql) and not directly integrate out of the box with the [REST Management API](https://developer.bigcommerce.com/docs/rest-management).

--- a/core/.gitignore
+++ b/core/.gitignore
@@ -57,3 +57,8 @@ build-config.json
 
 # Catalyst CLI config
 .bigcommerce
+
+# Deliberately NOT ignored: `bigcommerce.graphql` and `bigcommerce-graphql.d.ts`,
+# written by `npm run generate`. Commit them, so lint, typecheck and editor
+# tooling work without store credentials. See "GraphQL Schema and Types" in
+# README.md before adding them here.

--- a/core/README.md
+++ b/core/README.md
@@ -68,6 +68,66 @@ Check out the [Catalyst.dev One-Click Catalyst Documentation](https://www.cataly
 
 Learn more about Catalyst at [catalyst.dev](https://catalyst.dev).
 
+## GraphQL Schema and Types
+
+Catalyst types its GraphQL documents with [gql.tada](https://gql-tada.0no.co/), which needs a local
+copy of your store's GraphQL Storefront API schema. Two files at the project root hold it:
+
+| File                       | What it is                                                        |
+| -------------------------- | ----------------------------------------------------------------- |
+| `bigcommerce.graphql`      | Your channel's Storefront API schema, in SDL.                     |
+| `bigcommerce-graphql.d.ts` | The gql.tada introspection type that `client/graphql.ts` imports. |
+
+Both are build-time and editor-time artifacts. Nothing reads them while your storefront serves a
+request — they exist so `tsc`, ESLint, and your editor can check every query and mutation against
+the real schema.
+
+### Generating them
+
+```bash
+pnpm run generate
+```
+
+(`npm run generate` if your project uses npm — the `generate` script in `package.json` is the same
+either way.)
+
+The script reads `BIGCOMMERCE_STORE_HASH`, `BIGCOMMERCE_CHANNEL_ID`, and
+`BIGCOMMERCE_STOREFRONT_TOKEN` from `.env.local`, downloads the schema for that channel, and writes
+both files. `pnpm run dev`, `pnpm run build`, and `pnpm run deploy` each run `generate` first, so the
+usual development loop keeps them current on its own. Run it directly after switching channels or
+when you want to pick up a Storefront API schema change mid-session.
+
+### Commit both files
+
+**Commit `bigcommerce.graphql` and `bigcommerce-graphql.d.ts` to your repository.** They are
+deliberately absent from `.gitignore`:
+
+- `pnpm run lint` and `pnpm run typecheck` fail without `bigcommerce-graphql.d.ts`, because
+  `client/graphql.ts` imports it. Committing it lets CI check a pull request with no store
+  credentials at all.
+- A fresh clone gets GraphQL autocomplete and validation immediately, before anything is run.
+- Schema changes land in your diffs, so a field your storefront depends on going away is something
+  you see in review rather than at deploy time.
+
+They show up as untracked the first time you run `pnpm run dev`, because `catalyst create` makes its
+initial commit before the first `generate`. Add them:
+
+```bash
+git add bigcommerce.graphql bigcommerce-graphql.d.ts
+git commit -m "Add generated GraphQL schema and types"
+```
+
+### Local versus CI regeneration
+
+`build` and `deploy` regenerate the schema before Next.js compiles, so a deployment always uses
+whatever is live on the channel at that moment; the committed copies are never what ships. Your
+build environment therefore needs the same three variables `generate` does — the ones already
+required for the build itself.
+
+A CI job that only lints, typechecks, or runs unit tests needs no credentials, because it uses the
+committed files. If you would rather have CI verify that they are current, run `pnpm run generate`
+there and fail the job when `git diff --exit-code` reports a change.
+
 ## Resources
 
 - [Catalyst Documentation](https://catalyst.dev/docs/)


### PR DESCRIPTION
Linear: [LTRAC-1343](https://linear.app/commerce/issue/LTRAC-1343/fresh-catalyst-install-generates-untracked-graphql-artefacts)

## What/Why?

A merchant reported `bigcommerce.graphql` and `bigcommerce-graphql.d.ts` showing up untracked right after setup, and asked the reasonable question: commit them, or gitignore them? Nothing in a scaffolded project answers that.

Documentation only — no behaviour change.

Two details that make the report legitimate rather than user error:

- **The two contexts genuinely disagree, and neither is documented.** A scaffolded project *is* the extracted `core/` directory, so its `.gitignore` is `core/.gitignore`, which doesn't list either file. The monorepo's root `.gitignore` does. Merchants are supposed to commit them; contributors aren't. From inside a scaffolded project the omission is indistinguishable from an oversight, which is why this PR records the decision in `core/.gitignore` itself and warns in `CONTRIBUTING.md` against propagating the root entries down into it.
- **They appear after `pnpm run dev`, not after `create`.** `initGitRepo` makes the initial commit before anything runs `generate`, so the files are always born untracked. The README now covers that moment explicitly with the `git add` to run.

The substantive argument for committing (the decision the ticket asked me to document) is that `client/graphql.ts` imports `~/bigcommerce-graphql`, so `lint` and `typecheck` can't resolve without the `.d.ts`. Committing it means a merchant's CI can typecheck a PR with no store credentials — which is exactly the problem `basic.yml` solves the other way in this repo, by running `pnpm run -r generate` before lint and typecheck. Neither file is read at request time; `build`/`deploy` regenerate, so the committed copy is never what ships.

Included a `@bigcommerce/catalyst-core` patch changeset so the guidance reaches existing projects through the changelog, not just new ones.

### Not addressed here

Two adjacent problems I found and left alone as out of scope, both worth their own tickets:

- Root `graphql.config.json` points at `core/schema.graphql`, which doesn't exist anywhere in the repo.
- `core/README.md`'s footer links to `/docs`, so that link is broken in every scaffolded project.

Also worth considering: the CLI's post-create "Next steps" output is where the merchant actually hits this, so a line there would catch people who never open the README. The ticket scoped this to docs, so the CLI is untouched.

## Testing

`npx prettier --check core/README.md` passes. `CONTRIBUTING.md` has one pre-existing prettier warning at `canary` (a list-continuation blank line in the release section) that I deliberately left in place rather than reformatting an unrelated part of the file; the section I added is prettier-clean.

Worth a reviewer's eye on the accuracy of the claims rather than the prose:

- `core/scripts/generate.cjs` writes both files and requires `BIGCOMMERCE_STORE_HASH` + `BIGCOMMERCE_STOREFRONT_TOKEN` (channel ID optional), a subset of `REQUIRED_BUILD_ENV_VARS`.
- `git check-ignore -v core/bigcommerce.graphql` in the monorepo resolves to the root `.gitignore` — confirming the comment lands in the file that actually does the ignoring.

## Migration

None. No files moved, no breaking changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)