### PR TITLE
LTRAC-1859: docs(skills) - Fix the integration-branch sync docs

### DIFF
--- a/.claude/skills/sync-integration-branch/SKILL.md
+++ b/.claude/skills/sync-integration-branch/SKILL.md
@@ -47,6 +47,19 @@ git merge origin/<upstream>
 
 If the merge completes cleanly, skip to changeset cleanup. Otherwise, resolve conflicts.
 
+### `refusing to merge unrelated histories`
+
+This means the **clone is shallow**, not that the merge base was lost. A shallow clone has no common ancestor in it to find, so the failure looks alarming but says nothing about the branches. Two other symptoms point the same way: `git merge-base <upstream> <target>` exits non-zero with no output, and `git rev-list --max-parents=0 <branch>` reports *recent* commits as roots rather than the repo's first commit.
+
+Confirm and fix:
+
+```bash
+git rev-parse --is-shallow-repository   # "true" means shallow
+git fetch --unshallow origin
+```
+
+Then re-run the merge and confirm `git merge-base` now resolves. Do **not** reach for `--allow-unrelated-histories`; on a shallow clone it would fabricate a merge across two histories git cannot see the join of.
+
 ### Conflict resolution rules
 
 Keep the target branch's identity, its release-wiring overrides, and its integration surface; take the upstream's structure for everything else. Never let an upstream value overwrite one of these — in particular, a package-name regression would republish over the upstream's package.

--- a/.claude/skills/sync-integration-branch/references/b2b-makeswift.md
+++ b/.claude/skills/sync-integration-branch/references/b2b-makeswift.md
@@ -13,16 +13,16 @@ Load this when the sync target is `integrations/b2b-makeswift`. Fill the SKILL.m
 The B2B Edition + Buyer Portal surface layered over `integrations/makeswift`:
 
 - `core/b2b/*`
-- `core/middlewares/with-b2b.ts` and the `withB2B` wiring in `core/middleware.ts`
-- `core/next.config.ts` (B2B hooks)
-- the `app/[locale]/**/layout.tsx` files (the `B2BLoader`)
+- `core/proxies/with-b2b.ts` and the `withB2B` wiring in `core/proxy.ts`
+- `core/next.config.ts` (the `B2B_API_HOST` handling)
+- `core/app/[locale]/layout.tsx` (the `B2BLoader`, defined in `core/b2b/loader.tsx`)
 - `core/auth/index.ts` + `core/auth/types.ts` (B2B token fields)
-- the register `route.ts`
-- the cart "add to quote" + PDP quote vibes components
-- the B2B keys in `core/messages/en.json`
+- `core/app/[locale]/(default)/(auth)/register/route.ts`
+- the cart "add to quote" and PDP quote vibes components: `core/vibes/soul/sections/cart/add-cart-to-quote-button/index.tsx`, `core/vibes/soul/sections/cart/client.tsx`, and `core/vibes/soul/sections/product-detail/product-detail-form.tsx`
+- the B2B keys in `core/messages/en.json` (`addToQuote`, `addToQuoteFromCart`, `addToShoppingList`)
 
 ## Branch-specific notes
 
 - b2b-makeswift builds on `integrations/makeswift`, so it syncs from there (**not** `canary` directly). Run this **after** syncing `integrations/makeswift`.
 - **Never** let the upstream's `@bigcommerce/catalyst-makeswift` name win in `core/package.json`. Unlike a plain mispublish, regressing this name would republish over the **real, in-use Makeswift package**.
-- **Currently in one-time catch-up.** b2b-makeswift trails makeswift by several minors. Follow the "One-time catch-up" section in SKILL.md: merge `@bigcommerce/catalyst-makeswift` **minor** tags one at a time (`@1.7.0` → `@1.8.0` → `@1.9.0`) until level, then resume steady-state syncs that merge `origin/integrations/makeswift` directly.
+- Steady state: this branch is level with `integrations/makeswift` and is synced as part of each release, so the one-time catch-up flow does not apply. Confirm before assuming either way — compare the merge base against the upstream's latest release commit rather than trusting this note.


### PR DESCRIPTION
Linear: [LTRAC-1859](https://linear.app/commerce/issue/LTRAC-1859/release-bigcommercecatalyst-core1111-and-update-packages)

Two documentation fixes to the `sync-integration-branch` skill, both found by running it for the `1.11.1` release. No code.

## What/Why?

### 1. `references/b2b-makeswift.md` had three wrong claims

**The catch-up note was stale and actively misleading.** It said b2b-makeswift is "currently in one-time catch-up," trails makeswift "by several minors," and should be synced by merging `@bigcommerce/catalyst-makeswift` minor tags one at a time from `@1.7.0` to `@1.9.0`. None of that held: the merge base was [`46ddb22`](https://github.com/bigcommerce/catalyst/commit/46ddb22fc9935530b9062dfd8a6a4c74f74956e7) — makeswift's immediately preceding release — b2b was missing only the current release's commits, and both branches sat at `1.11.0`. I merged `origin/integrations/makeswift` directly instead.

The replacement describes steady state and says to verify rather than trust the note, by comparing the merge base against the upstream's latest release commit. A note that goes stale silently is the failure mode here, so it now carries its own caveat.

**Two surface paths predate canary's `middlewares/` to `proxies/` rename.** `core/middlewares/with-b2b.ts` is `core/proxies/with-b2b.ts`, and the `withB2B` wiring is in `core/proxy.ts`, not `core/middleware.ts`. This matters more than a dead path: the sync flow checks the integration surface survived the merge, and a check against paths that no longer exist reports the surface missing — indistinguishable from having actually clobbered it.

**The rest were correct but too vague to verify.** "the register `route.ts`", "the cart 'add to quote' + PDP quote vibes components", and "the B2B keys in `core/messages/en.json`" are now named explicitly. Worth noting the en.json entry *was* right — the keys are `addToQuote`, `addToQuoteFromCart`, and `addToShoppingList`, which do not match a grep for `b2b` or `quote` as a key prefix, so I initially misjudged it as stale. Naming them removes that trap. The layout entry also claimed a glob of `app/[locale]/**/layout.tsx` files; only `core/app/[locale]/layout.tsx` references `B2BLoader`.

Every path in the new version was verified against `origin/integrations/b2b-makeswift` with `git cat-file -e` and `git grep`.

### 2. `SKILL.md` now explains `refusing to merge unrelated histories`

Phase 1 of the b2b sync failed with that error, which reads as the merge base having been destroyed — the exact disaster the skill's do-not-squash warnings exist to prevent. It was only a shallow clone, which contains no common ancestor to find. `git fetch --unshallow origin` fixed it and nothing was wrong with the branches.

The two corroborating symptoms are documented alongside it, because they are equally alarming and equally benign: `git merge-base` exits non-zero with no output, and `git rev-list --max-parents=0` reports recent commits as roots. The note also warns off `--allow-unrelated-histories`, which is the tempting next move and would fabricate a merge across histories git cannot see the join of.

## Rollout/Rollback

Documentation for a Claude Code skill. No runtime effect, no consumer impact. Rollback is a revert.

## Testing

Not applicable — no code. The b2b claims were verified against `origin/integrations/b2b-makeswift` at `f89fe64a5`, and the corrected flow is what actually produced [#3218](https://github.com/bigcommerce/catalyst/pull/3218) and the `@bigcommerce/catalyst-b2b-makeswift@1.11.1` release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)