### PR TITLE
ci: TRAC-1601 Fix Linear release completion and scope pipeline keys per branch

### DIFF
--- a/.github/workflows/changesets-release.yml
+++ b/.github/workflows/changesets-release.yml
@@ -19,6 +19,12 @@ jobs:
   changesets-release:
     name: Changesets Release
     runs-on: ubuntu-latest
+    env:
+      # Linear access keys are per-pipeline, so each branch's package maps to
+      # its own pipeline: canary -> @bigcommerce/catalyst-core, the integration
+      # branches -> their makeswift packages. An unset key skips the Linear
+      # steps for that branch.
+      LINEAR_ACCESS_KEY: ${{ secrets[github.ref_name == 'integrations/makeswift' && 'LINEAR_ACCESS_KEY_MAKESWIFT' || github.ref_name == 'integrations/b2b-makeswift' && 'LINEAR_ACCESS_KEY_B2B_MAKESWIFT' || 'LINEAR_ACCESS_KEY'] }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -44,9 +50,10 @@ jobs:
           CLI_SEGMENT_WRITE_KEY: ${{ secrets.CLI_SEGMENT_WRITE_KEY }}
 
       - name: Sync Linear release
+        if: env.LINEAR_ACCESS_KEY != ''
         uses: linear/linear-release-action@v0
         with:
-          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          access_key: ${{ env.LINEAR_ACCESS_KEY }}
           command: sync
           # Only the storefront package ships as its own release; changes to
           # other workspace packages (client, create-catalyst, the CLI) are
@@ -90,16 +97,27 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Complete Linear release
-        if: steps.headline.outputs.found == 'true'
+      # The accumulating sync steps above run unversioned, so before completing
+      # we stamp the started release with its final version via one more sync
+      # (base_ref=HEAD scans no new commits). `complete` then targets that same
+      # version. Per Linear support, this versioned sync-then-complete pair is
+      # required for pipelines with no natural labeling moment.
+      - name: Version Linear release
+        if: steps.headline.outputs.found == 'true' && env.LINEAR_ACCESS_KEY != ''
         uses: linear/linear-release-action@v0
         with:
-          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          access_key: ${{ env.LINEAR_ACCESS_KEY }}
+          command: sync
+          base_ref: HEAD
+          version: ${{ steps.headline.outputs.tag }}
+          name: ${{ steps.headline.outputs.tag }}
+
+      - name: Complete Linear release
+        if: steps.headline.outputs.found == 'true' && env.LINEAR_ACCESS_KEY != ''
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ env.LINEAR_ACCESS_KEY }}
           command: complete
-          # No `version`: the `catalyst-release` pipeline is a scheduled pipeline
-          # whose started release is unversioned (the accumulating `sync` steps
-          # above run without a version). Passing `version` makes `complete` look
-          # up an existing release with that exact version, which never exists and
-          # fails with `No release found with version "…"`. Omitting it completes
-          # the latest started release — the one sync has been accumulating into.
+          version: ${{ steps.headline.outputs.tag }}
+          name: ${{ steps.headline.outputs.tag }}
           release_notes: /tmp/release-notes.md


### PR DESCRIPTION
Jira: [TRAC-1601](https://bigcommercecloud.atlassian.net/browse/TRAC-1601)

## What/Why?

Follow-up from [the Linear team's answer](https://makeswifthq.slack.com/archives/C0966RZUV9R/p1783549087987909) on why our releases never complete: the accumulating syncs run unversioned, so `complete` has no version to target. Pipelines with no natural labeling moment need one final non-dry `sync --release-version=X` right before `complete --release-version=X`, so this adds that step (`base_ref: HEAD` means it scans no new commits, it just stamps the version onto the started release).

Also scoped the access key per branch. Keys are per-pipeline in Linear, and all three release branches were sharing the one `LINEAR_ACCESS_KEY`, so makeswift releases were syncing into the `@bigcommerce/catalyst-core` pipeline. Now canary keeps `LINEAR_ACCESS_KEY` and the integration branches use `LINEAR_ACCESS_KEY_MAKESWIFT` / `LINEAR_ACCESS_KEY_B2B_MAKESWIFT`. An unset key skips the Linear steps entirely, so the integration branches are a no-op until we create their pipelines and add the secrets.

## Testing

Can't exercise this until the next publish, but I checked the pieces:

- Confirmed the input mappings in `linear/linear-release-action@v0`'s `action.yml`: `version` maps to the CLI's `--release-version`, and `base_ref`/`name` map to `--base-ref`/`--name`, so the new steps match the commands Linear support gave us.
- `npx yaml-lint .github/workflows/changesets-release.yml` passes.
- `gh secret list` shows only `LINEAR_ACCESS_KEY` exists today, and the only Catalyst pipeline in the workspace is `@bigcommerce/catalyst-core`, which is what the branch to secret mapping assumes.

## Migration

N/A

[TRAC-1601]: https://bigcommercecloud.atlassian.net/browse/TRAC-1601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ