### PR TITLE
LTRAC-1778: feat(cli) - Offer to set the checkout URL interactively

### DIFF
--- a/.changeset/ltrac-1778-interactive-checkout-url.md
+++ b/.changeset/ltrac-1778-interactive-checkout-url.md
@@ -1,0 +1,7 @@
+---
+"@bigcommerce/catalyst": minor
+---
+
+`catalyst channels checkout-url` now offers to set a checkout URL instead of only telling you one is needed. With the channel already selected and the site already fetched, it prompts right there — defaulting to the `checkout.` subdomain of the channel's storefront domain — rather than making you re-run the command with `--url`.
+
+The offer is withheld in the two cases where it wouldn't help: when the storefront sits on a BigCommerce-managed hosting zone, where no checkout URL can be issued a certificate and BigCommerce would reject every value, and in non-interactive runs, which print the command to run instead so the command stays scriptable.

--- a/packages/catalyst/src/cli/commands/channels.spec.ts
+++ b/packages/catalyst/src/cli/commands/channels.spec.ts
@@ -4,7 +4,17 @@ import Conf from 'conf';
 import { http, HttpResponse } from 'msw';
 import { existsSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
-import { afterAll, afterEach, beforeAll, describe, expect, MockInstance, test, vi } from 'vitest';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  MockInstance,
+  test,
+  vi,
+} from 'vitest';
 
 import { server } from '../../../tests/mocks/node';
 import { consola } from '../lib/logger';
@@ -855,7 +865,7 @@ describe('channels checkout URLs', () => {
     expect(consola.warn).toHaveBeenCalledWith(expect.stringContaining("default channel's domain"));
   });
 
-  test('stays quiet after --unset when the shared checkout domain still matches', async () => {
+  test('remove stays quiet when the shared checkout domain still matches', async () => {
     server.use(
       http.delete(checkoutPath, () => new HttpResponse(null, { status: 204 })),
       http.get(sitePath, () =>
@@ -874,7 +884,7 @@ describe('channels checkout URLs', () => {
       ),
     );
 
-    await run('--channel-id', '2', '--unset');
+    await run('remove', '--channel-id', '2');
 
     expect(consola.warn).not.toHaveBeenCalled();
   });
@@ -936,5 +946,146 @@ describe('channels checkout URLs', () => {
 
     expect(sitePutCalled).toBe(false);
     expect(mockSelect).not.toHaveBeenCalled();
+  });
+
+  describe('interactive offer to set a checkout URL', () => {
+    const crossDomainSite = {
+      data: {
+        id: 1,
+        url: 'https://canary.example.com',
+        channel_id: 2,
+        is_checkout_url_customized: false,
+        urls: [
+          { url: 'https://canary.example.com', type: 'primary' },
+          { url: 'https://store-abc-1.mybigcommerce.com', type: 'checkout' },
+        ],
+      },
+    };
+
+    const projectsPath = 'https://:apiHost/stores/:storeHash/v3/infrastructure/projects';
+
+    // The managed hosting zone is derived from the store's deployment
+    // hostnames, so this fixture makes `catalyst-sandbox.store` the zone.
+    const withManagedZone = () =>
+      server.use(
+        http.get(projectsPath, () =>
+          HttpResponse.json({
+            data: [
+              {
+                uuid: linkedProjectUuid,
+                name: 'Project One',
+                deployment_hostnames: ['project-one.catalyst-sandbox.store'],
+              },
+            ],
+          }),
+        ),
+      );
+
+    // `canary.example.com` is off that zone, so it reads as the merchant's own
+    // domain and the offer applies.
+    const onOwnDomain = () => {
+      withManagedZone();
+      server.use(http.get(sitePath, () => HttpResponse.json(crossDomainSite)));
+    };
+
+    beforeEach(() => {
+      Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    });
+
+    test('offers to set one, then writes the answer', async () => {
+      let putBody: unknown;
+
+      onOwnDomain();
+      server.use(
+        http.put(checkoutPath, async ({ request }) => {
+          putBody = await request.json();
+
+          return HttpResponse.json({
+            data: { id: 1, url: 'https://canary.example.com', channel_id: 2 },
+          });
+        }),
+      );
+
+      mockConfirm.mockResolvedValueOnce(true);
+      mockInput.mockResolvedValueOnce('https://checkout.canary.example.com');
+
+      await run('--channel-id', '2', '--project-uuid', linkedProjectUuid);
+
+      expect(mockConfirm.mock.calls[0]?.[0].message).toContain('Set a checkout URL');
+      expect(putBody).toEqual({ url: 'https://checkout.canary.example.com' });
+    });
+
+    test('declining leaves the channel alone and prints the command to run later', async () => {
+      let putCalled = false;
+
+      onOwnDomain();
+      server.use(
+        http.put(checkoutPath, () => {
+          putCalled = true;
+
+          return HttpResponse.json({ data: {} });
+        }),
+      );
+
+      mockConfirm.mockResolvedValueOnce(false);
+
+      await run('--channel-id', '2', '--project-uuid', linkedProjectUuid);
+
+      expect(putCalled).toBe(false);
+      expect(mockInput).not.toHaveBeenCalled();
+      expect(consola.info).toHaveBeenCalledWith(
+        expect.stringContaining('--channel-id 2 --checkout-url <domain>'),
+      );
+    });
+
+    // Offering here would walk the user into a guaranteed 422, since a checkout
+    // subdomain on the managed zone can't be issued a certificate.
+    test('does not offer when the storefront is on the managed hosting zone', async () => {
+      withManagedZone();
+      server.use(
+        http.get(sitePath, () =>
+          HttpResponse.json({
+            data: {
+              ...crossDomainSite.data,
+              url: 'https://project-one.catalyst-sandbox.store',
+              urls: [
+                { url: 'https://project-one.catalyst-sandbox.store', type: 'primary' },
+                { url: 'https://store-abc-1.mybigcommerce.com', type: 'checkout' },
+              ],
+            },
+          }),
+        ),
+      );
+
+      await run('--channel-id', '2', '--project-uuid', linkedProjectUuid);
+
+      expect(mockConfirm).not.toHaveBeenCalled();
+      expect(consola.info).toHaveBeenCalledWith(
+        expect.stringContaining('auto-generated deployment hostname'),
+      );
+    });
+
+    test('does not offer when checkout already matches the storefront', async () => {
+      await run('--channel-id', '2', '--project-uuid', linkedProjectUuid);
+
+      expect(mockConfirm).not.toHaveBeenCalled();
+    });
+
+    // `channels checkout-url` has to stay scriptable.
+    test('prints the command instead of prompting when not a TTY', async () => {
+      Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+      onOwnDomain();
+
+      await run('--channel-id', '2', '--project-uuid', linkedProjectUuid);
+
+      expect(mockConfirm).not.toHaveBeenCalled();
+      expect(consola.info).toHaveBeenCalledWith(
+        expect.stringContaining('--checkout-url https://checkout.canary.example.com'),
+      );
+    });
   });
 });

--- a/packages/catalyst/src/cli/commands/channels.ts
+++ b/packages/catalyst/src/cli/commands/channels.ts
@@ -1,8 +1,9 @@
-import { select } from '@inquirer/prompts';
+import { confirm, select } from '@inquirer/prompts';
 import { Command, InvalidArgumentError, Option } from 'commander';
 import type Conf from 'conf';
 import { colorize } from 'consola/utils';
 
+import { runChannelCheckoutUrlFlow } from '../lib/channel-checkout-url-flow';
 import { resolveChannel, runChannelSiteUrlFlow } from '../lib/channel-site-flow';
 import {
   channelPlatformLabel,
@@ -549,7 +550,51 @@ Examples:
     consola.success(`Channel ${label}:`);
     reportChannelSite(site);
 
-    await warnOnCrossDomainCheckout(site, { storeHash, accessToken, apiHost });
+    const report = await warnOnCrossDomainCheckout(site, { storeHash, accessToken, apiHost });
+
+    // The channel and site are already in hand, so offer to fix it rather than
+    // making the user re-run `channels update --checkout-url`.
+    //
+    // Not offered on a managed zone, where BigCommerce would reject every value
+    // (the diagnostic explains why), nor without a TTY, so the command stays
+    // scriptable — matching the guards in `commerce-hosting`.
+    if (report.crossDomain && report.storefrontOnManagedZone !== true) {
+      const suggested = report.suggestion ?? '<domain>';
+
+      if (!process.stdin.isTTY) {
+        consola.info(
+          `Set one with \`catalyst channels update --channel-id ${channel.id} --checkout-url ${suggested}\`.`,
+        );
+        process.exit(0);
+
+        return;
+      }
+
+      const shouldSet = await confirm({
+        message: 'Set a checkout URL for this channel now?',
+        default: true,
+      });
+
+      if (shouldSet) {
+        await runChannelCheckoutUrlFlow({
+          storeHash,
+          accessToken,
+          apiHost,
+          // Already chosen above; don't ask again.
+          channelId: channel.id,
+          channelName: channel.name,
+          storefrontUrl: findChannelSiteUrl(site, 'primary') ?? site.url,
+        });
+
+        process.exit(0);
+
+        return;
+      }
+
+      consola.info(
+        `When you're ready, run \`catalyst channels update --channel-id ${channel.id} --checkout-url <domain>\`.`,
+      );
+    }
 
     process.exit(0);
   });

--- a/packages/catalyst/src/cli/lib/channel-checkout-url-flow.ts
+++ b/packages/catalyst/src/cli/lib/channel-checkout-url-flow.ts
@@ -13,6 +13,10 @@ export interface ChannelCheckoutUrlFlowOptions {
   // skipped.
   channelId?: number;
   url?: string;
+  // Set by a caller that already resolved the channel and fetched the site, so
+  // the flow neither re-prompts nor re-reads.
+  channelName?: string;
+  storefrontUrl?: string;
 }
 
 // Prompts for a checkout URL and writes it.
@@ -24,27 +28,37 @@ export interface ChannelCheckoutUrlFlowOptions {
 export async function runChannelCheckoutUrlFlow(
   options: ChannelCheckoutUrlFlowOptions,
 ): Promise<void> {
-  const channel = await resolveChannel(options);
+  const channel =
+    options.channelId !== undefined
+      ? { id: options.channelId, name: options.channelName }
+      : await resolveChannel(options);
   const label = channel.name ? `"${channel.name}" (${channel.id})` : String(channel.id);
 
-  const site = await getChannelSite(
-    channel.id,
-    options.storeHash,
-    options.accessToken,
-    options.apiHost,
-  );
+  let storefrontUrl = options.storefrontUrl;
 
-  const storefrontUrl = findChannelSiteUrl(site, 'primary') ?? site.url;
-  const currentCheckoutUrl = findChannelSiteUrl(site, 'checkout');
-
-  consola.info(`Channel ${label} storefront is ${storefrontUrl}.`);
-
-  if (currentCheckoutUrl) {
-    consola.info(
-      `Checkout is currently ${currentCheckoutUrl}${
-        site.isCheckoutUrlCustomized ? '' : ', inherited from the default channel'
-      }.`,
+  // The storefront URL only feeds the prompt default, so skip the read when the
+  // caller already has it.
+  if (!storefrontUrl) {
+    const site = await getChannelSite(
+      channel.id,
+      options.storeHash,
+      options.accessToken,
+      options.apiHost,
     );
+
+    storefrontUrl = findChannelSiteUrl(site, 'primary') ?? site.url;
+
+    const currentCheckoutUrl = findChannelSiteUrl(site, 'checkout');
+
+    consola.info(`Channel ${label} storefront is ${storefrontUrl}.`);
+
+    if (currentCheckoutUrl) {
+      consola.info(
+        `Checkout is currently ${currentCheckoutUrl}${
+          site.isCheckoutUrlCustomized ? '' : ', inherited from the default channel'
+        }.`,
+      );
+    }
   }
 
   const answer =


### PR DESCRIPTION
Linear: [LTRAC-1778](https://linear.app/commerce/issue/LTRAC-1778) — under [LTRAC-447](https://linear.app/commerce/issue/LTRAC-447)

**4 of 4 in a stack.** Based on #3211 → #3210 → #3205. The diff shown here includes all three until they merge; the commit belonging to this PR is the `LTRAC-1778` one.

| | PR | Adds |
| --- | --- | --- |
| 1 | #3205 | The API layer and the channel checkout URL commands |
| 2 | #3210 | The cross-domain checkout warning |
| 3 | #3211 | `catalyst deploy --update-checkout-url` |
| 4 | **this one** | The interactive offer to set a checkout URL |

## What/Why?

`catalyst channels info` ended by explaining that checkout was on the wrong domain, then left you to re-run things as `channels update --checkout-url <domain>`. The channel is already selected and the site already fetched at that point, so it now just asks:

```
✔ Channel "Canary Catalyst Demo Site" (1543376):
  Storefront  https://canary.catalyst-demo.site
  Canonical   https://store-vcijajnodd-1543376.mybigcommerce.com
  Checkout    https://catalyst-demo-site.mybigcommerce.com
ℹ This channel has no checkout URL of its own, so BigCommerce falls back to the
  default channel's primary URL...
⚠ Checkout for this channel is on catalyst-demo-site.mybigcommerce.com, a
  different domain than the storefront (canary.catalyst-demo.site)...
? Set a checkout URL for this channel now? › (Y/n)
```

### Notes for review

**Two cases deliberately don't get the offer.** A storefront on a BigCommerce-managed hosting zone can't have a custom checkout URL at all — a checkout subdomain there is two levels deep and can't be issued a certificate — so prompting would walk the user into a guaranteed 422; the diagnostic explains that instead. And a non-interactive run prints the command rather than prompting, following the `!process.stdin.isTTY` guards in `commerce-hosting.ts`, so `channels info` stays scriptable.

**This PR is why #3210's gating signal changed.** Building the offer showed the original signal was wrong, and it was suppressing the offer on exactly the channel where it matters most. Details are in #3210, where the fix lives.

**Accepting reuses `runChannelCheckoutUrlFlow`** rather than duplicating the prompt, passing the channel and storefront URL already in hand so it neither re-prompts for the channel nor re-reads the site.

**Known rough edge, kept deliberately.** The prompt default comes from `suggestCheckoutUrl`, which strips only a leading `www.`. A storefront on `canary.catalyst-demo.site` therefore defaults to `checkout.canary.catalyst-demo.site` rather than `checkout.catalyst-demo.site`. Both satisfy BigCommerce's same-main-domain rule and the field is editable, so it's an unhelpful default rather than a wrong outcome — and guessing which label to strip is what reintroduces the `checkout.co.uk` bug #3210 fixes. If it proves annoying, the follow-up is a picker offering both candidates.

## Testing

`pnpm --filter @bigcommerce/catalyst test` — 758 pass. Lint and typecheck clean.

Five tests cover the offer being accepted and written, declining leaving the channel untouched, the managed-zone case withholding it, an already-correct channel not being nagged, and the non-TTY path printing the command instead.

Verified against store `vcijajnodd` (non-TTY, so the printed-command path):

| Channel | Storefront | Result |
| --- | --- | --- |
| 1543376 | `canary.catalyst-demo.site` | Correctly the merchant's own domain — advice plus a ready-to-run `channels update --checkout-url` command |
| 1799395 | `catalyst.catalyst-sandbox.store` | Correctly managed zone — no offer, explains why |
| 1825156 | `catalyst-demo.site` → `checkout.catalyst-demo.site` | Silent, no false positive |

The interactive prompt itself is covered by unit tests but not exercised live, since it needs a real TTY.

## Migration

None. Additive.

Refs LTRAC-1778
