### PR TITLE
TRAC-295: fix(core) - respect date modifier range options in PDP date picker

### DIFF
--- a/.changeset/trac-295-pdp-date-range.md
+++ b/.changeset/trac-295-pdp-date-range.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst-core": patch
+---
+
+Product detail page date modifiers now respect the date limits set in the control panel. A Date option's earliest date, latest date, and limit mode (earliest only, latest only, or a range) now disable out-of-range days in the PDP date picker, instead of letting shoppers pick any date.

--- a/core/data-transformers/product-options-transformer.ts
+++ b/core/data-transformers/product-options-transformer.ts
@@ -4,6 +4,7 @@ import { getTranslations } from 'next-intl/server';
 
 import { Field } from '@/vibes/soul/sections/product-detail/schema';
 import { ProductOptionsFragment } from '~/app/[locale]/(default)/product/[slug]/page-data';
+import { getDateFieldBounds } from '~/lib/date-field-limits';
 
 export const productOptionsTransformer = async (
   productOptions: ResultOf<typeof ProductOptionsFragment>['productOptions'],
@@ -204,6 +205,7 @@ export const productOptionsTransformer = async (
           required: option.isRequired,
           name: option.entityId.toString(),
           defaultValue: option.defaultDate ?? undefined,
+          ...getDateFieldBounds(option.limitDateBy, option.earliest, option.latest),
         };
       }
 

--- a/core/lib/date-field-limits.spec.ts
+++ b/core/lib/date-field-limits.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { getDateFieldBounds, getDisabledDates } from './date-field-limits';
+
+describe('getDateFieldBounds', () => {
+  const earliest = '2026-09-15T05:00:00Z';
+  const latest = '2026-09-19T05:00:00Z';
+
+  it('maps RANGE to both a min and a max bound', () => {
+    expect(getDateFieldBounds('RANGE', earliest, latest)).toEqual({
+      minDate: earliest,
+      maxDate: latest,
+    });
+  });
+
+  it('maps EARLIEST_DATE to a min bound only', () => {
+    const bounds = getDateFieldBounds('EARLIEST_DATE', earliest, latest);
+
+    expect(bounds.minDate).toBe(earliest);
+    expect(bounds.maxDate).toBeUndefined();
+  });
+
+  it('maps LATEST_DATE to a max bound only', () => {
+    const bounds = getDateFieldBounds('LATEST_DATE', earliest, latest);
+
+    expect(bounds.maxDate).toBe(latest);
+    expect(bounds.minDate).toBeUndefined();
+  });
+
+  it('maps NO_LIMIT to no bounds', () => {
+    expect(getDateFieldBounds('NO_LIMIT', earliest, latest)).toEqual({});
+  });
+
+  it('does not invent a bound when the timestamp is null', () => {
+    expect(getDateFieldBounds('RANGE', null, latest)).toEqual({
+      minDate: undefined,
+      maxDate: latest,
+    });
+  });
+});
+
+describe('getDisabledDates', () => {
+  const minDate = '2026-09-15T05:00:00Z';
+  const maxDate = '2026-09-19T05:00:00Z';
+
+  it('disables days outside the range with separate before/after matchers', () => {
+    expect(getDisabledDates({ minDate, maxDate })).toEqual([
+      { before: new Date(minDate) },
+      { after: new Date(maxDate) },
+    ]);
+  });
+
+  it('disables only days before the min when there is no max', () => {
+    expect(getDisabledDates({ minDate })).toEqual([{ before: new Date(minDate) }]);
+  });
+
+  it('disables only days after the max when there is no min', () => {
+    expect(getDisabledDates({ maxDate })).toEqual([{ after: new Date(maxDate) }]);
+  });
+
+  it('returns undefined when there are no bounds', () => {
+    expect(getDisabledDates({})).toBeUndefined();
+  });
+});

--- a/core/lib/date-field-limits.ts
+++ b/core/lib/date-field-limits.ts
@@ -1,0 +1,42 @@
+import { type Matcher } from 'react-day-picker';
+
+type LimitDateBy = 'EARLIEST_DATE' | 'LATEST_DATE' | 'NO_LIMIT' | 'RANGE';
+
+interface DateBounds {
+  minDate?: string;
+  maxDate?: string;
+}
+
+export function getDateFieldBounds(
+  limitDateBy: LimitDateBy,
+  earliest?: string | null,
+  latest?: string | null,
+): DateBounds {
+  switch (limitDateBy) {
+    case 'RANGE':
+      return { minDate: earliest ?? undefined, maxDate: latest ?? undefined };
+
+    case 'EARLIEST_DATE':
+      return { minDate: earliest ?? undefined };
+
+    case 'LATEST_DATE':
+      return { maxDate: latest ?? undefined };
+
+    case 'NO_LIMIT':
+      return {};
+  }
+}
+
+export function getDisabledDates({ minDate, maxDate }: DateBounds): Matcher[] | undefined {
+  const matchers: Matcher[] = [];
+
+  if (minDate != null) {
+    matchers.push({ before: new Date(minDate) });
+  }
+
+  if (maxDate != null) {
+    matchers.push({ after: new Date(maxDate) });
+  }
+
+  return matchers.length > 0 ? matchers : undefined;
+}

--- a/core/vibes/soul/sections/product-detail/product-detail-form.tsx
+++ b/core/vibes/soul/sections/product-detail/product-detail-form.tsx
@@ -32,6 +32,7 @@ import { Button } from '@/vibes/soul/primitives/button';
 import { toast } from '@/vibes/soul/primitives/toaster';
 import { useEvents } from '~/components/analytics/events';
 import { usePathname, useRouter } from '~/i18n/routing';
+import { getDisabledDates } from '~/lib/date-field-limits';
 
 import { revalidateCart } from './actions/revalidate-cart';
 import { Field, schema, SchemaRawShape } from './schema';
@@ -447,6 +448,7 @@ function FormField({
       return (
         <DatePicker
           defaultValue={controls.value}
+          disabledDays={getDisabledDates({ minDate: field.minDate, maxDate: field.maxDate })}
           errors={formField.errors}
           key={formField.id}
           label={field.label}

--- a/core/vibes/soul/sections/product-detail/schema.ts
+++ b/core/vibes/soul/sections/product-detail/schema.ts
@@ -54,6 +54,8 @@ type DateField = {
   type: 'date';
   defaultValue?: string;
   pattern?: string;
+  minDate?: string;
+  maxDate?: string;
 } & FormField;
 
 type SwatchRadioFieldOption =


### PR DESCRIPTION
## What/Why?

On the product detail page, a Date modifier's range limits were ignored: the
calendar let shoppers pick any date, regardless of the control panel config.

Root cause: the API fields (`earliest`, `latest`, `limitDateBy`) are fetched,
but `productOptionsTransformer` dropped them, the `vibes` `DateField` type had
no min/max to hold them, and the PDP renderer passed no `disabledDays` to
`<DatePicker>`.

Fix: a small `date-field-limits` helper carries the bounds through.

## Testing

Live PDP, CP modifier set to RANGE, Sep 15-19 2026:
- Before: all 30 September days selectable (0 disabled).
- After: only Sep 15-19 selectable; Aug/Oct/Nov fully disabled.

Unit: `core/lib/date-field-limits.spec.ts`, 9 cases (all four modes + matcher
shapes), red against a no-bounds stub, green with the fix. Full vitest 74/74,
typecheck and lint clean.

## Migration

None.

## Screenshots

Before: 
<img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/8881cef5-1432-4e98-a131-268658f6da06" />

After: 
<img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/87dc4940-cf83-4608-ab05-5e8e9884b712" />
