### PR TITLE
TRAC-1262: fix(cli) - run GraphQL codegen as part of the build

### DIFF
--- a/.changeset/trac-1262-run-generate-in-build.md
+++ b/.changeset/trac-1262-run-generate-in-build.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst": patch
+---
+
+`catalyst build` and `catalyst deploy` now run GraphQL codegen (`generate`) automatically, so a fresh project no longer needs a manual `pnpm build` before its first deploy.

--- a/packages/catalyst/src/cli/commands/build.spec.ts
+++ b/packages/catalyst/src/cli/commands/build.spec.ts
@@ -178,7 +178,11 @@ test('runs GraphQL codegen before the OpenNext build so it is not a silent prere
   );
 
   const steps = vi.mocked(execa).mock.calls.map(([file, args]) => {
-    if (file === 'node' && Array.isArray(args) && args.some((a) => String(a).includes('generate.cjs'))) {
+    if (
+      file === 'node' &&
+      Array.isArray(args) &&
+      args.some((a) => String(a).includes('generate.cjs'))
+    ) {
       return 'generate';
     }
 

--- a/packages/catalyst/src/cli/commands/build.spec.ts
+++ b/packages/catalyst/src/cli/commands/build.spec.ts
@@ -166,6 +166,32 @@ test('writes _headers into the assets directory so static assets get immutable C
   );
 });
 
+test('runs GraphQL codegen before the OpenNext build so it is not a silent prerequisite', async () => {
+  vi.mocked(getProjectState).mockReturnValue(transformedState);
+
+  await program.parseAsync(['node', 'catalyst', 'build']);
+
+  expect(execa).toHaveBeenCalledWith(
+    'node',
+    expect.arrayContaining([expect.stringContaining(join('scripts', 'generate.cjs'))]),
+    expect.objectContaining({ cwd: process.cwd() }),
+  );
+
+  const steps = vi.mocked(execa).mock.calls.map(([file, args]) => {
+    if (file === 'node' && Array.isArray(args) && args.some((a) => String(a).includes('generate.cjs'))) {
+      return 'generate';
+    }
+
+    if (Array.isArray(args) && args.includes('opennextjs-cloudflare')) {
+      return 'build';
+    }
+
+    return 'other';
+  });
+
+  expect(steps.indexOf('generate')).toBeLessThan(steps.indexOf('build'));
+});
+
 test('rejects an invalid --wrangler-version value', async () => {
   vi.mocked(getProjectState).mockReturnValue(transformedState);
 

--- a/packages/catalyst/src/cli/commands/build.ts
+++ b/packages/catalyst/src/cli/commands/build.ts
@@ -56,6 +56,15 @@ export async function buildCatalystProject(
   const openNextOutDir = join(coreDir, '.open-next');
   const bigcommerceDistDir = join(coreDir, '.bigcommerce', 'dist');
 
+  consola.start('Generating GraphQL types...');
+
+  await execa('node', [join(coreDir, 'scripts', 'generate.cjs')], {
+    stdio: 'inherit',
+    cwd: coreDir,
+  });
+
+  consola.success('GraphQL types generated');
+
   const wranglerConfig = getWranglerConfig(projectUuid);
 
   // Wrangler's --outdir writes alongside existing files instead of replacing


### PR DESCRIPTION
## What/Why?

Running `pnpm catalyst deploy` on a fresh Native Hosting project failed during
the build with `response.data is of type 'unknown'`, unless you had already run
`pnpm build` (or `pnpm dev`) by hand.

Root cause: the build needs gql.tada codegen output (`bigcommerce-graphql.d.ts`,
imported by `client/graphql.ts`), but that step (`generate`) was only wired into
the scaffold's npm wrapper scripts, not into the `catalyst` CLI. `catalyst deploy`
and `catalyst build` ran the OpenNext/Next build without it, so on a fresh project
(where the gitignored codegen file does not exist yet) the typecheck failed.

Fix: run `generate` at the start of `buildCatalystProject`, before the OpenNext
build. Codegen stops being a silent prerequisite.

## Testing

Verified against a real Native Hosting project, `deploy --dry-run`, schema file
removed to simulate a fresh scaffold:

- Before (published 1.3.0): dies at `Running TypeScript` -> exit 1.
- After (this change): prints `Generating GraphQL types...`, passes TypeScript,
  builds the bundle -> exit 0.

Unit test: `build.spec.ts` "runs GraphQL codegen before the OpenNext build"
(RED without the change, GREEN with it). Full suite: build 7/7, deploy 35/35.

## Migration

None.
