### PR TITLE
TRAC-1266: fix(cli) - reconcile native hosting files on upgrade

### DIFF
--- a/.changeset/trac-1266-reconcile-instrumentation-on-upgrade.md
+++ b/.changeset/trac-1266-reconcile-instrumentation-on-upgrade.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst": patch
+---
+
+`catalyst upgrade` now removes native-hosting-incompatible `instrumentation.ts` that a merge reintroduces, instead of leaving it for the merchant to delete by hand.

--- a/packages/catalyst/src/cli/commands/upgrade.spec.ts
+++ b/packages/catalyst/src/cli/commands/upgrade.spec.ts
@@ -1,14 +1,24 @@
 import { Command } from '@commander-js/extra-typings';
+import { confirm } from '@inquirer/prompts';
 import { execa } from 'execa';
 import { http, HttpResponse } from 'msw';
 import { execSync } from 'node:child_process';
 import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
-import { afterEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { server } from '../../../tests/mocks/node';
 import { detectLockfileManager } from '../lib/detect-package-manager';
+
+vi.mock('@inquirer/prompts', () => ({
+  confirm: vi.fn(),
+  input: vi.fn(),
+  select: vi.fn(),
+  Separator: class FakeSeparator {
+    type = 'separator';
+  },
+}));
 
 // The tree engine runs many git subprocesses sequentially on Windows CI; give
 // every test in this file enough headroom (the fast ones finish in < 1 s).
@@ -23,12 +33,29 @@ import {
   migrateWorkspaceDeps,
   normalizeWorkspaceDeps,
   parseRef,
+  reconcileNativeHosting,
   resolveBaseRef,
   resolveProject,
   resolveStrategy,
   rewriteWorkspaceSpecifier,
   upgrade,
 } from './upgrade';
+
+const confirmMock = vi.mocked(confirm);
+
+function withTty(value: boolean): () => void {
+  const previous = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
+
+  Object.defineProperty(process.stdin, 'isTTY', { value, configurable: true });
+
+  return () => {
+    if (previous) {
+      Object.defineProperty(process.stdin, 'isTTY', previous);
+    } else {
+      Reflect.deleteProperty(process.stdin, 'isTTY');
+    }
+  };
+}
 
 const createdDirs: string[] = [];
 
@@ -786,5 +813,113 @@ describe('detectLockfileManager', () => {
 
   test('returns null when there is no lockfile, so the caller can keep looking', async () => {
     expect(await detectLockfileManager(await mkTmp())).toBeNull();
+  });
+});
+
+describe('reconcileNativeHosting', () => {
+  let restoreTty: () => void;
+
+  beforeEach(() => {
+    confirmMock.mockReset();
+    restoreTty = withTty(true);
+  });
+
+  afterEach(() => {
+    restoreTty();
+  });
+
+  async function seedTransformedProject(withInstrumentation: boolean): Promise<string> {
+    const dir = await mkTmp();
+
+    await write(join(dir, 'middleware.ts'), 'export const middleware = () => {};\n');
+    await write(
+      join(dir, 'package.json'),
+      JSON.stringify(
+        {
+          name: 'my-store',
+          dependencies: {
+            '@opennextjs/cloudflare': '1.17.3',
+            '@vercel/otel': '^1.10.0',
+            next: '16.3.4',
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    if (withInstrumentation) {
+      await write(
+        join(dir, 'instrumentation.ts'),
+        "import { registerOTel } from '@vercel/otel';\nexport function register() { registerOTel(); }\n",
+      );
+    }
+
+    return dir;
+  }
+
+  test('removes an instrumentation.ts the merge brought back and clears it from the conflict list', async () => {
+    confirmMock.mockResolvedValue(true);
+
+    const dir = await seedTransformedProject(true);
+    const result = { applied: [], added: [], deleted: [], conflicted: ['instrumentation.ts'] };
+
+    await reconcileNativeHosting(dir, result);
+
+    expect(await exists(join(dir, 'instrumentation.ts'))).toBe(false);
+    expect(result.conflicted).not.toContain('instrumentation.ts');
+    expect(await readFile(join(dir, 'package.json'), 'utf-8')).not.toContain('@vercel/otel');
+  });
+
+  test('still reconciles a linked project when the merge left package.json unparseable', async () => {
+    confirmMock.mockResolvedValue(true);
+
+    const dir = await mkTmp();
+
+    await write(join(dir, '.bigcommerce', 'project.json'), JSON.stringify({ projectUuid: 'p1' }));
+    await write(join(dir, 'middleware.ts'), 'export const middleware = () => {};\n');
+    await write(
+      join(dir, 'package.json'),
+      [
+        '{',
+        '  "name": "my-store",',
+        '  "dependencies": {',
+        '<<<<<<< ours',
+        '    "@opennextjs/cloudflare": "1.17.3",',
+        '    "@vercel/otel": "^1.10.0"',
+        '=======',
+        '    "@vercel/otel": "^2.0.0"',
+        '>>>>>>> theirs',
+        '  }',
+        '}',
+      ].join('\n'),
+    );
+    await write(
+      join(dir, 'instrumentation.ts'),
+      "import { registerOTel } from '@vercel/otel';\nexport function register() { registerOTel(); }\n",
+    );
+
+    const result = { applied: [], added: [], deleted: [], conflicted: ['instrumentation.ts'] };
+
+    await reconcileNativeHosting(dir, result);
+
+    expect(await exists(join(dir, 'instrumentation.ts'))).toBe(false);
+    expect(result.conflicted).not.toContain('instrumentation.ts');
+  });
+
+  test('leaves the project alone when it is not set up for native hosting', async () => {
+    confirmMock.mockResolvedValue(true);
+
+    const dir = await seedTransformedProject(true);
+
+    await write(join(dir, 'proxy.ts'), 'export const proxy = () => {};\n');
+
+    const result = { applied: [], added: [], deleted: [], conflicted: ['instrumentation.ts'] };
+
+    await reconcileNativeHosting(dir, result);
+
+    expect(await exists(join(dir, 'instrumentation.ts'))).toBe(true);
+    expect(result.conflicted).toContain('instrumentation.ts');
+    expect(confirmMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/catalyst/src/cli/commands/upgrade.ts
+++ b/packages/catalyst/src/cli/commands/upgrade.ts
@@ -19,8 +19,10 @@ import { minVersion, satisfies, lt as semverLt, validRange, valid as validSemver
 import yoctoSpinner from 'yocto-spinner';
 import { z } from 'zod';
 
+import { cleanupCloudflareIncompatibilities } from '../lib/commerce-hosting';
 import { detectLockfileManager, PackageManager } from '../lib/detect-package-manager';
 import { consola } from '../lib/logger';
+import { getProjectState } from '../lib/project-state';
 import { getTelemetry } from '../lib/telemetry';
 
 const CorePackageJson = z.object({
@@ -1040,6 +1042,33 @@ function printSummary({
   }
 }
 
+export async function reconcileNativeHosting(
+  catalystRoot: string,
+  result: MergeResult,
+): Promise<void> {
+  const state = getProjectState(catalystRoot);
+
+  if (!state.isLinked && !state.isTransformed) return;
+
+  const instrumentationRel = 'instrumentation.ts';
+  const instrumentationPath = join(catalystRoot, instrumentationRel);
+  const hadInstrumentation = await pathExists(instrumentationPath);
+
+  try {
+    await cleanupCloudflareIncompatibilities(catalystRoot);
+  } catch (err) {
+    consola.warn(
+      `Couldn't fully reconcile native-hosting files (${err instanceof Error ? err.message : String(err)}). Remove @vercel/otel from package.json by hand if the merge brought it back.`,
+    );
+  }
+
+  if (hadInstrumentation && !(await pathExists(instrumentationPath))) {
+    result.conflicted = result.conflicted.filter((rel) => rel !== instrumentationRel);
+    result.applied = result.applied.filter((rel) => rel !== instrumentationRel);
+    result.added = result.added.filter((rel) => rel !== instrumentationRel);
+  }
+}
+
 export const upgrade = new Command('upgrade')
   .configureHelp({ showGlobalOptions: true })
   .aliases([
@@ -1381,6 +1410,8 @@ to raise the GitHub API rate limit.`,
           );
         }
       }
+
+      await reconcileNativeHosting(catalystRoot, result);
 
       // ── 7. Stage the clean changes; mark conflicts as real unmerged entries ─
       // Staging is a convenience; the merge already landed on disk, so never let

--- a/packages/catalyst/src/cli/lib/commerce-hosting.spec.ts
+++ b/packages/catalyst/src/cli/lib/commerce-hosting.spec.ts
@@ -1011,6 +1011,17 @@ describe('cleanupCloudflareIncompatibilities', () => {
     expect(readCorePackageJson().dependencies).toMatchObject({ next: '^15.0.0' });
   });
 
+  it('prompts with copy that ties the removal to native hosting', async () => {
+    writeCorePackageJson({ dependencies: { next: '^15.0.0', '@vercel/otel': '^2.1.0' } });
+    writeCoreInstrumentationFile('export function register() {}\n');
+
+    await cleanupCloudflareIncompatibilities(projectDir);
+
+    const message = confirmMock.mock.calls[0]?.[0].message ?? '';
+
+    expect(message.toLowerCase()).toContain('native hosting');
+  });
+
   it('leaves the file and the dep alone when the user declines (TTY)', async () => {
     confirmMock.mockResolvedValueOnce(false);
 

--- a/packages/catalyst/src/cli/lib/commerce-hosting.ts
+++ b/packages/catalyst/src/cli/lib/commerce-hosting.ts
@@ -98,8 +98,8 @@ export const cleanupCloudflareIncompatibilities = async (projectDir: string) => 
   const shouldRemove = await confirm({
     message:
       'Catalyst found instrumentation.ts, which is incompatible with the Cloudflare Workers ' +
-      'bundle when it uses @vercel/otel (causes "Failed to prepare server" at cold start). ' +
-      'Remove it and drop @vercel/otel from package.json?',
+      'bundle when it uses @vercel/otel (causes "Failed to prepare server" at cold start).\n' +
+      'Remove it and drop @vercel/otel from package.json? (required for native hosting)',
     default: true,
   });
 


### PR DESCRIPTION
## What/Why?
catalyst upgrade could pull instrumentation.ts back into a native-hosted
project. It's incompatible with the Cloudflare Workers bundle (the deploy
fails at cold start), and nothing on the upgrade path removed it, so merchants
had to delete it by hand after every upgrade.

Run the same check catalyst deploy already uses, right after the merge, and
scrub the file from the merge result so it isn't reported as a leftover
conflict.

Gate on isLinked, not just isTransformed: an upgrade can leave package.json
with conflict markers, which makes isTransformed read false (it can't find the
opennext dep).

## Testing
```bash
# unit + static checks (CLI package)
npm test            # full CLI suite green
npm run lint && npm run typecheck

# end to end on a real store
node dist/cli.js create --hosting commerce --gh-ref @bigcommerce/catalyst-core@1.3.7
cd <project> && node ../dist/cli.js upgrade 1.4.0
#   without the change: instrumentation.ts persists, no prompt
#   with the change:    prompt fires, instrumentation.ts removed
```

## Migration
None.
