### PR TITLE
LTRAC-1748: feat(cli) - Add `catalyst deploy --update-checkout-url`

### DIFF
--- a/.changeset/ltrac-1748-deploy-update-checkout-url.md
+++ b/.changeset/ltrac-1748-deploy-update-checkout-url.md
@@ -1,0 +1,7 @@
+---
+"@bigcommerce/catalyst": minor
+---
+
+Add `catalyst deploy --update-checkout-url`, alongside the existing `--update-site-url`, so a merchant setting up a custom domain can configure both of a channel's URLs in one pass. It prompts for the checkout URL after a successful deploy, defaulting to the `checkout.` subdomain of the channel's storefront domain — the near-certain answer given that BigCommerce requires the two to share a main domain. Unlike the site URL this can't be derived from the deployment, since the checkout domain has to already point at BigCommerce with a certificate provisioned there.
+
+Passing both flags now resolves the channel once rather than asking twice, and either flow failing leaves the deploy reported as successful, since the bundle is already live by that point.

--- a/packages/catalyst/src/cli/commands/channels.ts
+++ b/packages/catalyst/src/cli/commands/channels.ts
@@ -16,7 +16,7 @@ import {
   sortChannelsByPlatform,
   updateChannelCheckoutUrl,
 } from '../lib/channels';
-import { warnOnCrossDomainCheckout } from '../lib/checkout-url';
+import { normalizeCheckoutUrl, warnOnCrossDomainCheckout } from '../lib/checkout-url';
 import { NoLinkedProjectError } from '../lib/commerce-hosting';
 import { runCreateChannelFlow } from '../lib/create-channel-flow';
 import { parseEnvAssignment } from '../lib/env-config';
@@ -45,30 +45,14 @@ const parseChannelId = (value: string): number => {
   return parsed;
 };
 
-// Validates only the unambiguous parts: parses as a URL, uses https. The
-// same-main-domain rule is BigCommerce's to enforce (see
-// `updateChannelCheckoutUrl`). A bare hostname gets `https://` prefixed, as
-// `runChannelSiteUrlFlow` does for site URLs.
+// Adapts the shared normalizer to commander, which formats InvalidArgumentError
+// as an option-level usage error.
 const parseCheckoutUrl = (value: string): string => {
-  const withScheme = /^[a-z][a-z\d+.-]*:\/\//i.test(value) ? value : `https://${value}`;
-  let parsed: URL;
-
   try {
-    parsed = new URL(withScheme);
-  } catch {
-    throw new InvalidArgumentError(
-      `"${value}" is not a valid URL. Pass a hostname or an https URL, e.g. https://checkout.example.com.`,
-    );
+    return normalizeCheckoutUrl(value);
+  } catch (error) {
+    throw new InvalidArgumentError(error instanceof Error ? error.message : String(error));
   }
-
-  if (parsed.protocol !== 'https:') {
-    throw new InvalidArgumentError(
-      `The checkout URL must use https, but "${value}" uses ${parsed.protocol.replace(':', '')}.`,
-    );
-  }
-
-  // BigCommerce wants the origin; a pasted URL often carries more.
-  return parsed.origin;
 };
 
 const CHECKOUT_URL_NOTES = `

--- a/packages/catalyst/src/cli/commands/deploy.spec.ts
+++ b/packages/catalyst/src/cli/commands/deploy.spec.ts
@@ -1046,4 +1046,106 @@ describe('--update-site-url', () => {
     );
     expect(consola.info).toHaveBeenCalledWith(expect.stringContaining('catalyst auth login'));
   });
+
+  test('--update-checkout-url prompts for a checkout URL and PUTs it', async () => {
+    let putBody: unknown;
+    let putChannelId: string | undefined;
+
+    server.use(
+      http.put(
+        'https://:apiHost/stores/:storeHash/v3/channels/:channelId/site/checkout-url',
+        async ({ request, params }) => {
+          putBody = await request.json();
+          putChannelId = String(params.channelId);
+
+          return HttpResponse.json({
+            data: { id: 1, url: 'https://example.com', channel_id: 2 },
+          });
+        },
+      ),
+    );
+
+    vi.mocked(select).mockResolvedValueOnce(2); // channel
+    vi.mocked(input).mockResolvedValueOnce('https://checkout.example.com');
+
+    await program.parseAsync(deployArgs(['--update-checkout-url']));
+
+    expect(putChannelId).toBe('2');
+    expect(putBody).toEqual({ url: 'https://checkout.example.com' });
+    expect(consola.success).toHaveBeenCalledWith(
+      expect.stringContaining('checkout URL to https://checkout.example.com'),
+    );
+  });
+
+  // Running both flows must not ask which channel twice — the checkout flow
+  // reuses the channel the site-URL flow already resolved.
+  test('reuses the resolved channel when both update flags are passed', async () => {
+    let checkoutChannelId: string | undefined;
+
+    server.use(
+      http.put('https://:apiHost/stores/:storeHash/v3/channels/:channelId/site', () =>
+        HttpResponse.json({
+          data: { id: 1, url: 'https://project-one.catalyst-sandbox.store', channel_id: 2 },
+        }),
+      ),
+      http.put(
+        'https://:apiHost/stores/:storeHash/v3/channels/:channelId/site/checkout-url',
+        ({ params }) => {
+          checkoutChannelId = String(params.channelId);
+
+          return HttpResponse.json({
+            data: { id: 1, url: 'https://example.com', channel_id: 2 },
+          });
+        },
+      ),
+    );
+
+    vi.mocked(select)
+      .mockResolvedValueOnce(2) // channel, asked once by the site-URL flow
+      .mockResolvedValueOnce('project-one.catalyst-sandbox.store'); // hostname
+    vi.mocked(input).mockResolvedValueOnce('https://checkout.example.com');
+
+    await program.parseAsync(deployArgs(['--update-site-url', '--update-checkout-url']));
+
+    expect(checkoutChannelId).toBe('2');
+    // Two selects total: channel + hostname. A third would mean the checkout
+    // flow re-prompted for the channel.
+    expect(vi.mocked(select)).toHaveBeenCalledTimes(2);
+  });
+
+  test('does not call the checkout URL API when the flag is omitted', async () => {
+    let putCalled = false;
+
+    server.use(
+      http.put(
+        'https://:apiHost/stores/:storeHash/v3/channels/:channelId/site/checkout-url',
+        () => {
+          putCalled = true;
+
+          return HttpResponse.json({}, { status: 200 });
+        },
+      ),
+    );
+
+    await program.parseAsync(deployArgs());
+
+    expect(putCalled).toBe(false);
+  });
+
+  test('soft-fails with a warning when the checkout URL update errors', async () => {
+    server.use(
+      http.put('https://:apiHost/stores/:storeHash/v3/channels/:channelId/site/checkout-url', () =>
+        HttpResponse.json({}, { status: 401 }),
+      ),
+    );
+
+    vi.mocked(select).mockResolvedValueOnce(2);
+    vi.mocked(input).mockResolvedValueOnce('https://checkout.example.com');
+
+    await program.parseAsync(deployArgs(['--update-checkout-url']));
+
+    expect(consola.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to update channel checkout URL'),
+    );
+  });
 });

--- a/packages/catalyst/src/cli/commands/deploy.ts
+++ b/packages/catalyst/src/cli/commands/deploy.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 
 import { assertAuthorized } from '../lib/auth-errors';
 import { loadBuildEnv } from '../lib/build-env';
+import { runChannelCheckoutUrlFlow } from '../lib/channel-checkout-url-flow';
 import { runChannelSiteUrlFlow } from '../lib/channel-site-flow';
 import {
   cleanupCloudflareIncompatibilities,
@@ -391,6 +392,10 @@ Example:
     '--update-site-url',
     "After a successful deploy, prompt to update a channel's site URL to the new hostname.",
   )
+  .option(
+    '--update-checkout-url',
+    "After a successful deploy, prompt to update a channel's checkout URL.",
+  )
   .addOption(
     new Option(
       '--secret <value>',
@@ -586,26 +591,44 @@ Example:
       apiHost,
     );
 
-    if (!options.updateSiteUrl) {
-      return;
-    }
-
-    try {
-      await runChannelSiteUrlFlow({
-        storeHash,
-        accessToken,
-        apiHost,
-        projectUuid,
-        preferHostname: deploymentHostname,
-      });
-    } catch (error) {
-      // Soft-fail: the deploy already succeeded and the bundle is live. A
-      // non-zero exit here would be misleading.
+    // Soft-failed: the bundle is already live, so a non-zero exit here would
+    // misrepresent what happened.
+    const warnChannelFlowFailed = (what: string, error: unknown) => {
       consola.warn(
-        `Failed to update channel site URL: ${error instanceof Error ? error.message : String(error)}`,
+        `Failed to update channel ${what}: ${error instanceof Error ? error.message : String(error)}`,
       );
       consola.info(
         'Update it manually in the control panel, or re-run `catalyst auth login` if the token is missing the store_channel_settings scope.',
       );
+    };
+
+    // Carried over so both flags don't ask which channel twice.
+    let resolvedChannelId: number | undefined;
+
+    if (options.updateSiteUrl) {
+      try {
+        ({ channelId: resolvedChannelId } = await runChannelSiteUrlFlow({
+          storeHash,
+          accessToken,
+          apiHost,
+          projectUuid,
+          preferHostname: deploymentHostname,
+        }));
+      } catch (error) {
+        warnChannelFlowFailed('site URL', error);
+      }
+    }
+
+    if (options.updateCheckoutUrl) {
+      try {
+        await runChannelCheckoutUrlFlow({
+          storeHash,
+          accessToken,
+          apiHost,
+          channelId: resolvedChannelId,
+        });
+      } catch (error) {
+        warnChannelFlowFailed('checkout URL', error);
+      }
     }
   });

--- a/packages/catalyst/src/cli/lib/channel-checkout-url-flow.spec.ts
+++ b/packages/catalyst/src/cli/lib/channel-checkout-url-flow.spec.ts
@@ -1,0 +1,171 @@
+import { input, select } from '@inquirer/prompts';
+import { http, HttpResponse } from 'msw';
+import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { server } from '../../../tests/mocks/node';
+
+import { runChannelCheckoutUrlFlow } from './channel-checkout-url-flow';
+import { consola } from './logger';
+
+vi.mock('@inquirer/prompts', () => ({
+  select: vi.fn(),
+  confirm: vi.fn(),
+  input: vi.fn(),
+}));
+
+const selectMock = vi.mocked(select);
+const inputMock = vi.mocked(input);
+
+const storeHash = 'test-store';
+const accessToken = 'test-token';
+const apiHost = 'api.bigcommerce.com';
+
+const api = { storeHash, accessToken, apiHost };
+const sitePath = 'https://:apiHost/stores/:storeHash/v3/channels/:channelId/site';
+const checkoutPath = `${sitePath}/checkout-url`;
+
+beforeAll(() => {
+  consola.mockTypes(() => vi.fn());
+
+  vi.mock('./telemetry', () => {
+    const instance = {
+      identify: vi.fn(),
+      isEnabled: vi.fn(() => true),
+      track: vi.fn(),
+      correlationId: 'test-session-uuid',
+      commandName: 'unknown',
+      durationMs: vi.fn().mockReturnValue(0),
+      analytics: { closeAndFlush: vi.fn().mockResolvedValue(undefined) },
+    };
+
+    return {
+      Telemetry: vi.fn().mockImplementation(() => instance),
+      getTelemetry: vi.fn(() => instance),
+      resetTelemetry: vi.fn(),
+    };
+  });
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
+describe('runChannelCheckoutUrlFlow', () => {
+  test('prompts with the checkout subdomain of the storefront and writes the answer', async () => {
+    let putBody: unknown;
+
+    server.use(
+      http.get(sitePath, () =>
+        HttpResponse.json({
+          data: {
+            id: 1,
+            url: 'https://www.example.com',
+            channel_id: 2,
+            is_checkout_url_customized: false,
+            urls: [{ url: 'https://www.example.com', type: 'primary' }],
+          },
+        }),
+      ),
+      http.put(checkoutPath, async ({ request }) => {
+        putBody = await request.json();
+
+        return HttpResponse.json({
+          data: { id: 1, url: 'https://www.example.com', channel_id: 2 },
+        });
+      }),
+    );
+
+    inputMock.mockResolvedValueOnce('https://checkout.example.com');
+
+    await runChannelCheckoutUrlFlow({ ...api, channelId: 2 });
+
+    expect(inputMock).toHaveBeenCalledWith(
+      expect.objectContaining({ default: 'https://checkout.example.com' }),
+    );
+    expect(putBody).toEqual({ url: 'https://checkout.example.com' });
+    expect(consola.success).toHaveBeenCalledWith(
+      expect.stringContaining('checkout URL to https://checkout.example.com'),
+    );
+  });
+
+  test('--url skips the prompt', async () => {
+    let putBody: unknown;
+
+    server.use(
+      http.put(checkoutPath, async ({ request }) => {
+        putBody = await request.json();
+
+        return HttpResponse.json({ data: { id: 1, url: 'https://example.com', channel_id: 2 } });
+      }),
+    );
+
+    await runChannelCheckoutUrlFlow({ ...api, channelId: 2, url: 'checkout.example.com' });
+
+    expect(inputMock).not.toHaveBeenCalled();
+    expect(putBody).toEqual({ url: 'https://checkout.example.com' });
+  });
+
+  test('prompts for the channel when no channelId is given', async () => {
+    selectMock.mockResolvedValueOnce(2);
+    inputMock.mockResolvedValueOnce('https://checkout.example.com');
+
+    await runChannelCheckoutUrlFlow(api);
+
+    expect(selectMock).toHaveBeenCalledTimes(1);
+    expect(consola.success).toHaveBeenCalledWith(
+      expect.stringContaining('"Catalyst Storefront" (2)'),
+    );
+  });
+
+  // An inherited checkout URL is the state this flow usually exists to replace,
+  // so it needs to be visible before the merchant is asked for a new one.
+  test('reports an inherited checkout URL before prompting', async () => {
+    server.use(
+      http.get(sitePath, () =>
+        HttpResponse.json({
+          data: {
+            id: 1,
+            url: 'https://www.example.com',
+            channel_id: 2,
+            is_checkout_url_customized: false,
+            urls: [
+              { url: 'https://www.example.com', type: 'primary' },
+              { url: 'https://unrelated.mybigcommerce.com', type: 'checkout' },
+            ],
+          },
+        }),
+      ),
+    );
+
+    inputMock.mockResolvedValueOnce('https://checkout.example.com');
+
+    await runChannelCheckoutUrlFlow({ ...api, channelId: 2 });
+
+    expect(consola.info).toHaveBeenCalledWith(
+      expect.stringContaining('inherited from the default channel'),
+    );
+  });
+
+  test('rejects a non-https answer without calling the API', async () => {
+    let called = false;
+
+    server.use(
+      http.put(checkoutPath, () => {
+        called = true;
+
+        return HttpResponse.json({ data: {} });
+      }),
+    );
+
+    inputMock.mockResolvedValueOnce('http://checkout.example.com');
+
+    await expect(runChannelCheckoutUrlFlow({ ...api, channelId: 2 })).rejects.toThrow(
+      'must use https',
+    );
+    expect(called).toBe(false);
+  });
+});

--- a/packages/catalyst/src/cli/lib/channel-checkout-url-flow.ts
+++ b/packages/catalyst/src/cli/lib/channel-checkout-url-flow.ts
@@ -1,0 +1,68 @@
+import { input } from '@inquirer/prompts';
+
+import { resolveChannel } from './channel-site-flow';
+import { findChannelSiteUrl, getChannelSite, updateChannelCheckoutUrl } from './channels';
+import { normalizeCheckoutUrl, suggestCheckoutUrl } from './checkout-url';
+import { consola } from './logger';
+
+export interface ChannelCheckoutUrlFlowOptions {
+  storeHash: string;
+  accessToken: string;
+  apiHost: string;
+  // Non-interactive overrides. When supplied, the corresponding prompt is
+  // skipped.
+  channelId?: number;
+  url?: string;
+}
+
+// Prompts for a checkout URL and writes it.
+//
+// Unlike a site URL this can't be derived from the deployment: BigCommerce —
+// not this project's worker — serves checkout, so the domain must already point
+// there with a certificate. Defaults to the `checkout.` subdomain of the
+// storefront, which the same-main-domain rule makes the near-certain answer.
+export async function runChannelCheckoutUrlFlow(
+  options: ChannelCheckoutUrlFlowOptions,
+): Promise<void> {
+  const channel = await resolveChannel(options);
+  const label = channel.name ? `"${channel.name}" (${channel.id})` : String(channel.id);
+
+  const site = await getChannelSite(
+    channel.id,
+    options.storeHash,
+    options.accessToken,
+    options.apiHost,
+  );
+
+  const storefrontUrl = findChannelSiteUrl(site, 'primary') ?? site.url;
+  const currentCheckoutUrl = findChannelSiteUrl(site, 'checkout');
+
+  consola.info(`Channel ${label} storefront is ${storefrontUrl}.`);
+
+  if (currentCheckoutUrl) {
+    consola.info(
+      `Checkout is currently ${currentCheckoutUrl}${
+        site.isCheckoutUrlCustomized ? '' : ', inherited from the default channel'
+      }.`,
+    );
+  }
+
+  const answer =
+    options.url ??
+    (await input({
+      message: 'Checkout URL for this channel (must share a main domain with the storefront)',
+      default: suggestCheckoutUrl(storefrontUrl),
+    }));
+
+  const checkoutUrl = normalizeCheckoutUrl(answer);
+
+  await updateChannelCheckoutUrl(
+    channel.id,
+    checkoutUrl,
+    options.storeHash,
+    options.accessToken,
+    options.apiHost,
+  );
+
+  consola.success(`Updated channel ${label} checkout URL to ${checkoutUrl}.`);
+}

--- a/packages/catalyst/src/cli/lib/channel-site-flow.ts
+++ b/packages/catalyst/src/cli/lib/channel-site-flow.ts
@@ -184,7 +184,8 @@ export async function runChannelSiteUrlFlow(
     // Diagnostics are advisory; the write above succeeded.
   }
 
-  // Returned so `channels update --hostname --checkout-url` reuses this channel
-  // rather than resolving it twice.
+  // Returned so a caller running several channel flows back to back — `channels
+  // update --hostname --checkout-url`, or `deploy --update-site-url
+  // --update-checkout-url` — reuses this channel instead of resolving it twice.
   return { channelId: channel.id };
 }

--- a/packages/catalyst/src/cli/lib/checkout-url.ts
+++ b/packages/catalyst/src/cli/lib/checkout-url.ts
@@ -1,6 +1,7 @@
 import { getDomain } from 'tldts';
 
 import { type ChannelSiteDetails, findChannelSiteUrl } from './channels';
+import { UserActionableError } from './errors';
 import { consola } from './logger';
 import { fetchProjects } from './project';
 
@@ -59,6 +60,30 @@ export function suggestCheckoutUrl(storefrontUrl: string): string | undefined {
   const base = normalizeHostname(host).replace(/^www\./, '');
 
   return `https://checkout.${base}`;
+}
+
+// Validates only the unambiguous parts: parses as a URL, uses https. A bare
+// hostname gets `https://` prefixed; path and query are dropped since the API
+// wants an origin.
+export function normalizeCheckoutUrl(value: string): string {
+  const withScheme = /^[a-z][a-z\d+.-]*:\/\//i.test(value) ? value : `https://${value}`;
+  let parsed: URL;
+
+  try {
+    parsed = new URL(withScheme);
+  } catch {
+    throw new UserActionableError(
+      `"${value}" is not a valid URL. Pass a hostname or an https URL, e.g. https://checkout.example.com.`,
+    );
+  }
+
+  if (parsed.protocol !== 'https:') {
+    throw new UserActionableError(
+      `The checkout URL must use https, but "${value}" uses ${parsed.protocol.replace(':', '')}.`,
+    );
+  }
+
+  return parsed.origin;
 }
 
 // Whether a hostname sits on a BigCommerce-managed hosting zone — the


### PR DESCRIPTION
Linear: [LTRAC-1748](https://linear.app/commerce/issue/LTRAC-1748) — under [LTRAC-447](https://linear.app/commerce/issue/LTRAC-447)

**3 of 4 in a stack.** Based on #3210 → #3205 — review those first. The diff shown here includes both until they merge; the commit belonging to this PR is the `LTRAC-1748` one.

| | PR | Adds |
| --- | --- | --- |
| 1 | #3205 | The API layer and the channel checkout URL commands |
| 2 | #3210 | The cross-domain checkout warning |
| 3 | **this one** | `catalyst deploy --update-checkout-url` |
| 4 | #3212 | The interactive offer to set a checkout URL |

## What/Why?

Pairs with the existing `--update-site-url` so a merchant bringing up a custom domain can set both of a channel's URLs straight after a deploy, without switching to `catalyst channels update` afterwards.

### Notes for review

**Why it prompts instead of inferring.** Unlike the site URL, a checkout URL can't be derived from the deployment: BigCommerce serves checkout, not this project's worker, so the domain has to already point at BigCommerce with a certificate provisioned there. The flow asks, defaulting to the `checkout.` subdomain of the channel's storefront domain — the near-certain answer given the same-main-domain rule — and reports the current checkout URL first, flagging it when the channel is inheriting one from the default channel.

**Passing both flags resolves the channel once.** `runChannelSiteUrlFlow` returns the channel it resolved (added in #3205, where `channels update` needs the same thing), so the checkout flow reuses it rather than re-prompting. There's a test asserting the select count, so a regression that asks twice fails.

**Both flows share one soft-fail helper.** By the time either runs, the bundle is uploaded and live — so neither a failed site URL nor a failed checkout URL should exit non-zero and imply the deploy itself failed.

**`normalizeCheckoutUrl` moves into `lib/checkout-url`**, shared by this flow and the `channels update --checkout-url` parser, which is a thin adapter rethrowing as `InvalidArgumentError` so commander still formats it as a usage error.

## Testing

`pnpm --filter @bigcommerce/catalyst test` — 753 pass. Lint and typecheck clean.

Covers the prompt default, a caller-supplied URL skipping the prompt, the channel prompt, the inherited-URL reporting, and rejection of a non-https answer before any API call. On the deploy side: the flag prompting and writing, both flags resolving the channel only once, the flag being absent, and the soft-fail branch leaving the deploy reported as successful.

Not exercised live — the prompt needs a real TTY, and triggering it end-to-end would mean running a full deploy.

## Migration

None. Additive — one new deploy flag, no changed defaults.

Refs LTRAC-1748
