### PR TITLE
LTRAC-1720: fix(cli) - Stop writing CATALYST_ACCESS_TOKEN to .env.local

### DIFF
--- a/.changeset/ltrac-1720-cli-creds-project-json.md
+++ b/.changeset/ltrac-1720-cli-creds-project-json.md
@@ -1,0 +1,5 @@
+---
+"@bigcommerce/catalyst": patch
+---
+
+Stop writing `CATALYST_ACCESS_TOKEN` into `.env.local` during `catalyst create`. The CLI never read it back — env files are not consulted when resolving credentials — so its only effect was to imply that they are, leading users to add `CATALYST_STORE_HASH` alongside it and then hit "Missing credentials" from `catalyst project list` and `catalyst deploy`. `.env.local` now carries `BIGCOMMERCE_*` build variables only, and CLI configuration lives in `.bigcommerce/project.json`, which scaffolding already writes. Existing projects are unaffected: the stale entry is harmless and is left in place.

--- a/packages/catalyst/src/cli/commands/create.spec.ts
+++ b/packages/catalyst/src/cli/commands/create.spec.ts
@@ -186,9 +186,14 @@ describe('happy paths', () => {
         BIGCOMMERCE_STORE_HASH: storeHash,
         BIGCOMMERCE_CHANNEL_ID: '42',
         BIGCOMMERCE_STOREFRONT_TOKEN: 'flag-storefront-token',
-        CATALYST_ACCESS_TOKEN: accessToken,
       }),
     );
+
+    // `.env.local` is BIGCOMMERCE_* only. `objectContaining` above would happily
+    // pass if a CATALYST_* credential crept back in, so assert none is written.
+    const [, writtenEnv] = vi.mocked(writeEnv).mock.calls[0];
+
+    expect(Object.keys(writtenEnv).filter((key) => key.startsWith('CATALYST_'))).toEqual([]);
   });
 
   test('--hosting commerce sets up commerce hosting and writes BIGCOMMERCE_ACCESS_TOKEN', async () => {

--- a/packages/catalyst/src/cli/commands/create.ts
+++ b/packages/catalyst/src/cli/commands/create.ts
@@ -333,13 +333,6 @@ Examples:
       envVars.BIGCOMMERCE_ACCESS_TOKEN = accessToken;
     }
 
-    // Convenience for shells that auto-load .env.local (direnv, dotenv-cli):
-    // exporting CATALYST_ACCESS_TOKEN lets the CLI's `--access-token` env
-    // binding pick it up. The CLI itself does *not* read this file when
-    // resolving credentials — `.bigcommerce/project.json`, written below, is
-    // what makes subsequent commands work without re-auth.
-    if (accessToken) envVars.CATALYST_ACCESS_TOKEN = accessToken;
-
     // Resolve the Commerce Hosting project before extraction so credential checks
     // and prompts happen up-front. We defer the file mutations
     // (`setupCommerceHosting`) until after extraction.

--- a/packages/catalyst/src/cli/lib/write-env.spec.ts
+++ b/packages/catalyst/src/cli/lib/write-env.spec.ts
@@ -78,7 +78,7 @@ ENABLE_ADMIN_ROUTE=true
 
     writeEnv(projectDir, {
       BIGCOMMERCE_STORE_HASH: 'abc123',
-      CATALYST_ACCESS_TOKEN: 'tok_secret',
+      CUSTOM_TRACKING_ID: 'trk_123',
     });
 
     expect(readLocal()).toBe(
@@ -92,7 +92,7 @@ BIGCOMMERCE_CHANNEL_ID=1
 ENABLE_ADMIN_ROUTE=true
 
 # Additional variables set by the Catalyst CLI (not in .env.example).
-CATALYST_ACCESS_TOKEN=tok_secret
+CUSTOM_TRACKING_ID=trk_123
 `,
     );
   });


### PR DESCRIPTION
Linear: [LTRAC-1720](https://linear.app/commerce/issue/LTRAC-1720/investigate-envlocal-authentication-failure)

## What/Why?

`catalyst create` wrote `CATALYST_ACCESS_TOKEN` into `.env.local`. The CLI never read it back, so the entry's only real effect was to imply that it did — which is what the reported bug turned out to be. A user put `CATALYST_STORE_HASH` next to the token the CLI had already written there, and got `Missing credentials` from `catalyst projects list` and `catalyst deploy`.

Env files can't supply CLI credentials, for three independent reasons:

- `program.ts` scopes env-file loading to `build`/`deploy` only, so `projects list` never loads them.
- `shared-options.ts` binds `--store-hash`/`--access-token` via Commander's `.env()`, which reads `process.env` at **parse** time, before any action handler runs.
- In `deploy`, `loadBuildEnv` runs ~126 lines after `resolveCredentials` (and not at all under `--prebuilt`).

This splits the two files by role: `.env.local` carries `BIGCOMMERCE_*` build variables, CLI configuration lives in `.bigcommerce/project.json` — which `create` already writes at the same point, so post-scaffold auth is unaffected.

**Deliberately not aliasing `CATALYST_ACCESS_TOKEN` ← `BIGCOMMERCE_ACCESS_TOKEN`** to preserve the direnv convenience. The two tokens need different scopes (the CLI's needs modify on Infrastructure Projects/Deployments), so a storefront-scoped token would be picked up and then 403 mid-deploy instead of failing cleanly. It would also re-create the coupling this removes. The pre-existing `CATALYST_STORE_HASH` ← `BIGCOMMERCE_STORE_HASH` alias stays — shipped, documented, and a store hash carries no scope semantics.

Docs counterpart: bigcommerce/docs-v2 `jorgemoya/ltrac-1720-envlocal-cli-config-docs`.

Worth a careful look: whether dropping the direnv path for the token is acceptable, given `project.json` covers the scaffold case and CI exports `CATALYST_ACCESS_TOKEN` explicitly.

## Testing

`pnpm test` (692 passed), `pnpm lint` (`--max-warnings 0`), `pnpm typecheck` — all clean in `packages/catalyst`.

`create.spec.ts` now asserts no key starting with `CATALYST_` reaches `writeEnv`, rather than just dropping the old expectation — `expect.objectContaining` would have silently passed if the write came back. Verified the guard bites by re-injecting the removed line:

```
× happy paths > scaffolds with full creds + flag-provided channel info (no commerce hosting)
  → expected [ 'CATALYST_ACCESS_TOKEN' ] to deeply equal []
```

Manual: scaffold a project and confirm `.env.local` contains no `CATALYST_*` key, while `.bigcommerce/project.json` still has `storeHash` and `accessToken`, and a follow-up `catalyst projects list` works without re-auth.

## Migration

None. Existing projects keep the stale `CATALYST_ACCESS_TOKEN` line in `.env.local`; nothing reads it unless a direnv-style shell loads it, in which case it still resolves through `process.env`. Both `.env*.local` and `.bigcommerce` are gitignored, so there's no clone scenario where one survives without the other.