### PR TITLE
LTRAC-1746: feat(cli) - Add channel checkout URL support

### DIFF
--- a/.changeset/ltrac-1746-channel-checkout-url.md
+++ b/.changeset/ltrac-1746-channel-checkout-url.md
@@ -1,0 +1,9 @@
+---
+"@bigcommerce/catalyst": minor
+---
+
+Add `catalyst channels checkout-url` to show, set, or remove a channel's checkout URL.
+
+Checkout is hosted by BigCommerce and the redirect target is resolved server-side from channel config, so a storefront moved onto a Native Hosting domain keeps sending shoppers to whatever checkout domain the channel had before — with nothing in the CLI to inspect or change it. `catalyst channels info` — or bare `catalyst channels`, which now defaults to it — prints the channel's storefront, canonical and checkout URLs, and calls out when the channel has no checkout URL of its own (in which case BigCommerce falls back to the *default* channel's primary URL, which may be an unrelated domain). `catalyst channels update` gains `--checkout-url` alongside `--hostname`, so both of a channel's URLs can be set in one command; passing `--checkout-url` on its own changes only the checkout URL and leaves the storefront URL alone. `catalyst channels remove-checkout-url` reverts to the shared checkout domain and then reports where checkout actually landed, since the domain it falls back to belongs to the default channel and can't be known beforehand.
+
+BigCommerce requires the checkout URL to share a main domain with the channel's storefront URL, so sessions carry between the two. That rule is enforced by the API rather than pre-checked locally — determining the registrable domain correctly requires the public suffix list — so the server's own explanation is surfaced verbatim on rejection. Note this also means a custom checkout URL is only possible on a custom storefront domain, and that the checkout domain must be pointed at BigCommerce with a certificate provisioned there, not added with `catalyst domains add`.

--- a/packages/catalyst/src/cli/commands/channels.spec.ts
+++ b/packages/catalyst/src/cli/commands/channels.spec.ts
@@ -117,6 +117,33 @@ describe('channels', () => {
     expect(create).toBeDefined();
     expect(create?.description()).toContain('Create a new Catalyst storefront channel');
   });
+
+  test('exposes info, create, link and update', () => {
+    expect(channels.commands.map((cmd) => cmd.name()).sort()).toEqual([
+      'create',
+      'info',
+      'link',
+      'update',
+    ]);
+  });
+
+  test('defaults to info so bare `channels` reports the current state', async () => {
+    mockSelect.mockResolvedValueOnce(2);
+
+    await program.parseAsync([
+      'node',
+      'catalyst',
+      'channels',
+      '--store-hash',
+      storeHash,
+      '--access-token',
+      accessToken,
+    ]);
+
+    expect(consola.success).toHaveBeenCalledWith(
+      expect.stringContaining('Channel "Catalyst Storefront" (2)'),
+    );
+  });
 });
 
 describe('channels update', () => {
@@ -628,5 +655,260 @@ describe('channels create', () => {
       additionalLocales: ['es'],
     });
     expect(consola.success).toHaveBeenCalledWith(expect.stringContaining('Created channel 42'));
+  });
+});
+
+describe('channels checkout URLs', () => {
+  const sitePath = 'https://:apiHost/stores/:storeHash/v3/channels/:channelId/site';
+  const checkoutPath = `${sitePath}/checkout-url`;
+
+  const credentials = ['--store-hash', storeHash, '--access-token', accessToken];
+
+  const run = (...args: string[]) =>
+    program.parseAsync(['node', 'catalyst', 'channels', ...args, ...credentials]);
+
+  test('shows the storefront, canonical and checkout URLs for a channel', async () => {
+    await run('info', '--channel-id', '2');
+
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining('https://example.com'));
+    expect(consola.log).toHaveBeenCalledWith(
+      expect.stringContaining('https://store-abc-1.mybigcommerce.com'),
+    );
+    expect(consola.log).toHaveBeenCalledWith(
+      expect.stringContaining('https://checkout.example.com'),
+    );
+    expect(exitMock).toHaveBeenCalledWith(0);
+  });
+
+  // An inherited checkout URL is the failure mode this command exists to make
+  // visible, so the explanation must appear rather than a bare URL list.
+  test('explains the fallback when the channel has no checkout URL of its own', async () => {
+    server.use(
+      http.get(sitePath, () =>
+        HttpResponse.json({
+          data: {
+            id: 1,
+            url: 'https://storefront.example.com',
+            channel_id: 2,
+            ssl_status: null,
+            is_checkout_url_customized: false,
+            urls: [
+              { url: 'https://storefront.example.com', type: 'primary' },
+              { url: 'https://unrelated.mybigcommerce.com', type: 'checkout' },
+            ],
+          },
+        }),
+      ),
+    );
+
+    await run('info', '--channel-id', '2');
+
+    expect(consola.info).toHaveBeenCalledWith(
+      expect.stringContaining("falls back to the default channel's primary URL"),
+    );
+  });
+
+  test('prints (none) when the site has no checkout URL at all', async () => {
+    server.use(
+      http.get(sitePath, () =>
+        HttpResponse.json({
+          data: { id: 1, url: 'https://storefront.example.com', channel_id: 2, urls: [] },
+        }),
+      ),
+    );
+
+    await run('info', '--channel-id', '2');
+
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining('(none)'));
+  });
+
+  test('prompts for the channel when --channel-id is omitted', async () => {
+    mockSelect.mockResolvedValueOnce(2);
+
+    await run();
+
+    expect(mockSelect).toHaveBeenCalledTimes(1);
+    expect(consola.success).toHaveBeenCalledWith(
+      expect.stringContaining('Channel "Catalyst Storefront" (2)'),
+    );
+  });
+
+  test('update --checkout-url sets the checkout URL', async () => {
+    let putBody: unknown;
+    let putChannelId: string | undefined;
+
+    server.use(
+      http.put(checkoutPath, async ({ request, params }) => {
+        putBody = await request.json();
+        putChannelId = String(params.channelId);
+
+        return HttpResponse.json({
+          data: {
+            id: 1,
+            url: 'https://example.com',
+            channel_id: 2,
+            is_checkout_url_customized: true,
+            urls: [
+              { url: 'https://example.com', type: 'primary' },
+              { url: 'https://checkout.example.com', type: 'checkout' },
+            ],
+          },
+        });
+      }),
+    );
+
+    await run('update', '--channel-id', '2', '--checkout-url', 'https://checkout.example.com');
+
+    expect(putChannelId).toBe('2');
+    expect(putBody).toEqual({ url: 'https://checkout.example.com' });
+    expect(consola.success).toHaveBeenCalledWith(
+      expect.stringContaining('checkout URL to https://checkout.example.com'),
+    );
+    expect(exitMock).toHaveBeenCalledWith(0);
+  });
+
+  test('update --checkout-url accepts a bare hostname and normalises a path', async () => {
+    let putBody: unknown;
+
+    server.use(
+      http.put(checkoutPath, async ({ request }) => {
+        putBody = await request.json();
+
+        return HttpResponse.json({ data: { id: 1, url: 'https://example.com', channel_id: 2 } });
+      }),
+    );
+
+    await run('update', '--channel-id', '2', '--checkout-url', 'checkout.example.com/some/path');
+
+    expect(putBody).toEqual({ url: 'https://checkout.example.com' });
+  });
+
+  test('update rejects a non-https checkout URL before calling the API', async () => {
+    let called = false;
+
+    server.use(
+      http.put(checkoutPath, () => {
+        called = true;
+
+        return HttpResponse.json({ data: {} });
+      }),
+    );
+
+    await expect(
+      run('update', '--channel-id', '2', '--checkout-url', 'http://checkout.example.com'),
+    ).rejects.toThrow('must use https');
+    expect(called).toBe(false);
+  });
+
+  test('update rejects an unparseable checkout URL', async () => {
+    await expect(run('update', '--channel-id', '2', '--checkout-url', 'https://')).rejects.toThrow(
+      'is not a valid URL',
+    );
+  });
+
+  test('update --remove-checkout-url unsets the checkout URL', async () => {
+    let deleted = false;
+
+    server.use(
+      http.delete(checkoutPath, () => {
+        deleted = true;
+
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    await run('update', '--channel-id', '2', '--remove-checkout-url');
+
+    expect(deleted).toBe(true);
+    expect(consola.success).toHaveBeenCalledWith(expect.stringContaining('shared checkout domain'));
+    expect(exitMock).toHaveBeenCalledWith(0);
+  });
+
+  // The domain checkout falls back to belongs to the default channel, so it
+  // can't be predicted before the delete — it has to be reported afterwards.
+  test('update --remove-checkout-url reports where checkout landed', async () => {
+    server.use(
+      http.delete(checkoutPath, () => new HttpResponse(null, { status: 204 })),
+      http.get(sitePath, () =>
+        HttpResponse.json({
+          data: {
+            id: 1,
+            url: 'https://www.example.com',
+            channel_id: 2,
+            is_checkout_url_customized: false,
+            urls: [
+              { url: 'https://www.example.com', type: 'primary' },
+              { url: 'https://store-abc-1.mybigcommerce.com', type: 'checkout' },
+            ],
+          },
+        }),
+      ),
+    );
+
+    await run('update', '--channel-id', '2', '--remove-checkout-url');
+
+    expect(consola.success).toHaveBeenCalledWith(expect.stringContaining('shared checkout domain'));
+    expect(consola.log).toHaveBeenCalledWith(
+      expect.stringContaining('https://store-abc-1.mybigcommerce.com'),
+    );
+  });
+
+  // Commander enforces this via `Option.conflicts`. It exits 1, which ends the
+  // process in production; here `process.exit` is mocked, so the action still
+  // runs afterwards — the exit code is the signal worth asserting.
+  test('update refuses --checkout-url together with --remove-checkout-url', async () => {
+    server.use(
+      http.put(checkoutPath, () =>
+        HttpResponse.json({ data: { id: 1, url: 'https://example.com', channel_id: 2 } }),
+      ),
+    );
+
+    await run(
+      'update',
+      '--channel-id',
+      '2',
+      '--checkout-url',
+      'checkout.example.com',
+      '--remove-checkout-url',
+    );
+
+    expect(exitMock).toHaveBeenCalledWith(1);
+  });
+
+  // `--checkout-url` on its own must not drag the caller through the hostname
+  // prompt for a storefront URL they never asked to change.
+  test('update --checkout-url alone leaves the storefront URL untouched', async () => {
+    let sitePutCalled = false;
+
+    server.use(
+      http.put(sitePath, () => {
+        sitePutCalled = true;
+
+        return HttpResponse.json({ data: { id: 1, url: 'https://example.com', channel_id: 2 } });
+      }),
+    );
+
+    await run('update', '--channel-id', '2', '--checkout-url', 'checkout.example.com');
+
+    expect(sitePutCalled).toBe(false);
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
+  test('update --remove-checkout-url alone leaves the storefront URL untouched', async () => {
+    let sitePutCalled = false;
+
+    server.use(
+      http.put(sitePath, () => {
+        sitePutCalled = true;
+
+        return HttpResponse.json({ data: { id: 1, url: 'https://example.com', channel_id: 2 } });
+      }),
+      http.delete(checkoutPath, () => new HttpResponse(null, { status: 204 })),
+    );
+
+    await run('update', '--channel-id', '2', '--remove-checkout-url');
+
+    expect(sitePutCalled).toBe(false);
+    expect(mockSelect).not.toHaveBeenCalled();
   });
 });

--- a/packages/catalyst/src/cli/commands/channels.ts
+++ b/packages/catalyst/src/cli/commands/channels.ts
@@ -3,13 +3,18 @@ import { Command, InvalidArgumentError, Option } from 'commander';
 import type Conf from 'conf';
 import { colorize } from 'consola/utils';
 
-import { runChannelSiteUrlFlow } from '../lib/channel-site-flow';
+import { resolveChannel, runChannelSiteUrlFlow } from '../lib/channel-site-flow';
 import {
   channelPlatformLabel,
+  type ChannelSiteDetails,
   checkChannelEligibility,
+  deleteChannelCheckoutUrl,
   fetchAvailableChannels,
+  findChannelSiteUrl,
   getChannelInit,
+  getChannelSite,
   sortChannelsByPlatform,
+  updateChannelCheckoutUrl,
 } from '../lib/channels';
 import { NoLinkedProjectError } from '../lib/commerce-hosting';
 import { runCreateChannelFlow } from '../lib/create-channel-flow';
@@ -38,6 +43,42 @@ const parseChannelId = (value: string): number => {
 
   return parsed;
 };
+
+// Validates only the unambiguous parts: parses as a URL, uses https. The
+// same-main-domain rule is BigCommerce's to enforce (see
+// `updateChannelCheckoutUrl`). A bare hostname gets `https://` prefixed, as
+// `runChannelSiteUrlFlow` does for site URLs.
+const parseCheckoutUrl = (value: string): string => {
+  const withScheme = /^[a-z][a-z\d+.-]*:\/\//i.test(value) ? value : `https://${value}`;
+  let parsed: URL;
+
+  try {
+    parsed = new URL(withScheme);
+  } catch {
+    throw new InvalidArgumentError(
+      `"${value}" is not a valid URL. Pass a hostname or an https URL, e.g. https://checkout.example.com.`,
+    );
+  }
+
+  if (parsed.protocol !== 'https:') {
+    throw new InvalidArgumentError(
+      `The checkout URL must use https, but "${value}" uses ${parsed.protocol.replace(':', '')}.`,
+    );
+  }
+
+  // BigCommerce wants the origin; a pasted URL often carries more.
+  return parsed.origin;
+};
+
+const CHECKOUT_URL_NOTES = `
+Checkout is hosted by BigCommerce, so a checkout URL must be a domain you have
+pointed at BigCommerce with a certificate provisioned there — not one added with
+\`catalyst domains add\`, which only routes traffic to this project.
+
+BigCommerce also requires the checkout URL to share a main domain with the
+channel's storefront URL, so that sessions carry between the two. This means a
+custom checkout URL is only possible on a custom storefront domain; channels on
+an auto-generated deployment hostname use the shared checkout domain.`;
 
 // Resolve credentials from flags/env → persisted project config → interactive
 // login (persisting on success). Returns null when the user aborts login.
@@ -74,18 +115,30 @@ async function resolveCredentialsWithLogin(
 
 const update = new Command('update')
   .configureHelp({ showGlobalOptions: true })
-  .description(
-    "Update a BigCommerce channel's site URL to point at one of your project's deployment hostnames.",
-  )
+  .description("Update a BigCommerce channel's storefront and checkout URLs.")
   .addHelpText(
     'after',
-    `
+    `${CHECKOUT_URL_NOTES}
+
+With no flags, this updates the storefront URL and prompts for the hostname.
+Pass a checkout flag on its own to change only the checkout URL, leaving the
+storefront URL alone.
+
 Examples:
   # Pick a channel and hostname interactively
   $ catalyst channels update
 
-  # Skip both prompts
-  $ catalyst channels update --channel-id 123 --hostname my-storefront.example.com`,
+  # Point the storefront at a deployment hostname
+  $ catalyst channels update --channel-id 123 --hostname my-storefront.example.com
+
+  # Set both at once
+  $ catalyst channels update --channel-id 123 --hostname my-storefront.example.com --checkout-url checkout.example.com
+
+  # Change only the checkout URL
+  $ catalyst channels update --channel-id 123 --checkout-url checkout.example.com
+
+  # Fall back to the shared checkout domain
+  $ catalyst channels update --channel-id 123 --remove-checkout-url`,
   )
   .addOption(storeHashOption())
   .addOption(accessTokenOption())
@@ -103,6 +156,18 @@ Examples:
       "Skip the hostname prompt and use this hostname directly. Must be one of the project's deployment_hostnames.",
     ),
   )
+  .addOption(
+    new Option(
+      '--checkout-url <url>',
+      "Set the channel's checkout URL. Must share a main domain with the storefront URL.",
+    ).argParser(parseCheckoutUrl),
+  )
+  .addOption(
+    new Option(
+      '--remove-checkout-url',
+      "Remove the channel's custom checkout URL so checkout falls back to the shared checkout domain.",
+    ).conflicts('checkoutUrl'),
+  )
   .action(async (options) => {
     const config = getProjectConfig();
     const apiHost = resolveApiHost(options, config);
@@ -110,27 +175,69 @@ Examples:
 
     await getTelemetry().identify(storeHash);
 
-    try {
-      await runChannelSiteUrlFlow({
-        storeHash,
-        accessToken,
-        apiHost,
-        projectUuid: options.projectUuid ?? config.get('projectUuid'),
-        channelId: options.channelId,
-        hostname: options.hostname,
-      });
-    } catch (error) {
-      if (error instanceof NoLinkedProjectError) {
-        consola.info(
-          "When you're ready to create a project, run `catalyst projects create` or re-run `catalyst channels update`.",
-        );
-        process.exit(0);
+    // A checkout flag on its own means "change only the checkout URL": going
+    // through the site-URL flow would prompt for a hostname the caller never
+    // asked to change.
+    const touchesCheckout = options.checkoutUrl !== undefined || options.removeCheckoutUrl === true;
+    const updatesSiteUrl = options.hostname !== undefined || !touchesCheckout;
+    let channelId = options.channelId;
 
-        // Unreachable in production; prevents continuation when process.exit is mocked in tests.
-        return;
+    if (updatesSiteUrl) {
+      try {
+        ({ channelId } = await runChannelSiteUrlFlow({
+          storeHash,
+          accessToken,
+          apiHost,
+          projectUuid: options.projectUuid ?? config.get('projectUuid'),
+          channelId: options.channelId,
+          hostname: options.hostname,
+        }));
+      } catch (error) {
+        if (error instanceof NoLinkedProjectError) {
+          consola.info(
+            "When you're ready to create a project, run `catalyst projects create` or re-run `catalyst channels update`.",
+          );
+          process.exit(0);
+
+          // Unreachable in production; prevents continuation when process.exit is mocked in tests.
+          return;
+        }
+
+        throw error;
       }
+    }
 
-      throw error;
+    if (touchesCheckout) {
+      const channel =
+        channelId === undefined
+          ? await resolveChannel({ storeHash, accessToken, apiHost })
+          : { id: channelId, name: undefined };
+      const label = channel.name ? `"${channel.name}" (${channel.id})` : String(channel.id);
+
+      if (options.checkoutUrl !== undefined) {
+        const updated = await updateChannelCheckoutUrl(
+          channel.id,
+          options.checkoutUrl,
+          storeHash,
+          accessToken,
+          apiHost,
+        );
+
+        consola.success(`Updated channel ${label} checkout URL to ${options.checkoutUrl}.`);
+        reportChannelSite(updated);
+      } else {
+        await deleteChannelCheckoutUrl(channel.id, storeHash, accessToken, apiHost);
+
+        consola.success(
+          `Removed the custom checkout URL from channel ${label}. Checkout now uses the shared checkout domain.`,
+        );
+
+        // The fallback domain belongs to the default channel, so it can't be
+        // known before the delete. Re-read the site to show where it landed.
+        const reverted = await getChannelSite(channel.id, storeHash, accessToken, apiHost);
+
+        reportChannelSite(reverted);
+      }
     }
 
     process.exit(0);
@@ -361,12 +468,111 @@ Examples:
     process.exit(0);
   });
 
+const CHECKOUT_LABEL_WIDTH = 'Storefront'.length;
+
+const row = (label: string, value: string) => `  ${label.padEnd(CHECKOUT_LABEL_WIDTH)}  ${value}`;
+
+// `primary` is the merchant-facing storefront, `canonical` BigCommerce's own
+// permanent address, `checkout` where hosted checkout lives — easy to conflate
+// when debugging a redirect.
+function reportChannelSite(site: ChannelSiteDetails): void {
+  const canonical = findChannelSiteUrl(site, 'canonical');
+  const checkout = findChannelSiteUrl(site, 'checkout');
+
+  consola.log(row('Storefront', findChannelSiteUrl(site, 'primary') ?? site.url));
+
+  if (canonical) {
+    consola.log(row('Canonical', canonical));
+  }
+
+  consola.log(row('Checkout', checkout ?? '(none)'));
+
+  if (!site.isCheckoutUrlCustomized) {
+    consola.info(
+      'This channel has no checkout URL of its own, so BigCommerce falls back to the default ' +
+        "channel's primary URL. That may be a different domain than the storefront above.",
+    );
+  }
+}
+
+interface ChannelTargetOptions {
+  storeHash?: string;
+  accessToken?: string;
+  apiHost?: string;
+  channelId?: number;
+}
+
+// Resolves credentials and the target channel — the preamble every
+// channel-scoped command below shares.
+async function resolveChannelTarget(options: ChannelTargetOptions) {
+  const config = getProjectConfig();
+  const apiHost = resolveApiHost(options, config);
+  const { storeHash, accessToken } = resolveCredentials(options, config);
+
+  await getTelemetry().identify(storeHash);
+
+  const channel = await resolveChannel({
+    storeHash,
+    accessToken,
+    apiHost,
+    channelId: options.channelId,
+  });
+
+  return {
+    config,
+    apiHost,
+    storeHash,
+    accessToken,
+    channel,
+    label: channel.name ? `"${channel.name}" (${channel.id})` : String(channel.id),
+  };
+}
+
+const info = new Command('info')
+  .configureHelp({ showGlobalOptions: true })
+  .description("Show a channel's site URLs — storefront, canonical and checkout.")
+  .addHelpText(
+    'after',
+    `${CHECKOUT_URL_NOTES}
+
+Examples:
+  # Pick a channel interactively; the same as bare \`catalyst channels\`
+  $ catalyst channels info
+
+  # Target a channel directly
+  $ catalyst channels info --channel-id 123`,
+  )
+  .addOption(storeHashOption())
+  .addOption(accessTokenOption())
+  .addOption(apiHostOption())
+  .addOption(
+    new Option(
+      '--channel-id <id>',
+      'Skip the channel prompt and target this channel directly.',
+    ).argParser(parseChannelId),
+  )
+  .action(async (options: ChannelTargetOptions) => {
+    const { apiHost, storeHash, accessToken, channel, label } = await resolveChannelTarget(options);
+
+    consola.start('Fetching channel site...');
+
+    const site = await getChannelSite(channel.id, storeHash, accessToken, apiHost);
+
+    consola.success(`Channel ${label}:`);
+    reportChannelSite(site);
+
+    process.exit(0);
+  });
+
 // Resource commands are plural; the singular form stays as an alias so existing
 // scripts and muscle memory keep working.
 export const channels = new Command('channels')
   .alias('channel')
   .configureHelp({ showGlobalOptions: true })
   .description('Manage BigCommerce channels.')
+  // `info` is the default so bare `catalyst channels` reports the current
+  // state, matching how `logs` defaults to `tail`.
+  .addCommand(info, { isDefault: true })
   .addCommand(create)
   .addCommand(link)
   .addCommand(update);

--- a/packages/catalyst/src/cli/lib/channel-site-flow.ts
+++ b/packages/catalyst/src/cli/lib/channel-site-flow.ts
@@ -45,9 +45,14 @@ async function resolveProject(options: ChannelSiteFlowOptions): Promise<ProjectL
   return selectOrCreateInfrastructureProject(api, options.projectUuid);
 }
 
-async function resolveChannel(
-  options: ChannelSiteFlowOptions,
-): Promise<{ id: number; name?: string }> {
+// Exported so `channels info` and `channels update` resolve channels the same
+// way rather than re-deriving the Catalyst-platform filter and its error copy.
+export async function resolveChannel(options: {
+  storeHash: string;
+  accessToken: string;
+  apiHost: string;
+  channelId?: number;
+}): Promise<{ id: number; name?: string }> {
   if (options.channelId !== undefined) {
     return { id: options.channelId };
   }
@@ -119,7 +124,13 @@ async function resolveHostname(
   return selected;
 }
 
-export async function runChannelSiteUrlFlow(options: ChannelSiteFlowOptions): Promise<void> {
+export interface ChannelSiteFlowResult {
+  channelId: number;
+}
+
+export async function runChannelSiteUrlFlow(
+  options: ChannelSiteFlowOptions,
+): Promise<ChannelSiteFlowResult> {
   const project = await resolveProject(options);
   const channel = await resolveChannel(options);
   const hostname = await resolveHostname(project, options);
@@ -136,4 +147,8 @@ export async function runChannelSiteUrlFlow(options: ChannelSiteFlowOptions): Pr
   const channelLabel = channel.name ? `"${channel.name}" (${channel.id})` : String(channel.id);
 
   consola.success(`Updated channel ${channelLabel} site URL to ${siteUrl}.`);
+
+  // Returned so `channels update --hostname --checkout-url` reuses this channel
+  // rather than resolving it twice.
+  return { channelId: channel.id };
 }

--- a/packages/catalyst/src/cli/lib/channels.spec.ts
+++ b/packages/catalyst/src/cli/lib/channels.spec.ts
@@ -6,7 +6,11 @@ import { server } from '../../../tests/mocks/node';
 import {
   type Channel,
   channelPlatformLabel,
+  deleteChannelCheckoutUrl,
+  findChannelSiteUrl,
+  getChannelSite,
   sortChannelsByPlatform,
+  updateChannelCheckoutUrl,
   updateChannelSiteUrl,
 } from './channels';
 
@@ -108,6 +112,193 @@ describe('updateChannelSiteUrl', () => {
     await expect(
       updateChannelSiteUrl(channelId, 'https://x.example', storeHash, accessToken, apiHost),
     ).rejects.toThrow('Failed to update channel site: Something went wrong on our end.');
+  });
+});
+
+const sitePath = 'https://:apiHost/stores/:storeHash/v3/channels/:channelId/site';
+const checkoutPath = `${sitePath}/checkout-url`;
+
+const siteBody = {
+  id: 7,
+  url: 'https://example.com',
+  channel_id: channelId,
+  ssl_status: null,
+  is_checkout_url_customized: true,
+  urls: [
+    { url: 'https://example.com', type: 'primary' },
+    { url: 'https://store-abc-1.mybigcommerce.com', type: 'canonical' },
+    { url: 'https://checkout.example.com', type: 'checkout' },
+  ],
+};
+
+describe('getChannelSite', () => {
+  test('maps the site, tolerating the null ssl_status the API really returns', async () => {
+    server.use(http.get(sitePath, () => HttpResponse.json({ data: siteBody })));
+
+    const site = await getChannelSite(channelId, storeHash, accessToken, apiHost);
+
+    expect(site).toEqual({
+      id: 7,
+      url: 'https://example.com',
+      channelId,
+      sslStatus: null,
+      isCheckoutUrlCustomized: true,
+      urls: [
+        { url: 'https://example.com', type: 'primary' },
+        { url: 'https://store-abc-1.mybigcommerce.com', type: 'canonical' },
+        { url: 'https://checkout.example.com', type: 'checkout' },
+      ],
+    });
+  });
+
+  // The narrower `PUT .../site` response omits these, so they must default
+  // rather than fail to parse.
+  test('defaults the optional fields when the response omits them', async () => {
+    server.use(
+      http.get(sitePath, () =>
+        HttpResponse.json({ data: { id: 7, url: 'https://example.com', channel_id: channelId } }),
+      ),
+    );
+
+    const site = await getChannelSite(channelId, storeHash, accessToken, apiHost);
+
+    expect(site.sslStatus).toBeNull();
+    expect(site.isCheckoutUrlCustomized).toBe(false);
+    expect(site.urls).toEqual([]);
+  });
+
+  test('throws with a re-auth hint on 403', async () => {
+    server.use(http.get(sitePath, () => HttpResponse.json({}, { status: 403 })));
+
+    await expect(getChannelSite(channelId, storeHash, accessToken, apiHost)).rejects.toThrow(
+      'Re-run `catalyst auth login`',
+    );
+  });
+
+  test('throws a readable error on other failures', async () => {
+    server.use(http.get(sitePath, () => HttpResponse.json({}, { status: 500 })));
+
+    await expect(getChannelSite(channelId, storeHash, accessToken, apiHost)).rejects.toThrow(
+      'Failed to fetch channel site: Something went wrong on our end.',
+    );
+  });
+});
+
+describe('updateChannelCheckoutUrl', () => {
+  test('PUTs the url to the hyphenated channel-scoped path and returns the site', async () => {
+    let receivedBody: unknown;
+    let receivedChannelId: string | undefined;
+
+    server.use(
+      http.put(checkoutPath, async ({ request, params }) => {
+        receivedBody = await request.json();
+        receivedChannelId = String(params.channelId);
+
+        return HttpResponse.json({ data: siteBody });
+      }),
+    );
+
+    const site = await updateChannelCheckoutUrl(
+      channelId,
+      'https://checkout.example.com',
+      storeHash,
+      accessToken,
+      apiHost,
+    );
+
+    expect(receivedBody).toEqual({ url: 'https://checkout.example.com' });
+    expect(receivedChannelId).toBe(String(channelId));
+    expect(site.isCheckoutUrlCustomized).toBe(true);
+  });
+
+  // The same-main-domain rule is enforced by BigCommerce, not locally, so its
+  // explanation has to survive the trip to the user verbatim.
+  test("surfaces BigCommerce's same-main-domain 422 verbatim", async () => {
+    server.use(
+      http.put(checkoutPath, () =>
+        HttpResponse.json(
+          {
+            status: 422,
+            title: 'Incorrect checkout url https://checkout.example.org.',
+            detail:
+              'Your checkout and storefront must be within the same main domain like "main.com" and "subdomain.main.com"',
+          },
+          { status: 422 },
+        ),
+      ),
+    );
+
+    await expect(
+      updateChannelCheckoutUrl(
+        channelId,
+        'https://checkout.example.org',
+        storeHash,
+        accessToken,
+        apiHost,
+      ),
+    ).rejects.toThrow('must be within the same main domain');
+  });
+
+  test('throws with a re-auth hint on 401', async () => {
+    server.use(http.put(checkoutPath, () => HttpResponse.json({}, { status: 401 })));
+
+    await expect(
+      updateChannelCheckoutUrl(channelId, 'https://c.example.com', storeHash, accessToken, apiHost),
+    ).rejects.toThrow('Re-run `catalyst auth login`');
+  });
+});
+
+describe('deleteChannelCheckoutUrl', () => {
+  test('DELETEs the checkout url', async () => {
+    let called = false;
+
+    server.use(
+      http.delete(checkoutPath, () => {
+        called = true;
+
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    await expect(
+      deleteChannelCheckoutUrl(channelId, storeHash, accessToken, apiHost),
+    ).resolves.toBeUndefined();
+    expect(called).toBe(true);
+  });
+
+  test('throws with a re-auth hint on 403', async () => {
+    server.use(http.delete(checkoutPath, () => HttpResponse.json({}, { status: 403 })));
+
+    await expect(
+      deleteChannelCheckoutUrl(channelId, storeHash, accessToken, apiHost),
+    ).rejects.toThrow('Re-run `catalyst auth login`');
+  });
+
+  test('throws a readable error on other failures', async () => {
+    server.use(http.delete(checkoutPath, () => HttpResponse.json({}, { status: 500 })));
+
+    await expect(
+      deleteChannelCheckoutUrl(channelId, storeHash, accessToken, apiHost),
+    ).rejects.toThrow('Failed to remove channel checkout URL: Something went wrong on our end.');
+  });
+});
+
+describe('findChannelSiteUrl', () => {
+  const site = {
+    id: 7,
+    url: 'https://example.com',
+    channelId,
+    sslStatus: null,
+    isCheckoutUrlCustomized: true,
+    urls: [
+      { url: 'https://example.com', type: 'primary' },
+      { url: 'https://checkout.example.com', type: 'checkout' },
+    ],
+  };
+
+  test('returns the url for a role, or undefined when absent', () => {
+    expect(findChannelSiteUrl(site, 'checkout')).toBe('https://checkout.example.com');
+    expect(findChannelSiteUrl(site, 'canonical')).toBeUndefined();
   });
 });
 

--- a/packages/catalyst/src/cli/lib/channels.ts
+++ b/packages/catalyst/src/cli/lib/channels.ts
@@ -87,13 +87,38 @@ const eligibilityResponseSchema = z.object({
   }),
 });
 
+// `type` is a plain string, not an enum: the API documents
+// `primary | canonical | checkout`, but an unrecognised role shouldn't crash a
+// diagnostic read.
+const siteUrlSchema = z.object({
+  url: z.string(),
+  type: z.string(),
+});
+
+// `ssl_status` is documented `dedicated | shared` but comes back null on shared
+// SSL. The rest are optional because the narrower `PUT .../site` response omits
+// them.
 const channelSiteSchema = z.object({
   data: z.object({
     id: z.number(),
     url: z.string(),
     channel_id: z.number(),
+    ssl_status: z.string().nullable().optional(),
+    is_checkout_url_customized: z.boolean().optional(),
+    urls: z.array(siteUrlSchema).optional(),
   }),
 });
+
+// Tokens minted before `store_channel_settings`/`store_sites` joined
+// `DEVICE_OAUTH_SCOPES` 401/403 here, and re-login is the only recovery — so say
+// that rather than surfacing a bare status.
+function assertChannelSettingsAuthorized(response: Response, action: string): void {
+  if (response.status === 401 || response.status === 403) {
+    throw new UserActionableError(
+      `${action} (${response.status}). Re-run \`catalyst auth login\` to refresh your access token with the store_channel_settings and store_sites scopes.`,
+    );
+  }
+}
 
 export interface ChannelInit {
   storefrontToken: string;
@@ -236,11 +261,7 @@ export async function updateChannelSiteUrl(
     },
   );
 
-  if (response.status === 401 || response.status === 403) {
-    throw new UserActionableError(
-      `Failed to update channel site (${response.status}). Re-run \`catalyst auth login\` to refresh your access token with the store_channel_settings scope.`,
-    );
-  }
+  assertChannelSettingsAuthorized(response, 'Failed to update channel site');
 
   if (!response.ok) {
     throw await httpError(response, 'Failed to update channel site');
@@ -250,4 +271,106 @@ export async function updateChannelSiteUrl(
   const { data } = channelSiteSchema.parse(res);
 
   return { id: data.id, url: data.url, channelId: data.channel_id };
+}
+
+export interface ChannelSiteUrl {
+  url: string;
+  type: string;
+}
+
+export interface ChannelSiteDetails extends ChannelSite {
+  sslStatus: string | null;
+  // When false, BigCommerce falls back to the *default* channel's primary URL —
+  // not this channel's — which can silently put checkout on an unrelated domain.
+  isCheckoutUrlCustomized: boolean;
+  urls: ChannelSiteUrl[];
+}
+
+const toChannelSiteDetails = (
+  data: z.infer<typeof channelSiteSchema>['data'],
+): ChannelSiteDetails => ({
+  id: data.id,
+  url: data.url,
+  channelId: data.channel_id,
+  sslStatus: data.ssl_status ?? null,
+  isCheckoutUrlCustomized: data.is_checkout_url_customized ?? false,
+  urls: data.urls ?? [],
+});
+
+export function findChannelSiteUrl(site: ChannelSiteDetails, type: string): string | undefined {
+  return site.urls.find((entry) => entry.type === type)?.url;
+}
+
+export async function getChannelSite(
+  channelId: number,
+  storeHash: string,
+  accessToken: string,
+  apiHost: string,
+): Promise<ChannelSiteDetails> {
+  const response = await fetch(
+    `https://${apiHost}/stores/${storeHash}/v3/channels/${channelId}/site`,
+    { method: 'GET', headers: authHeaders(accessToken) },
+  );
+
+  assertChannelSettingsAuthorized(response, 'Failed to fetch channel site');
+
+  if (!response.ok) {
+    throw await httpError(response, 'Failed to fetch channel site');
+  }
+
+  const res: unknown = await response.json();
+
+  return toChannelSiteDetails(channelSiteSchema.parse(res).data);
+}
+
+// Channel-scoped and hyphenated. The headless guide's `/sites/{site_id}/checkout_url`
+// is wrong; the OpenAPI spec and API reference both use this form.
+const checkoutUrlPath = (storeHash: string, apiHost: string, channelId: number) =>
+  `https://${apiHost}/stores/${storeHash}/v3/channels/${channelId}/site/checkout-url`;
+
+// BigCommerce requires the checkout URL to share a main domain with the
+// storefront and 422s otherwise. Not pre-validated here: the registrable domain
+// needs the public suffix list, and a wrong local check would block a valid
+// setup. `httpError` surfaces the API's own explanation instead.
+export async function updateChannelCheckoutUrl(
+  channelId: number,
+  checkoutUrl: string,
+  storeHash: string,
+  accessToken: string,
+  apiHost: string,
+): Promise<ChannelSiteDetails> {
+  const response = await fetch(checkoutUrlPath(storeHash, apiHost, channelId), {
+    method: 'PUT',
+    headers: { ...authHeaders(accessToken), 'Content-Type': 'application/json' },
+    body: JSON.stringify({ url: checkoutUrl }),
+  });
+
+  assertChannelSettingsAuthorized(response, 'Failed to update channel checkout URL');
+
+  if (!response.ok) {
+    throw await httpError(response, 'Failed to update channel checkout URL');
+  }
+
+  const res: unknown = await response.json();
+
+  return toChannelSiteDetails(channelSiteSchema.parse(res).data);
+}
+
+// Drops the channel back to the shared checkout domain. No useful response body.
+export async function deleteChannelCheckoutUrl(
+  channelId: number,
+  storeHash: string,
+  accessToken: string,
+  apiHost: string,
+): Promise<void> {
+  const response = await fetch(checkoutUrlPath(storeHash, apiHost, channelId), {
+    method: 'DELETE',
+    headers: authHeaders(accessToken),
+  });
+
+  assertChannelSettingsAuthorized(response, 'Failed to remove channel checkout URL');
+
+  if (!response.ok) {
+    throw await httpError(response, 'Failed to remove channel checkout URL');
+  }
 }

--- a/packages/catalyst/tests/mocks/handlers.ts
+++ b/packages/catalyst/tests/mocks/handlers.ts
@@ -310,6 +310,54 @@ export const handlers = [
     }),
   ),
 
+  // Handler for getChannelSite. Mirrors a real response: null `ssl_status`, and
+  // a checkout URL under the storefront domain.
+  http.get('https://:apiHost/stores/:storeHash/v3/channels/:channelId/site', () =>
+    HttpResponse.json({
+      data: {
+        id: 1,
+        url: 'https://example.com',
+        channel_id: 1,
+        ssl_status: null,
+        is_checkout_url_customized: true,
+        urls: [
+          { url: 'https://example.com', type: 'primary' },
+          { url: 'https://store-abc-1.mybigcommerce.com', type: 'canonical' },
+          { url: 'https://checkout.example.com', type: 'checkout' },
+        ],
+      },
+    }),
+  ),
+
+  // Handlers for updateChannelCheckoutUrl / deleteChannelCheckoutUrl. The PUT
+  // echoes back the full site, as the real API does.
+  http.put(
+    'https://:apiHost/stores/:storeHash/v3/channels/:channelId/site/checkout-url',
+    async ({ request }) => {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      const body = (await request.json()) as { url: string };
+
+      return HttpResponse.json({
+        data: {
+          id: 1,
+          url: 'https://example.com',
+          channel_id: 1,
+          ssl_status: null,
+          is_checkout_url_customized: true,
+          urls: [
+            { url: 'https://example.com', type: 'primary' },
+            { url: body.url, type: 'checkout' },
+          ],
+        },
+      });
+    },
+  ),
+
+  http.delete(
+    'https://:apiHost/stores/:storeHash/v3/channels/:channelId/site/checkout-url',
+    () => new HttpResponse(null, { status: 204 }),
+  ),
+
   // Default handler for the npm registry — 404 so the stale-CLI check stays
   // silent by default. Tests that assert on it override with a version payload.
   http.get('https://registry.npmjs.org/:scope/:name/latest', () =>


### PR DESCRIPTION
Linear: [LTRAC-1746](https://linear.app/commerce/issue/LTRAC-1746) — under [LTRAC-447](https://linear.app/commerce/issue/LTRAC-447)

**1 of 4 in a stack.** Review this one first; the other three build on it.

| | PR | Adds |
| --- | --- | --- |
| 1 | **this one** | The API layer and the channel checkout URL commands |
| 2 | #3210 | The cross-domain checkout warning |
| 3 | #3211 | `catalyst deploy --update-checkout-url` |
| 4 | #3212 | The interactive offer to set a checkout URL |

## What/Why?

Checkout is hosted by BigCommerce and the redirect target is resolved server-side from channel config — `core/app/[locale]/(default)/checkout/route.ts` just follows whatever `redirectedCheckoutUrl` the API returns. So pointing a channel's site URL at a Native Hosting domain leaves checkout on whatever domain the channel had before, and until now the CLI had no way to inspect or change it. On the sandbox store this left one channel still redirecting to a checkout domain last touched in May 2024.

Rather than a new command group, this folds into the channel surface that already exists:

```shell
catalyst channels info                                        # or bare `catalyst channels`
catalyst channels update --hostname <h> --checkout-url <url>
catalyst channels update --remove-checkout-url
```

`info` prints the storefront, canonical, and checkout URLs — three things that are easy to conflate when debugging a redirect — and says so when the channel has no checkout URL of its own. It's registered `isDefault`, so bare `catalyst channels` reports state instead of printing help, following the `logs tail` precedent already in the repo.

### Notes for review

**Why `--checkout-url` on `update` rather than its own command.** Every channel URL now moves through one place. The two checkout flags are mutually exclusive, enforced by commander's `Option.conflicts` rather than a hand-rolled guard — so it surfaces as a usage error, and there's no runtime check to keep in sync.

**Passing a checkout flag alone skips the site-URL flow entirely.** Going through it would prompt for a hostname the caller never asked to change. Two tests pin that: neither the site `PUT` nor the hostname prompt happens. `runChannelSiteUrlFlow` now returns the channel it resolved so combining flags doesn't resolve it twice.

**Removal reports after the fact rather than preflighting.** It's the one operation that *creates* the inherited-checkout state, and the domain it falls back to belongs to the store's *default* channel — no API field identifies that channel, so the result can't be known beforehand. It re-reads the site afterwards and prints where checkout landed. Judging that domain is the diagnostic's job and arrives in #3210.

**The same-main-domain rule is enforced by BigCommerce, not pre-checked locally.** Determining the registrable domain correctly needs the public suffix list, and a wrong local check would reject a valid setup. `httpError` already prefers server prose, so BC's own explanation surfaces verbatim:

> `Your checkout and storefront must be within the same main domain like 'main.com' and 'subdomain.main.com'`

Only the unambiguous parts are validated here — that the value parses and uses https, with a bare hostname getting `https://` prefixed the way `runChannelSiteUrlFlow` already treats site URLs.

**Two schema details come from hitting the live API, not the spec.** `ssl_status` is documented `dedicated | shared` but returns `null` for sites on shared SSL, and `urls[].type` is kept a plain string so an unrecognised role can't crash what is mostly a diagnostic read.

**Refactors:** the 401/403 re-auth branch moves out of `updateChannelSiteUrl` into a shared helper now that four call sites need it, and `resolveChannel` is exported from `channel-site-flow` so the new commands reuse the Catalyst-platform picker rather than re-deriving its filter and error copy.

**No `core/` change is needed or included** — this is entirely CLI plus channel configuration.

## Testing

`pnpm --filter @bigcommerce/catalyst test` — 718 pass. Lint and typecheck clean. Based on canary at `bb35f22d1`.

New coverage includes BigCommerce's real 422 body (asserting its message survives to the user), `ssl_status: null`, the removal reporting path, the response shape that omits the optional fields, each checkout flag leaving the storefront URL untouched, and the two flags being rejected together.

Also exercised against store `vcijajnodd`:

| Case | Result |
| --- | --- |
| `channels info`, channel 1825156 (vanity domain) | Shows `checkout.catalyst-demo.site` |
| `channels info`, channel 1799395 (auto-generated hostname) | Shows the stale inherited domain and notes the fallback |
| Bare `catalyst channel` | Resolves to `info` |
| `update --checkout-url` with the value already set | Idempotent; confirmed only `updated_at` moved |
| `update --checkout-url checkout.catalyst-demo.site` (bare hostname) | Normalised to `https://…`, accepted |
| `update --checkout-url https://checkout.example.com` (cross-domain) | BC's 422 surfaces verbatim, no bug-report framing |
| `update --checkout-url` alone | Storefront URL untouched, no hostname prompt |
| Both checkout flags together | Rejected by commander before any API call |
| `update --remove-checkout-url` on 1799395 (already uncustomized, so a state no-op) | Reports the inherited target; confirmed byte-identical state before/after |

Removal was not run against 1825156, which has a working custom checkout domain that DELETE would drop to the shared URL.

## Migration

None. Additive — one new subcommand and two new flags, no changed defaults. Nothing is published yet, so the earlier shapes this went through never shipped.

Bare `catalyst channels` now runs `info` instead of printing help. `resolveChannel` is newly exported from `channel-site-flow`, and `runChannelSiteUrlFlow` returns `{ channelId }` instead of `void` — both internal to the CLI package with no external callers.

Refs LTRAC-1746